### PR TITLE
Spec: automatic heading identifiers + corpus pair

### DIFF
--- a/docs/case-study/parsing-ast.md
+++ b/docs/case-study/parsing-ast.md
@@ -82,6 +82,10 @@ Inline
 └── RawInline { format, content }
 ```
 
+(`id` is optional in the parsed AST but always populated after the
+identifier-resolution pass — automatic or explicit — so consumers
+downstream of resolution can treat it as required.)
+
 ### 6.2 Source Mapping
 
 Every node includes:

--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -169,6 +169,14 @@ See </#intro> for background.
 The `</#id>` syntax auto-fills link text from the target heading.
 No need to repeat yourself or keep text in sync.
 
+`</#id>` resolves against the document's full identifier namespace —
+both explicit `{#id}` attributes and the automatic identifiers defined
+under "Automatic Identifiers" above. So `# Getting Started` is reachable
+as `</#getting-started>` without an explicit attribute. When a bare
+identifier is ambiguous because of duplicate headings, it resolves to
+the first occurrence; target a later one explicitly with its numeric
+suffix (`</#setup-2>`).
+
 #### Wiki-Style Links
 For internal documents, use collapsed reference links:
 ```

--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -34,6 +34,57 @@ Heading 2
 ---------
 ```
 
+#### Automatic Identifiers
+
+Every heading has an identifier. If the heading carries an explicit
+`{#id}` attribute, that value is the identifier and is used **verbatim**
+(no normalization). Otherwise the identifier is generated from the
+heading text by the following algorithm, applied in order:
+
+1. Take the heading's rendered plain text (inline markup removed:
+   `# *Setup* guide` yields `Setup guide`).
+2. Lowercase it (Unicode-aware).
+3. Trim leading and trailing whitespace.
+4. Delete every CSS-unsafe punctuation character: `'` `"` `;` `:`
+   (so `What's New` becomes `whats-new`, not `what-s-new`).
+5. Replace each maximal run of characters that are not Unicode letters,
+   Unicode digits, `_`, or `-` — spaces included — with a single `-`.
+6. Unicode letters, Unicode digits, `_` and `-` are preserved. `_` and
+   `-` are valid CSS identifier characters and meaningful in technical
+   headings, so they are kept rather than folded into `-`.
+7. Collapse runs of `-`, then trim leading and trailing `-`.
+8. If the result starts with a digit, prefix `section-`
+   (`2024 Recap` becomes `section-2024-recap`). A CSS identifier may not
+   start with a digit, and generated IDs must be usable as CSS selectors
+   and `querySelector` arguments, not only as URL fragments.
+9. If the result is empty, the identifier is `section`.
+10. Deduplicate against the document's identifier namespace. Explicit
+    `{#id}` values are reserved first, in document order; generated IDs
+    are reserved as headings are processed. The first use of an
+    identifier is kept bare; each later collision takes the next numeric
+    suffix, 1-based (the second is `-2`, the third `-3`). Explicit and
+    generated identifiers share one namespace.
+
+| Heading | Identifier |
+|---|---|
+| `# Getting Started` | `getting-started` |
+| `# Café & Crème` | `café-crème` |
+| `# Über uns` | `über-uns` |
+| `# RFC 2119: Key Words` | `rfc-2119-key-words` |
+| `# 2024 Recap` | `section-2024-recap` |
+| `# What's New?` | `whats-new` |
+| `# user_id field` | `user_id-field` |
+| `# 日本語の見出し` | `日本語の見出し` |
+| `# !!!` | `section` |
+| `# Setup` then `# Setup` | `setup`, then `setup-2` |
+| `# Introduction {#intro}` then `# Intro` | `intro`, then `intro-2` |
+
+Identifiers are lowercased and CSS-selector-safe by design: the rendered
+`id` is consumed by code Carve does not control (TOC scripts, anchor
+highlighting, `:target` rules, `document.querySelector('#' + id)`), and a
+predictable lowercase slug is also what an author must be able to guess
+when writing a `</#id>` cross-reference.
+
 ### 4.2 Inline Formatting
 
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -862,3 +862,35 @@ Content begins here.
 ```
 
 :::
+
+## Heading IDs
+
+::: compare
+
+```carve
+# Café Notes
+
+# Über uns
+
+# 2024 Recap
+
+## Setup
+
+## Setup
+
+# API {#api-v2}
+
+See </#café-notes>, </#section-2024-recap>, </#setup-2>, and </#api-v2>.
+```
+
+```html
+<h1 id="café-notes">Café Notes</h1>
+<h1 id="über-uns">Über uns</h1>
+<h1 id="section-2024-recap">2024 Recap</h1>
+<h2 id="setup">Setup</h2>
+<h2 id="setup-2">Setup</h2>
+<h1 id="api-v2">API</h1>
+<p>See <a href="#café-notes">Café Notes</a>, <a href="#section-2024-recap">2024 Recap</a>, <a href="#setup-2">Setup</a>, and <a href="#api-v2">API</a>.</p>
+```
+
+:::

--- a/tests/corpus/19-heading-ids.crv
+++ b/tests/corpus/19-heading-ids.crv
@@ -1,0 +1,13 @@
+# Café Notes
+
+# Über uns
+
+# 2024 Recap
+
+## Setup
+
+## Setup
+
+# API {#api-v2}
+
+See </#café-notes>, </#section-2024-recap>, </#setup-2>, and </#api-v2>.

--- a/tests/corpus/19-heading-ids.html
+++ b/tests/corpus/19-heading-ids.html
@@ -1,0 +1,7 @@
+<h1 id="café-notes">Café Notes</h1>
+<h1 id="über-uns">Über uns</h1>
+<h1 id="section-2024-recap">2024 Recap</h1>
+<h2 id="setup">Setup</h2>
+<h2 id="setup-2">Setup</h2>
+<h1 id="api-v2">API</h1>
+<p>See <a href="#café-notes">Café Notes</a>, <a href="#section-2024-recap">2024 Recap</a>, <a href="#setup-2">Setup</a>, and <a href="#api-v2">API</a>.</p>

--- a/tests/spec/19-heading-ids.test
+++ b/tests/spec/19-heading-ids.test
@@ -1,0 +1,25 @@
+Heading IDs
+
+```
+# Café Notes
+
+# Über uns
+
+# 2024 Recap
+
+## Setup
+
+## Setup
+
+# API {#api-v2}
+
+See </#café-notes>, </#section-2024-recap>, </#setup-2>, and </#api-v2>.
+.
+<h1 id="café-notes">Café Notes</h1>
+<h1 id="über-uns">Über uns</h1>
+<h1 id="section-2024-recap">2024 Recap</h1>
+<h2 id="setup">Setup</h2>
+<h2 id="setup-2">Setup</h2>
+<h1 id="api-v2">API</h1>
+<p>See <a href="#café-notes">Café Notes</a>, <a href="#section-2024-recap">2024 Recap</a>, <a href="#setup-2">Setup</a>, and <a href="#api-v2">API</a>.</p>
+```


### PR DESCRIPTION
## Summary

Pins Carve's automatic heading-identifier rule into the spec and locks it with one generated corpus pair. Implementations (carve-js, carve-php) are out of scope and handled separately.

- `docs/case-study/syntax.md`: new normative "Automatic Identifiers" subsection (lowercase, Unicode-preserving, CSS-selector-safe, `section-` prefix for leading digits, 1-based duplicate suffixing, explicit `{#id}` verbatim and namespace-shared) plus a `</#id>` resolution note (shared namespace, first-occurrence wins on ambiguity).
- `docs/case-study/parsing-ast.md`: `Heading.id` is always populated after the resolution pass.
- `docs/examples.md` + `tests/corpus/19-heading-ids.{crv,html}` + `tests/spec/19-heading-ids.test`: a focused contract example covering Unicode preservation, the leading-digit `section-` prefix, duplicate suffixing, explicit-id reservation, and `</#id>` resolution. It is expected to fail against the current no-id renderer; that failure is the intended signal that carve-js implementation work remains. Existing corpus pairs are intentionally not retrofitted.

## Rationale

Heading IDs are a public HTML surface consumed by code Carve does not control (TOC scripts, anchor highlighting, `:target` rules, `document.querySelector('#' + id)`), so CSS-selector safety is baked into the spec rather than left implementation-defined. Lowercasing makes the slug guessable when authoring a `</#id>` cross-reference. Background: jgm/djot # 391 and the djot-php CSS-safe heading-ID deviation.
