### PR TITLE
Spec: resolve four backtracking/lookahead self-contradictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,17 @@ Carve inherits and extends Djot's rationale:
 
 ### From Djot
 
-1. **Linear parsing** - Parse in linear time with no backtracking
-2. **Local inline parsing** - No dependency on later references for syntax highlighting
+1. **Linear parsing** - Parse in linear time with no backtracking. Inline
+   emphasis is resolved with a delimiter stack in a single left-to-right pass;
+   document-level definitions (link/footnote/abbreviation references, heading
+   IDs) are collected in a first pass before inline resolution. Both are O(n);
+   neither requires backtracking.
+2. **Local inline parsing** - Inline *tokenization and syntax highlighting*
+   never depend on later content. Semantic *expansion* that does need the
+   definition table (abbreviation `<abbr>`, `</#id>` auto-text, `[text][ref]`
+   targets) runs after the first-pass collection above — a definition that
+   appears later in document order is still resolved. This is the defined
+   two-pass model, not backtracking.
 3. **Simple emphasis** - Single characters, no complex disambiguation rules
 4. **No expressive blind spots** - All outputs achievable without workarounds
 5. **Simple list indentation** - Indented content belongs to the list item

--- a/docs/case-study/parsing-ast.md
+++ b/docs/case-study/parsing-ast.md
@@ -27,12 +27,17 @@ Parse in this precedence order:
 
 ### 5.3 The Disambiguation Rule
 
-When ambiguous, prefer:
-1. Literal text over markup
-2. Shorter spans over longer
-3. Earlier opening over later
+1. **Literal over markup.** A delimiter with no valid match (per the
+   word-boundary conditions) is literal text.
+2. **Opener → nearest valid same-type closer.** Same-type delimiters between
+   them are literal content (same-type spans do not nest), so `/usr/local/`
+   is `<em>usr/local</em>`, *not* `<em>usr</em>local/`.
+3. **Different-type spans nest**, resolved with a delimiter stack in a single
+   left-to-right pass — linear time, no backtracking (Design Principle 1).
 
-Example: `*a *b* c*` parses as `*a ` + bold(b) + ` c*` (literal asterisks around)
+This is *not* "shortest span / earliest opening wins": that rule would truncate
+`/usr/local/` to `<em>usr</em>` and break nested emphasis. See
+`resources/grammar.ebnf` PART 8 and PART 9 §9, and `docs/edge-cases.md` §1, §8.
 
 ### 5.4 Whitespace Rules
 

