### PR TITLE
Surface math and frontmatter on landing, add Security page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -211,6 +211,7 @@ export default defineConfig({
           { text: 'Edge Cases', link: '/edge-cases' },
           { text: 'Native Features', link: '/native-features-analysis' },
           { text: 'Markup Language Comparison', link: '/markup-languages' },
+          { text: 'Security', link: '/security' },
         ],
       },
       { text: 'Case Study', link: '/case-study/' },
@@ -236,6 +237,7 @@ export default defineConfig({
           { text: 'Edge Cases', link: '/edge-cases' },
           { text: 'Native Features', link: '/native-features-analysis' },
           { text: 'Markup Language Comparison', link: '/markup-languages' },
+          { text: 'Security', link: '/security' },
         ],
       },
       {

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ tags: [carve, markup]
 ---
 ```
 
-A leading `---` fenced block holds document metadata. Add a format token to the opening fence for non-YAML metadata (`---toml`, `---json`, or any label); a bare `---` defaults to `yaml`:
+A leading `---` fenced block holds document metadata. Add a format token to the opening fence for non-YAML metadata (`---toml`, `---json`, or any label); a bare `---` uses the configurable default format (`yaml` unless the host sets `defaultFrontmatterFormat`):
 
 ```carve
 ---toml

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,17 @@ features:
 
 ## Quick Reference
 
+### Frontmatter
+
+```carve
+---
+title: My Document
+tags: [carve, markup]
+---
+```
+
+A leading `---` fenced block holds YAML metadata. It is parsed into the document's `frontmatter` and never rendered as body content.
+
 ### Emphasis
 
 ```carve
@@ -83,6 +94,13 @@ _underline_   ~strikethrough~
 code block
 ```
 ````
+
+### Math
+
+```carve
+Inline: $`e^{i\pi} + 1 = 0`
+Display: $$`\int_0^1 x \, dx`
+```
 
 ### Quotes & admonitions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,15 @@ tags: [carve, markup]
 ---
 ```
 
-A leading `---` fenced block holds YAML metadata. It is parsed into the document's `frontmatter` and never rendered as body content.
+A leading `---` fenced block holds document metadata. Add a format token to the opening fence for non-YAML metadata (`---toml`, `---json`, or any label); a bare `---` defaults to `yaml`:
+
+```carve
+---toml
+title = "My Document"
+---
+```
+
+Carve holds the content **raw** - the verbatim text plus the format label - and does not parse it; your application interprets the declared format. The block is leading-only and never rendered as body content.
 
 ### Emphasis
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,93 @@
+# Security
+
+Carve is designed to be safe to render from untrusted input by default. This
+page documents what the renderer guarantees, what you still own, and how to
+tighten the policy.
+
+## HTML is text, not markup
+
+Carve has no raw-HTML passthrough. Angle brackets carry no special meaning, so
+authored `<` and `>` are escaped on output rather than interpreted:
+
+```carve
+<script>alert(1)</script>
+```
+
+renders as the literal, inert text `&lt;script&gt;alert(1)&lt;/script&gt;`.
+This removes the entire class of injection that comes from Markdown/CommonMark
+passing raw HTML through to the output.
+
+## URL scheme sanitization (on by default)
+
+The HTML renderer filters the URL on every clickable sink - link `href` and
+image `src` - against a scheme allowlist. A URL whose scheme is not allowed
+collapses to an empty value, so the link text or image `alt` stays visible but
+the element is inert:
+
+| Input | Rendered |
+|---|---|
+| `[x](javascript:alert(1))` | `<a href="">x</a>` |
+| `[d](data:text/html;base64,...)` | `<a href="">d</a>` |
+| `![i](javascript:alert(1))` | `<img src="" alt="i">` |
+| `[ok](https://example.com)` | `<a href="https://example.com">ok</a>` |
+| `[rel](/docs/page)` | `<a href="/docs/page">rel</a>` |
+
+What always passes through:
+
+- Relative URLs (no scheme), e.g. `/docs/page`, `page.crv`
+- Fragments, e.g. `#section`
+- Protocol-relative URLs, e.g. `//cdn.example.com/x`
+- Any scheme in the allowlist (default: `http`, `https`, `mailto`)
+
+An attribute block cannot reintroduce a dangerous URL: a `{href=...}` or
+`{src=...}` override (in any letter case) is dropped in favor of the sanitized
+structural URL. Scheme detection also ignores the tab, newline, and leading
+control/space characters that browsers discard when reading a scheme, so a
+scheme split by a tab or newline (e.g. `java<TAB>script:`) does not slip
+through.
+
+### Configuration
+
+The behavior is controlled through `RenderOptions` (passed to `renderHtml` or
+`carveToHtml`):
+
+```js
+import { carveToHtml } from '@markup-carve/carve'
+
+// Safe by default - nothing to configure.
+carveToHtml(userInput)
+
+// Extend the allowlist (e.g. allow tel: links).
+carveToHtml(userInput, { allowedUrlSchemes: ['http', 'https', 'mailto', 'tel'] })
+
+// Trusted input only: pass authored URLs through verbatim.
+carveToHtml(trustedInput, { sanitizeUrls: false })
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `sanitizeUrls` | `true` | Filter link/image URL schemes. Set `false` only for fully trusted input. |
+| `allowedUrlSchemes` | `['http', 'https', 'mailto']` | Schemes permitted when `sanitizeUrls` is on. Case-insensitive. |
+
+## What you still own
+
+- **Social-token URLs.** `@mention` and `#tag` render as inert spans unless you
+  provide `mentionUrl` / `tagUrl` templates. Those templates are your trusted
+  configuration; the token name is URL-encoded into them.
+- **Arbitrary attributes on non-link elements.** Carve escapes attribute values,
+  but it does not run a full HTML sanitizer over attributes you allow authors to
+  attach via `{key=value}` to arbitrary elements. If you accept fully untrusted
+  input and permit arbitrary attributes, run the rendered HTML through a DOM
+  sanitizer (e.g. DOMPurify) as defense in depth.
+- **Where the HTML ends up.** Carve produces an HTML string; your application is
+  responsible for inserting it into a trusted context and for the surrounding
+  Content-Security-Policy.
+
+## Relationship to the spec's SafeMode
+
+The case study describes a broader `SafeMode` / `Profile` link policy (scheme
+allow/deny lists, domain allow/deny, `rel=nofollow`, nesting and length limits).
+The scheme allowlist on this page is the part enforced today by the reference
+JavaScript implementation. The wider feature-restriction surface is documented
+in the [Syntax Specification](./case-study/syntax) and may land in
+implementations incrementally.


### PR DESCRIPTION
## What

Two documentation gaps surfaced while comparing Carve against other markup languages:

1. **Math and frontmatter were invisible on the landing page.** Both are implemented in `carve-js`, but the overview Quick Reference never showed them, so a reader skimming the docs would conclude they do not exist.
2. **There was no single page describing the security model**, even though the renderer makes real guarantees and the spec describes a `SafeMode` link policy.

## Changes

- **`docs/index.md`** - add a **Frontmatter** section (leading `---` YAML fence) and a **Math** section (inline `` $`...` `` / display `` $$`...` ``) to the Quick Reference.
- **`docs/security.md`** (new) - document:
  - HTML is escaped, not passed through (no raw-HTML injection class).
  - URL scheme sanitization on link `href` / image `src` is on by default, with the allow/block table, the `sanitizeUrls` and `allowedUrlSchemes` options, and the attribute-override / obfuscation guarantees.
  - What the application still owns (social-token URL templates, arbitrary attributes on non-link elements, CSP / insertion context).
  - Its relationship to the spec's broader `SafeMode` / `Profile` policy.
- **`docs/.vitepress/config.ts`** - wire the Security page into the top nav Reference dropdown and the sidebar Reference group.

## Notes

- The security page matches the default-on URL sanitization shipped in `carve-js` (see markup-carve/carve-js#60).
- The corpus generator reads only `docs/examples.md`, so the new `carve` snippets in `index.md` / `security.md` do not affect `tests/corpus` - conformance CI is unaffected.
