### PR TITLE
Docs: note trailing comment in Djot comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Carve inherits and extends Djot's rationale:
 | Generic divs | `:::` (→ `<div>`) | bare `:::` / `::: {…}` → plain `<div>`; `::: word` two-tier (canonical → `<aside>`, custom → `<div class=word>`) |
 | Inline spans | `[text]{.c}` (→ `<span>`) | `[text]{.c}` (→ `<span>`) |
 | Editorial markup | `{+ +}` `{- -}` `{= =}` | `{+ +}` `{- -}` `{~ ~> ~}` `{= =}` `{# #}` |
-| Comments | `{% … %}` | `%%` line / `%%%` block |
+| Comments | `{% … %}` | `%%` line / `text %% trailing` / `%%%` block |
 | Raw / passthrough | inline `` `…`{=html} `` + ` ```=html ` block | inline `` `…`{=html} `` + ` ```raw html ` block |
 | Includes | N/A | `{{ path/to/file }}` |
 | Abbreviations | N/A | `*[ABBR]: ...` |


### PR DESCRIPTION
Follow-up to #63. The Comparison with Djot table's Comments row listed only the whole-line and block forms; add the trailing form so it matches the Quick Reference and the shipped feature.