--- a/docs/edge-cases.md
+++ b/docs/edge-cases.md
@@ -213,7 +213,18 @@ See *[the docs](url) for more* info
 /*Bold italic*/                # Valid: combined
 ```
 
-**Parsing:** First matched delimiter wins. Inner delimiters of same type are literal.
+**Parsing:** An opener matches a valid closer of the same type (a delimiter
+closes only when not preceded by whitespace, see §1). Same-type delimiters
+*inside* the span are literal content — same-type spans do not nest — so
+`/usr/local/` is `<em>usr/local</em>`, not `<em>usr</em>local/`. Different-type
+spans nest fully (`*Bold with /italic/ inside*`). Resolution uses a delimiter
+stack in a single left-to-right pass: linear time, no backtracking.
+
+> This is *not* "shortest span / first match wins" — that rule would truncate
+> `/usr/local/` to `<em>usr</em>` and break nested emphasis. The ambiguous form
+> `/This /does not/ nest/` is discouraged (use code spans for paths, §1); its
+> exact output is intentionally unspecified. See grammar.ebnf PART 8
+> (Disambiguation rule) and PART 9 §9.
 
 ---
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -173,7 +173,15 @@ paragraph = inline_content+, blank_line ;
    PART 3: INLINE ELEMENTS
    ============================================================================ *)
 
-inline_content = {inline_element | text_run}+ ;
+inline_content = {inline_element | text_run | literal_special}+ ;
+
+(* A special_char that does not begin (or close) a construct under PART 8
+   precedence + PART 9 conditions is literal text. Without this production
+   the grammar cannot represent "a/b/c", "x = a*b", or an inner delimiter
+   such as the middle '/' of /usr/local/ -- yet these are canonical outputs
+   (edge-cases.md §1, corpus 01-emphasis). The "is this a construct?"
+   decision is the semantic constraint in PART 9, not a context-free one. *)
+literal_special = special_char ;
 
 inline_element = escaped_char
                | code_span
@@ -276,14 +284,20 @@ superscript = '^', super_content, '^' ;
 subscript = ",,", sub_content, ",," ;
 highlight = "==", highlight_content, "==" ;
 
-emphasis_content = (inline_element | text_run - '/')+ ;
-strong_content = (inline_element | text_run - '*')+ ;
-bi_content = (inline_element | text_run - "*/")+;
-underline_content = (inline_element | text_run - '_')+ ;
-strike_content = (inline_element | text_run - '~')+ ;
-super_content = (inline_element | text_run - '^')+ ;
-sub_content = (inline_element | text_run - ",,")+;
-highlight_content = (inline_element | text_run - "==")+;
+(* Content MAY contain the delimiter character: a delimiter that does not
+   satisfy the close condition (PART 9 §1) is literal content, not the span
+   boundary. The span ends at the matched closer only. Subtracting the
+   delimiter here would make e.g. "/usr/local/" -> <em>usr/local</em>
+   ungrammatical, contradicting edge-cases.md §1. The boundary is a semantic
+   constraint (PART 9 §1, §9), not a context-free one. *)
+emphasis_content = (inline_element | text_run | literal_special)+ ;
+strong_content = (inline_element | text_run | literal_special)+ ;
+bi_content = (inline_element | text_run | literal_special)+ ;
+underline_content = (inline_element | text_run | literal_special)+ ;
+strike_content = (inline_element | text_run | literal_special)+ ;
+super_content = (inline_element | text_run | literal_special)+ ;
+sub_content = (inline_element | text_run | literal_special)+ ;
+highlight_content = (inline_element | text_run | literal_special)+ ;
 
 (* Word boundary rule for emphasis openers/closers *)
 emphasis_open_condition = (* preceding char is whitespace or start, following is non-whitespace *) ;
@@ -443,9 +457,19 @@ EOF = (* end of file *) ;
    11. Plain text
 
    Disambiguation rule:
-   - Prefer literal text over markup
-   - Prefer shorter spans over longer
-   - Prefer earlier opening over later
+   - Prefer literal text over markup: a delimiter that has no valid match
+     (per the word-boundary conditions, PART 9 §1) is literal.
+   - An opener matches the NEAREST following valid closer of the same type.
+     Delimiters of the same type between them are literal content (same-type
+     spans do not nest, PART 9 §3); e.g. /usr/local/ -> <em>usr/local</em>.
+   - Different-type spans nest and are resolved with a delimiter stack in a
+     single left-to-right pass (NO backtracking, linear time); e.g.
+     *bold /italic/* and /italic *bold*/ nests fully.
+
+   Note: "shorter spans / earlier opening wins" does NOT apply -- it would
+   truncate /usr/local/ to <em>usr</em> and break nested emphasis. The
+   delimiter-stack model is what makes Design Principle 1 (no backtracking)
+   hold while still producing the canonical outputs in the corpus.
 *)
 
 (* ============================================================================
@@ -478,6 +502,14 @@ EOF = (* end of file *) ;
       - Reference links [text][ref] resolved to [ref]: url definitions
       - Collapsed references [text][] use text as reference label
       - Abbreviations matched at word boundaries only
+      - All definitions (link/footnote/abbreviation references, heading IDs)
+        are collected in the first pass (PART 8, "first pass") BEFORE inline
+        resolution runs. A document-order definition appearing AFTER its use
+        is still resolved -- this is the defined two-pass model, not
+        backtracking, and is O(n). Design Principle 2 ("no dependency on
+        later references") scopes to inline *tokenization/highlighting*,
+        which never needs the definition table; semantic *expansion*
+        (abbr <abbr>, </#id> auto-text, [ref] targets) uses it.
 
    7. MENTION/TAG BOUNDARIES
       - @ and # only start mentions/tags at word boundaries
@@ -486,4 +518,16 @@ EOF = (* end of file *) ;
    8. SMART TYPOGRAPHY CONTEXT
       - Only applies outside code spans/blocks
       - Patterns must match exactly (not partial)
+
+   9. EMPHASIS SPAN BOUNDARY (governs *_content productions in PART 3)
+      - A delimiter opens only if NOT followed by whitespace AND preceded by
+        whitespace, start, or punctuation (left word boundary).
+      - A delimiter closes only if NOT preceded by whitespace (right word
+        boundary). "/ not italic /" stays literal (ws after opener).
+      - The span runs from the opener to its matched closer; any same-type
+        delimiter in between is LITERAL content (no same-type nesting, §3).
+        Hence /usr/local/ -> <em>usr/local</em> and the/path/here is literal
+        (first / has no left boundary). See edge-cases.md §1.
+      - Resolution uses a delimiter stack, single left-to-right pass, no
+        backtracking (Design Principle 1).
 *)


### PR DESCRIPTION
## Summary

The normative spec contradicted its own canonical corpus and the "linear, no backtracking" design principle in four places. The corpus (`tests/spec` / `corpus`, generated from `docs/examples.md`) is authoritative for intended behavior, so only the contradicting text is corrected. **No behavior change, no corpus regeneration** — the test expectations were already correct; the spec text describing how to reach them was wrong.

## The four contradictions fixed

**1. Grammar cannot derive its own canonical output.**
`emphasis_content = (inline_element | text_run - '/')+` — but `text_run = (character - special_char)+` already excludes every delimiter, and there was no literal-fallback production. So the grammar could not derive `<em>usr/local</em>` (corpus `01-emphasis`), nor even `a/b/c` as plain paragraph text. Added a `literal_special = special_char` production to `inline_content` and all emphasis `*_content` rules; the span boundary is declared a PART 9 semantic constraint (as fences already are), not a context-free one.

**2. "Prefer shorter spans / earliest opening / first matched delimiter wins".**
Stated in `grammar.ebnf` PART 8, `edge-cases.md` §8, and `case-study/parsing-ast.md` §5.3. That rule truncates `/usr/local/` to `<em>usr</em>` and breaks the nested-emphasis corpus case, and implies backtracking — contradicting Design Principle 1. Replaced with the actual rule: an opener matches the nearest valid same-type closer, inner same-type delimiters are literal, different types nest via a delimiter stack in a single left-to-right pass (linear, no backtracking). Removed the untested `*a *b* c*` example in parsing-ast.md, which encoded the opposite (inner-pair) rule and is not in the corpus.

**3 & 4. "No dependency on later references" vs. abbreviations / heading-id auto-text.**
README principle 2 read as contradicted by abbreviation expansion and `</#id>` auto-text, which resolve from definitions appearing later in document order. Scoped principle 2 to inline tokenization/highlighting, and documented the *already-existing* two-pass model (definitions collected in the first pass, before inline resolution — see PART 8 "first pass", `parse.js`) in principle 1, PART 9 reference-resolution, and a new PART 9 §9. This is the defined model, not backtracking.

## Notes

- Self-review caught a sibling restatement in `case-study/parsing-ast.md` that a naive pass would miss; all four files are now mutually consistent (`grep` for the old phrasings returns only the new corrective "this is *not* …" notes).
- One mid-edit over-reach (asserting a parse for the explicitly "Invalid - ambiguous" `/This /does not/ nest/` example) was backed out; that case is left intentionally unspecified, anchored only to the two authoritative corpus facts.
