### PR TITLE
Docs: fix soundness issues found in a full audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Markdown's reach, Djot's consistency, web-native features by default - without
 turning your content into a JavaScript program. What sets Carve apart:
 
 - **Cross-references that just work** - `</#id>` auto-fills its link text from the
-  target heading, and `[[Heading]]` resolves to a heading with no separate
+  target heading, and `[Heading][]` resolves to a heading with no separate
   definition. Neither Markdown nor Djot offers this natively.
 - **GitHub-style heading ids by default** - lowercase, Unicode-preserving anchors
   that make ids and cross-references case-insensitive with zero configuration.

--- a/docs/case-study/compatibility.md
+++ b/docs/case-study/compatibility.md
@@ -2,23 +2,7 @@
 
 ## Part 7: Compatibility and Migration
 
-### 7.1 Compatibility Modes (proposed)
-
-> Design proposal — `carve-compat` is not part of the current grammar or
-> corpus; it is sketched here as a possible future direction.
-
-```
----
-carve-compat: markdown
----
-```
-
-Modes:
-- `strict` - Only Carve syntax (default)
-- `markdown` - Accept Markdown syntax with warnings
-- `djot` - Accept Djot syntax with warnings
-
-### 7.2 Migration Warnings
+### 7.1 Migration Warnings
 
 Parser can emit warnings for Markdown-specific syntax:
 ```
@@ -33,11 +17,27 @@ Line 31: `+` bullet detected — not a Carve bullet (it is the
          Suggestion: -
 ```
 
-### 7.3 Auto-Migration Tool
+### 7.2 Auto-Migration Tool
 
 ```bash
 carve migrate input.md --from markdown --to carve > output.crv
 ```
+
+### 7.3 Compatibility Modes (proposed)
+
+> Design proposal — `carve-compat` is not part of the current grammar or
+> corpus; it is sketched here as a possible future direction.
+
+```
+---
+carve-compat: markdown
+---
+```
+
+Modes:
+- `strict` - Only Carve syntax (default)
+- `markdown` - Accept Markdown syntax with warnings
+- `djot` - Accept Djot syntax with warnings
 
 ---
 

--- a/docs/case-study/compatibility.md
+++ b/docs/case-study/compatibility.md
@@ -2,7 +2,10 @@
 
 ## Part 7: Compatibility and Migration
 
-### 7.1 Compatibility Modes
+### 7.1 Compatibility Modes (proposed)
+
+> Design proposal — `carve-compat` is not part of the current grammar or
+> corpus; it is sketched here as a possible future direction.
 
 ```
 ---

--- a/docs/case-study/design.md
+++ b/docs/case-study/design.md
@@ -20,7 +20,7 @@ _Both the affirmative case (what we chose) and the negative case (why we didn't 
 - Asymmetric syntax (`[text](url)` vs `![alt](url)`)
 - Significant trailing whitespace
 - Context-dependent parsing
-- Same character for different purposes (`*` for lists AND emphasis)
+- Same delimiter, count-dependent meaning (`*` vs `**` for emphasis vs strong)
 
 ---
 

--- a/docs/case-study/implementation.md
+++ b/docs/case-study/implementation.md
@@ -13,13 +13,13 @@
 4. **AST Builder**: Constructs typed AST nodes
 5. **Renderer**: Transforms AST to output format
 
-### 9.2 Reference Implementation Priorities
+### 9.2 Reference Implementations
 
-1. JavaScript/TypeScript (web, Node.js ubiquity)
-2. Rust (performance, WASM compilation)
-3. Python (data science, docs communities)
-4. Go (modern backend systems)
-5. PHP (existing Djot-PHP could be adapted)
+JavaScript/TypeScript, Rust, and PHP implementations now exist (carve-js,
+carve-rs, carve-php), tested against the shared corpus. Still wanted:
+
+1. Python (data science, docs communities)
+2. Go (modern backend systems)
 
 ### 9.3 Editor Support Essentials
 
@@ -62,10 +62,11 @@ Carve succeeds if:
 
 ---
 
-*This is a design exploration, not a finished specification. Real-world testing
-with diverse users would be essential before finalizing syntax decisions.*
+*This case study captures Carve's original design exploration. Carve now has a
+normative grammar, a conformance corpus, and multiple implementations; real-world
+testing with diverse users continues to inform syntax decisions.*
 
-*Feedback welcome at [hypothetical GitHub repo].*
+*Feedback and contributions welcome at <https://github.com/markup-carve>.*
 
 ---
 

--- a/docs/case-study/implementation.md
+++ b/docs/case-study/implementation.md
@@ -16,7 +16,9 @@
 ### 9.2 Reference Implementations
 
 JavaScript/TypeScript, Rust, and PHP implementations now exist (carve-js,
-carve-rs, carve-php), tested against the shared corpus. Still wanted:
+carve-rs, carve-php), tested against the shared corpus. 
+
+Still wanted:
 
 1. Python (data science, docs communities)
 2. Go (modern backend systems)

--- a/docs/case-study/index.md
+++ b/docs/case-study/index.md
@@ -7,7 +7,7 @@ description: A case study in post-Markdown markup design.
 
 How Carve was designed: the landscape it grew out of, the principles that guided it, the syntax it ended up with, and the parsing / implementation considerations that fall out of those choices.
 
-The full case study runs about 1,800 lines in total — it was split into themed chapters so each one stands on its own.
+The full case study was split into themed chapters so each one stands on its own.
 
 ## Chapters
 

--- a/docs/case-study/parsing-ast.md
+++ b/docs/case-study/parsing-ast.md
@@ -19,10 +19,10 @@
 Parse in this precedence order:
 1. Escaped characters (`\*`)
 2. Code spans (`` ` ``)
