### PR TITLE
Docs: inline/sidenote footnotes are deferred core syntax, not Tier 3

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -24,8 +24,12 @@ core-and-default-on everywhere and its default output is corpus-pinned.
 - Tier 2: configuration over Tier-1 syntax — mention/tag→URL, emoji glyph map,
   locale smart-quote sets, bare-URL autolinking.
 - Tier 3: Mermaid, Tabs, CodeGroup, TableOfContents, HeadingPermalinks,
-  HeadingLevelShift, ExternalLinks, DefaultAttributes, Wikilinks, InlineFootnotes
-  (`.fn`), SemanticSpan.
+  HeadingLevelShift, ExternalLinks, DefaultAttributes, Wikilinks, SemanticSpan.
+
+Inline and sidenote footnotes are **not** Tier 3. They are deferred core
+reserved syntax (`[^…]` inline, `[>…]` sidenote; `resources/grammar.ebnf`
+PART 9 §16), not an app extension. The djot-php `[…]{.fn}` form maps onto
+carve's `[^…]`; see `native-features-analysis.md`.
 
 ## 2. Extension system
 


### PR DESCRIPTION
## Problem

The extension taxonomy in `docs/extensions.md` listed `InlineFootnotes (.fn)` as a **Tier-3 app extension**, contradicting two normative sources:

- `resources/grammar.ebnf` PART 9 §16 reserves `[^…]` (inline) / `[>…]` (sidenote) as **deferred core** syntax, not an app extension.
- `docs/native-features-analysis.md` (L50) labels `[…]{.fn}` the **djot-php** form that maps onto carve's `[^…]` — so `.fn` is not carve's syntax either.

So one feature was described as both Tier-3 (`.fn`) and deferred core (`[^…]`), with two different syntaxes.

## Fix

Align the outlier (`extensions.md`) to the normative grammar:

- Remove `InlineFootnotes (.fn)` from the Tier-3 list.
- Add a one-line note that inline/sidenote footnotes are deferred core reserved syntax (`[^…]` / `[>…]`), with a pointer to the grammar and the `.fn` mapping.

Docs-only. VitePress build passes locally.
