### PR TITLE
Spec: <section> wrapper around headings (P1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Carve inherits and extends Djot's rationale:
 | Wiki-style links | `[Page Name][]` (reference link; needs a `[Page Name]: url` definition) | `[Page Name][]` (auto-resolves, no definition) |
 | Cross-references | N/A (manual `[](#id)`) | `</#id>` (auto-fills link text from the target heading) |
 | Heading IDs | Auto-generated (Unicode, case-preserving) | Auto-generated (ASCII-safe transliteration, lowercase, CSS-selector-safe) |
+| Heading structure | `<section id="…"><h*>…</h*></section>` with level-aware nesting | `<section id="…"><h*>…</h*></section>` with level-aware nesting (matches djot — id on `<section>`, not on `<h*>`) |
 
 ### Lists & tables
 

--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -39,6 +39,57 @@ Heading 2
 ---------
 ```
 
+#### Section wrapping
+
+Every heading emits a `<section id="…">` wrapper around itself and the
+content that follows it (paragraphs, lists, blockquotes, …) until the
+next heading at the same or shallower level. The id derived from the
+heading text (or the explicit `{#id}` attribute) lives on the
+`<section>` element, not on the `<h*>`. This matches djot and lets
+authors target sections directly with CSS, JavaScript, and `:target`
+selectors:
+
+```
+# Intro
+
+A paragraph.
+
+## Background
+
+Another paragraph.
+
+# Next chapter
+
+Body.
+```
+
+renders as
+
+```html
+<section id="intro">
+  <h1>Intro</h1>
+  <p>A paragraph.</p>
+  <section id="background">
+    <h2>Background</h2>
+    <p>Another paragraph.</p>
+  </section>
+</section>
+<section id="next-chapter">
+  <h1>Next chapter</h1>
+  <p>Body.</p>
+</section>
+```
+
+Skipped levels nest by the heading number — a `# H1` followed by
+`### H3` puts the H3 section two levels deep inside the H1 section,
+without synthesizing an intermediate H2.
+
+The fragment URL `https://example.com/page#intro` resolves the same
+way whether the id is on `<h1>` or `<section>` — browsers locate the
+first element matching the id. Existing `</#id>` cross-references and
+`[Heading][]` implicit references keep working unchanged. See PART 9
+§13 of the grammar for the full algorithm.
+
 #### Automatic Identifiers
 
 Every heading has an identifier. If the heading carries an explicit

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -658,4 +658,49 @@ EOF = (* end of file *) ;
       (syntax.md §4.20) may, in a future revision of this rule,
       intercept the type identifier before the admonition fallback
       fires. Today every `:::` block goes through the rule above.
+
+   13. HEADING SECTION WRAPPING -- NORMATIVE (governs `atx_heading` in
+      PART 2 and the renderer; matches djot, see `jgm/djot` official
+      `headings.test`). Every heading emits a `<section id="{id}">`
+      wrapper around itself and the following content up to the next
+      same-or-shallower heading. The slug-derivation rule (§4.1 plus
+      ASCII transliteration, see PART 9 §0 / syntax.md §4.1) computes
+      the id; the id lives on the `<section>` element, NOT on the
+      `<h*>` element. This shifts the existing carve behavior
+      (id-on-h*, no section wrapper) to match djot's structural model.
+      Algorithm (one stateful pass over top-level blocks):
+        let openSections : Stack of (level, sectionElement) = []
+        for each top-level child node:
+          if node is Heading at level N:
+            while openSections is non-empty AND top.level >= N:
+              emit </section>; pop openSections
+            emit <section id="{slug}">; push (N, ...)
+            emit <h{N}>{inline-rendered children}</h{N}>
+          else:
+            emit node normally
+        while openSections is non-empty:
+          emit </section>; pop openSections
+      Properties:
+      - Adjacent same-level headings: produce sibling sections at the
+        same level (`# A / # B` -> two <section>s).
+      - Skipped levels: a `# H1 / ### H3` sequence nests H3's section
+        inside H1's, because the §11-style stack-close test (top.level
+        >= N) only closes sections at level >= 3 (none open at level 3
+        or 5/6). The structure mirrors djot's behavior; carve does NOT
+        synthesize intermediate <h2>/<section> nodes.
+      - Explicit `{#id}` on a heading: the id still lives on the
+        `<section>`, not on the `<h*>`. The dedup namespace (PART 9 §1
+        / heading-id-tracker rules) is unchanged -- explicit ids are
+        reserved before auto-ids in document order.
+      - Empty document or doc with no headings: zero <section> elements
+        are emitted.
+      - The two-pass id resolution (collect explicit ids first, then
+        auto-slug headings with collision-dedup) is unaffected by this
+        rule -- only the EMISSION site of the id moves from <h*> to
+        <section>. Existing crossref (`</#id>`) and implicit-heading
+        ref (`[Heading][]`) resolution continue to target the same
+        slug; the fragment URL `#{slug}` resolves to <section id> the
+        same way browsers resolve to <h* id>.
+      - Carve does NOT add `<section>` wrappers around non-heading
+        top-level blocks. Headings are the only trigger.
 *)


