### PR TITLE
Docs: fix principle source attribution and table consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ COMMENTS
 
 ## Design Principles
 
-Carve inherits and extends Djot's rationale:
+Carve takes its rationale from Djot and Markdown, and extends both:
 
 ### From Djot
 
@@ -149,16 +149,20 @@ Carve inherits and extends Djot's rationale:
 3. **Simple emphasis** - Single characters, no complex disambiguation rules
 4. **No expressive blind spots** - All outputs achievable without workarounds
 5. **Simple list indentation** - Indented content belongs to the list item
-6. **Reduced parser complexity** - No HTML recognition, entity parsing, or case-folding
-7. **Markdown-like interruption** - A block opener on a new line starts a block, no blank line required (§10)
-8. **Uniform composition** - Content meaning consistent inside/outside containers
-9. **Arbitrary attributes** - `{#id .class key=value}` on any element
-10. **Generic containers** - Fenced divs (`:::`) for extensibility
-11. **Syntax simplicity** - One way to do things, no redundant syntax
+6. **Reduced parser complexity** - No HTML recognition, entity parsing, or case-folding during tokenization (heading-id slugs and reference matching are case-insensitive, but that is a resolve-time transform, not parsing)
+7. **Uniform composition** - Content meaning consistent inside/outside containers
+8. **Arbitrary attributes** - `{#id .class key=value}` on any element
+9. **Generic containers** - Fenced divs (`:::`) for extensibility
+10. **Syntax simplicity** - One way to do things, no redundant syntax
+11. **No invisible syntax** - No trailing-space hard breaks (Djot uses a visible end-of-line backslash) and no significant-whitespace tricks
+
+### From Markdown
+
+12. **Paragraph interruption** - A block opener on a new line starts a block, no blank line required (§10). Djot requires a blank line here; Carve follows Markdown instead.
 
 ### Carve Additions
 
-12. **Visual mnemonics** - Syntax characters suggest their output:
+13. **Visual mnemonics** - Syntax characters suggest their output:
     - `/italic/` - slashes lean like italic text
     - `*bold*` - asterisks are heavy/bold
     - `_underline_` - underscore is literally underneath
@@ -166,12 +170,10 @@ Carve inherits and extends Djot's rationale:
     - `^super^` - caret points up
     - `,,sub,,` - commas pull down
 
-13. **Five-Second Rule** - Syntax should be:
+14. **Five-Second Rule** - Syntax should be:
     - Learnable in 5 seconds for basic use
     - Memorable after 5 days without use
     - Unambiguous within 5 characters of context
-
-14. **No invisible syntax** - No trailing spaces, no significant whitespace tricks
 
 15. **Simpler tables** - `|=` marks headers (from Creole), no separator row required
 
@@ -214,7 +216,7 @@ Carve inherits and extends Djot's rationale:
 |---------|----------|------|------|
 | Links | `[text](url)` | `[text](url)` | `[text](url)` |
 | Wiki-style links | n/a (no auto wiki links) | `[Page Name][]` (reference link; needs a `[Page Name]: url` definition) | `[Page Name][]` (auto-resolves, no definition) |
-| Cross-references | n/a (manual `[](#id)`) | N/A (manual `[](#id)`) | `</#id>` (auto-fills link text from the target heading) |
+| Cross-references | n/a (manual `[](#id)`) | n/a (manual `[](#id)`) | `</#id>` (auto-fills link text from the target heading) |
 | Heading IDs | n/a (auto only on some renderers, e.g. GitHub) | Auto-generated (Unicode, case-preserving) | Auto-generated (lowercase, Unicode-preserving, CSS-selector-safe; opt-in ASCII fold) |
 | Heading structure | n/a (flat `<h1>`–`<h6>`, no wrappers) | `<section id="…"><h*>…</h*></section>` with level-aware nesting | `<section id="…"><h*>…</h*></section>` with level-aware nesting (matches djot — id on `<section>`, not on `<h*>`) |
 
@@ -226,10 +228,10 @@ Carve inherits and extends Djot's rationale:
 | Ordered list dialects | `1.` / `1)` (decimal only) | decimal/alpha/roman; `.` `)` `(1)` delimiters | decimal/alpha/roman; `.` `)` delimiters (`(1)` deliberately omitted — prose-ambiguity) |
 | Table headers | `\|---\|` separator (GFM) | `\|---\|` separator | `\|=` prefix |
 | Table alignment | `:--` / `--:` (GFM) | `:--` / `--:` separator | `\|=<` / `\|=>` / `\|=~` (column), `\|<` / `\|>` / `\|~` (cell) |
