### PR TITLE
Spec: tabs in code preserved verbatim; expansion is an opt-in extension

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -871,6 +871,23 @@ print("hi")
 
 :::
 
+Literal tabs in code content are preserved verbatim (a tab is not the same as spaces; display width is a CSS `tab-size` concern). Opt in to tab→space expansion with a tab-normalize extension.
+
+::: compare
+
+````carve
+```
+	indented with a tab
+```
+````
+
+```html
+<pre><code>	indented with a tab
+</code></pre>
+```
+
+:::
+
 A fenced block with no info string renders without a language class.
 
 ::: compare

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -150,6 +150,12 @@ tilde_fence = '~', '~', '~', {'~'} ;
 
 language_info = (letter | digit | '-' | '_' | '+' | '#' | '.')+ ;  (* a single token; the punctuation covers real language tags like c++, c#, f#, asp.net. May start with a digit. A multiword/quoted info (```js title="x") is NOT a fence. *)
 code_content = (* any text until matching fence, preserved literally *) ;
+(* TABS IN CODE -- NORMATIVE. Literal tab characters in code content (fenced
+   code blocks and inline code spans) are PRESERVED verbatim; a tab and N spaces
+   are not interchangeable. Tab display width is a presentation concern (CSS
+   `tab-size`). Tab-to-space expansion is NOT a default behavior -- it is opt-in
+   via a tab-normalize extension (flat replacement, default 2 spaces, content
+   only). Matches djot / CommonMark. Pinned by corpus tabs-in-code-preserved. *)
 
 (* --- Blockquotes --- *)
 blockquote = blockquote_line+, {lazy_continuation_line}, [caption] ;

--- a/tests/corpus/11-fenced-code-2.crv
+++ b/tests/corpus/11-fenced-code-2.crv
@@ -1,3 +1,3 @@
 ```
-plain text
+	indented with a tab
 ```

--- a/tests/corpus/11-fenced-code-2.html
+++ b/tests/corpus/11-fenced-code-2.html
@@ -1,2 +1,2 @@
-<pre><code>plain text
+<pre><code>	indented with a tab
 </code></pre>

--- a/tests/corpus/11-fenced-code-3.crv
+++ b/tests/corpus/11-fenced-code-3.crv
@@ -1,4 +1,3 @@
-{.fancy #x}
-```php
-code
+```
+plain text
 ```

--- a/tests/corpus/11-fenced-code-3.html
+++ b/tests/corpus/11-fenced-code-3.html
@@ -1,2 +1,2 @@
-<pre class="fancy" id="x"><code class="language-php">code
+<pre><code>plain text
 </code></pre>

--- a/tests/corpus/11-fenced-code-4.crv
+++ b/tests/corpus/11-fenced-code-4.crv
@@ -1,3 +1,4 @@
-~~~yaml
-key: value
-~~~
+{.fancy #x}
+```php
+code
+```

--- a/tests/corpus/11-fenced-code-4.html
+++ b/tests/corpus/11-fenced-code-4.html
@@ -1,2 +1,2 @@
-<pre><code class="language-yaml">key: value
+<pre class="fancy" id="x"><code class="language-php">code
 </code></pre>

--- a/tests/corpus/11-fenced-code-5.crv
+++ b/tests/corpus/11-fenced-code-5.crv
@@ -1,5 +1,3 @@
-````markdown
-```python
-print("hi")
-```
-````
+~~~yaml
+key: value
+~~~

--- a/tests/corpus/11-fenced-code-5.html
+++ b/tests/corpus/11-fenced-code-5.html
@@ -1,4 +1,2 @@
-<pre><code class="language-markdown">```python
-print("hi")
-```
+<pre><code class="language-yaml">key: value
 </code></pre>

--- a/tests/corpus/11-fenced-code-6.crv
+++ b/tests/corpus/11-fenced-code-6.crv
@@ -1,4 +1,5 @@
+````markdown
+```python
+print("hi")
 ```
-# not a heading
-/not italic/  *not bold*  #notatag
-```
+````

--- a/tests/corpus/11-fenced-code-6.html
+++ b/tests/corpus/11-fenced-code-6.html
@@ -1,3 +1,4 @@
-<pre><code># not a heading
-/not italic/  *not bold*  #notatag
+<pre><code class="language-markdown">```python
+print("hi")
+```
 </code></pre>

--- a/tests/corpus/11-fenced-code-7.crv
+++ b/tests/corpus/11-fenced-code-7.crv
@@ -1,0 +1,4 @@
+```
+# not a heading
+/not italic/  *not bold*  #notatag
+```

--- a/tests/corpus/11-fenced-code-7.html
+++ b/tests/corpus/11-fenced-code-7.html
@@ -1,0 +1,3 @@
+<pre><code># not a heading
+/not italic/  *not bold*  #notatag
+</code></pre>

--- a/tests/spec/11-fenced-code.test
+++ b/tests/spec/11-fenced-code.test
@@ -11,6 +11,15 @@ print("hi")
 
 ````
 ```
+	indented with a tab
+```
+.
+<pre><code>	indented with a tab
+</code></pre>
+````
+
+````
+```
 plain text
 ```
 .


### PR DESCRIPTION
Aligns Carve on **preserving literal tabs** in code content (djot/CommonMark), with tab→space expansion moved to an opt-in extension (default 2 spaces).

## Rule
- Literal tabs in code blocks + inline code are **preserved verbatim** — a tab is not N spaces; display width is a CSS `tab-size` concern.
- Tab→space expansion is **not** a default. It is an opt-in tab-normalize extension: **flat** replacement (every tab = N spaces, no elastic tab-stops), **content only**, default **2 spaces** (djot-ish).

## Changes
- Grammar: NORMATIVE `TABS IN CODE` note under `code_content`.
- Examples + corpus: pinned a code block with a real tab byte → tab preserved.

Impl PRs: carve-php (default flip + `TabNormalizeExtension`), carve-js (`tabNormalize()` extension).