### PR TITLE
spec: document raw-inline (grammar §20) + correct stale list/raw docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Carve inherits and extends Djot's rationale:
 | Feature | Djot | Carve |
 |---------|------|------|
 | Definition lists | `: term` + indented def | `:: term` / `:  def` |
+| Ordered list dialects | decimal/alpha/roman; `.` `)` `(1)` delimiters | decimal/alpha/roman; `.` `)` delimiters (`(1)` deliberately omitted — prose-ambiguity) |
 | Table headers | `\|---\|` separator | `\|=` prefix |
 | Table alignment | `:--` / `--:` separator | `\|=<` / `\|=>` / `\|=~` (column), `\|<` / `\|>` / `\|~` (cell) |
 | Headerless tables | N/A (header + separator required) | omit `\|=` |
@@ -180,7 +181,7 @@ Carve inherits and extends Djot's rationale:
 | Inline spans | `[text]{.c}` (→ `<span>`) | `[text]{.c}` (→ `<span>`) |
 | Editorial markup | `{+ +}` `{- -}` `{= =}` | `{+ +}` `{- -}` `{~ ~> ~}` `{= =}` `{# #}` |
 | Comments | `{% … %}` | `%%` line / `%%%` block |
-| Raw / passthrough | `` `…`{=html} `` | ` ```raw html ` fenced block |
+| Raw / passthrough | inline `` `…`{=html} `` + ` ```=html ` block | inline `` `…`{=html} `` + ` ```raw html ` block |
 | Includes | N/A | `{{ path/to/file }}` |
 | Abbreviations | N/A | `*[ABBR]: ...` |
 | Attributes | `{.class}` | `{.class}` |

--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -1021,6 +1021,16 @@ Useful for:
 ```
 ~~~
 
+Inline raw passthrough is the inline parallel of the `raw` block: a code
+span tagged with `{=format}`. The verbatim content is emitted unescaped
+when the format matches the output, and dropped otherwise. Any *other*
+trailing `{…}` on a code span is a generic attribute block, not raw
+passthrough (PART 9 §20).
+
+```
+Use `<br>`{=html} to force a break, and `\foo`{=latex} is dropped in HTML.
+```
+
 ### 4.16 Includes
 
 Includes are a **processor-level** directive, not part of the core

--- a/docs/native-features-analysis.md
+++ b/docs/native-features-analysis.md
@@ -174,13 +174,15 @@ feature-level boundary.
 ### MUST (core) — pinned by the corpus, identical across implementations
 
 - **Blocks:** headings (+ `<section>` wrapping, §13), paragraphs,
