### PR TITLE
Spec: element attribute coverage - grammar gaps + figure decision

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -75,7 +75,19 @@ _None currently._
 
 ### Open (tracked)
 
-_None currently._
+Decided canonical behavior. The **Pin** column says whether the conformance
+pair is already in `docs/examples.md` (green against the canonical impl) or is
+**held** until the listed impl PR lands; the corpus has no xfail, so a pin that
+the vendored carve-js fails cannot land until carve-js implements it (lockstep
+order: carve-js first, then the carve pin). A row moves to *Resolved* once both
+impls agree and the pin is in the corpus.
+
+| Input | Canonical | Impl(s) to change | Pin |
+|-------|-----------|-------------------|-----|
+| `-{.c} text` / `1.{#x} text` (list-item attributes, NEW Carve syntax) | An attribute block **abutting** the marker (no space before `{`) attributes the `<li>`; the marker's required space follows the block. A **space** before `{` makes it ordinary content (a leading inline `{…}` with no preceding node is literal), NOT a li-attribute. The whitespace is the discriminator. The carve-php lazy-continuation accident (trailing `{…}` line folded onto a tight item) is rejected as the mechanism. Grammar `item_attributes` (extends §15) is normative now. | BOTH: neither implements it. carve-js drops/literalizes; carve-php makes an inline span / swallows the leading block. | HELD (grammar landed; pin waits for both impls) |
+| `{.glossary}` line before a definition list | carve-js: a preceding block-attribute line floats onto the `<dl>` (§15), like every other block. carve-php already does this. | carve-js must stop dropping it. | HELD (waits for carve-js) |
+| `![a](x){.img}` + caption (figure/image attributes) | carve-js: a **trailing** attribute is the image's and stays on `<img>` even when wrapped in a `<figure>` (same target as a standalone block image); a **preceding** block-attribute line targets the `<figure>` (§15). carve-php is inconsistent: it moves the trailing attr to the `<figure>` (so the same `![a](x){.img}` hits a different element depending on whether a caption follows) and drops the preceding block-attr line. | carve-php must keep the image's trailing attr on `<img>` and float a preceding block-attr line onto `<figure>`. | **PINNED** *(08-image-with-caption-2/3)*, green on carve-js; carve-php red until fixed |
+| `` $`x`{.c} `` / `` $$`x`{.c} `` (trailing attribute on math) | UNDECIDED. Divergence found: carve-js applies it (merges into the math span class, `class="math inline c"`); carve-php drops it (`class="math inline"`). math reuses `code_span`, which carries the generic `[attributes]` slot. Grammar math note flags it. | TBD once canonical is chosen. | none |
 
 ### Extension API surface (parity beyond corpus output)
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -814,6 +814,44 @@ Only `[x]`/`[X]` render a checked box; every other state (`[ ]`, `[-]`, `[_]`, `
 
 :::
 
+A trailing attribute block is the **image's** attribute, so it stays on the
+`<img>` even when the image is wrapped in a `<figure>`, the same target as a
+standalone block image. To attribute the `<figure>` instead, use a preceding
+block-attribute line, which floats onto the outer block (§15).
+
+::: compare
+
+```carve
+![Apollo 11](apollo.jpg){.hero}
+^ Figure 1: First moon landing
+```
+
+```html
+<figure>
+  <img src="apollo.jpg" alt="Apollo 11" class="hero">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>
+```
+
+:::
+
+::: compare
+
+```carve
+{.gallery}
+![Apollo 11](apollo.jpg)
+^ Figure 1: First moon landing
+```
+
+```html
+<figure class="gallery">
+  <img src="apollo.jpg" alt="Apollo 11">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>
+```
+
+:::
+
 ## Tables
 
 ::: compare

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -183,7 +183,7 @@ lazy_continuation_line = inline_content, newline ;  (* see the NORMATIVE note ab
 list = unordered_list | ordered_list | definition_list ;
 
 unordered_list = unordered_item+ ;
-unordered_item = bullet_marker, space, list_item_content ;
+unordered_item = bullet_marker, [item_attributes], space, list_item_content ;
 bullet_marker = '-' | '*' ;  (* `+` is NOT a bullet in Carve -- it is the list
                                 continuation marker (PART 9 §17); a `+ ` line is
                                 ordinary paragraph text. Deviates from djot. *)
@@ -198,7 +198,7 @@ bullet_marker = '-' | '*' ;  (* `+` is NOT a bullet in Carve -- it is the list
    content-less-marker-is-not-a-list. *)
 
 ordered_list = ordered_item+ ;
-ordered_item = ordered_marker, space, list_item_content ;
+ordered_item = ordered_marker, [item_attributes], space, list_item_content ;
 (* The first item fixes the dialect (decimal / alpha / roman) and the
    delimiter (`.` or `)`); classification and the ambiguous-letter
    tie-break are in PART 9 §11. An ordered list does NOT interrupt a paragraph
@@ -212,6 +212,38 @@ ordered_item = ordered_marker, space, list_item_content ;
 ordered_marker = (digit+ | letter | roman_numeral), ('.' | ')') ;
 roman_numeral = ('i' | 'v' | 'x' | 'l' | 'c' | 'd' | 'm')+
               | ('I' | 'V' | 'X' | 'L' | 'C' | 'D' | 'M')+ ;
+
+(* LIST-ITEM ATTRIBUTES (Carve addition; NORMATIVE -- extends PART 9 §15). An
+   attribute block ABUTTING the marker (no space between marker and `{`)
+   attaches its attributes to the `<li>` itself; the marker's required space
+   follows the block:
+     `-{.c} text`     -> `<li class="c">text</li>`
+     `3.{#x k=v} text`-> `<li id="x" k="v">text</li>`
+   For task items the block abuts the marker, before the task marker:
+     `-{.c} [ ] text` -> `<li class="c"><input ...> text</li>`.
+   WHITESPACE IS THE DISCRIMINATOR -- NORMATIVE:
+   - `-{.c} text` (attr ABUTS marker) -> the `{.c}` is part of the MARKER and
+     attributes the `<li>`. This is the ONLY way to attribute the `<li>`.
+   - `- {.c} text` (a space BEFORE `{`) -> the `{.c}` is ordinary item CONTENT,
+     NOT a li-attribute. It then follows the normal inline/block rules: a
+     same-line `{.c}` is leading inline content; a `{.c}` alone on its own line
+     (inside the item) is a block-attribute line that floats to the next block
+     within the item -- e.g. a `{.blue}` line preceding an indented `> quote`
+     puts `.blue` on the `<blockquote>` (§15), NOT on the `<li>`. This keeps
+     li-attributes and block-attributes cleanly separated.
+   - DISAMBIGUATION of the abutting block mirrors the inline-span rule (§14):
+     it is consumed as li-attributes only if it yields >= 1 attribute (`#id`,
+     `.class`, `key=value`) OR is the blessed empty block (`-{} text` -> bare
+     `<li>`). Otherwise (`-{+a+}`, `-{not attrs}`) the `-{` is not a marker and
+     the line stays ordinary paragraph/inline text.
+   - Free slot: `-{` and `1.{` / `1){` are NOT list markers today (bullet and
+     ordered both require the space), so no existing input changes meaning.
+   - Diverges from djot (which has no li-attribute form); deliberate Carve
+     extension. The lazy-continuation accident -- a trailing `{…}` line folded
+     onto a tight item, which carve-php attached to the `<li>` and carve-js
+     dropped -- is REJECTED as the mechanism: it was position-dependent (broke
+     once a sub-list intervened) and is not normative. *)
+item_attributes = attributes ;
 
 list_item_content = first_block_content
                   | (inline_content, newline, {list_continuation | nested_list | continuation_marker_block}) ;

--- a/tests/corpus/08-image-with-caption-2.crv
+++ b/tests/corpus/08-image-with-caption-2.crv
@@ -1,0 +1,2 @@
+![Apollo 11](apollo.jpg){.hero}
+^ Figure 1: First moon landing

--- a/tests/corpus/08-image-with-caption-2.html
+++ b/tests/corpus/08-image-with-caption-2.html
@@ -1,0 +1,4 @@
+<figure>
+  <img src="apollo.jpg" alt="Apollo 11" class="hero">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>

--- a/tests/corpus/08-image-with-caption-3.crv
+++ b/tests/corpus/08-image-with-caption-3.crv
@@ -1,0 +1,3 @@
+{.gallery}
+![Apollo 11](apollo.jpg)
+^ Figure 1: First moon landing

--- a/tests/corpus/08-image-with-caption-3.html
+++ b/tests/corpus/08-image-with-caption-3.html
@@ -1,0 +1,4 @@
+<figure class="gallery">
+  <img src="apollo.jpg" alt="Apollo 11">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>

--- a/tests/spec/08-image-with-caption.test
+++ b/tests/spec/08-image-with-caption.test
@@ -9,3 +9,24 @@ Image with caption
   <figcaption>Figure 1: First moon landing</figcaption>
 </figure>
 ```
+
+```
+![Apollo 11](apollo.jpg){.hero}
+^ Figure 1: First moon landing
+.
+<figure>
+  <img src="apollo.jpg" alt="Apollo 11" class="hero">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>
+```
+
+```
+{.gallery}
+![Apollo 11](apollo.jpg)
+^ Figure 1: First moon landing
+.
+<figure class="gallery">
+  <img src="apollo.jpg" alt="Apollo 11">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>
+```


### PR DESCRIPTION
## What

Audit of which elements accept `{}` attribute blocks across the Carve grammar, closing EBNF gaps and recording four attribute-attachment divergences with decided canonicals.

### Grammar (`resources/grammar.ebnf`)

- **Emphasis family + autolink gain the `[attributes]` slot.** `*x*{.c}`, `<https://x>{.ext}` etc. already worked in the corpus/examples (pinned at `75-trailing-attribute-block-edge-cases`); only the EBNF productions lacked the slot. Now consistent with the other inline carriers.
- **Stale `code_span` note corrected.** It claimed carve-js drops a trailing attribute block on a code span. Both impls now apply it (``` `c`{.x} ``` -> `<code class="x">`), so the note was wrong.
- **Math trailing-attribute slot documented + divergence flagged.** Math reuses `code_span`, so it inherits the `[attributes]` slot. carve-js applies it (merges into the math class); carve-php drops it. Undecided, flagged in the grammar.
- **New normative list-item-attribute rule (`item_attributes`).** An attribute block **abutting** the marker (no space) attributes the `<li>`: `-{.c} text` -> `<li class="c">text</li>`, `1.{#x} text` -> `<li id="x">`. A **space** before the brace makes it ordinary content (a leading inline `{…}` with no preceding node is literal). Whitespace is the discriminator. `-{` / `1.{` are not markers today, so it is a free slot. This is the only way to attribute the `<li>` element (djot has no such form). The carve-php lazy-continuation accident (a trailing `{…}` line folded onto a tight item) is rejected as the mechanism, because it was position-dependent and broke once a sub-list intervened.

### Corpus (`docs/examples.md` -> `tests/`)

- **Figure/image attribute targeting pinned.** A trailing attribute is the image's and stays on `<img>` even when wrapped in a `<figure>` (same target as a standalone block image); a preceding block-attribute line targets the `<figure>` (§15). Matches carve-js; carve-php is inconsistent (moves the trailing attr to `<figure>`, drops the preceding line) and is tracked to fix.

### `MAINTAINING.md`

Four decisions recorded under **Open (tracked)**:

| Behavior | Canonical | Pin |
|---|---|---|
| list-item attributes (`-{.c}`) | new syntax; both impls to implement | held |
| def-list block attribute (`{.x}` before `<dl>`) | carve-php; carve-js to fix | held |
| figure/image attribute | carve-js; carve-php to fix | pinned here |
| math trailing attribute | undecided | none |

## Scope / order

Only the **figure** pin and the grammar text land here, keeping the corpus green against the vendored carve-js. The **def-list** and **list-item** corpus pins are held until their carve-js implementation lands, per the lockstep order (carve-js first, then the carve pin). Follow-ups:

- carve-js: float a preceding block-attribute line onto `<dl>` (def-list); implement the `-{attrs}` list-item form.
- carve-php: keep an image's trailing attribute on `<img>` when wrapped, and float a preceding block-attribute line onto `<figure>`; implement the `-{attrs}` list-item form.
- math canonical to be decided.
