### PR TITLE
Spec: two-tier ::: rendering (canonical aside / custom div)

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -740,10 +740,14 @@ This action cannot be undone.
 :::
 ```
 
-**Canonical types:** `note`, `tip`, `warning`, `danger`, `info`,
-`success`, `example`, `quote`, `details`. The carve VitePress theme
-and most third-party themes ship CSS targeting these exact class
-names. Render as:
+Carve renders a `:::` block by a **two-tier rule** on the type
+identifier (PART 9 §12):
+
+**Tier 1 — canonical admonition types** render as a semantic `<aside>`
+with the `admonition` marker class. The canonical set is `note`, `tip`,
+`warning`, `danger`, `info`, `success`, `example`, `quote`. The carve
+VitePress theme and most third-party themes ship CSS targeting these
+exact class names:
 
 ```html
 <aside class="admonition note">
@@ -751,40 +755,41 @@ names. Render as:
 </aside>
 ```
 
-**Custom types** render to the same shape — no prefix, no
-special-casing:
+**Tier 2 — any other (custom) type** renders as a generic block-level
+`<div>` carrying the verbatim type as its class. This is the carve
+fenced-div primitive that the block-extension mechanism (§4.20) builds
+on (`::: tabs`, `::: mermaid`, `::: codepen` → `<div class="tabs">`
+etc., post-processed by a registered extension; an unregistered type
+still renders as its plain `<div class="{type}">`):
 
 ```
 ::: hint "Pro tip"
 Project-specific call-out.
 :::
 
-::: glossary
-A custom type without an explicit title renders without one.
+::: tabs
+...
 :::
 ```
 
 →
 
 ```html
-<aside class="admonition hint">
+<div class="hint">
   <p class="admonition-title">Pro tip</p>
   <p>Project-specific call-out.</p>
-</aside>
-<aside class="admonition glossary">
-  <p>A custom type without an explicit title renders without one.</p>
-</aside>
+</div>
+<div class="tabs">
+  ...
+</div>
 ```
 
 A `<p class="admonition-title">…</p>` line is emitted **only** when an
-explicit `quoted_title` is given. Carve does **not** synthesize a
-default title from the type name — `::: note` without `"…"` produces
-no title element at all (canonical and custom types alike).
-
-The §4.20 extension registry MAY in a future revision intercept a
-matching type identifier before the admonition fallback fires (e.g.
-`::: youtube` rendering via a registered handler). Today every `:::`
-block goes through the admonition rule above; see PART 9 §12.
+explicit `quoted_title` is given (both tiers). The quote characters are
+delimiters and are stripped — they never appear in the rendered title,
+and the title is never folded into the class. Carve does **not**
+synthesize a default title from the type name; `::: note` without `"…"`
+produces no title element at all.
 
 > **No bare `:::` blocks.** Every `:::` block must declare a type
 > identifier. Carve does not accept djot's "generic fenced div with no

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -924,7 +924,7 @@ Heads up — this is important.
 
 :::
 
-Each admonition type produces a matching CSS class — `note`, `tip`, `warning`, `danger`, `info`, `success`, `example`, `quote`, and `details` are the canonical types. Custom identifiers (e.g. `hint`, `glossary`) render to the same shape with the literal type as the class. See PART 9 §12 of the grammar for the full rule.
+Carve renders `:::` blocks by a two-tier rule (PART 9 §12). The eight canonical types — `note`, `tip`, `warning`, `danger`, `info`, `success`, `example`, `quote` — render as `<aside class="admonition {type}">`. Any other identifier (`hint`, `tabs`, `mermaid`, `details`, …) renders as a generic `<div class="{type}">`, the fenced-div primitive the block-extension mechanism builds on. A quoted title after the type becomes a `<p class="admonition-title">` in either tier; the quotes are stripped and never folded into the class.
 
 ::: compare
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -156,9 +156,10 @@ admonition_open = ":::", space, admonition_type, [space, quoted_title], [attribu
 admonition_close = ":::" ;
 
 admonition_type = "note" | "tip" | "warning" | "danger" | "info"
-                | "success" | "example" | "quote" | "details"
-                | identifier ;  (* custom types -- see PART 9 §12 for
-                                   rendering semantics *)
+                | "success" | "example" | "quote"  (* Tier 1 canonical *)
+                | identifier ;  (* Tier 2 custom types (incl. `details`)
+                                   -- see PART 9 §12 for the two-tier
+                                   rendering rule *)
 
 quoted_title = '"', {character - '"'}, '"' ;
 
@@ -631,33 +632,51 @@ EOF = (* end of file *) ;
       (RE_ORDERED accepts digits only); the tie-breaker is pinned here
       for the implementations that will.
 
-   12. ADMONITION RENDERING -- NORMATIVE (governs `admonition` in PART 2).
+   12. FENCED ":::" BLOCK RENDERING -- NORMATIVE (governs `admonition`
+      in PART 2; cross-references syntax.md §4.20 "Block Extensions").
       Every `:::` block carries a required `type` identifier (bare
       `:::` is a syntax error -- carve does not accept djot's
-      "generic fenced div with no class"). The renderer emits, for
-      every type, a uniform wrapper:
+      "generic fenced div with no class"). The renderer chooses the
+      wrapper element by a TWO-TIER rule on the type identifier:
+
+      Tier 1 -- CANONICAL ADMONITION TYPES render as a semantic
+        `<aside>` with the `admonition` marker class:
             <aside class="admonition {type}">
               [<p class="admonition-title">{quoted_title}</p>]
               {body}
             </aside>
-      Two pinned rules:
-        a. The wrapper class is `admonition` followed by the literal
-           type identifier separated by a single space (no prefix form:
-           `admonition note`, NOT `admonition-note`).
+        The canonical set is the eight call-out types
+        `note`, `tip`, `warning`, `danger`, `info`, `success`,
+        `example`, `quote`. Consuming CSS frameworks target these exact
+        class names.
+
+      Tier 2 -- ANY OTHER (custom) type renders as a generic block-level
+        `<div>` carrying the verbatim type as its class:
+            <div class="{type}">
+              [<p class="admonition-title">{quoted_title}</p>]
+              {body}
+            </div>
+        This is the carve fenced-div primitive that the block-extension
+        mechanism (syntax.md §4.20) builds on -- e.g. `::: tabs`,
+        `::: mermaid`, `::: codepen` produce `<div class="tabs">`,
+        `<div class="mermaid">`, `<div class="codepen">` respectively,
+        which a registered extension may post-process. An unregistered
+        custom type still renders as its generic `<div class="{type}">`
+        so the document stays readable. `details` is an ordinary Tier-2
+        type (`<div class="details">`); an extension that wants the
+        HTML5 `<details>/<summary>` disclosure element opts in via §4.20.
+
+      Pinned rules common to both tiers:
+        a. The class is the literal type identifier (Tier 1 prefixes it
+           with `admonition ` separated by a single space:
+           `admonition note`, NOT `admonition-note`; Tier 2 uses the
+           bare `{type}`). The type is NEVER folded together with the
+           quoted title -- the title is a child element, never a class.
         b. A `<p class="admonition-title">…</p>` line is emitted ONLY
            when the author supplied a `quoted_title` after the type.
-           Carve does NOT invent a default title from the type name --
-           `::: note` without `"…"` produces no title line at all.
-           This holds for canonical and custom types alike.
-      The eight canonical types (`note`, `tip`, `warning`, `danger`,
-      `info`, `success`, `example`, `quote`) plus `details` are carve
-      idioms that consuming CSS frameworks target by exact class name.
-      Custom types render to the same shape; authors layer their own
-      CSS against the `{type}` class.
-      Forward-compatibility: a registered block-extension mechanism
-      (syntax.md §4.20) may, in a future revision of this rule,
-      intercept the type identifier before the admonition fallback
-      fires. Today every `:::` block goes through the rule above.
+           Carve does NOT invent a default title from the type name.
+           An explicitly empty `""` still counts as a supplied (empty)
+           title. Applies to both tiers.
 
    13. HEADING SECTION WRAPPING -- NORMATIVE (governs `atx_heading` in
       PART 2 and the renderer; matches djot, see `jgm/djot` official


### PR DESCRIPTION
Revises PART 9 §12 to a **two-tier rule**, resolving the cross-impl divergence on how non-canonical `:::` block types render. (Decision: tier model.)

## The rule

**Tier 1 — canonical admonition types** (`note`, `tip`, `warning`, `danger`, `info`, `success`, `example`, `quote`) render as:

```html
<aside class="admonition note">
  [<p class="admonition-title">…</p>]
  …
