### PR TITLE
Consolidate normativity + CI-enforce (priority 3)

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -1,5 +1,10 @@
 # Syntax Specification
 
+> **Non-normative.** This page is explanatory prose. The normative
+> specification is [`resources/grammar.ebnf`](../../resources/grammar.ebnf)
+> (PART 9 for semantic constraints); `docs/examples.md` + `tests/corpus`
+> are the conformance contract. On any disagreement, the grammar wins.
+
 ## Part 4: Carve Syntax Specification
 
 ### 4.1 Document Structure

--- a/docs/edge-cases.md
+++ b/docs/edge-cases.md
@@ -1,5 +1,10 @@
 # Carve Edge Cases Analysis
 
+> **Non-normative.** This document analyzes tricky cases for humans. The
+> normative specification is [`resources/grammar.ebnf`](../resources/grammar.ebnf)
+> (PART 9 for semantic constraints); `docs/examples.md` + `tests/corpus`
+> are the conformance contract. On any disagreement, the grammar wins.
+
 This document analyzes potentially ambiguous or tricky parsing scenarios in Carve syntax.
 
 ---

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "docs:preview": "vitepress preview docs",
     "corpus:build": "node scripts/generate-corpus.mjs",
     "sync-carve-lib": "node scripts/sync-carve-lib.mjs",
-    "test": "node --test tests/corpus.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/normativity.test.mjs",
     "test:conformance": "npm run corpus:build && npm test"
   },
   "devDependencies": {

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -16,6 +16,18 @@
    - x+      = repetition (1 or more)
    - x - y   = exception (x but not y)
    - (x)     = grouping
+
+   NORMATIVITY
+   - This file (resources/grammar.ebnf) is the NORMATIVE specification of
+     Carve. Where any document disagrees with it, this file wins. Within
+     it, PART 9 (semantic constraints not expressible in pure EBNF) is the
+     authority for behavior the grammar productions cannot encode.
+   - docs/case-study/syntax.md and docs/edge-cases.md are EXPLANATORY and
+     DERIVED — prose for humans, non-normative.
+   - docs/examples.md and the generated tests/corpus/* pairs are the
+     CONFORMANCE CONTRACT: every example is checked against the reference
+     implementation in CI. A spec change is not real until a corpus pair
+     pins it.
    ============================================================================ *)
 
 (* ============================================================================

--- a/tests/normativity.test.mjs
+++ b/tests/normativity.test.mjs
@@ -1,0 +1,86 @@
+/*
+ * Normativity-consistency checks.
+ *
+ * Enforces the single-source-of-truth policy declared in
+ * resources/grammar.ebnf:
+ *   - grammar.ebnf is normative; PART 9 holds the semantic constraints
+ *   - syntax.md / edge-cases.md are explanatory and must say so
+ *   - every "PART 9 §N" reference across the docs must resolve to a
+ *     real PART 9 section (no dangling normative cross-references)
+ *
+ * Run by the same `node --test` invocation as the corpus suite.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repo = resolve(here, '..')
+const grammarPath = resolve(repo, 'resources/grammar.ebnf')
+const grammar = readFileSync(grammarPath, 'utf8')
+
+// PART 9 is the last PART; collect its section numbers from the
+// "   N. TITLE" headings that follow the PART 9 banner.
+const part9 = grammar.slice(grammar.indexOf('PART 9: SEMANTIC CONSTRAINTS'))
+const part9Sections = new Set(
+  [...part9.matchAll(/^ {3}(\d+)\. {1,3}[A-Z]/gm)].map((m) => Number(m[1])),
+)
+
+const docFiles = [
+  ...readdirSync(resolve(repo, 'docs'))
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => resolve(repo, 'docs', f)),
+  ...readdirSync(resolve(repo, 'docs/case-study'))
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => resolve(repo, 'docs/case-study', f)),
+]
+
+test('grammar.ebnf declares the normativity policy', () => {
+  assert.match(grammar, /\bNORMATIVITY\b/)
+  assert.match(grammar, /NORMATIVE specification of\s+Carve/)
+})
+
+test('PART 9 has at least the known semantic-constraint sections', () => {
+  // Sanity: parsing worked and found a plausible set.
+  assert.ok(part9Sections.size >= 8, `found sections: ${[...part9Sections]}`)
+})
+
+test('every "PART 9 §N" reference resolves to a real section', () => {
+  // Match a whole citation group so multi-section shorthand like
+  // "PART 9 §1, §9 and §10" is fully validated, not just the first.
+  const citation = /PART 9 §\d+(?:\s*(?:,|&|and|or|to|–|-)?\s*§\d+)*/g
+  const dangling = []
+  for (const file of docFiles) {
+    const text = readFileSync(file, 'utf8')
+    for (const group of text.match(citation) ?? []) {
+      for (const sm of group.matchAll(/§(\d+)/g)) {
+        const n = Number(sm[1])
+        if (!part9Sections.has(n)) dangling.push(`${file}: PART 9 §${n}`)
+      }
+    }
+  }
+  assert.deepEqual(
+    dangling,
+    [],
+    `dangling normative references (valid: §${[...part9Sections].sort((a, b) => a - b).join(', §')}):\n${dangling.join('\n')}`,
+  )
+})
+
+test('explanatory docs carry the non-normative banner', () => {
+  for (const rel of ['docs/case-study/syntax.md', 'docs/edge-cases.md']) {
+    const text = readFileSync(resolve(repo, rel), 'utf8')
+    assert.match(text, /\*\*Non-normative\.\*\*/, `${rel} missing banner`)
+    assert.match(text, /grammar\.ebnf/, `${rel} must point to the grammar`)
+  }
+})
+
+test('the conformance contract exists and is non-empty', () => {
+  assert.ok(existsSync(resolve(repo, 'docs/examples.md')))
+  const crv = readdirSync(resolve(repo, 'tests/corpus')).filter((f) =>
+    f.endsWith('.crv'),
+  )
+  assert.ok(crv.length > 0, 'tests/corpus has no .crv fixtures')
+})


### PR DESCRIPTION
## Summary

Priority 3 — make normativity single-source and CI-enforced.

- **`resources/grammar.ebnf`** now explicitly declares itself the
  normative spec (PART 9 = semantic constraints; on any disagreement
  the grammar wins). `syntax.md` / `edge-cases.md` are explanatory and
  carry a **Non-normative** banner pointing at the grammar.
  `examples.md` + `tests/corpus` is the conformance contract.
- **`tests/normativity.test.mjs`** enforces it in CI:
  - the normativity policy is declared in the grammar
  - every `PART 9 §N` citation across all docs resolves to a real
    section (multi-section groups like `§1, §9 and §10` fully parsed)
    — no dangling normative references
  - the explanatory docs carry the banner and link the grammar
  - the conformance corpus exists and is non-empty
- **`package.json`** — `npm test` runs corpus + normativity suites;
  CI already calls `npm test`, so this guards every PR.

65/65 (60 corpus + 5 normativity). Reviewed with `codex review`
(strengthened the citation parser per its feedback).
