### PR TITLE
Spec: pin list-marker-change + admonition rendering rules (P1.4, P1.12)

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -260,7 +260,25 @@ The `^` prefix on the following line creates a `<figure>` with `<figcaption>`.
 + And this
 ```
 
-All three (`-`, `*`, `+`) are equivalent. User preference.
+Use whichever marker you prefer for a given list. The three markers are
+**not interchangeable within one list**: changing the marker character
+starts a new list (matching djot, see PART 9 §11). So
+
+```
+- a
+- b
++ c
++ d
+```
+
+renders as two separate `<ul>`s, not one merged list. The same rule
+applies to task-list markers: a `- [ ] x` line followed by a `+ [ ] y`
+line produces two single-item task lists, not one. This keeps the
+parser stateless about "which marker came first" and matches the
+reader's intuition that the visual change signals a structural break.
+
+To consolidate visually-mixed bullets into a single list, normalize the
+markers in the source.
 
 #### Ordered
 ```
@@ -671,21 +689,56 @@ This action cannot be undone.
 :::
 ```
 
-**Built-in types:** note, tip, warning, danger, info, success, example, quote
+**Canonical types:** `note`, `tip`, `warning`, `danger`, `info`,
+`success`, `example`, `quote`, `details`. The carve VitePress theme
+and most third-party themes ship CSS targeting these exact class
+names. Render as:
 
-**Custom types:**
+```html
+<aside class="admonition note">
+  <p>Heads up — this is important.</p>
+</aside>
 ```
-::: custom-type
-Content here.
+
+**Custom types** render to the same shape — no prefix, no
+special-casing:
+
+```
+::: hint "Pro tip"
+Project-specific call-out.
+:::
+
+::: glossary
+A custom type without an explicit title renders without one.
 :::
 ```
 
-**Collapsible blocks:**
+→
+
+```html
+<aside class="admonition hint">
+  <p class="admonition-title">Pro tip</p>
+  <p>Project-specific call-out.</p>
+</aside>
+<aside class="admonition glossary">
+  <p>A custom type without an explicit title renders without one.</p>
+</aside>
 ```
-::: details "Click to expand"
-Hidden content revealed on interaction.
-:::
-```
+
+A `<p class="admonition-title">…</p>` line is emitted **only** when an
+explicit `quoted_title` is given. Carve does **not** synthesize a
+default title from the type name — `::: note` without `"…"` produces
+no title element at all (canonical and custom types alike).
+
+The §4.20 extension registry MAY in a future revision intercept a
+matching type identifier before the admonition fallback fires (e.g.
+`::: youtube` rendering via a registered handler). Today every `:::`
+block goes through the admonition rule above; see PART 9 §12.
+
+> **No bare `:::` blocks.** Every `:::` block must declare a type
+> identifier. Carve does not accept djot's "generic fenced div with no
+> class" form (`:::\n…\n:::`); use `::: note` or `::: info` for the
+> unstyled case.
 
 ### 4.13 Comments
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -902,7 +902,7 @@ Heads up — this is important.
 
 :::
 
-Each admonition type produces a matching CSS class — `note`, `tip`, `warning`, and `caution` are the named variants.
+Each admonition type produces a matching CSS class — `note`, `tip`, `warning`, `danger`, `info`, `success`, `example`, `quote`, and `details` are the canonical types. Custom identifiers (e.g. `hint`, `glossary`) render to the same shape with the literal type as the class. See PART 9 §12 of the grammar for the full rule.
 
 ::: compare
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -157,7 +157,8 @@ admonition_close = ":::" ;
 
 admonition_type = "note" | "tip" | "warning" | "danger" | "info"
                 | "success" | "example" | "quote" | "details"
-                | identifier ;  (* custom types *)
+                | identifier ;  (* custom types -- see PART 9 §12 for
+                                   rendering semantics *)
 
 quoted_title = '"', {character - '"'}, '"' ;
 
