### PR TITLE
Spec: a bare list marker is paragraph text, not a list

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -437,6 +437,22 @@ Span content is parsed recursively, and an inline link still wins over a span.
 
 :::
 
+A bullet (or ordered) marker is a list item only when followed by a space. A **bare** marker — `-` with no space and no content — is not a list; it stays paragraph text. (A marker followed by a space but no content, `- `, is a valid empty item.) Carve is stricter than CommonMark here, where a bare `-` line is an empty item; requiring the space keeps a lone dash from silently becoming a list.
+
+::: compare
+
+```carve
+-
+not a list
+```
+
+```html
+<p>-
+not a list</p>
+```
+
+:::
+
 Ordered lists use `N.` prefixes — numbering starts from the first marker.
 
 ::: compare

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -148,6 +148,14 @@ list = unordered_list | ordered_list | definition_list ;
 unordered_list = unordered_item+ ;
 unordered_item = bullet_marker, space, list_item_content ;
 bullet_marker = '-' | '*' | '+' ;
+(* MARKER REQUIRES A SPACE -- NORMATIVE. A bullet (or ordered) marker is a list
+   item only when followed by a space. A BARE marker line (`-` / `*` / `1.` with
+   no trailing space and no content) is NOT a list -- it is paragraph text. A
+   marker followed by a space but no content (`- ` with a trailing space) is a
+   valid EMPTY item. Carve is stricter than CommonMark here, which treats a bare
+   `-` line as an empty item; requiring the space keeps a lone `-` (a common
+   prose dash / placeholder) from silently becoming a list. Pinned by corpus
+   bare-marker-is-not-a-list. *)
 
 ordered_list = ordered_item+ ;
 ordered_item = ordered_marker, space, list_item_content ;

--- a/tests/corpus/05-lists-10.crv
+++ b/tests/corpus/05-lists-10.crv
@@ -1,4 +1,2 @@
-Intro
-
-> Stay hungry
-^ Steve Jobs
+- parent
+  - child

--- a/tests/corpus/05-lists-10.html
+++ b/tests/corpus/05-lists-10.html
@@ -1,5 +1,7 @@
-<p>Intro</p>
-<figure>
-  <blockquote><p>Stay hungry</p></blockquote>
-  <figcaption>Steve Jobs</figcaption>
-</figure>
+<ul>
+  <li>parent
+    <ul>
+      <li>child</li>
+    </ul>
+  </li>
+</ul>

--- a/tests/corpus/05-lists-11.crv
+++ b/tests/corpus/05-lists-11.crv
@@ -1,0 +1,4 @@
+Intro
+
+> Stay hungry
+^ Steve Jobs

--- a/tests/corpus/05-lists-11.html
+++ b/tests/corpus/05-lists-11.html
@@ -1,0 +1,5 @@
+<p>Intro</p>
+<figure>
+  <blockquote><p>Stay hungry</p></blockquote>
+  <figcaption>Steve Jobs</figcaption>
+</figure>

--- a/tests/corpus/05-lists-2.crv
+++ b/tests/corpus/05-lists-2.crv
@@ -1,3 +1,2 @@
-1. first
-2. second
-3. third
+-
+not a list

--- a/tests/corpus/05-lists-2.html
+++ b/tests/corpus/05-lists-2.html
@@ -1,5 +1,2 @@
-<ol>
-  <li>first</li>
-  <li>second</li>
-  <li>third</li>
-</ol>
+<p>-
+not a list</p>

--- a/tests/corpus/05-lists-3.crv
+++ b/tests/corpus/05-lists-3.crv
@@ -1,4 +1,3 @@
-- fruit
-  - apples
-  - oranges
-- vegetables
+1. first
+2. second
+3. third

--- a/tests/corpus/05-lists-3.html
+++ b/tests/corpus/05-lists-3.html
@@ -1,9 +1,5 @@
-<ul>
-  <li>fruit
-    <ul>
-      <li>apples</li>
-      <li>oranges</li>
-    </ul>
-  </li>
-  <li>vegetables</li>
-</ul>
+<ol>
+  <li>first</li>
+  <li>second</li>
+  <li>third</li>
+</ol>

--- a/tests/corpus/05-lists-4.crv
+++ b/tests/corpus/05-lists-4.crv
@@ -1,4 +1,4 @@
-1. setup
-   - clone
-   - install
-2. build
+- fruit
+  - apples
+  - oranges
+- vegetables

