### PR TITLE
Render mentions and tags as non-links by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Carve builds on Markdown's basics and Djot's technical rigor while adding:
 - **Visual mnemonics** - Syntax resembles its output
 - **Human factors research** - Based on how non-technical users naturally mark up text
 - **Progressive disclosure** - Basic usage is trivial, power features exist when needed
-- **Social conventions** - `@mentions` and `#tags` work as users expect
+- **Social conventions** - `@mentions` and `#tags` are recognized as first-class inline tokens
 
 ## Quick Reference
 
@@ -124,7 +124,7 @@ Carve inherits and extends Djot's rationale:
 
 18. **Abbreviations** - `*[ABBR]: expansion` for automatic `<abbr>` tags
 
-19. **Social integration** - `@mentions` and `#tags` work as expected from social platforms
+19. **Social integration** - `@mentions` and `#tags` are built into the syntax
 
 20. **Extension system** - `:type[content]{attrs}` for custom inline elements
 
@@ -192,6 +192,53 @@ Carve inherits and extends Djot's rationale:
 | Extensions | Fenced divs | `:type[content]{attrs}` |
 | Mentions | N/A | `@user` |
 | Tags | N/A | `#tag` |
+
+### Mention and tag rendering
+
+Carve parses `@user` and `#tag` into dedicated AST nodes. The default HTML
+renderer does **not** invent destination URLs. Without renderer config, they
+render as non-link spans:
+
+```html
+<span class="mention"><strong>@alice</strong></span>
+<span class="tag"><strong>#release</strong></span>
+```
+
+If your application has real routes, provide URL templates at render time:
+
+```ts
+carveToHtml(source, {
+  mentionUrl: 'https://github.com/{user}',
+  tagUrl: '/topics/{name}',
+})
+```
+
+Suggested CSS:
+
+```css
+.mention,
+.tag {
+  font: inherit;
+}
+
+.mention strong,
+.tag strong {
+  font-weight: 600;
+}
+
+a.mention,
+a.tag {
+  font-weight: 600;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.14em;
+}
+```
+
+Guidelines:
+
+- Keep the default non-link styling close to body text; mentions and tags are identifiers, not calls to action.
+- Reserve stronger color and hover treatment for real links so users can tell whether interaction is available.
+- Target `.mention` and `.tag` in shared rules so switching from `<span>` to `<a>` does not require a CSS rewrite.
 
 > **Djot accuracy notes:** Djot defines captions for pipe **tables only** (a
 > `^ ` line after the table); Carve extends the same `^` prefix to images and

