### PR TITLE
Docs: add Ecosystem and Build Your Own Implementation pages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -216,6 +216,13 @@ export default defineConfig({
           { text: 'Security', link: '/security' },
         ],
       },
+      {
+        text: 'Ecosystem',
+        items: [
+          { text: 'Implementations & Tooling', link: '/ecosystem' },
+          { text: 'Build Your Own', link: '/implementing-carve' },
+        ],
+      },
       { text: 'Case Study', link: '/case-study/' },
       { text: 'Design Notes', link: '/dismissed-syntax' },
     ],
@@ -242,6 +249,13 @@ export default defineConfig({
           { text: 'Carve vs Markdown/Djot/MDX', link: '/comparison' },
           { text: 'Markup Language Comparison', link: '/markup-languages' },
           { text: 'Security', link: '/security' },
+        ],
+      },
+      {
+        text: 'Ecosystem',
+        items: [
+          { text: 'Implementations & Tooling', link: '/ecosystem' },
+          { text: 'Build Your Own', link: '/implementing-carve' },
         ],
       },
       {

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,0 +1,53 @@
+# Ecosystem
+
+Everything that speaks Carve, grouped by role. All of it lives under the
+[markup-carve](https://github.com/markup-carve) organization. For live corpus
+conformance numbers of the reference parsers, see
+[Implementation Comparison](./implementation-comparison).
+
+## Parsers
+
+The engines that turn Carve source into an AST and HTML. Conformance is
+measured against the shared [spec corpus](https://github.com/markup-carve/carve);
+the bar for "a Carve implementation" is **Tier-1 core** (native syntax) - see
+[Build Your Own Implementation](./implementing-carve).
+
+| Project | Language | Status |
+|---|---|---|
+| [carve-js](https://github.com/markup-carve/carve-js) | TypeScript | Reference implementation. Tier-1 corpus passing. |
+| [carve-rs](https://github.com/markup-carve/carve-rs) | Rust | Parser + HTML renderer with a `carve` CLI. Tier-1 corpus passing. |
+| [carve-php](https://github.com/markup-carve/carve-php) | PHP | Forked from djot-php; syntax migration in progress. *Alpha.* |
+| [carve-wasm](https://github.com/markup-carve/carve-wasm) | WASM | Browser/Node bindings for carve-rs. *Early.* |
+
+## Editor support
+
+Syntax highlighting, structural editing, and diagnostics inside editors.
+
+| Project | Target | Status |
+|---|---|---|
+| [vscode-carve](https://github.com/markup-carve/vscode-carve) | VS Code | Highlighting, snippets, live preview. |
+| [zed-carve](https://github.com/markup-carve/zed-carve) | Zed | Editor support. |
+| [tree-sitter-carve](https://github.com/markup-carve/tree-sitter-carve) | Tree-sitter | Grammar for highlighting and structural editing. |
+| [carve-lsp](https://github.com/markup-carve/carve-lsp) | LSP | Language server - syntax diagnostics, Djot/Markdown collision hints. *Early.* |
+
+## Integrations
+
+Carve embedded in another tool or framework.
+
+| Project | Host | Status |
+|---|---|---|
+| [wp-carve](https://github.com/markup-carve/wp-carve) | WordPress | Plugin on the carve-php engine - live preview, multi-format paste, REST API. |
+| [carve-grammars](https://github.com/markup-carve/carve-grammars) | Tiptap | Editor kit and Carve serializer. |
+| [vite-plugin-carve](https://github.com/markup-carve/vite-plugin-carve) | Vite | Import `.carve` / `.crv` documents as rendered HTML. *Early.* |
+
+## Resources
+
+| Project | Description |
+|---|---|
+| [awesome-carve](https://github.com/markup-carve/awesome-carve) | Curated list of Carve tools, libraries, and resources. |
+
+---
+
+Building something new? See [Build Your Own Implementation](./implementing-carve).
+External tools are welcome in [awesome-carve](https://github.com/markup-carve/awesome-carve)
+even if they do not live in the org.

--- a/docs/implementing-carve.md
+++ b/docs/implementing-carve.md
@@ -1,0 +1,78 @@
+# Build Your Own Implementation
+
+Carve is designed to be re-implementable. The parsing is linear-time with no
+backtracking and no forward references, the rules are unambiguous, and there is
+a shared conformance corpus you can test against. This page is the starting
+point for writing a new parser, an editor integration, or a framework plugin -
+and for getting it adopted into the [markup-carve](https://github.com/markup-carve)
+organization.
+
+## The spec surface
+
+Everything normative lives in the [carve](https://github.com/markup-carve/carve)
+repository. In rough order of usefulness when implementing:
+
+- **[Spec corpus](https://github.com/markup-carve/carve)** - the `.crv` / `.html`
+  example pairs in the repo. This is the executable contract: your output for a
+  given input must match. It is the same corpus every reference parser runs
+  against.
+- **[Formal Grammar](./grammar)** - the block and inline grammar.
+- **[Case Study](./case-study/)** - design rationale and the syntax
+  specification, including [Parsing & AST](./case-study/parsing-ast) and
+  [Implementation & Reflection](./case-study/implementation).
+- **[Extensions Contract](./extensions)** - the normative contract for the
+  `:type[content]{attrs}` extension syntax (optional - see tiers below).
+- **[Edge Cases](./edge-cases)** and **[Divergence from Djot](./divergence-from-djot)**
+  - the corners where Carve makes a specific, tested choice.
+
+## Conformance tiers
+
+The bar to call something **a Carve implementation** is **Tier-1 core**: it
+parses and renders the native syntax correctly against the spec corpus.
+
+- **Tier-1 (core, required)** - native blocks and inlines: headings, paragraphs,
+  lists, blockquotes, fenced code, tables, frontmatter, captions, admonitions,
+  and the inline mnemonics (`/italic/`, `*bold*`, `_underline_`, `~strike~`,
+  `^sup^`, `,,sub,,`, `==highlight==`), links, images, attributes.
+- **Tier-2 (extensions and adapters, optional)** - the extension registry,
+  `:type[content]{attrs}` handlers, and host-specific adapters. Implementations
+  may omit these and still be conformant.
+
+A partial tool (highlighting-only, an editor grammar, a one-way converter) is
+still welcome in the ecosystem - it is listed on the [Ecosystem](./ecosystem)
+page with an honest status tag rather than claimed as a full implementation.
+
+## Testing against the corpus
+
+The corpus lives in the carve repo, which also owns the cross-implementation
+comparison runner (`scripts/compare-impls.mjs`). It runs sibling implementation
+checkouts against the same `.crv` / `.html` pairs and reports default
+conformance, optional Tier-2 adapter coverage, rough CLI timing, and the
+extension hook surface each implementation exposes. See
+[Implementation Comparison](./implementation-comparison) for the current
+snapshot and how the runner is wired.
+
+A new parser only needs to:
+
+1. Read each `.crv` input from the corpus.
+2. Produce HTML.
+3. Compare against the paired `.html`, normalizing trailing whitespace.
+
+## Getting your project into the org
+
+The org is curated, and the entry point is an issue - not a surprise transfer
+request.
+
+1. **Open an issue** on the [carve](https://github.com/markup-carve/carve) repo
+   describing what you are building (language/host, scope, which tier you target).
+   Start the conversation early; feedback before you are "done" is cheaper.
+2. **Build it** in your own namespace and get Tier-1 core passing against the
+   corpus (or, for editor/integration tooling, get it usefully working).
+3. **Request adoption** in that issue once it stands on its own. A maintainer
+   transfers or creates the repo under
+   [markup-carve](https://github.com/markup-carve) and adds it to the
+   [Ecosystem](./ecosystem) page.
+
+Not every tool needs to join the org. External projects are welcome in
+[awesome-carve](https://github.com/markup-carve/awesome-carve); the org is for
+the maintained core and first-party tooling.

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,6 +166,8 @@ block comment
 
 Carve is a design exploration. The specification lives in the [Case Study](./case-study/). Reference material covers the normative [extensions contract](./extensions), the [technical rationale](./technical-rationale), [parsing edge cases](./edge-cases), [native features](./native-features-analysis), and the [broader markup landscape](./markup-languages).
 
+Looking for a parser, editor plugin, or framework integration? See the [Ecosystem](./ecosystem). Want to write your own? Start with [Build Your Own Implementation](./implementing-carve).
+
 **File extension:** `.crv`
 
 ## Influences


### PR DESCRIPTION
## Summary

The docs site listed only the three reference parsers (via Implementation Comparison) and never enumerated the wider org ecosystem, nor explained how to write a new implementation. The org profile README was effectively ahead of the docs. This adds two pages to close that gap.

## New pages

- **Ecosystem** (`/ecosystem`) - directory of every markup-carve repo grouped by role: parsers, editor support, integrations, resources. Mirrors the org profile so the two stay in sync. Links to Implementation Comparison for live corpus numbers rather than duplicating them.
- **Build Your Own Implementation** (`/implementing-carve`) - the spec surface (corpus, grammar, extensions contract), conformance tiers (Tier-1 core required; Tier-2 extensions/adapters optional), how to test against the corpus with the comparison runner, and the open-an-issue path to org adoption.

## Wiring

- New **Ecosystem** group in both the nav dropdown and the sidebar.
- Discovery links from the home Status section.

Local `docs:build` passes (also gated by the new CI docs-build job).