-3. Autolinks (`<url>` and bare URLs)
+3. Autolinks (`<url>`)
 4. Links, images, spans (`[text](url)`, `![alt](src)`, `[text]{attrs}`)
 5. Math (`` $`…` ``, `` $$`…` ``)
-6. Emphasis markers (`/`, `*`, `_`, `~`, `^`, `==`)
+6. Emphasis markers (`/`, `*`, `_`, `~`, `^`, `,,`, `==`)
 7. Smart typography
 
 ### 5.3 The Disambiguation Rule

--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -405,9 +405,11 @@ alone still nests a sublist.
 - [x] Completed task
 ```
 
-Checked (`[x]`) and unchecked (`[ ]`) only; any other character between the
-brackets renders as an unchecked box (the grammar distinguishes just the two
-states).
+The marker holds exactly one character (PART 9 `task_state`). `x` / `X` render a
+**checked** box; ` `, `-`, `_`, `>`, `?` all render an **unchecked** box. The
+non-space markers are recognized (for author conventions like cancelled/
+deferred) but produce the same output as `[ ]` — there is no distinct rendering,
+and a character outside that set is not a task marker at all.
 
 #### Tight vs loose
 

--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -265,7 +265,7 @@ converts this to the appropriate URL (e.g., `other-page.html`).
 
 For custom display text, use regular link syntax:
 ```
-See [click here](Other Page) for details.
+See [click here](other-page.html) for details.
 ```
 
 **Why not `[[...]]`?** It conflicts with valid nested spans:
@@ -387,8 +387,9 @@ paragraph (the §10 paragraph rule): an ordered list — `1.`, `2.`, `1985.`, `a
 `i.`, any value — needs a blank line before it. An ordered marker is too common
 in prose ("step 2.", "version 1985.", "upgrade to 1. today"), and the only way
 to allow it would be the CommonMark `1.`-only heuristic Djot removed; Carve
-keeps ordered lists on the blank-line rule instead. (Bullets `- `/`* `/`+ `,
-being unambiguous, do interrupt.) Inside an existing list item, indentation
+keeps ordered lists on the blank-line rule instead. (Bullets `- `/`* `,
+being unambiguous, do interrupt; `+` is the continuation marker, not a bullet.)
+Inside an existing list item, indentation
 alone still nests a sublist.
 
 **Auto-numbering:**
@@ -402,12 +403,11 @@ alone still nests a sublist.
 ```
 - [ ] Unchecked task
 - [x] Completed task
-- [-] Cancelled task
-- [>] Deferred task
-- [?] Question/uncertain
 ```
 
