### PR TITLE
spec: add normative extensions contract

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -24,6 +24,10 @@ automated by the `Bump spec corpus` workflow (`.github/workflows/bump-spec.yml`)
 in each impl repo — weekly + manual dispatch, idempotent on a single
 `automation/bump-spec` branch.
 
+The feature taxonomy (Core / Standard-recommended / App) and the normative
+extension contract live in [`docs/extensions.md`](docs/extensions.md). App-level
+behavior must ride the extension system there, not the core parser.
+
 ### Order for a cross-cutting behavior change
 
 1. **carve-js first.** Land the behavior in the reference impl with unit tests.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -200,6 +200,7 @@ export default defineConfig({
         text: 'Reference',
         items: [
           { text: 'Technical Rationale', link: '/technical-rationale' },
+          { text: 'Extensions Contract', link: '/extensions' },
           { text: 'Formal Grammar', link: '/grammar' },
           { text: 'Edge Cases', link: '/edge-cases' },
           { text: 'Native Features', link: '/native-features-analysis' },
@@ -223,6 +224,7 @@ export default defineConfig({
         text: 'Reference',
         items: [
           { text: 'Technical Rationale', link: '/technical-rationale' },
+          { text: 'Extensions Contract', link: '/extensions' },
           { text: 'Formal Grammar', link: '/grammar' },
           { text: 'Edge Cases', link: '/edge-cases' },
           { text: 'Native Features', link: '/native-features-analysis' },

--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -1148,6 +1148,9 @@ defines how browsers render <abbr title="World Wide Web">WWW</abbr> content.</p>
 
 ### 4.20 Extensions (Custom Elements)
 
+> Non-normative narrative. The normative taxonomy + extension contract are in
+> [`../extensions.md`](../extensions.md).
+
 Carve needs a generic extension mechanism for domain-specific elements that
 don't belong in core (embeds, mentions, custom widgets, etc.).
 

--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -1149,7 +1149,7 @@ defines how browsers render <abbr title="World Wide Web">WWW</abbr> content.</p>
 ### 4.20 Extensions (Custom Elements)
 
 > Non-normative narrative. The normative taxonomy + extension contract are in
-> [`../extensions.md`](../extensions.md).
+> [`../extensions`](../extensions).
 
 Carve needs a generic extension mechanism for domain-specific elements that
 don't belong in core (embeds, mentions, custom widgets, etc.).

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,4 +1,4 @@
-# Carve extensions (NORMATIVE)
+# Carve extensions contract (NORMATIVE)
 
 This document is normative. The conformance corpus (`tests/corpus`) remains the
 authority for Tier-1 output; this document defines the feature taxonomy and the
@@ -8,7 +8,7 @@ extension mechanism every implementation realizes.
 
 | Tier | Definition | Default | Conformance |
 |------|------------|---------|-------------|
-| 1 · Core | Normative syntax in grammar.ebnf + the corpus; identical output everywhere. | Always on | Mandatory (corpus) |
+| 1 · Core | Normative syntax in `resources/grammar.ebnf` + the corpus; identical output everywhere. | Always on | Mandatory (corpus) |
 | 2 · Standard-recommended | Spec-listed behaviors every impl SHOULD offer but ship off/passthrough. | Off / passthrough | Optional corpus when enabled |
 | 3 · App extension | Not in the spec, not conformance-tested, may exist in one impl only. | Off | Never |
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,69 @@
+# Carve extensions (NORMATIVE)
+
+This document is normative. The conformance corpus (`tests/corpus`) remains the
+authority for Tier-1 output; this document defines the feature taxonomy and the
+extension mechanism every implementation realizes.
+
+## 1. Feature taxonomy
+
+| Tier | Definition | Default | Conformance |
+|------|------------|---------|-------------|
+| 1 · Core | Normative syntax in grammar.ebnf + the corpus; identical output everywhere. | Always on | Mandatory (corpus) |
+| 2 · Standard-recommended | Spec-listed behaviors every impl SHOULD offer but ship off/passthrough. | Off / passthrough | Optional corpus when enabled |
+| 3 · App extension | Not in the spec, not conformance-tested, may exist in one impl only. | Off | Never |
+
+Invariant: a feature's tier is identical in every language; a Tier-1 feature is
+core-and-default-on everywhere and its default output is corpus-pinned.
+
+- Tier 1: corpus categories 01–73 (incl. admonitions, footnotes, smart
+  typography, cross-references, `<…>` autolinks, the `:name[…]` / `::: name`
+  extension syntax, and `@mention` / `#tag` / `:emoji:` parsing).
+- Tier 2: configuration over Tier-1 syntax — mention/tag→URL, emoji glyph map,
+  locale smart-quote sets, bare-URL autolinking.
+- Tier 3: Mermaid, Tabs, CodeGroup, TableOfContents, HeadingPermalinks,
+  HeadingLevelShift, ExternalLinks, DefaultAttributes, Wikilinks, InlineFootnotes
+  (`.fn`), SemanticSpan.
+
+## 2. Extension system
+
+An extension is a named unit contributing any subset of four things, run as:
+
+    parse (core + extension MATCHERS)
+      → afterParse TRANSFORM → beforeRender TRANSFORM
+      → render (core + extension RENDERERS)
+
+### 2.1 Matchers (parse stage) — scanner-function contract
+
+- inline: `(text, pos, ctx) -> { node, end } | null`
+- block:  `(lines, ctx) -> { node, linesConsumed } | null`
+- `ctx` exposes: definition tables (link/footnote/abbr); recursive
+  `parseInlines(text)` / `parseBlocks(lines)`; the extension's config.
+- Precedence: core matchers run first at each position; extension matchers are
+  tried only where core does not consume (extensions add syntax, never hijack
+  core). Extension matchers run in registration order; optional integer priority
+  is the escape hatch.
+
+### 2.2 Transforms
+
+- afterParse `(Document) -> Document` (collection/inspection)
+- beforeRender `(Document) -> Document` (mutation)
+- Every extension's afterParse runs before any extension's beforeRender; within a
+  phase, registration order.
+
+### 2.3 Renderers
+
+- Registered per node type / extension name; receive the node, emit
+  implementation-specific output. Renderers are the impl-idiomatic half; matchers
+  and transforms are the portable contract.
+
+### 2.4 Registration & config
+
+- Impl-idiomatic (PHP `addExtension`/ctor; JS `extensions: [...]` option),
+  declaring the same lifecycle contributions.
+
+## 3. Home, conformance, per-impl
+
+- This document is the normative home for the taxonomy + contract.
+- syntax.md §4.20 is the non-normative narrative.
+- Conformance: Tier-1 = existing corpus (mandatory); Tier-2 = optional corpus
+  subset, run per enabled feature; Tier-3 = never in any corpus.

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,7 +128,7 @@ admonition content
 
 ## Status
 
-Carve is a design exploration. The specification lives in the [Case Study](./case-study/). Reference material covers the new [technical rationale](./technical-rationale), [parsing edge cases](./edge-cases), [native features](./native-features-analysis), and the [broader markup landscape](./markup-languages).
+Carve is a design exploration. The specification lives in the [Case Study](./case-study/). Reference material covers the normative [extensions contract](./extensions), the [technical rationale](./technical-rationale), [parsing edge cases](./edge-cases), [native features](./native-features-analysis), and the [broader markup landscape](./markup-languages).
 
 **File extension:** `.crv`
 


### PR DESCRIPTION
## Summary
- add a new normative `docs/extensions.md` page defining the 3-tier feature taxonomy and the extension-system lifecycle
- cross-link the contract from `MAINTAINING.md` and mark `docs/case-study/syntax.md` §4.20 as non-normative narrative
- surface the new contract page in the docs nav and home-page reference copy

## Testing
- `npm test`
- `npm run docs:build`