</aside>
```

**Tier 2 — any other type** renders as a generic block-level div — the fenced-div primitive the block-extension mechanism (§4.20) builds on:

```html
<div class="tabs">…</div>
<div class="mermaid">…</div>
<div class="hint"><p class="admonition-title">…</p>…</div>
```

`details` is an ordinary Tier-2 type (`<div class="details">`); an extension opts into the HTML5 `<details>/<summary>` disclosure element via §4.20.

Both tiers: a quoted title becomes `<p class="admonition-title">` with the quote delimiters **stripped** (never folded into the class); an empty `""` still counts as a supplied title; no title is synthesized from the type name.

## Why

carve-php uses `:::` as a generic fenced-div primitive that its extension ecosystem (`TabsExtension`, `MermaidExtension`, `CodeGroupExtension`) depends on — `::: tabs` → `<div class="tabs">`, etc. The previous §12 ("every `:::` → `<aside>`") would have broken those extensions and ~98 test assertions. carve-js currently renders custom types as `<aside>`; it will move to `<div>` for Tier 2 to match.

## Changes

- `resources/grammar.ebnf` PART 9 §12 rewritten to the two-tier rule; `details` dropped from the explicit `admonition_type` alternatives (now covered by the `identifier` custom branch).
- `docs/case-study/syntax.md` §4.12 + `docs/examples.md` admonitions prose updated.

## Follow-ups (spec leads, impl + re-vendor after — established sequence)

- carve-js: render Tier-2 custom types as `<div class="{type}">` (canonical stays `<aside>`); the quoted-title stripping already landed in carve-js #18.
- carve-php: parse the quoted title separately (currently leaks into the class) + tier rendering.
- carve repo: re-vendor carve-lib + add tier corpus fixtures (canonical+title, custom-type) once both impls match.

86/86 corpus + normativity tests pass.