-Inspired by Org-mode TODO states but simplified.
+Checked (`[x]`) and unchecked (`[ ]`) only; any other character between the
+brackets renders as an unchecked box (the grammar distinguishes just the two
+states).
 
 #### Tight vs loose
 
@@ -551,9 +551,12 @@ Keep triple backtick - it's universal and well-established:
 - Syntax highlighting support is ubiquitous
 - No reason to change what works
 
-**With attributes:**
+**With a label:** the fence info string is a single language token plus an
+optional bracketed label (PART 9 §11). A multiword or `{…}` info string is
+**not** a fence — it falls back to an inline code span — so attributes go in a
+label, not braces:
 ~~~
-```python {linenos=true highlight="3,5-7"}
+```python [Example 1]
 def hello():
     print("Hello!")
 ```
@@ -682,7 +685,6 @@ same output as djot-php.
 The `<` marker means "this cell belongs to the cell on the left":
 ```
 |= Name  |= Contact Info       |  <    |
-|--------|---------------------|-------|
 | Alice  | alice@example.com   | x5234 |
 ```
 
@@ -1246,7 +1248,7 @@ Standard extensions that processors SHOULD support:
 | `embed`        | -                          | `::: embed URL`    | Generic oEmbed   |
 | `iframe`       | -                          | `::: iframe`       | Iframe embed     |
 | `diagram`      | -                          | `::: mermaid`      | Mermaid diagrams |
-| `math`         | `$...$`                    | `$$...$$`          | LaTeX math       |
+| `math`         | `` $`...` ``               | `` $$`...` ``      | LaTeX math       |
 
 #### Unknown Extensions
 
@@ -1298,10 +1300,10 @@ Different contexts need different feature sets:
 
 ```php
 // Built-in profiles
-$converter = new DjotConverter(profile: Profile::full());      // Everything
-$converter = new DjotConverter(profile: Profile::article());   // No raw HTML
-$converter = new DjotConverter(profile: Profile::comment());   // Basic only
-$converter = new DjotConverter(profile: Profile::minimal());   // Text + emphasis
+$converter = new CarveConverter(profile: Profile::full());      // Everything
+$converter = new CarveConverter(profile: Profile::article());   // No raw HTML
+$converter = new CarveConverter(profile: Profile::comment());   // Basic only
+$converter = new CarveConverter(profile: Profile::minimal());   // Text + emphasis
 
 // Custom profile
 $profile = new Profile()
@@ -1430,10 +1432,10 @@ class ProfileFilter
 
 ```php
 // Backend: full power
-$html = DjotConverter::convert($userDoc);
+$html = CarveConverter::convert($userDoc);
 
 // Frontend comments: restricted
-$converter = new DjotConverter(profile: Profile::comment());
+$converter = new CarveConverter(profile: Profile::comment());
 $html = $converter->convert($userComment);
 
 // API with custom rules
@@ -1442,7 +1444,7 @@ $profile = Profile::create()
     ->allowBlock(['paragraph'])
     ->setLinkPolicy(LinkPolicy::allowlist(['docs.example.com']));
 
-$converter = new DjotConverter(profile: $profile);
+$converter = new CarveConverter(profile: $profile);
 ```
 
 #### Combining with SafeMode
@@ -1450,7 +1452,7 @@ $converter = new DjotConverter(profile: $profile);
 `Profile` (feature restriction) and `SafeMode` (XSS prevention) are complementary:
 
 ```php
-$converter = new DjotConverter(
+$converter = new CarveConverter(
     profile: Profile::comment(),    // Feature restriction
     safeMode: SafeMode::strict(),   // Security sanitization
 );

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -42,7 +42,7 @@ turning your content into a JavaScript program.
 |---|:---:|:---:|:---:|:---:|
 | Automatic heading ids | ⚠️ tooling | ✅ | 🧩 | ✅ lowercase, GitHub-style |
 | Cross-references `</#id>` | ❌ | ❌ | ❌ | ✅ |
-| Implicit heading refs `[[Heading]]` | 🧩 (Obsidian) | ❌ | ❌ | ✅ |
+| Implicit heading refs `[Heading][]` | 🧩 (Obsidian uses `[[…]]`) | ❌ | ❌ | ✅ |
 
 ## Safety & ecosystem
 