--- a/docs/.vitepress/carve-lib/render-html.d.ts
+++ b/docs/.vitepress/carve-lib/render-html.d.ts
@@ -1,6 +1,8 @@
 import type { Document } from './ast.js';
 export interface RenderOptions {
+    /** URL template for mentions. Without this, mentions render as non-link spans. */
     mentionUrl?: string;
+    /** URL template for tags. Without this, tags render as non-link spans. */
     tagUrl?: string;
     /** Emoji shortcode -> glyph map. `:name:` with no entry renders literally. */
     emoji?: Record<string, string>;

--- a/docs/.vitepress/carve-lib/render-html.d.ts
+++ b/docs/.vitepress/carve-lib/render-html.d.ts
@@ -1,8 +1,8 @@
 import type { Document } from './ast.js';
 export interface RenderOptions {
-    /** URL template for mentions. Without this, mentions render as non-link spans. */
+    /** URL template for mentions using the `{user}` placeholder. Without this, mentions render as non-link spans. */
     mentionUrl?: string;
-    /** URL template for tags. Without this, tags render as non-link spans. */
+    /** URL template for tags using the `{name}` placeholder. Without this, tags render as non-link spans. */
     tagUrl?: string;
     /** Emoji shortcode -> glyph map. `:name:` with no entry renders literally. */
     emoji?: Record<string, string>;

--- a/docs/.vitepress/carve-lib/render-html.js
+++ b/docs/.vitepress/carve-lib/render-html.js
@@ -621,14 +621,14 @@ function renderInline(node, opts) {
             const text = `@${escapeHtml(node.user)}`;
             if (!opts.mentionUrl)
                 return `<span class="mention"><strong>${text}</strong></span>`;
-            const href = opts.mentionUrl.replace('{user}', node.user);
+            const href = opts.mentionUrl.replaceAll('{user}', encodeURIComponent(node.user));
             return `<a class="mention" href="${escapeAttr(href)}">${text}</a>`;
         }
         case 'tag': {
             const text = `#${escapeHtml(node.name)}`;
             if (!opts.tagUrl)
                 return `<span class="tag"><strong>${text}</strong></span>`;
-            const href = opts.tagUrl.replace('{name}', node.name);
+            const href = opts.tagUrl.replaceAll('{name}', encodeURIComponent(node.name));
             return `<a class="tag" href="${escapeAttr(href)}">${text}</a>`;
         }
         case 'extension':

--- a/docs/.vitepress/carve-lib/render-html.js
+++ b/docs/.vitepress/carve-lib/render-html.js
@@ -618,14 +618,18 @@ function renderInline(node, opts) {
             return `<a href="${escapeAttr(node.href)}"${renderAttrs(stripKeyValue(node.attrs, 'href'))}>${escapeHtml(display)}</a>`;
         }
         case 'mention': {
-            const href = opts.mentionUrl
-                ? opts.mentionUrl.replace('{user}', node.user)
-                : `/users/${node.user}`;
-            return `<a class="mention" href="${escapeAttr(href)}">@${escapeHtml(node.user)}</a>`;
+            const text = `@${escapeHtml(node.user)}`;
+            if (!opts.mentionUrl)
+                return `<span class="mention"><strong>${text}</strong></span>`;
+            const href = opts.mentionUrl.replace('{user}', node.user);
+            return `<a class="mention" href="${escapeAttr(href)}">${text}</a>`;
         }
         case 'tag': {
-            const href = opts.tagUrl ? opts.tagUrl.replace('{name}', node.name) : `/tags/${node.name}`;
-            return `<a class="tag" href="${escapeAttr(href)}">#${escapeHtml(node.name)}</a>`;
+            const text = `#${escapeHtml(node.name)}`;
+            if (!opts.tagUrl)
+                return `<span class="tag"><strong>${text}</strong></span>`;
+            const href = opts.tagUrl.replace('{name}', node.name);
+            return `<a class="tag" href="${escapeAttr(href)}">${text}</a>`;
         }
         case 'extension':
             return renderExtension(node.name, node.content, opts);

--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -1180,8 +1180,8 @@ These are **opt-in** per document or processor config:
 ```
 ---
 extensions:
-  mentions: github    # @user links to GitHub
-  tags: true          # #tag creates tag links
+  mentions: github    # renderer may map @user to GitHub
+  tags: true          # renderer may map #tag to application routes
   emoji: true         # :smile: converts
 ---
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -262,7 +262,8 @@ Inline emphasis renders inside heading text.
 
 :::
 
-A `#` at line start without a following space is a tag, not a heading. The line renders as a paragraph containing the tag, with a `/tags/<slug>` URL.
+A `#` at line start without a following space is a tag, not a heading. By
+default it renders as a styled inline token, not an invented link target.
 
 ::: compare
 
@@ -271,7 +272,7 @@ A `#` at line start without a following space is a tag, not a heading. The line 
 ```
 
 ```html
-<p><a class="tag" href="/tags/notaheading">#notaheading</a></p>
+<p><span class="tag"><strong>#notaheading</strong></span></p>
 ```
 
 :::
@@ -1108,7 +1109,7 @@ Hey @alice, see #release-1.0.
 ```
 
 ```html
-<p>Hey <a class="mention" href="/users/alice">@alice</a>, see <a class="tag" href="/tags/release-1.0">#release-1.0</a>.</p>
+<p>Hey <span class="mention"><strong>@alice</strong></span>, see <span class="tag"><strong>#release-1.0</strong></span>.</p>
 ```
 
 :::
@@ -1530,7 +1531,7 @@ Write me@example.com or ping @markus.
 ```
 
 ```html
-<p>Write me@example.com or ping <a class="mention" href="/users/markus">@markus</a>.</p>
+<p>Write me@example.com or ping <span class="mention"><strong>@markus</strong></span>.</p>
 ```
 
 :::
@@ -1546,7 +1547,7 @@ A #tag here, but not in foo#bar.
 ```
 
 ```html
-<p>A <a class="tag" href="/tags/tag">#tag</a> here, but not in foo#bar.</p>
+<p>A <span class="tag"><strong>#tag</strong></span> here, but not in foo#bar.</p>
 ```
 
 :::

--- a/tests/corpus.test.mjs
+++ b/tests/corpus.test.mjs
@@ -49,3 +49,20 @@ for (const slug of slugs) {
     assert.equal(carveToHtml(crv).trim(), expected.trim())
   })
 }
+
+test('mentions and tags render as non-link spans by default', () => {
+  assert.equal(
+    carveToHtml('Hey @alice, see #release-1.0.').trim(),
+    '<p>Hey <span class="mention"><strong>@alice</strong></span>, see <span class="tag"><strong>#release-1.0</strong></span>.</p>',
+  )
+})
+
+test('mentions and tags render as links when URL templates are configured', () => {
+  assert.equal(
+    carveToHtml('Hey @alice, see #release-1.0.', {
+      mentionUrl: 'https://github.com/{user}',
+      tagUrl: '/topics/{name}',
+    }).trim(),
+    '<p>Hey <a class="mention" href="https://github.com/alice">@alice</a>, see <a class="tag" href="/topics/release-1.0">#release-1.0</a>.</p>',
+  )
+})

