### PR TITLE
Docs highlighting: + is not a bullet; highlight the continuation marker

### DIFF
--- a/docs/.vitepress/syntaxes/carve.tmLanguage.json
+++ b/docs/.vitepress/syntaxes/carve.tmLanguage.json
@@ -18,6 +18,7 @@
     { "include": "#table_row" },
     { "include": "#multiline_cell" },
     { "include": "#task_item" },
+    { "include": "#list_continuation" },
     { "include": "#list_item" },
     { "include": "#numbered_item" },
     { "include": "#inline" }
@@ -152,7 +153,7 @@
       }
     },
     "task_item": {
-      "match": "^(\\s*)([-*+])\\s+(\\[)([ xX])(\\])\\s+",
+      "match": "^(\\s*)([-*])\\s+(\\[)([ xX])(\\])\\s+",
       "captures": {
         "2": { "name": "punctuation.definition.list.carve" },
         "3": { "name": "punctuation.definition.checkbox.carve" },
@@ -160,8 +161,15 @@
         "5": { "name": "punctuation.definition.checkbox.carve" }
       }
     },
+    "list_continuation": {
+      "comment": "A lone `+` at the list-marker column is the list-continuation marker (not a bullet -- `+` is never a bullet in Carve); it attaches the following flush-left block to the item.",
+      "match": "^(\\s*)(\\+)(\\s*)$",
+      "captures": {
+        "2": { "name": "punctuation.definition.list.continuation.carve" }
+      }
+    },
     "list_item": {
-      "match": "^(\\s*)([-*+])(\\s+)",
+      "match": "^(\\s*)([-*])(\\s+)",
       "captures": {
         "2": { "name": "punctuation.definition.list.unnumbered.carve" }
       }


### PR DESCRIPTION
**Draft.** Fixes the docs syntax-highlighting grammar; `+` is the list-continuation marker, not a bullet.

## Bugs

The VitePress docs grammar (`docs/.vitepress/syntaxes/carve.tmLanguage.json`):

1. **`+` highlighted as a bullet.** `list_item` / `task_item` matched `[-*+]`, so `+ item` got list-marker coloring. But `+` is never a bullet in Carve — `grammar.ebnf` has `bullet_marker = '-' | '*'`, and both impls render `+ item` as `<p>+ item</p>`. The highlighter contradicted the spec and the prose next to it ("Carve's bullet markers are `-` and `*` only").
2. **Lone `+` continuation marker unhighlighted.** The pattern required `marker + whitespace + content`, so a bare `+` line fell through — yet lone `+` is live in `examples.md` (the continuation-marker / compact-list sections) and `divergence-from-djot.md`.

## Fix

- `[-*+]` → `[-*]` in the bullet and task patterns.
- New `list_continuation` pattern for a lone `+` at the marker column.

JSON validates. Local deps aren't installed so the VitePress build wasn't run here — the docs build is the rendering gate.

Siblings get the same sweep (the `+`-as-bullet error is shared): vscode-carve, zed-carve, tree-sitter-carve.