-| Headerless tables | n/a (header + separator required) | N/A (header + separator required) | omit `\|=` |
-| Table rowspan | n/a (raw HTML only) | N/A (raw HTML only) | `^` marker |
-| Table colspan | n/a (raw HTML only) | N/A (raw HTML only) | `<` marker |
-| Multi-line cells | n/a (raw HTML only) | N/A (raw HTML only) | `+` continuation |
+| Headerless tables | n/a (header + separator required) | n/a (header + separator required) | omit `\|=` |
+| Table rowspan | n/a (raw HTML only) | n/a (raw HTML only) | `^` marker |
+| Table colspan | n/a (raw HTML only) | n/a (raw HTML only) | `<` marker |
+| Multi-line cells | n/a (raw HTML only) | n/a (raw HTML only) | `+` continuation |
 | Captions | n/a | Tables only (`^ caption`) | `^ caption` (images, quotes, tables) |
 
 ### Blocks & structure
@@ -243,8 +245,8 @@ Carve inherits and extends Djot's rationale:
 | Editorial markup | n/a | `{+ +}` `{- -}` `{= =}` | `{+ +}` `{- -}` `{~ ~> ~}` `{= =}` `{# #}` |
 | Comments | `<!-- … -->` (HTML) | `{% … %}` | `%%` line / `text %% trailing` / `%%%` block |
 | Raw / passthrough | inline / block HTML | inline `` `…`{=html} `` + ` ```=html ` block | inline `` `…`{=html} `` + ` ```raw html ` block |
-| Includes | n/a | N/A | `{{ path/to/file }}` |
-| Abbreviations | n/a (PHP-Markdown ext: `*[ABBR]: ...`) | N/A | `*[ABBR]: ...` |
+| Includes | n/a | n/a | `{{ path/to/file }}` |
+| Abbreviations | n/a (PHP-Markdown ext: `*[ABBR]: ...`) | n/a | `*[ABBR]: ...` |
 | Attributes | n/a | `{.class}` | `{.class}` |
 
 ### Social & extensibility
@@ -252,8 +254,8 @@ Carve inherits and extends Djot's rationale:
 | Feature | Markdown | Djot | Carve |
 |---------|----------|------|------|
 | Extensions | n/a | Fenced divs | `:type[content]{attrs}` |
-| Mentions | n/a (auto-linked on GitHub only) | N/A | `@user` |
-| Tags | n/a | N/A | `#tag` |
+| Mentions | n/a (auto-linked on GitHub only) | n/a | `@user` |
+| Tags | n/a | n/a | `#tag` |
 
 ### Mention and tag rendering
 

--- a/README.md
+++ b/README.md
@@ -175,17 +175,29 @@ Carve takes its rationale from Djot and Markdown, and extends both:
     - Memorable after 5 days without use
     - Unambiguous within 5 characters of context
 
-15. **Simpler tables** - `|=` marks headers (from Creole), no separator row required
+15. **Cross-references** - `</#id>` auto-fills its link text from the target heading (neither Markdown nor Djot offers this natively)
 
-16. **Table spanning** - `^` for rowspan, `<` for colspan, `+` for multi-line cells
+16. **Auto-resolving wiki links** - `[Page Name][]` resolves to a heading with no separate `[Page Name]: url` definition
 
-17. **Captions** - `^` prefix adds captions to images, blockquotes, and tables
+17. **GitHub-style heading ids** - lowercase, Unicode-preserving, case-insensitive anchors by default; opt-in ASCII fold for share-safe URL fragments
 
-18. **Abbreviations** - `*[ABBR]: expansion` for automatic `<abbr>` tags
+18. **Simpler tables** - `|=` marks headers (from Creole), no separator row required
 
-19. **Social integration** - `@mentions` and `#tags` are built into the syntax
+19. **Table spanning** - `^` for rowspan, `<` for colspan, `+` for multi-line cells
 