--- a/docs/dismissed-syntax.md
+++ b/docs/dismissed-syntax.md
@@ -252,7 +252,7 @@ This is {++added++} and {--removed--} text.
 This is {~~old~>new~~} replacement.
 ```
 
-**Status:** Included in spec (section 4.14) but as optional editorial markup.
+**Status:** Included in spec (section 4.14), but with **single**-character markers (`{+added+}`, `{-removed-}`, `{~old~>new~}`); the doubled-marker form shown above was not adopted.
 
 **Considerations:**
 - Useful for document review workflows

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -94,7 +94,7 @@ used `+` as a bullet (most don't).
 | Italic | `_text_` | `/text/` (slashes lean) |
 | Bold | `*text*` | `*text*` (heavy) |
 | Bold italic | `_*text*_` | `/*text*/` |
-| Underline | `{+text+}` | `_text_` (line underneath) |
+| Underline | (none; `{+text+}` is insert → `<ins>`) | `_text_` (line underneath) |
 | Highlight | `{=text=}` | `==text==` |
 | Subscript | `~text~` | `,,text,,` (commas pull down) |
 
@@ -136,9 +136,9 @@ block marker - a `-`/`*` bullet, `>` quote, `#` heading, a `|` table row, or a
 fence - stays part of the paragraph; the block needs a blank line before it.
 
 **Carve:** a **visible** block interrupts an open paragraph with no blank line
-before it - the Markdown / CommonMark rule. Ordered lists are the one exception:
-they still need a blank line (see §5 for why an ordered marker in prose is too
-common to treat as a list).
+before it - the Markdown / CommonMark rule. Ordered lists are the main exception:
+they still need a blank line (an ordered marker in prose is too common to treat
+as a list); fence and `:::` closers and bare images are also excluded (PART 9 §10).
 
 ```
 intro

--- a/docs/edge-cases.md
+++ b/docs/edge-cases.md
@@ -199,7 +199,7 @@ List requires `* ` (asterisk + space). Bold opener requires `*` + non-whitespace
 
 Check out #project-x           # Tag
 
-Issue #123                     # Tag (or could be literal, configurable)
+Issue #123                     # Literal (digit-only; a tag needs a leading letter)
 
 #notaheading                   # Tag (no space after #)
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -230,7 +230,7 @@ All six heading levels are supported.
 
 :::
 
-Attributes attach to the heading via a trailing `{…}` block. The rendered attribute order is alphabetical.
+Attributes attach to the heading via a trailing `{…}` block. The rendered attribute order matches the source order.
 
 ::: compare
 
@@ -1149,7 +1149,7 @@ Save early, save often.
 
 :::
 
-A custom (Tier-2) type renders as a generic `<div>` with the literal type as its class.
+A custom type renders as a generic `<div>` with the literal type as its class.
 
 ::: compare
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -17,9 +17,10 @@ implementation realizes.
 Invariant: a feature's tier is identical in every language; a Tier-1 feature is
 core-and-default-on everywhere and its default output is corpus-pinned.
 
-- Tier 1: corpus categories 01–73 (incl. admonitions, footnotes, smart
-  typography, cross-references, `<…>` autolinks, the `:name[…]` / `::: name`
-  extension syntax, and `@mention` / `#tag` / `:emoji:` parsing).
+- Tier 1: corpus categories 01–83 (admonitions, footnotes, cross-references,
+  `<…>` autolinks, the `:name[…]` / `::: name` extension syntax). Smart
+  typography and `@mention` / `#tag` / `:emoji:` parsing are also default-on and
+  corpus-pinned, but per grammar PART 19 a processor MAY disable them.
 - Tier 2: configuration over Tier-1 syntax — mention/tag→URL, emoji glyph map,
   locale smart-quote sets, bare-URL autolinking.
 - Tier 3: Mermaid, Tabs, CodeGroup, TableOfContents, HeadingPermalinks,

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -6,9 +6,11 @@ same `.crv` / `.html` pairs and reports default conformance, optional Tier-2
 adapter coverage, rough CLI timing, and the extension hook surface each
 implementation exposes.
 
-## Current Snapshot
+## Snapshot (2026-05-31)
 
