### PR TITLE
fix: VitePress Pages deploy (dead links) + register ebnf/org/textile grammars

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,9 +7,17 @@ import githubDark from 'shiki/themes/github-dark.mjs'
 import container from 'markdown-it-container'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const carveGrammar = JSON.parse(
-  readFileSync(resolve(__dirname, './syntaxes/carve.tmLanguage.json'), 'utf8'),
-)
+const loadGrammar = (file: string) =>
+  JSON.parse(readFileSync(resolve(__dirname, `./syntaxes/${file}`), 'utf8'))
+
+const carveGrammar = loadGrammar('carve.tmLanguage.json')
+// Languages used in the docs that Shiki does not bundle. Without these,
+// the build warns ("language 'ebnf' is not loaded, falling back to
+// 'txt'") for the formal-grammar snippet import and the background.md
+// comparison fences.
+const ebnfGrammar = loadGrammar('ebnf.tmLanguage.json')
+const orgGrammar = loadGrammar('org.tmLanguage.json')
+const textileGrammar = loadGrammar('textile.tmLanguage.json')
 
 // Extend the bundled GitHub themes with rules for Carve scopes that don't
 // have stock styling: highlight, subscript, superscript. Strikethrough has
@@ -154,7 +162,7 @@ export default defineConfig({
   lastUpdated: true,
 
   markdown: {
-    languages: [carveGrammar],
+    languages: [carveGrammar, ebnfGrammar, orgGrammar, textileGrammar],
     theme: { light: carveLightTheme, dark: carveDarkTheme },
     codeTransformers: [carveStylingTransformer],
     config(md) {

--- a/docs/.vitepress/syntaxes/ebnf.tmLanguage.json
+++ b/docs/.vitepress/syntaxes/ebnf.tmLanguage.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "ebnf",
+  "scopeName": "source.ebnf",
+  "fileTypes": [
+    "ebnf"
+  ],
+  "patterns": [
+    {
+      "include": "#comment"
+    },
+    {
+      "include": "#string"
+    },
+    {
+      "include": "#special"
+    },
+    {
+      "include": "#definition"
+    },
+    {
+      "include": "#operator"
+    }
+  ],
+  "repository": {
+    "comment": {
+      "name": "comment.block.ebnf",
+      "begin": "\\(\\*",
+      "end": "\\*\\)"
+    },
+    "string": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.ebnf",
+          "begin": "\"",
+          "end": "\""
+        },
+        {
+          "name": "string.quoted.single.ebnf",
+          "begin": "'",
+          "end": "'"
+        }
+      ]
+    },
+    "special": {
+      "name": "string.regexp.ebnf",
+      "begin": "\\?",
+      "end": "\\?"
+    },
+    "definition": {
+      "match": "^\\s*([A-Za-z][A-Za-z0-9_]*)\\s*(=)",
+      "captures": {
+        "1": {
+          "name": "entity.name.function.ebnf"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.ebnf"
+        }
+      }
+    },
+    "operator": {
+      "name": "keyword.operator.ebnf",
+      "match": "[|,;]|\\.\\.\\.|[\\[\\]{}()*+-]"
+    }
+  }
+}

--- a/docs/.vitepress/syntaxes/org.tmLanguage.json
+++ b/docs/.vitepress/syntaxes/org.tmLanguage.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "org",
+  "scopeName": "source.org",
+  "fileTypes": [
+    "org"
+  ],
+  "patterns": [
+    {
+      "include": "#srcblock"
+    },
+    {
+      "include": "#keyword"
+    },
+    {
+      "include": "#heading"
+    },
+    {
+      "include": "#checkbox"
+    },
+    {
+      "include": "#listmarker"
+    },
+    {
+      "include": "#tablerow"
+    },
+    {
+      "include": "#bold"
+    },
+    {
+      "include": "#italic"
+    },
+    {
+      "include": "#underline"
+    },
+    {
+      "include": "#strike"
+    }
+  ],
+  "repository": {
+    "srcblock": {
+      "name": "meta.embedded.block.org",
+      "begin": "(?i)^\\s*(#\\+BEGIN_SRC)\\b.*$",
+      "end": "(?i)^\\s*(#\\+END_SRC)\\b.*$",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.org"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "keyword.control.org"
+        }
+      }
+    },
+    "keyword": {
+      "name": "keyword.control.org",
+      "match": "(?i)^\\s*#\\+[A-Z_]+:?.*$"
+    },
+    "heading": {
+      "name": "markup.heading.org",
+      "match": "^(\\*+)\\s+.*$",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.heading.org"
+        }
+      }
+    },
+    "checkbox": {
+      "name": "constant.language.checkbox.org",
+      "match": "\\[[ xX-]\\]"
+    },
+    "listmarker": {
+      "name": "punctuation.definition.list.org",
+      "match": "^\\s*([-+])\\s+"
+    },
+    "tablerow": {
+      "name": "markup.other.table.org",
+      "match": "^\\s*\\|.*$"
+    },
+    "bold": {
+      "name": "markup.bold.org",
+      "match": "(?<![\\w*])\\*(?![\\s*])[^*\\n]*\\*(?![\\w*])"
+    },
+    "italic": {
+      "name": "markup.italic.org",
+      "match": "(?<![\\w/])/(?![\\s/])[^/\\n]*/(?![\\w/])"
+    },
+    "underline": {
+      "name": "markup.underline.org",
+      "match": "(?<![\\w_])_(?![\\s_])[^_\\n]*_(?![\\w_])"
+    },
+    "strike": {
+      "name": "markup.strikethrough.org",
+      "match": "(?<![\\w+])\\+(?![\\s+])[^+\\n]*\\+(?![\\w+])"
+    }
+  }
+}