-  thematic breaks, fenced code, blockquotes, lists (ordered digits-only,
+  thematic breaks, fenced code, blockquotes, lists (ordered
+  decimal/alpha/roman with `.` and `)` delimiters + `start`, §10/§11;
   unordered, task; tight/loose §17), tables (`|=` headers, alignment,
   rowspan/colspan/multi-line), the two-tier `:::` model (canonical
   `<aside class="admonition …">` / custom `<div class="…">`, §12),
   figures/captions, abbreviation definitions, raw blocks, comments.
 - **Inline:** emphasis family (`/ * _ ~ ^ ,, ==` + `/* */`, §9), code
-  spans, links (inline / reference / collapsed), angle-bracket autolinks
+  spans, raw inline (`` `…`{=format} `` passthrough, §20), links
+  (inline / reference / collapsed), angle-bracket autolinks
   (`<url>` / `<email>`), images, spans (§14), math (djot form, §18), footnotes
   (reference form, §16), abbreviations, editorial markup, crossrefs
   (`</#id>`, markup-preserving §19), hard/soft breaks.
@@ -200,5 +202,15 @@ feature-level boundary.
 ### Deferred (reserved syntax, not yet implemented)
 
 - Inline footnotes (`[^content]`) and sidenotes (`[>content]`).
-- Ordered-list letter/roman dialects and the `)` delimiter.
 - Setext (underline) headings — intentionally excluded (matches djot).
+
+### Deliberate gaps (will not implement)
+
+- Djot's both-parens ordered-list delimiter `(1)` / `(a)` / `(i)`. Carve
+  supports the decimal/alpha/roman dialects and the `.` and `)` delimiters,
+  which cover the practical need. The `(1)` form is the most prose-ambiguous
+  marker (a wrapped line beginning `(1) …` reads as a parenthetical aside),
+  and accepting it would force the clean §10 interruption rule (decimal
+  always interrupts; letter/roman are ambiguous) to instead branch on
+  delimiter style. Refusing it keeps Carve's bias toward literal prose
+  interpretation. The rendered paren glyph is a CSS `list-style` concern.

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -230,6 +230,7 @@ inline_content = {inline_element | text_run | literal_special}+ ;
 literal_special = special_char ;
 
 inline_element = escaped_char
+               | raw_inline
                | code_span
                | autolink
                | auto_text_link
@@ -272,8 +273,17 @@ code_span = backtick_run, code_span_content, backtick_run, [attributes] ;
 backtick_run = '`'+ ;  (* matching count *)
 code_span_content = (* any chars except matching backtick run *) ;
 (* A trailing `{…}` on a code span is the generic inline-attribute
-   block, NOT a language tag. Both impls consume it; carve-js then drops
-   the attributes and carve-php applies them (an impl divergence). *)
+   block, NOT a language tag -- EXCEPT the exact form `{=format}`, which is
+   raw inline passthrough (raw_inline below, PART 9 §20). For any OTHER
+   `{…}`: both impls consume it; carve-js then drops the attributes and
+   carve-php applies them (an impl divergence). *)
+
+(* --- Raw Inline (inline parallel of raw_block; PART 9 §20) --- *)
+(* A code span whose trailing attribute block is EXACTLY `{=format}` is raw
+   inline passthrough: the verbatim span content is emitted unescaped when
+   `format` matches the output, else dropped. Any OTHER trailing `{…}` is a
+   generic attributed code span (above), NOT raw inline. *)
+raw_inline = backtick_run, code_span_content, backtick_run, '{=', format_name, '}' ;
 
 (* --- Links --- *)
 link = inline_link | reference_link | collapsed_reference_link ;
@@ -935,6 +945,18 @@ EOF = (* end of file *) ;
         of the core parser; a conformant core MAY leave `{{ … }}` literal.
         An implementing processor MUST forbid path traversal outside the
         project root, bound recursion depth, and treat includes as opt-in.
+
+   20. RAW INLINE -- NORMATIVE (governs `raw_inline` in PART 3; the inline
+      parallel of `raw_block`). A code span whose trailing attribute block
+      is EXACTLY `{=format}` (a single `=`-prefixed format name, with no
+      other classes/ids/keys) is raw passthrough: the verbatim span content
+      is emitted UNESCAPED when `format` matches the output format (`html`),
+      and DROPPED otherwise. The `{=format}` tag is consumed, not rendered.
+      A code span with any OTHER trailing `{…}` is a generic attributed code
+      span (PART 3 `code_span` note), not raw inline. The corpus pins this
+      (tests/corpus/50-raw-inline):
+        `<br>`{=html}   -> <br>            (emitted verbatim)
+        `\foo`{=latex}  ->                (dropped in HTML output)
 *)
 
 (* ============================================================================


### PR DESCRIPTION
## Summary

Raw inline passthrough (`` `…`{=format} ``) and ordered-list alpha/roman dialects with the `)` delimiter are **already implemented and corpus-pinned** (`50-raw-inline`, `52`/`53`/`54-ordered-*`), but several spec/docs surfaces still described them as gaps. This brings the docs in line with the implementation and promotes raw inline to a named normative grammar production.

No parser, corpus, or vendored-lib change — docs and grammar only.

## Changes

- **`resources/grammar.ebnf`** — new normative **PART 9 §20 (RAW INLINE)** plus a named `raw_inline` production listed in `inline_element`; reconciled the `code_span` `{=format}` note that previously contradicted the raw-inline behavior.
- **`docs/native-features-analysis.md`** — moved ordered dialects out of *Deferred* into the MUST core; added raw inline to MUST; recorded Djot's both-parens `(1)` / `(a)` / `(i)` marker as a **deliberate gap** (it is the most prose-ambiguous marker — a wrapped line beginning `(1) …` reads as a parenthetical aside — and accepting it would fork the clean §10 interrupt rule onto delimiter style).
- **`README.md`** — fixed the stale *Raw / passthrough* row (Carve has both the inline and block forms); added an ordered-list-dialect row noting the `(1)` gap.
- **`docs/case-study/syntax.md`** — documented the inline `{=format}` form in §4.15 (it previously covered only the block form).