-20. **Extension system** - `:type[content]{attrs}` for custom inline elements
+20. **Captions** - `^` prefix adds captions to images, blockquotes, and tables
+
+21. **Admonitions** - two-tier fenced divs (`::: word`): canonical names render to `<aside>`, custom to `<div class=word>`
+
+22. **Abbreviations** - `*[ABBR]: expansion` for automatic `<abbr>` tags
+
+23. **Comments** - visible `%%` line, `text %% trailing`, and `%%%` block comments (not HTML comments)
+
+24. **Social integration** - `@mentions` and `#tags` are built into the syntax
+
+25. **Extension system** - `:type[content]{attrs}` for custom inline elements
+
+26. **Target-aware rendering** - one parsed document emits to HTML, ANSI, Markdown, or plain text by swapping the renderer
 
 ## Comparison with Markdown and Djot
 

--- a/README.md
+++ b/README.md
@@ -187,17 +187,19 @@ Carve takes its rationale from Djot and Markdown, and extends both:
 
 20. **Captions** - `^` prefix adds captions to images, blockquotes, and tables
 
-21. **Admonitions** - two-tier fenced divs (`::: word`): canonical names render to `<aside>`, custom to `<div class=word>`
+21. **List continuation** - a lone `+` attaches a flush-left block (code, table, quote) to the current list item with no indentation, keeping the item tight; `+` is the continuation marker, not a bullet
 
-22. **Abbreviations** - `*[ABBR]: expansion` for automatic `<abbr>` tags
+22. **Admonitions** - two-tier fenced divs (`::: word`): canonical names render to `<aside>`, custom to `<div class=word>`
 
-23. **Comments** - visible `%%` line, `text %% trailing`, and `%%%` block comments (not HTML comments)
+23. **Abbreviations** - `*[ABBR]: expansion` for automatic `<abbr>` tags
 
-24. **Social integration** - `@mentions` and `#tags` are built into the syntax
+24. **Comments** - visible `%%` line, `text %% trailing`, and `%%%` block comments (not HTML comments)
 
-25. **Extension system** - `:type[content]{attrs}` for custom inline elements
+25. **Social integration** - `@mentions` and `#tags` are built into the syntax
 
-26. **Target-aware rendering** - one parsed document emits to HTML, ANSI, Markdown, or plain text by swapping the renderer
+26. **Extension system** - `:type[content]{attrs}` for custom inline elements
+
+27. **Target-aware rendering** - one parsed document emits to HTML, ANSI, Markdown, or plain text by swapping the renderer
 
 ## Comparison with Markdown and Djot
 


### PR DESCRIPTION
Follow-up to the README review. Source-bucket corrections, consistency fixes, and the missing Carve additions.

## Source-bucket fixes
- **Paragraph interruption** moved out of `### From Djot` into a new `### From Markdown`. Djot requires a blank line between blocks; the no-blank-line interruption is Markdown-derived (Carve aligns with the post-Markdown spec, section 10), so it contradicted the `From Djot` header.
- **No invisible syntax / no trailing-space hard breaks** moved *into* `### From Djot`. Dropping Markdown's invisible two-space hard break for a visible end-of-line backslash is a Djot inheritance, not a Carve original.

## Missing Carve additions
The Carve Additions list omitted features the README already headlines in "Why Carve?" and the comparison tables. Added so the list is self-consistent:
- Cross-references (`</#id>` auto-text)
- Auto-resolving wiki links (`[Page Name][]`)
- GitHub-style lowercase, case-insensitive heading ids
- List continuation (`+` attaches a flush-left block to a list item with no indentation)
- Admonitions (two-tier `::: word` divs to `<aside>`)
- Comments (`%%` / `%%%`)
- Target-aware rendering (HTML / ANSI / Markdown / plain text)

The `+` continuation was verified to remain useful under the new interrupt default: the two are orthogonal. Interrupt governs the no-blank-line block boundary; `+` governs flush-left attachment to the item. Without `+`, a flush-left block after a list item escapes to the top level (confirmed by parsing against current main), so `+` is the explicit keep-it-tight override.

## Other logic/consistency fixes
- Scoped "no case-folding" to tokenization, so it no longer reads as contradicting Carve's lowercase, case-insensitive heading ids (a resolve-time transform).
- Reworded the section intro to credit both Djot and Markdown.
- Normalized the Djot column's `N/A` to `n/a` (9 cells) to match the table legend.

Numbering stays continuous (1-27). Five-Second Rule was checked and left under Carve Additions (it is not a Djot principle). `` ```raw html `` was verified correct per spec section 4.15 and left as-is.