### PR TITLE
docs: polish playground demo styling + use canonical feature demo

### DIFF
--- a/docs/.vitepress/examples/demo.crv
+++ b/docs/.vitepress/examples/demo.crv
@@ -1,0 +1,195 @@
+---
+title: Carve Feature Demo
+date: 2026-06-02
+author: Carve
+tags: [demo, reference]
+---
+
+%% This file exercises the Carve markup constructs supported by the grammar.
+%% Lines beginning with %% are comments and do not render.
+
+# Carve Feature Demo {#top}
+
+A single document touching every core construct, plus a few renderer-dependent
+extensions at the end. Open it with **Carve: Open Preview** to see it rendered.
+
+## Headings and attributes {#headings .featured}
+
+# Level 1
+## Level 2
+### Level 3
+#### Level 4
+##### Level 5
+###### Level 6
+
+A heading can carry an explicit id and classes: `## Setup {#install .lead}`.
+
+## Inline formatting {#inline}
+
+/italic/, *bold*, /*bold italic*/, _underline_, ~strikethrough~, ==highlight==,
+super^script^ and sub,,script,,. Inline `code span`, and raw inline passthrough
+`<abbr>HTML</abbr>`{=html} emitted verbatim.
+
+Editorial markup: {+ added text +}, {- deleted text -},
+{~ old phrase ~> new phrase ~}, and an {# editorial note #}.
+
+Escapes keep specials literal: \*not bold\*, \/not italic\/, \#not-a-tag.
+
+## Links and images {#links}
+
+Inline [link](https://example.com), titled
+[link](https://example.com "Hover title"), autolink <https://example.com>,
+email autolink <hello@example.com>, and a reference [link][site].
+
+A collapsed reference [site][] reuses the label as the reference.
+
+Cross-reference to a heading by id: jump to </#top>.
+
+[site]: https://example.com "Reference definition"
+
+![A descriptive alt text](images/diagram.png)
+^ Figure 1: images may carry a caption line.
+
+## Lists {#lists}
+
+Unordered:
+
+- apples
+- oranges
+  - clementines
+  - blood oranges
+- pears
+
+Ordered:
+
+1. clone the repo
+2. install dependencies
+   - run the build
+   - run the tests
+3. ship it
+
+Tasks:
+
+- [x] write the grammar
+- [x] write the corpus
+- [ ] write more demos
+
+Definition list:
+
+:: Carve
+:  A post-Djot lightweight markup language.
+:: Djot
+:  The markup language Carve evolves from.
+
+## Blockquotes {#quotes}
+
+> The best way to predict the future is to invent it.
+^ Alan Kay
+
+## Tables {#tables}
+
+|= Fruit       |=> Price |=~ Stock |
+| Apple        |    1.20 |   In     |
+| Banana       |    0.50 |   In     |
+| Dragon fruit |    4.00 |   Out    |
+^ Table 1: column alignment - left, right, center.
+
+## Code and raw blocks {#code}
+
+A fenced code block with a language:
+
+```python
+def greet(name: str) -> str:
+    return f"Hello, {name}!"
+```
+
+A tilde fence works too:
+
+~~~yaml
+key: value
+list:
+  - one
+  - two
+~~~
+
+A raw block passes content through to a named format unchanged:
+
+```raw html
+<details><summary>Native HTML</summary>Rendered as-is.</details>
+```
+
+## Math {#math}
+
+Inline math uses a dollar before a code span: $`e = mc^2`.
+
+Display math uses a double dollar:
+
+$$`\int_0^\infty e^{-x^2}\,dx = \frac{\sqrt{\pi}}{2}`
+
+## Admonitions and divs {#admonitions}
+
+::: note
+A plain note callout.
+:::
+
+::: tip "With a title"
+Admonitions accept an optional quoted title.
+:::
+
+::: warning
+Heed this warning.
+:::
+
+::: danger
+Critical information.
+:::
+
+A bare `:::` fence with only `{#id .class}` and no admonition type is a
+generic styled container, not a colored callout:
+
+::: {#callout .highlight}
+This block has only an id and classes, so it renders as a plain
+`<div id="callout" class="highlight">` wrapper you can target with your own CSS.
+:::
+
+## Mentions, tags, and inline extensions {#tokens}
+
+Mention a person with @alice and reference a tag like #release-1.0.
+An inline extension names a role: press :kbd[Ctrl+C] to copy.
+
+## Footnotes {#footnotes}
+
+Carve supports footnotes[^note] with definitions collected anywhere.[^second]
+
+[^note]: The reference and its definition are linked by label.
+[^second]: Definitions can appear in any order.
+
+## Smart typography {#typography}
+
+Dashes and ellipsis: an em dash --- an en range 10--20 ... and so on.
+Arrows and comparisons: -> <- <-> => , != <= >= , (c) (r) (tm).
+
+---
+
+## Mermaid (Tier-3 extension) {#mermaid}
+
+%% Mermaid is a third-party extension, not core Carve. It is written as a
+%% fenced code block tagged `mermaid`. It only renders as a diagram when the
+%% renderer enables the Mermaid extension; otherwise it shows as a code block.
+
+```mermaid
+graph TD
+    A[Write Carve] --> B{LSP diagnostics}
+    B -->|clean| C[Preview]
+    B -->|warnings| D[Quick fix]
+    D --> A
+    C --> E[Publish]
+```
+
+```mermaid
+sequenceDiagram
+    Author->>Editor: type Carve
+    Editor->>LSP: textDocument/didChange
+    LSP-->>Editor: diagnostics + semantic tokens
+    Editor-->>Author: live preview
+```

--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -2,30 +2,9 @@
 import { ref, computed } from 'vue'
 // @ts-expect-error - vendored ESM module without TS resolution context
 import { carveToHtml } from '../../carve-lib/index.js'
-
-const DEFAULT_SOURCE = `# Hello, Carve
-
-This is a *bold* claim, /italic/ truth, and a [link](https://example.com).
-
-- one
-- two
-- [ ] todo
-- [x] done
-
-> The best markup is the one you don't have to think about.
-^ — anonymous
-
-|= Item |= Price |
-| Apple | $1     |
-| Pear  | $2     |
-^ Two fruits and their prices.
-
-Press :kbd[Ctrl+C] to copy. See @alice for the #release-1.0 thread.
-
-*[HTML]: HyperText Markup Language
-
-The HTML spec covers it all.
-`
+// The canonical feature-demo document (also used by the VS Code extension),
+// loaded as raw Carve source via vite-plugin-carve.
+import { source as DEFAULT_SOURCE } from '../../examples/demo.crv'
 
 const source = ref(DEFAULT_SOURCE)
 
@@ -51,7 +30,7 @@ function escapeHtml(s: string): string {
     </div>
     <div class="pane">
       <label>Rendered HTML</label>
-      <div class="output" v-html="html" />
+      <div class="output vp-doc carve-render" v-html="html" />
     </div>
     <div class="pane pane-full">
       <label>HTML source</label>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -193,3 +193,129 @@ html.dark .vp-code span[data-carve-highlight] {
     justify-self: start;
   }
 }
+
+/*
+ * Carve rendered output (Playground + dogfood). The container also carries
+ * `vp-doc`, so prose (headings, lists, tables, code, blockquotes) inherits the
+ * VitePress document styling. These rules add the Carve-specific constructs
+ * VitePress has no styling for: admonitions, kbd keycaps, mentions/tags,
+ * figure captions, table captions, and inline/display math.
+ */
+
+/* Admonitions: <aside class="admonition {type}"> with optional title <p>. */
+.carve-render .admonition {
+  margin: 1rem 0;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border-left: 4px solid var(--vp-c-default-1);
+  background: var(--vp-c-default-soft);
+}
+.carve-render .admonition > :first-child {
+  margin-top: 0;
+}
+.carve-render .admonition > :last-child {
+  margin-bottom: 0;
+}
+.carve-render .admonition-title {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 0.8rem;
+  margin-bottom: 0.4rem;
+}
+.carve-render .admonition.note,
+.carve-render .admonition.info {
+  border-left-color: var(--vp-c-note-1, var(--vp-c-brand-1));
+  background: var(--vp-c-note-soft, var(--vp-c-brand-soft));
+}
+.carve-render .admonition.tip,
+.carve-render .admonition.success {
+  border-left-color: var(--vp-c-green-1);
+  background: var(--vp-c-green-soft);
+}
+.carve-render .admonition.warning {
+  border-left-color: var(--vp-c-yellow-1);
+  background: var(--vp-c-yellow-soft);
+}
+.carve-render .admonition.danger {
+  border-left-color: var(--vp-c-red-1);
+  background: var(--vp-c-red-soft);
+}
+.carve-render .admonition.example {
+  border-left-color: var(--vp-c-purple-1);
+  background: var(--vp-c-purple-soft);
+}
+.carve-render .admonition.quote {
+  border-left-color: var(--vp-c-default-1);
+  background: var(--vp-c-default-soft);
+}
+
+/* Keyboard keys: a subtle keycap. */
+.carve-render kbd {
+  display: inline-block;
+  padding: 0.15em 0.45em;
+  font-family: var(--vp-font-family-mono, ui-monospace, monospace);
+  font-size: 0.82em;
+  line-height: 1.2;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-bottom-width: 2px;
+  border-radius: 5px;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
+}
+
+/* Mentions and tags: a flat, colored pill. */
+.carve-render .mention,
+.carve-render .tag {
+  display: inline-block;
+  padding: 0.05em 0.5em;
+  border-radius: 999px;
+  font-size: 0.9em;
+  font-weight: 500;
+  line-height: 1.4;
+  text-decoration: none;
+}
+.carve-render .mention,
+.carve-render .mention strong {
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  font-weight: 500;
+}
+.carve-render .tag,
+.carve-render .tag strong {
+  color: var(--vp-c-green-1, var(--vp-c-brand-1));
+  background: var(--vp-c-green-soft, var(--vp-c-brand-soft));
+  font-weight: 500;
+}
+
+/* Figure caption (blockquote / image with `^ caption`). */
+.carve-render figure {
+  margin: 1rem 0;
+}
+.carve-render figcaption {
+  margin-top: 0.4rem;
+  color: var(--vp-c-text-2);
+  font-size: 0.88rem;
+  font-style: italic;
+}
+
+/* Table caption. */
+.carve-render table caption {
+  caption-side: bottom;
+  margin-top: 0.5rem;
+  color: var(--vp-c-text-2);
+  font-size: 0.85rem;
+  text-align: left;
+}
+
+/* Inline / display math (KaTeX not loaded — show the TeX legibly). */
+.carve-render .math {
+  font-family: var(--vp-font-family-mono, ui-monospace, monospace);
+  font-size: 0.95em;
+}
+.carve-render .math.display {
+  display: block;
+  text-align: center;
+  margin: 1rem 0;
+}

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -319,3 +319,23 @@ html.dark .vp-code span[data-carve-highlight] {
   text-align: center;
   margin: 1rem 0;
 }
+
+/*
+ * Demo styling for a generic attributed div. Carve's `::: {#id .class}` (no
+ * admonition type) emits a plain <div class="…"> that carries no styling of
+ * its own — the author targets it with their own CSS. The feature demo uses
+ * `.highlight`, so style it here to show the hook actually working.
+ */
+.carve-render div.highlight {
+  margin: 1rem 0;
+  padding: 0.75rem 1rem;
+  border: 1px dashed var(--vp-c-brand-1);
+  border-radius: 8px;
+  background: var(--vp-c-brand-soft);
+}
+.carve-render div.highlight > :first-child {
+  margin-top: 0;
+}
+.carve-render div.highlight > :last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Polishes the [Playground](https://markup-carve.github.io/carve/playground) so the live preview looks like a real rendered document, not bare browser defaults.

## Changes

- **Rendered pane inherits VitePress prose styling** - the output `<div>` now carries `vp-doc`, so headings, lists, tables (borders!), code, and blockquotes match the rest of the docs.
- **Carve-specific element styling** (new `carve-render` hook in `custom.css`) for constructs VitePress doesn't know: admonitions (all eight types, color-coded with title), `<kbd>` keycaps, mention/tag pills, figure + table captions, inline/display math. Light and dark mode verified.
- **Default source is the canonical feature demo** - the same `demo.crv` the VS Code extension ships, loaded as raw Carve via `vite-plugin-carve`, so the playground exercises every core construct end-to-end.
- Clarifies the generic-div (`::: {#id .class}`) example wording.

Browser-verified (light + dark); production `docs:build` passes.