--- a/tests/corpus/05-lists-4.html
+++ b/tests/corpus/05-lists-4.html
@@ -1,9 +1,9 @@
-<ol>
-  <li>setup
+<ul>
+  <li>fruit
     <ul>
-      <li>clone</li>
-      <li>install</li>
+      <li>apples</li>
+      <li>oranges</li>
     </ul>
   </li>
-  <li>build</li>
-</ol>
+  <li>vegetables</li>
+</ul>

--- a/tests/corpus/05-lists-5.crv
+++ b/tests/corpus/05-lists-5.crv
@@ -1,3 +1,4 @@
-- apples
-
-- oranges
+1. setup
+   - clone
+   - install
+2. build

--- a/tests/corpus/05-lists-5.html
+++ b/tests/corpus/05-lists-5.html
@@ -1,4 +1,9 @@
-<ul>
-  <li><p>apples</p></li>
-  <li><p>oranges</p></li>
-</ul>
+<ol>
+  <li>setup
+    <ul>
+      <li>clone</li>
+      <li>install</li>
+    </ul>
+  </li>
+  <li>build</li>
+</ol>

--- a/tests/corpus/05-lists-6.crv
+++ b/tests/corpus/05-lists-6.crv
@@ -1,2 +1,3 @@
-Die Frage ist x = 5
-* 3 + 17 wahr.
+- apples
+
+- oranges

--- a/tests/corpus/05-lists-6.html
+++ b/tests/corpus/05-lists-6.html
@@ -1,2 +1,4 @@
-<p>Die Frage ist x = 5
-* 3 + 17 wahr.</p>
+<ul>
+  <li><p>apples</p></li>
+  <li><p>oranges</p></li>
+</ul>

--- a/tests/corpus/05-lists-7.crv
+++ b/tests/corpus/05-lists-7.crv
@@ -1,3 +1,2 @@
-Liste:
-- eins
-- zwei
+Die Frage ist x = 5
+* 3 + 17 wahr.

--- a/tests/corpus/05-lists-7.html
+++ b/tests/corpus/05-lists-7.html
@@ -1,3 +1,2 @@
-<p>Liste:
-- eins
-- zwei</p>
+<p>Die Frage ist x = 5
+* 3 + 17 wahr.</p>

--- a/tests/corpus/05-lists-8.crv
+++ b/tests/corpus/05-lists-8.crv
@@ -1,3 +1,3 @@
-Text hier
-
-- nur eins
+Liste:
+- eins
+- zwei

--- a/tests/corpus/05-lists-8.html
+++ b/tests/corpus/05-lists-8.html
@@ -1,4 +1,3 @@
-<p>Text hier</p>
-<ul>
-  <li>nur eins</li>
-</ul>
+<p>Liste:
+- eins
+- zwei</p>

--- a/tests/corpus/05-lists-9.crv
+++ b/tests/corpus/05-lists-9.crv
@@ -1,2 +1,3 @@
-- parent
-  - child
+Text hier
+
+- nur eins

--- a/tests/corpus/05-lists-9.html
+++ b/tests/corpus/05-lists-9.html
@@ -1,7 +1,4 @@
+<p>Text hier</p>
 <ul>
-  <li>parent
-    <ul>
-      <li>child</li>
-    </ul>
-  </li>
+  <li>nur eins</li>
 </ul>

--- a/tests/spec/05-lists.test
+++ b/tests/spec/05-lists.test
@@ -13,6 +13,14 @@ Lists
 ```
 
 ```
+-
+not a list
+.
+<p>-
+not a list</p>
+```
+
+```
 1. first
 2. second
 3. third


### PR DESCRIPTION
Clarifies an under-documented list rule (impls already agree).

## Rule
A bullet or ordered marker is a list item only when followed by a space:
- a **bare** marker line (`-`/`*`/`1.` with no space, no content) is **paragraph text**, not a list;
- a marker + space + empty content (`- `) is a valid **empty item**.

Carve is stricter than CommonMark, which treats a bare `-` line as an empty item. Requiring the space keeps a lone dash (a common prose dash / placeholder) from silently becoming a list.

## Changes
- Grammar: NORMATIVE note on `unordered_item` / marker-requires-space.
- Examples + corpus: pinned `05-lists-2` (bare `-` -> paragraph). Both impls already produce this byte-identically; no parser change.