### PR TITLE
Docs: note all three impls have non-HTML renderers

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,12 +1,24 @@
 # Maintaining the Carve ecosystem
 
-Three repositories move in lockstep:
+The spec and three implementations move in lockstep:
 
 | Repo | Role |
 |------|------|
 | [`carve`](https://github.com/markup-carve/carve) | Specification. `resources/grammar.ebnf` is **normative**; `docs/examples.md` generates the `tests/corpus/*.crv` + `*.html` pairs that are the **cross-impl conformance contract**. |
 | [`carve-js`](https://github.com/markup-carve/carve-js) | Reference implementation (TypeScript). Its compiled output is vendored into `carve` to render the docs and validate the corpus. |
 | [`carve-php`](https://github.com/markup-carve/carve-php) | PHP implementation. Conforms to the same corpus. |
+| [`carve-rs`](https://github.com/markup-carve/carve-rs) | Rust implementation. Conforms to the same corpus. |
+
+### Output renderers
+
+All three implementations (`carve-js`, `carve-php`, `carve-rs`) are **multi-target
+renderers**: besides the corpus-validated **HTML**, each emits **Markdown**,
+**plain text**, and **ANSI**. Only HTML has a cross-impl corpus contract; the
+non-HTML renderers have no spec corpus, so they are kept **byte-identical to
+`carve-php`** (the reference for non-HTML output) via golden fixtures — a battery
+of carve inputs rendered by carve-php, asserted byte-for-byte by `carve-js` and
+`carve-rs` test suites. When changing a non-HTML renderer, update that golden
+battery and keep all three in agreement.
 
 ## The lockstep
 


### PR DESCRIPTION
Records that `carve-js`, `carve-php`, and `carve-rs` are now multi-target renderers (HTML + Markdown + plain text + ANSI), and adds the missing `carve-rs` row to the repositories table.

- New **Output renderers** subsection: non-HTML output has no cross-impl corpus, so it is kept **byte-identical to carve-php** (the reference) via golden fixtures asserted by carve-js + carve-rs test suites.
- Reworded the intro to "The spec and three implementations" and added the `carve-rs` row.

Docs-only.