@@ -596,4 +597,65 @@ EOF = (* end of file *) ;
       Unambiguous starts (heading, fence, thematic break, admonition, bare
       image, abbreviation definition, ordered list) always interrupt on a
       single line -- they cannot be confused with prose operators.
+
+   11. LIST MARKER CHANGE STARTS A NEW LIST -- NORMATIVE (governs `list`
+      in PART 2). §10 decides FIRST whether a sequence of marker lines
+      establishes a list at all (paragraph-interruption gate); §11 then
+      decides whether established list items belong to one list or to
+      adjacent sibling lists. The rules layer; §11 never overrides §10.
+      Given two adjacent list items at the same indent that both passed
+      §10, they belong to the SAME list only when their marker matches:
+        - same character within `-`, `*`, `+` for unordered;
+        - same `ordered_marker` alternative for ordered;
+        - same plain-vs-task classification.
+      A line whose marker differs from the immediately-preceding item
+      on any of those axes starts a new sibling list at the same indent.
+      Matches djot. Example:
+        - a              produces:    <ul><li>a</li><li>b</li></ul>
+        - b                            <ul><li>c</li><li>d</li></ul>
+        + c
+        + d
+      Same axis for ordered-list dialect changes: a switch between
+      `digit+ '.'`, `letter '.'`, and `roman_numeral '.'` between adjacent
+      items splits. Same axis for plain-vs-task: `- a` followed by
+      `- [x] b` is two lists (matches djot, where `- [ ]` and `- a` are
+      treated as distinct kinds). Parser stateless w.r.t. marker history
+      -- the rule looks one line back.
+      LETTER-VS-ROMAN TIE-BREAKER (open). The markers `i.`, `v.`, and
+      `x.` match both `letter '.'` and `roman_numeral '.'`. When the
+      letter and roman dialects are both supported by an implementation,
+      a single-character item that could be either classifies as
+      ROMAN if the immediately-following item is a multi-character
+      roman continuation (`ii.`, `iii.`, ...), otherwise as LETTER.
+      Carve-js does not yet implement letter or roman ordered lists
+      (RE_ORDERED accepts digits only); the tie-breaker is pinned here
+      for the implementations that will.
+
+   12. ADMONITION RENDERING -- NORMATIVE (governs `admonition` in PART 2).
+      Every `:::` block carries a required `type` identifier (bare
+      `:::` is a syntax error -- carve does not accept djot's
+      "generic fenced div with no class"). The renderer emits, for
+      every type, a uniform wrapper:
+            <aside class="admonition {type}">
+              [<p class="admonition-title">{quoted_title}</p>]
+              {body}
+            </aside>
+      Two pinned rules:
+        a. The wrapper class is `admonition` followed by the literal
+           type identifier separated by a single space (no prefix form:
+           `admonition note`, NOT `admonition-note`).
+        b. A `<p class="admonition-title">…</p>` line is emitted ONLY
+           when the author supplied a `quoted_title` after the type.
+           Carve does NOT invent a default title from the type name --
+           `::: note` without `"…"` produces no title line at all.
+           This holds for canonical and custom types alike.
+      The eight canonical types (`note`, `tip`, `warning`, `danger`,
+      `info`, `success`, `example`, `quote`) plus `details` are carve
+      idioms that consuming CSS frameworks target by exact class name.
+      Custom types render to the same shape; authors layer their own
+      CSS against the `{type}` class.
+      Forward-compatibility: a registered block-extension mechanism
+      (syntax.md §4.20) may, in a future revision of this rule,
+      intercept the type identifier before the admonition fallback
+      fires. Today every `:::` block goes through the rule above.
 *)


### PR DESCRIPTION
Spec-text PR pinning two normative rules surfaced in the carve/djot/djot-php gap audit:

## P1.4 — List marker change starts a new list (PART 9 §11)

`syntax.md` previously claimed the three unordered markers (`-`, `*`, `+`) were "equivalent. User preference." Djot disagrees: switching the marker character starts a new sibling list (verified against `jgm/djot` official test suite vendored under `djot-php/tests/official/lists.test`). PR aligns carve's normative rule with djot:

- **Same marker character** for adjacent unordered items → same list
- **Different marker character** → adjacent sibling lists
- Same axis applies to ordered-list dialect changes (`1.` vs `a.` vs `i.`) and to plain-vs-task classification (`- a` followed by `- [x] b` → two lists, matching djot's distinct-kind rule)
- §10 (paragraph-interruption gate) takes precedence: §11 only decides one-or-many for items that already pass §10's "does this establish a list?" check
- **Letter-vs-roman tie-breaker** pinned for `i.` / `v.` / `x.`: classify as ROMAN if the next item is a multi-character roman continuation (`ii.`, `iii.`, …); otherwise LETTER

### Impl gap (intentional)

Carve-js's `matchListMarker` currently merges any unordered marker change into one list, and `RE_ORDERED` accepts digits only (no letter/roman ordered markers). This PR pins the rule; impl follow-ups in carve-js and carve-php will close the gap. **Same pattern as carve PR #16** (ASCII slugs landed in spec ahead of carve-js #13).

## P1.12 — Admonition rendering (PART 9 §12)

The grammar permits `admonition_type = "note" | "tip" | … | identifier` (custom types) but PART 9 was silent on how custom types render. This PR pins the uniform shape:

```html
<aside class="admonition {type}">
  [<p class="admonition-title">{quoted_title}</p>]
  {body}
</aside>
```

- Class: `admonition` + literal type identifier separated by space (no `admonition-{type}` prefix form). Aligns with the existing `13-admonitions` corpus.
- Title `<p>` emitted **only** when an explicit `quoted_title` was given. Carve does **not** synthesize a default title from the type name — `::: note` without `"…"` produces no title element at all. Consistent for canonical and custom types alike.
- **Bare `:::` is a syntax error.** Carve does not accept djot's "generic fenced div with no class" form; every `:::` block must declare a type.
- Forward note: a registered block-extension mechanism (§4.20) MAY in a future spec revision intercept the type before the admonition fallback fires (e.g. `::: youtube` via a handler). Today every `:::` block goes through the admonition rule.

### Impl gap (intentional)

- carve-js currently accepts unquoted title text after the type (`::: note hello` → title "hello"); spec pins the quoted form as canonical, impl tightens later.
- carve-js currently leaks the literal `"` characters into the rendered title and runs smart-typography over them (`"hello"` → `“hello”`); impl follow-up will strip the delimiters before render.
- carve-php's custom-type admonition rendering is broken today — `<div class="hint &quot;Pro tip&quot;">` (concatenates quoted title into class attr). Impl follow-up will align to the spec'd `<aside class="admonition {type}">…` shape.

## Also fixes

- `examples.md` §admonitions listed canonical types as `note, tip, warning, caution`. `caution` is not a carve canonical type. Replaced with the full nine-item canonical set (`note`, `tip`, `warning`, `danger`, `info`, `success`, `example`, `quote`, `details`) plus a note that custom identifiers render to the same shape.

## Tests

86/86 corpus + normativity tests pass (`node --test tests/corpus.test.mjs tests/normativity.test.mjs`). New corpus fixtures for §11 and §12 deliberately deferred — they require the impl fixes to pass, so they'll land alongside the carve-js and carve-php follow-up PRs.

## Closes out

- P1.4 of the gap audit
- P1.12 of the gap audit
- Two follow-up tasks on the audit board: (a) carve-js impl fixes for both rules, (b) carve-php impl fixes for both rules.

## Audit reference

This PR is the first of four landing the high-impact findings from the cross-impl gap audit (carve vs djot vs djot-php). Remaining big items:

- **P1.2** — Adopt djot's `<section id="…">` wrapper around headings (medium effort: stateful renderer + corpus migration)
- **P1.5** — Inline span `[text]{.attr}` construct (largest: new grammar production + parser + renderer across both impls)