--- a/tests/corpus.test.mjs
+++ b/tests/corpus.test.mjs
@@ -66,3 +66,13 @@ test('mentions and tags render as links when URL templates are configured', () =
     '<p>Hey <a class="mention" href="https://github.com/alice">@alice</a>, see <a class="tag" href="/topics/release-1.0">#release-1.0</a>.</p>',
   )
 })
+
+test('mention and tag URL templates replace every placeholder occurrence', () => {
+  assert.equal(
+    carveToHtml('Hey @john.doe, see #release-1.0.', {
+      mentionUrl: '/users/{user}?q={user}',
+      tagUrl: '/topics/{name}?tag={name}',
+    }).trim(),
+    '<p>Hey <a class="mention" href="/users/john.doe?q=john.doe">@john.doe</a>, see <a class="tag" href="/topics/release-1.0?tag=release-1.0">#release-1.0</a>.</p>',
+  )
+})

--- a/tests/corpus/02-headings-5.html
+++ b/tests/corpus/02-headings-5.html
@@ -1,1 +1,1 @@
-<p><a class="tag" href="/tags/notaheading">#notaheading</a></p>
+<p><span class="tag"><strong>#notaheading</strong></span></p>

--- a/tests/corpus/15-mentions-and-tags.html
+++ b/tests/corpus/15-mentions-and-tags.html
@@ -1,1 +1,1 @@
-<p>Hey <a class="mention" href="/users/alice">@alice</a>, see <a class="tag" href="/tags/release-1.0">#release-1.0</a>.</p>
+<p>Hey <span class="mention"><strong>@alice</strong></span>, see <span class="tag"><strong>#release-1.0</strong></span>.</p>

--- a/tests/corpus/31-mention-ignores-email-addresses.html
+++ b/tests/corpus/31-mention-ignores-email-addresses.html
@@ -1,1 +1,1 @@
-<p>Write me@example.com or ping <a class="mention" href="/users/markus">@markus</a>.</p>
+<p>Write me@example.com or ping <span class="mention"><strong>@markus</strong></span>.</p>

--- a/tests/corpus/32-tag-requires-a-word-boundary.html
+++ b/tests/corpus/32-tag-requires-a-word-boundary.html
@@ -1,1 +1,1 @@
-<p>A <a class="tag" href="/tags/tag">#tag</a> here, but not in foo#bar.</p>
+<p>A <span class="tag"><strong>#tag</strong></span> here, but not in foo#bar.</p>

--- a/tests/spec/02-headings.test
+++ b/tests/spec/02-headings.test
@@ -63,5 +63,5 @@ Headings
 ```
 #notaheading
 .
-<p><a class="tag" href="/tags/notaheading">#notaheading</a></p>
+<p><span class="tag"><strong>#notaheading</strong></span></p>
 ```

--- a/tests/spec/15-mentions-and-tags.test
+++ b/tests/spec/15-mentions-and-tags.test
@@ -3,5 +3,5 @@ Mentions and tags
 ```
 Hey @alice, see #release-1.0.
 .
-<p>Hey <a class="mention" href="/users/alice">@alice</a>, see <a class="tag" href="/tags/release-1.0">#release-1.0</a>.</p>
+<p>Hey <span class="mention"><strong>@alice</strong></span>, see <span class="tag"><strong>#release-1.0</strong></span>.</p>
 ```

--- a/tests/spec/31-mention-ignores-email-addresses.test
+++ b/tests/spec/31-mention-ignores-email-addresses.test
@@ -3,5 +3,5 @@ Mention ignores email addresses
 ```
 Write me@example.com or ping @markus.
 .
-<p>Write me@example.com or ping <a class="mention" href="/users/markus">@markus</a>.</p>
+<p>Write me@example.com or ping <span class="mention"><strong>@markus</strong></span>.</p>
 ```

--- a/tests/spec/32-tag-requires-a-word-boundary.test
+++ b/tests/spec/32-tag-requires-a-word-boundary.test
@@ -3,5 +3,5 @@ Tag requires a word boundary
 ```
 A #tag here, but not in foo#bar.
 .
-<p>A <a class="tag" href="/tags/tag">#tag</a> here, but not in foo#bar.</p>
+<p>A <span class="tag"><strong>#tag</strong></span> here, but not in foo#bar.</p>
 ```


### PR DESCRIPTION
## Summary
- stop inventing `/users/{user}` and `/tags/{name}` links when no routing config exists
- render mentions and tags as bold non-link spans by default, while keeping opt-in URL-template linking
- document the renderer contract and add CSS guidance for styling non-link vs linked mentions/tags
- update conformance fixtures and add explicit tests for both default and configured-link behavior

## Testing
- `npm run corpus:build`
- `npm test`