### PR DESCRIPTION
Third of four landing the high-impact findings from the cross-impl gap audit (carve vs djot vs djot-php).

## P1.2 — Adopt djot `<section>` wrapper around headings

### Today

Carve emits bare headings:

```html
<h1 id="welcome">Welcome</h1>
<h2 id="getting-started">Getting started</h2>
<h3 id="setup">Setup</h3>
```

### After this PR (spec) + impl follow-ups

Carve will match djot's structural model:

```html
<section id="welcome">
  <h1>Welcome</h1>
  <section id="getting-started">
    <h2>Getting started</h2>
    <section id="setup">
      <h3>Setup</h3>
    </section>
  </section>
</section>
```

Verified against djot's official `headings.test` (vendored at `djot-php/tests/official/headings.test`).

## Why move

The audit surfaced this as the biggest single carve-vs-djot divergence that the README didn't even document. Investigating the history: the bare-`<h*>` choice was set in early M1 and never revisited; recent PRs focused on features (translit, refs, smart typography) not output structure. It was almost certainly **Markdown muscle memory** rather than a deliberate divergence from djot.

Reasons to move:

1. **Document structure as queryable data.** JS gets `document.querySelectorAll('section')`; CSS can style "current section"; TOC generation is trivial.
2. **Anchor stability.** `<section id="intro">` puts the anchor on the *container*. Renaming heading text doesn't break inbound deep-links if the section element survives.
3. **Implicit hierarchy → nested sections.** `# H1 / ## H2` becomes a DOM tree matching the outline. Print stylesheets, screen readers, OPDS generators, page-break controllers all benefit.
4. **Accessibility.** HTML5 spec recommends grouping under `<section>` for proper document outline. ARIA tooling understands sections as landmarks.

Cost we accept:

1. **Output size roughly doubles** for heading-dense docs.
2. **Renderer becomes stateful** — tracking the open-section stack and closing all sections of equal-or-deeper level when a new heading arrives.
3. **CSS migration cost** for projects styling `.content > h1`, `h2 + p`, etc.

## What's in this PR (spec only)

- `resources/grammar.ebnf` — new PART 9 §13 pinning the algorithm with full edge cases (adjacent same-level, skipped levels, explicit `{#id}` placement, empty docs).
- `docs/case-study/syntax.md` §4.1 — section-wrapping rule documented with a worked example.
- `README.md` comparison table — gains a "Heading structure" row.

Fragment-URL behavior (`#slug`) is unchanged — browsers resolve to whichever element carries the id, `<h*>` or `<section>`. Existing `</#id>` cross-references and `[Heading][]` implicit references resolve via the same slug; only the *emission site* of the id moves.

## What lands separately

This is **spec only**, same pattern as carve PRs #16 (ASCII slugs) and #17 (list/admonition rules):

- **carve-js impl** — switch `render-html.ts` to the section-wrapping algorithm; update corpus fixtures (02-headings, 19-heading-ids, anywhere headings appear in expected output).
- **carve-php impl** — same. Algorithm closely mirrors djot-php's `renderDocumentWithSections` (`/tmp/djot-php/src/Renderer/HtmlRenderer.php:343-425`).
- **carve repo follow-up** — re-vendor carve-lib + update `tests/corpus/02-headings*.html` / `19-heading-ids.html` to the new shape.

## Audit reference

Spec sequencing for the gap audit's four big findings:
- ✅ **P1.4** list marker change (#17)
- ✅ **P1.12** admonition rendering rule (#17)
- 👉 **P1.2** `<section>` wrapper (this PR)
- ⏳ **P1.5** inline span `[text]{.attr}` (next, largest)