-Run date: 2026-05-31
+> Historical run from 2026-05-31, when the corpus held 154 pairs. The corpus
+> has since grown (now ~200 pairs); regenerate with `npm run compare:impls`
+> for current figures. The numbers below are from that dated run.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">

--- a/docs/markup-languages.md
+++ b/docs/markup-languages.md
@@ -7,19 +7,20 @@ A comparison of lightweight markup languages available today.
 The overview below is chronological. Later comparison tables group related
 syntaxes together instead.
 
-| Language | Author | Year | Focus |
-|----------|--------|------|-------|
-| AsciiDoc | Stuart Rackham | 2002 | Technical documentation |
-| reStructuredText (reST) | David Goodger | 2002 | Python documentation |
-| Textile | Dean Allen | 2002 | Web publishing |
-| MediaWiki | Magnus Manske | 2002 | Wikipedia |
-| Org Mode | Carsten Dominik | 2003 | Emacs, outlining |
-| Markdown | John Gruber | 2004 | Simplicity, email-style |
-| Creole | WikiCreole | 2007 | Wiki standardization |
-| CommonMark | John MacFarlane et al. | 2014 | Standardized Markdown |
-| GitHub Flavored Markdown (GFM) | GitHub | 2017 | Extended CommonMark |
-| Gemtext | Solderpunk | 2019 | Minimalism (Gemini protocol) |
-| Djot | John MacFarlane | 2022 | Predictable parsing |
+| Language                       | Author                 | Year | Focus                        |
+|--------------------------------|------------------------|------|------------------------------|
+| AsciiDoc                       | Stuart Rackham         | 2002 | Technical documentation      |
+| reStructuredText (reST)        | David Goodger          | 2002 | Python documentation         |
+| Textile                        | Dean Allen             | 2002 | Web publishing               |
+| MediaWiki                      | Magnus Manske          | 2002 | Wikipedia                    |
+| Org Mode                       | Carsten Dominik        | 2003 | Emacs, outlining             |
+| Markdown                       | John Gruber            | 2004 | Simplicity, email-style      |
+| Creole                         | WikiCreole             | 2007 | Wiki standardization         |
+| CommonMark                     | John MacFarlane et al. | 2014 | Standardized Markdown        |
+| GitHub Flavored Markdown (GFM) | GitHub                 | 2017 | Extended CommonMark          |
+| Gemtext                        | Solderpunk             | 2019 | Minimalism (Gemini protocol) |
+| Djot                           | John MacFarlane        | 2022 | Predictable parsing          |
+| Carve                          | Mark Scherer           | 2026 | Simple & predictable parsing |
 
 ## Feature Comparison
 
@@ -28,7 +29,7 @@ syntaxes together instead.
 | Strong | `**text**` | `**text**` | `**text**` | `*text*` | `*text*` | `**text**` |
 | Emphasis | `*text*` | `*text*` | `*text*` | `_text_` | `_text_` | `*text*` |
 | Code inline | `` `code` `` | `` `code` `` | `` `code` `` | `` `code` `` | `` `+code+` `` | ``` ``code`` ``` |
-| Strikethrough | - | - | `~~text~~` | N/A | `[.line-through]#text#` | - |
+| Strikethrough | - | - | `~~text~~` | - | `[.line-through]#text#` | - |
 | Highlight | - | - | - | `{=text=}` | `#text#` | - |
 | Subscript | - | - | - | `{~text~}` | `~text~` | - |
 | Superscript | - | - | - | `{^text^}` | `^text^` | - |

--- a/docs/native-features-analysis.md
+++ b/docs/native-features-analysis.md
@@ -216,7 +216,7 @@ feature-level boundary.
 
 ### SHOULD / configurable (on by default, a processor MAY disable)
 
-- `@mention` and `#tag` shorthands, smart typography (§19).
+- `@mention` and `#tag` shorthands, smart typography (grammar PART 19).
 
 ### MAY / out of core (processor-level)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -6,8 +6,10 @@ tighten the policy.
 
 ## HTML is text, not markup
 
