### PR TITLE
spec: clarify single-quote link/image titles + apostrophe escaping

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -192,10 +192,16 @@ The `/italic/` syntax comes from Org-mode, where it has worked well for decades.
 See the [documentation](https://docs.example.com) for more.
 ```
 
-**With title:**
+**With title:** titles accept double **or** single quotes (a deliberate
+enhancement over djot, which has no single-quote titles and would fold
+`'…'` into the URL). The two forms are equivalent:
 ```
 Visit [Google](https://google.com "Search engine") today.
+Visit [Google](https://google.com 'Search engine') today.
 ```
+Each quote style may contain the other (`"it's"`, `'say "hi"'`); a
+literal quote in the rendered `title`/`alt` is escaped (`&apos;`,
+`&quot;`). The same applies to image titles: `![alt](img.png 'caption')`.
 
 **Reference style:**
 ```

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -283,6 +283,9 @@ collapsed_reference_link = '[', link_text, ']', '[', ']', [attributes] ;
 
 link_text = inline_content - ']' ;
 link_destination = url | ('<', url, '>') ;
+(* Titles accept double OR single quotes -- a deliberate enhancement
+   over djot (which has no single-quote titles; it would fold `'...'`
+   into the URL). The non-delimiting quote may appear inside the title. *)
 link_title = space, ('"', {character - '"'}, '"')
            | space, ("'", {character - "'"}, "'") ;
 
@@ -943,8 +946,8 @@ EOF = (* end of file *) ;
 
    2. ATTRIBUTE QUOTING + ESCAPING. Attribute values are double-quoted.
       In an attribute value escape `&`->&amp;, `<`->&lt;, `>`->&gt;,
-      `"`->&quot;. In text/content escape `&`,`<`,`>` (NOT `"`). No other
-      entities are produced.
+      `"`->&quot;, `'`->&apos;. In text/content escape `&`,`<`,`>` (NOT
+      quotes). No other entities are produced.
 
    3. VOID ELEMENTS are written WITHOUT a trailing slash: `<hr>`,
       `<img …>`, `<br>`. A hard break serializes as `<br>` + newline.


### PR DESCRIPTION
Documents the single-quote link/image title support that carve-js #32 added (matching carve-php) — a deliberate enhancement over djot, which has no single-quote titles and folds `'…'` into the URL.

- **syntax.md §4.3**: both quote forms shown as equivalent, with the djot divergence noted and that the non-delimiting quote may appear inside (`"it's"`, `'say "hi"'`).
- **grammar `link_title`**: comment noting the deliberate divergence (the production already permitted both quotes).
- **grammar PART 9 §2** (attribute escaping): now includes `'` → `&apos;` (matches djot + carve-php + the carve-js renderer).

**Doc/grammar only.** The bundled `carve-lib` re-vendor + a corpus fixture are intentionally deferred: the carve repo's `carve-lib` currently carries the still-open fence-length-nesting feature (carve-js #30), which `61-nested-containers` pins ahead of impl — so re-vendoring from carve-js *main* would regress it. Once #30 lands, a single re-vendor captures both fence-nesting and single-quote titles, plus the corpus pin.

118/118 corpus + normativity pass.