### PR TITLE
docs: correct §14 empty/invalid inline-span attribute-block behavior

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -62,6 +62,7 @@ the behavior is pinned in `docs/examples.md`:
 | `text\n[^f]: note` — footnote defined but never referenced | No endnotes section is emitted. carve-php stopped leaking an empty `<ol>`. *(43-footnotes)* |
 | Mention URL template | Canonical placeholder `{name}` for mentions and tags, value URL-encoded. carve-js accepts `{name}` (with `{user}` as a legacy alias); carve-php encodes the value. Config-only, so not corpus-testable. |
 | `[x]{}` — bracket + empty attribute block | A valid attribute block forms a span even when empty; both emit `<span>x</span>` (carve-js now materializes the empty span, matching carve-php/djot). *(66-inline-span)* |
+| `[x]{ }` / `[x]{???}` / `[x]{=y=}` — bracket + whitespace/invalid attr block | A whitespace-only block is a valid empty block → `<span>x</span>` (both impls); an invalid block is not an attribute block → the `]` and `{...}` stay literal, inner content still inline-parsed (`[*x*]{???}` → `[<strong>x</strong>]{???}`). carve-php stopped leaking the block (markup-carve/carve-php#43). Normative behavior in grammar §14; not corpus-pinned (impls still diverge at the margins — booleans, colon keys, comment-only blocks). |
 
 ### Intentional divergences (kept on purpose)
 
@@ -69,9 +70,7 @@ _None currently._
 
 ### Open (tracked)
 
-| Input | carve-js | carve-php | Status |
-|-------|----------|-----------|--------|
-| `[x]{ }` / `[x]{???}` / `[x]{"{y}"}` — bracket + whitespace/invalid attr block | `<span>x</span>` (whitespace) / literal (invalid) | leaks the block after materializing the span | carve-php bug — should treat a valid (incl. whitespace) block as the span and an invalid block as literal. Tracked: markup-carve/carve-php#37 |
+_None currently._
 
 When a new divergence is found, verify it on both impls, decide the canonical,
 and either pin it as a `docs/examples.md` pair (and move it to *Resolved*) or

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -878,14 +878,24 @@ EOF = (* end of file *) ;
       Because the `{` test fires only when the attribute block directly
       abuts `]`, `[text] {.x}` (with a space) is literal `[text]`
       followed by a literal `{.x}` -- the span requires adjacency.
-      IMPLEMENTATION-DEFINED EDGE: a block carrying no recognized
-      attribute (`[text]{}`, `[text]{ }`, `[text]{???}`) sits between
-      "valid span" and "literal text". carve-js treats it as literal
-      (the `attributes` production needs at least one attribute);
-      carve-php emits a bare `<span>text</span>` so a default-attribute
-      extension can target it. Authors MUST NOT rely on this edge --
-      use a real attribute (`[text]{.x}`) for a span, or no braces for
-      literal text.
+      EMPTY OR INVALID ATTRIBUTE BLOCK -- NORMATIVE. The directly-abutting
+      `{...}` is classified by its content:
+        - yields at least one attribute (`[text]{.c}`) -> span with those
+          attributes.
+        - empty or whitespace-only (`[text]{}`, `[text]{ }`) -> a valid EMPTY
+          block: a bare `<span>text</span>`. Both reference impls agree, even
+          though the bare `attribute_list` production nominally needs >= 1
+          attribute; the empty block is a blessed exception so a
+          default-attribute processor can target the span.
+        - unrecognized non-empty content (`[text]{???}`, `[text]{=y=}`) -> NOT
+          an attribute block: the `]` and the `{...}` render literally. The
+          inner bracket content is still inline-parsed, so `[*x*]{???}` ->
+          `[<strong>x</strong>]{???}`.
+      The boundary of "yields an attribute" still differs at the margins:
+      carve-php additionally accepts bareword booleans (`[text]{kbd}`),
+      colon-bearing keys/classes (`{xml:lang="en"}`, `{.sm:hover}`) and
+      comment-only blocks (`{% c %}`) as spans, where carve-js treats those as
+      literal. Use a plain `.class` / `#id` / `key=value` for a portable span.
 
    15. BLOCK ATTRIBUTE LINES -- NORMATIVE (governs `block_attributes`
       in PART 2; matches djot). A `{...}` attribute block on its own


### PR DESCRIPTION
Follow-up to the inline-span fix in carve-php (markup-carve/carve-php#43, resolving carve-php#37).

## Stale §14 prose

`resources/grammar.ebnf` PART 9 §14 claimed:

> carve-js treats it as literal (the `attributes` production needs at least one attribute)

That is wrong for the empty/whitespace case. Verified actual behavior of both reference impls:

| input | carve-js | carve-php |
|-------|----------|-----------|
| `[x]{}` | `<span>x</span>` | `<span>x</span>` |
| `[x]{ }` | `<span>x</span>` | `<span>x</span>` |
| `[x]{???}` | `[x]{???}` (literal) | `[x]{???}` (literal) |
| `[x]{=y=}` | `[x]{=y=}` (literal) | `[x]{=y=}` (literal) |

Both emit a bare `<span>` for empty/whitespace-only blocks; only unrecognized non-empty content stays literal (with the inner bracket content still inline-parsed, e.g. `[*x*]{???}` -> `[<strong>x</strong>]{???}`).

## Changes

- Rewrite the §14 edge as **normative + converged**: empty/whitespace -> bare span; invalid -> literal. Document the remaining marginal divergence where carve-php is more permissive (bareword booleans `{kbd}`, colon keys/classes `{xml:lang="en"}` / `{.sm:hover}`, comment-only `{% c %}`), which carve-js treats as literal.
- `MAINTAINING.md`: move the carve-php#37 row out of *Open (tracked)* into *Resolved* (the empty-span case stays corpus-pinned via 66-inline-span; the whitespace/invalid cases are normative-but-not-pinned because the impls still diverge at the margins).

Docs-only; corpus and grammar productions are unchanged. `npm test` green (164 pass, 2 skip).

Optional next step (not in this PR): pin `[x]{ }` and `[x]{???}` as `docs/examples.md` compare pairs to lock the convergence in the corpus - deferred because it would also assert against carve-rs.
