### PR TITLE
spec: P3 grammar wording/precision polish

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -485,10 +485,9 @@ Or with indentation:
 Use the `print()` function.
 ```
 
-With language hint:
-```
-The `SELECT * FROM users`{sql} query returns all users.
-```
+Code spans have no language hint. A trailing `{…}` is the generic
+inline-attribute block (not a language tag); use a fenced block with a
+language info string when you need highlighting.
 
 #### Blocks
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -86,12 +86,12 @@ fenced_code_block = code_fence_open, [language_info], [attributes], newline,
                     code_fence_close, newline ;
 
 code_fence_open = backtick_fence | tilde_fence ;
-code_fence_close = backtick_fence | tilde_fence ;  (* must match opener length *)
+code_fence_close = backtick_fence | tilde_fence ;  (* same fence char; length >= opener (PART 9 §2) *)
 
 backtick_fence = '`', '`', '`', {'`'} ;
 tilde_fence = '~', '~', '~', {'~'} ;
 
-language_info = identifier ;
+language_info = (letter | digit | '-' | '_')+ ;  (* may start with a digit, e.g. `123abc` *)
 code_content = (* any text until matching fence, preserved literally *) ;
 
 (* --- Blockquotes --- *)
@@ -224,6 +224,7 @@ literal_special = special_char ;
 inline_element = escaped_char
                | code_span
                | autolink
+               | auto_text_link
                | link
                | inline_span
                | image
@@ -259,17 +260,21 @@ ascii_punctuation = '!' | '"' | '#' | '$' | '%' | '&' | "'" | '(' | ')'
                   | '^' | '_' | '`' | '{' | '|' | '}' | '~' ;
 
 (* --- Code Spans --- *)
-code_span = backtick_run, code_span_content, backtick_run, [language_hint] ;
+code_span = backtick_run, code_span_content, backtick_run, [attributes] ;
 backtick_run = '`'+ ;  (* matching count *)
 code_span_content = (* any chars except matching backtick run *) ;
-language_hint = '{', identifier, '}' ;
+(* A trailing `{…}` on a code span is the generic inline-attribute
+   block, NOT a language tag. Both impls consume it; carve-js then drops
+   the attributes and carve-php applies them (an impl divergence). *)
 
 (* --- Links --- *)
-link = inline_link | reference_link | collapsed_reference_link | autolink | auto_text_link ;
+link = inline_link | reference_link | collapsed_reference_link ;
+(* autolink and auto_text_link (crossref) are listed directly in
+   inline_element, not here. *)
 
-inline_link = '[', link_text, ']', '(', link_destination, [link_title], ')' ;
-reference_link = '[', link_text, ']', '[', reference_label, ']' ;
-collapsed_reference_link = '[', link_text, ']', '[', ']' ;
+inline_link = '[', link_text, ']', '(', link_destination, [link_title], ')', [attributes] ;
+reference_link = '[', link_text, ']', '[', reference_label, ']', [attributes] ;
+collapsed_reference_link = '[', link_text, ']', '[', ']', [attributes] ;
 
 link_text = inline_content - ']' ;
 link_destination = url | ('<', url, '>') ;
@@ -294,7 +299,7 @@ email_autolink = {email_char}+, '@', {email_char}+, '.', {letter}+ ;
 auto_text_link = "</#", identifier, '>' ;  (* cross-reference with auto text *)
 
 url = scheme, ':', {url_char}+ ;
-scheme = letter, {letter | digit | '+' | '-' | '.'}+ ;
+scheme = letter, {letter | digit | '+' | '-' | '.'} ;  (* 1+ chars; single-letter schemes ok *)
 url_char = letter | digit | '-' | '.' | '_' | '~' | ':' | '/' | '?'
          | '#' | '[' | ']' | '@' | '!' | '$' | '&' | "'" | '(' | ')'
          | '*' | '+' | ',' | ';' | '=' | '%' ;
@@ -733,8 +738,8 @@ EOF = (* end of file *) ;
       PART 2 and the renderer; matches djot, see `jgm/djot` official
       `headings.test`). Every heading emits a `<section id="{id}">`
       wrapper around itself and the following content up to the next
-      same-or-shallower heading. The slug-derivation rule (§4.1 plus
-      ASCII transliteration, see PART 9 §0 / syntax.md §4.1) computes
+      same-or-shallower heading. The slug-derivation rule (ASCII
+      transliteration etc., see syntax.md §4.1) computes
       the id; the id lives on the `<section>` element, NOT on the
       `<h*>` element. This shifts the existing carve behavior
       (id-on-h*, no section wrapper) to match djot's structural model.
@@ -759,8 +764,8 @@ EOF = (* end of file *) ;
         or 5/6). The structure mirrors djot's behavior; carve does NOT
         synthesize intermediate <h2>/<section> nodes.
       - Explicit `{#id}` on a heading: the id still lives on the
-        `<section>`, not on the `<h*>`. The dedup namespace (PART 9 §1
-        / heading-id-tracker rules) is unchanged -- explicit ids are
+        `<section>`, not on the `<h*>`. The dedup namespace (syntax.md
+        §4.1 / heading-id-tracker rules) is unchanged -- explicit ids are
         reserved before auto-ids in document order.
       - Empty document or doc with no headings: zero <section> elements
         are emitted.


### PR DESCRIPTION
Grammar-only wording/precision corrections — **no behavior change**; each verified against both impls before editing.

- **code_span**: drop the fictional `language_hint`; a trailing `{…}` is the generic inline-attribute block (carve-js drops the attrs, carve-php applies them). Also fixed the misleading 'language hint' code-span example in syntax.md §4.6.
- **inline_link / reference_link / collapsed_reference_link**: allow trailing `[attributes]` (both impls accept `[t](u){.x}`, `[t][r]{.x}`, `[t][]{.x}`).
- **language_info**: `(letter|digit|-|_)+` — may start with a digit (`123abc`).
- **scheme**: 1+ chars (single-letter schemes like `a:foo` accepted).
- **code_fence_close** comment: closer is same char, length **>= opener** (not 'must match').
- **link** production: dedup — `autolink` / `auto_text_link` now listed only in `inline_element`.
- **§13 cross-refs**: fixed `PART 9 §0` and `PART 9 §1` (neither covers slug derivation / dedup) → syntax.md §4.1.

### Out of scope (real cross-impl divergences surfaced by the audit, not wording — tracked separately)
thematic-break chars, definition-list syntax, raw blocks, `%%` comments, single-quote link titles, angle-bracket destinations, abbreviation case, unquoted-value dots, mention/tag name class.

100/100 corpus + normativity pass.