### PR TITLE
Spec: inline footnotes ^[content]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ docs/.vitepress/.temp/
 
 # Scratch files and working plans (underscore-prefixed) - never versioned
 _*
+
+# Superpowers working docs (specs/plans) - never versioned
+docs/superpowers/

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -168,6 +168,9 @@ as more than restyled Djot:
 - **Tables with rowspan / colspan / multi-line cells** and captions on images,
   quotes, and tables.
 - **Native admonitions**, editorial/critic markup, `@mentions`, and `#tags`.
+- **Inline footnotes** - `^[content]` carries a note in place (pandoc-style),
+  numbered into the same endnotes as a reference `[^label]`. Canonical djot has
+  only reference footnotes; `^[…]` is a carve addition (grammar §16).
 - **Target-aware rendering** - one parsed document, multiple renderers (HTML,
   ANSI, Markdown, plain text) behind a single extension contract.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4208,3 +4208,36 @@ An escaped `\#` is a literal number sign, never a placeholder.
 ```
 
 :::
+
+## Inline footnotes
+
+An inline footnote `^[content]` carries its note text in place (pandoc-style),
+with no separate definition. It is numbered into the same endnotes section as a
+reference footnote, interleaved by document order, and its content is inline
+(§16). A caret immediately before `[` opens the note; `^[x]^` is therefore a
+note plus a literal `^`, `^^[x]` is suppressed, and `\^[x]` is literal.
+
+::: compare
+
+```carve
+A note^[see *later*] inline. And a ref[^a].
+
+[^a]: reference body.
+```
+
+```html
+<p>A note<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> inline. And a ref<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a>.</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>see <strong>later</strong><a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>reference body.<a href="#fnref2" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+:::

--- a/docs/native-features-analysis.md
+++ b/docs/native-features-analysis.md
@@ -47,7 +47,7 @@ Grammar references point at `resources/grammar.ebnf`.
 | **Abbreviations** | `*[ABBR]: expansion` | `*[ABBR]: expansion` | ✅ In grammar (PART 5: Abbreviations). |
 | **Semantic spans** | `[text]{.kbd}` → `<kbd>` | `:kbd[text]` | ✅ Via `:type[content]` extension syntax (4.20). |
 | **Autolinks** | `<url>` / `<email>` | Angle-bracket autolinks only | ✅ In spec (4.3). Bare URLs are *not* auto-linked (djot-aligned). |
-| **Inline footnotes** | `[content]{.fn}` | `[^inline content]` | Deferred (reserved syntax, see Conformance Core). |
+| **Inline footnotes** | `[content]{.fn}` | `^[content]` | ✅ In grammar (§16). A carve extension beyond djot; pandoc-style `^[content]`, numbered into the shared endnotes. |
 | **Table alignment** | `:--`, `--:`, `:--:` | `\|=<` / `\|=>` / `\|=~` markers | ✅ In spec (4.8). |
 | **Rowspan/colspan** | `^` and `<` markers | `^` and `<` markers | ✅ In grammar (span_cell / rowspan_marker / colspan_marker). |
 | **Multi-line cells** | `+` continuation | `+` continuation | ✅ In grammar (table multi-line cells). |
@@ -226,7 +226,7 @@ feature-level boundary.
 
 ### Deferred (reserved syntax, not yet implemented)
 
-- Inline footnotes (`[^content]`) and sidenotes (`[>content]`).
+- Sidenotes (`[>content]`). (Inline footnotes `^[content]` are now implemented — §16.)
 - Setext (underline) headings — intentionally excluded (matches djot).
 
 ### Deliberate gaps (will not implement)

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -704,15 +704,17 @@ EOF = (* end of file *) ;
    1. Escaped characters (\x)
    2. Code spans (`...`)
    3. Autolinks (<url>)
-   4. Links and images ([text](url), ![alt](src))
-   5. Math ($`…`, $$`…`)
-   6. Emphasis markers (/, *, _, ~, ^, ==, ,,)
-   7. Editorial markup ({+...+}, etc.)
-   8. Extensions (:type[content])
-   9. Mentions and tags (@user, #tag)
-   10. Smart typography (--, ---, etc.)
-   11. Trailing line comments (%%, PART 9 §21)
-   12. Plain text
+   4. Inline footnotes (^[content]) -- above emphasis, so `^[` is a note,
+      not superscript; see PART 9 §16
+   5. Links and images ([text](url), ![alt](src))
+   6. Math ($`…`, $$`…`)
+   7. Emphasis markers (/, *, _, ~, ^, ==, ,,)
+   8. Editorial markup ({+...+}, etc.)
+   9. Extensions (:type[content])
+   10. Mentions and tags (@user, #tag)
+   11. Smart typography (--, ---, etc.)
+   12. Trailing line comments (%%, PART 9 §21)
+   13. Plain text
 
    Disambiguation rule:
    - Prefer literal text over markup: a delimiter that has no valid match
@@ -1120,8 +1122,9 @@ EOF = (* end of file *) ;
       84-block-attribute-lines.
 
    16. FOOTNOTES -- NORMATIVE (governs `footnote` / `footnote_definition`
-      in PART 3). Only the reference form `[^label]` + `[^label]: body`
-      is implemented (inline-footnote and sidenote are deferred).
+      in PART 3). The reference form `[^label]` + `[^label]: body` and the
+      INLINE form `^[content]` are implemented; the sidenote (`[>content]`)
+      remains deferred.
       - A `[^label]` reference with a matching definition is NUMBERED by
         document reference order (first referenced = 1); the same label
         referenced again reuses its number.
@@ -1144,9 +1147,30 @@ EOF = (* end of file *) ;
         repeat uses `fnref{n}-{k}` and adds another backlink. The
         backlink glyph is the plain return arrow `↩` (Carve's choice;
         djot appends a variation selector).
-      - LIMITATION: a footnote reference inside link text (`[t[^1]](u)`)
-        or inside a heading later cloned by a `</#id>` crossref nests an
-        <a> in an <a>; avoid footnotes in those positions.
+      - INLINE FOOTNOTE `^[content]` (pandoc form; a deliberate carve
+        extension -- canonical djot has no inline footnotes). A `^`
+        IMMEDIATELY before `[` opens an anonymous note whose content is the
+        balanced bracket span (escape- and code-span-aware close, same as link
+        text). Properties:
+          * Content is INLINE-only, parsed recursively with footnote
+            recognition DISABLED inside it (no `^[…]` or `[^ref]` nested in a
+            note, either direction).
+          * Numbered in the SAME document-order sequence as reference notes
+            (an inline note always takes a fresh anonymous number; it cannot
+            be re-referenced). Renders the same noteref + an `<li id="fn{n}">`
+            in the one endnotes section, content as one `<p>` + backlink.
+          * A trailing `{attrs}` attaches to the noteref `<a>` (like a
+            reference note).
+          * Empty or whitespace-only (`^[]`, `^[ ]`) is literal; an unclosed
+            `^[…` is literal.
+        PRECEDENCE (PART 8): `^[` is ranked ABOVE superscript. Consequences:
+        `^[x]^` is a note then a literal `^` (no longer superscript-of-`[x]`;
+        escape `\^[x]^` to keep superscript); `^^[x]` is suppressed by
+        same-delimiter `^` adjacency (literal); `\^[x]` is literal; a `^` not
+        immediately followed by `[` is superscript as before.
+      - LIMITATION: a footnote (reference `[^1]` or inline `^[…]`) inside link
+        text (`[t[^1]](u)`) or inside a heading later cloned by a `</#id>`
+        crossref nests an <a> in an <a>; avoid footnotes in those positions.
 
    17. TIGHT vs LOOSE LISTS -- NORMATIVE (governs `list` rendering). A list is
       LOOSE if any item is followed by a blank line before the next sibling

--- a/tests/corpus/86-inline-footnotes.crv
+++ b/tests/corpus/86-inline-footnotes.crv
@@ -1,0 +1,3 @@
+A note^[see *later*] inline. And a ref[^a].
+
+[^a]: reference body.

--- a/tests/corpus/86-inline-footnotes.html
+++ b/tests/corpus/86-inline-footnotes.html
@@ -1,0 +1,12 @@
+<p>A note<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> inline. And a ref<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a>.</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>see <strong>later</strong><a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>reference body.<a href="#fnref2" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>

--- a/tests/spec/86-inline-footnotes.test
+++ b/tests/spec/86-inline-footnotes.test
@@ -1,0 +1,20 @@
+Inline footnotes
+
+```
+A note^[see *later*] inline. And a ref[^a].
+
+[^a]: reference body.
+.
+<p>A note<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> inline. And a ref<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a>.</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>see <strong>later</strong><a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>reference body.<a href="#fnref2" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```


### PR DESCRIPTION
Pins the carve-js inline-footnote feature (markup-carve/carve-js#107) into the conformance corpus and the normative spec. (Rebased clean on current main after #95; replaces the conflicted #96.)

The vendored carve-lib already carries the feature on main, so this PR is spec + corpus + docs only — no lib churn.

## Changes

- **`docs/examples.md`** — new `## Inline footnotes` section, generating corpus pair `86-inline-footnotes` (interleaved numbering with a reference footnote).
- **`resources/grammar.ebnf`** — §16 gains the inline form: pandoc-style `^[content]`, a carve extension beyond djot. Inline-only content, shared document-order numbering, attrs on the noteref, no notes-in-notes. PART 8 ranks `^[` above superscript (`^[x]^` is a note + literal `^`, `^^[x]` suppressed, `\^[x]` literal).
- **`docs/native-features-analysis.md`** — inline footnotes move from Deferred to implemented; notation `[^inline content]` becomes `^[content]`. Sidenotes stay deferred.
- **`docs/divergence-from-djot.md`** — record `^[content]` under "what Carve adds on top".
- **`.gitignore`** — ignore `docs/superpowers/` working docs.

## Lockstep

carve-js #107 and carve-php #91 are merged. Conformance: corpus + grammar green locally (231 pass).