--- a/docs/.vitepress/syntaxes/textile.tmLanguage.json
+++ b/docs/.vitepress/syntaxes/textile.tmLanguage.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "textile",
+  "scopeName": "source.textile",
+  "fileTypes": [
+    "textile"
+  ],
+  "patterns": [
+    {
+      "include": "#heading"
+    },
+    {
+      "include": "#tablerow"
+    },
+    {
+      "include": "#link"
+    },
+    {
+      "include": "#image"
+    },
+    {
+      "include": "#strong"
+    },
+    {
+      "include": "#emphasis"
+    },
+    {
+      "include": "#deleted"
+    },
+    {
+      "include": "#inserted"
+    }
+  ],
+  "repository": {
+    "heading": {
+      "name": "markup.heading.textile",
+      "match": "^\\s*(h[1-6]|bq|p)\\.\\s+.*$",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.heading.textile"
+        }
+      }
+    },
+    "tablerow": {
+      "name": "markup.other.table.textile",
+      "match": "^\\s*\\|.*\\|\\s*$"
+    },
+    "link": {
+      "name": "markup.underline.link.textile",
+      "match": "\"[^\"\\n]+\":\\S+"
+    },
+    "image": {
+      "name": "markup.other.image.textile",
+      "match": "!\\S+!"
+    },
+    "strong": {
+      "name": "markup.bold.textile",
+      "match": "(?<![\\w*])\\*(?![\\s*])[^*\\n]*\\*(?![\\w*])"
+    },
+    "emphasis": {
+      "name": "markup.italic.textile",
+      "match": "(?<![\\w_])_(?![\\s_])[^_\\n]*_(?![\\w_])"
+    },
+    "deleted": {
+      "name": "markup.deleted.textile",
+      "match": "(?<![\\w-])-(?![\\s-])[^-\\n]*-(?![\\w-])"
+    },
+    "inserted": {
+      "name": "markup.inserted.textile",
+      "match": "(?<![\\w+])\\+(?![\\s+])[^+\\n]*\\+(?![\\w+])"
+    }
+  }
+}

--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -1,7 +1,7 @@
 # Syntax Specification
 
 > **Non-normative.** This page is explanatory prose. The normative
-> specification is [`resources/grammar.ebnf`](../../resources/grammar.ebnf)
+> specification is [`resources/grammar.ebnf`](https://github.com/markup-carve/carve/blob/main/resources/grammar.ebnf)
 > (PART 9 for semantic constraints); `docs/examples.md` + `tests/corpus`
 > are the conformance contract. On any disagreement, the grammar wins.
 

--- a/docs/edge-cases.md
+++ b/docs/edge-cases.md
@@ -1,7 +1,7 @@
 # Carve Edge Cases Analysis
 
 > **Non-normative.** This document analyzes tricky cases for humans. The
-> normative specification is [`resources/grammar.ebnf`](../resources/grammar.ebnf)
+> normative specification is [`resources/grammar.ebnf`](https://github.com/markup-carve/carve/blob/main/resources/grammar.ebnf)
 > (PART 9 for semantic constraints); `docs/examples.md` + `tests/corpus`
 > are the conformance contract. On any disagreement, the grammar wins.
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -9,6 +9,6 @@ This is the canonical EBNF specification of Carve. It defines block-level constr
 
 Implementations should match this grammar. The [case study](./case-study/) explains the design rationale, the [reference page](./edge-cases) covers parsing edge cases, and the [examples](./examples) show the expected HTML output for each construct.
 
-The full grammar lives at [`resources/grammar.ebnf`](https://github.com/markup-carve/carve/blob/master/resources/grammar.ebnf) in the repository.
+The full grammar lives at [`resources/grammar.ebnf`](https://github.com/markup-carve/carve/blob/main/resources/grammar.ebnf) in the repository.
 
 <<< ../resources/grammar.ebnf{ebnf}


### PR DESCRIPTION
## Why the deploy was red

The **"Deploy VitePress site to Pages"** workflow has failed on every push since #12 (2026-05-19). The spec-conformance "CI" job was always green — only the docs deploy was broken. Root cause: `vitepress build` aborts on **2 dead links** to the EBNF source file, which isn't a built docs page:

```
(!) Found dead link ./../resources/grammar.ebnf in file edge-cases.md
(!) Found dead link ./../../resources/grammar.ebnf in file case-study/syntax.md
[vitepress] 2 dead link(s) found.
```

The `org`/`textile`/`ebnf` "language not loaded" messages were **warnings, not the failure** (Shiki falls back to `txt`); the build continued past them.

## Fix

- **Dead links → GitHub blob URLs.** `edge-cases.md` and `case-study/syntax.md` now link the normative spec to `https://github.com/markup-carve/carve/blob/main/resources/grammar.ebnf` — a working clickable target. `grammar.md` already used a GitHub URL; bumped its stale `master` → `main`.
- **Register real grammars.** Hand-authored TextMate grammars for the three Shiki doesn't bundle: `ebnf` (the formal-grammar snippet import), `org` + `textile` (background.md comparison fences). Removes the warnings; gives real highlighting. Consistent with the existing hand-authored `carve.tmLanguage.json`.

## Verification

`npm run docs:build` now succeeds — **no dead-link error, no language warnings, no circular-alias error**. Spec corpus + normativity: 90/90 still pass.