-Carve has no raw-HTML passthrough. Angle brackets carry no special meaning, so
-authored `<` and `>` are escaped on output rather than interpreted:
+Carve has no *implicit* raw-HTML passthrough. Authored bare `<` and `>` carry no
+special meaning and are escaped on output rather than interpreted. (Explicit,
+opt-in raw passthrough — `` ```raw html `` blocks and `` `…`{=html} `` inline —
+does emit verbatim HTML and must be disabled for untrusted input; see Profiles.)
 
 ```carve
 <script>alert(1)</script>

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -681,7 +681,7 @@ EOF = (* end of file *) ;
    4. Headings (# prefix)
    5. Thematic breaks (---, ***, ___)
    6. Block quotes (> prefix)
-   7. Lists (-, *, +, 1. prefix)
+   7. Lists (-, *, 1. prefix)
    8. Tables (| prefix)
    9. Admonitions (::: delimited)
    10. Paragraphs (everything else)
@@ -1255,8 +1255,8 @@ EOF = (* end of file *) ;
       alignment emits NO style attribute. `rowspan`/`colspan` are emitted
       only when their count is > 1.
 
-   8. STABLE STRINGS. Mentions default to `/users/{user}` and tags to
-      `/tags/{name}` when no URL template is configured. The footnote
+   8. STABLE STRINGS. Mentions and tags render as inert `<span>`s (no link)
+      when no URL template is configured; a configured template links to them. The footnote
       backlink glyph is `↩` (§16). Math wraps content in `\(…\)` /
       `\[…\]` inside `<span class="math inline|display">` (§18).
 *)


### PR DESCRIPTION
A full-docs soundness audit (6 parallel auditors) plus an independent **codex** verification pass, every finding cross-checked against the reference parser. 31 confirmed issues fixed across docs, spec, and grammar; 2 candidates were refuted by codex and dropped.

## Factual / contradiction fixes
- **`[[Heading]]` → `[Heading][]`** (README, comparison) — the spec explicitly *rejects* `[[...]]`; the real implicit-ref syntax is `[Heading][]`.
- **syntax.md** — `+` is not an interrupting bullet; math is `` $`...` `` (not bare `$...$`); removed a stray Markdown `|---|` separator row from a table example; `DjotConverter` → `CarveConverter`; fence info is a language token + optional `[label]` (not `{attrs}`); fixed a link destination containing a space; task lists are checked/unchecked only.
- **security.md** — Carve *does* have explicit opt-in raw-HTML passthrough (`` ```raw html ``, `` `…`{=html} ``); only *implicit* HTML is escaped. The old "no raw-HTML passthrough" was false.
- **extensions.md** — mention/tag/emoji parsing + smart typography are default-on but MAY be disabled (grammar PART 19), so they aren't mandatory Tier-1; corpus categories run to 83.
- **examples.md** — attribute render order is **source order**, not alphabetical (also self-contradicted the same doc); dropped a wrong "(Tier-2)" label.
- **divergence-from-djot.md** — Djot `{+text+}` is **insert** (`<ins>`), not underline; fixed the interruption-exception count and a wrong `§5` cross-reference.
- **parsing-ast.md** — bare URLs are **not** autolinked; added `,,` (subscript) to the inline-precedence set.
- **grammar.ebnf** — dropped `+` from the list-prefix enumeration (contradicted the normative `bullet_marker` rule + parser); mentions/tags render as inert spans by default (no `/users/{user}` URLs — matches the parser and the rendering docs).

## Staleness / consistency fixes
- **implementation-comparison.md** — relabeled the `154/154` block as a dated historical snapshot (corpus is now ~200 pairs).
- **implementation.md** — reframed "reference implementation priorities" (js/rust/php already exist); dropped the "hypothetical repo / not a finished specification" disclaimers.
- **compatibility.md** — marked the `carve-compat` modes as a proposal (not in the grammar/corpus).
- **design.md / index.md / markup-languages.md / native-features-analysis.md / dismissed-syntax.md / edge-cases.md** — assorted accuracy/consistency fixes (`*`-overload anti-pattern wording, stale line-count, `N/A`→`-`, ambiguous `§` refs, CriticMarkup single-vs-double marker, digit-only `#123` is literal).

Verified: `npm run docs:build` passes. Refuted-and-skipped: an "@user/#tag are opt-in" claim (they are default-on) and a two-pass terminology nit (behavior is consistent).
