### PR TITLE
docs: Blocks & Attributes reference page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -206,6 +206,7 @@ export default defineConfig({
         items: [
           { text: 'Technical Rationale', link: '/technical-rationale' },
           { text: 'Divergence from Djot', link: '/divergence-from-djot' },
+          { text: 'Blocks & Attributes', link: '/blocks-and-attributes' },
           { text: 'Extensions Contract', link: '/extensions' },
           { text: 'Implementation Comparison', link: '/implementation-comparison' },
           { text: 'Formal Grammar', link: '/grammar' },
@@ -241,6 +242,7 @@ export default defineConfig({
         items: [
           { text: 'Technical Rationale', link: '/technical-rationale' },
           { text: 'Divergence from Djot', link: '/divergence-from-djot' },
+          { text: 'Blocks & Attributes', link: '/blocks-and-attributes' },
           { text: 'Extensions Contract', link: '/extensions' },
           { text: 'Implementation Comparison', link: '/implementation-comparison' },
           { text: 'Formal Grammar', link: '/grammar' },

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -40,6 +40,8 @@ Read this first.
 
 renders the heading as `<h2 id="install" class="featured">` and the admonition as `<aside class="admonition note callout">`.
 
+This is uniform across every block - headings, block quotes, lists, code blocks, divs/admonitions, line-blocks, tables. They all take their attributes on the preceding line; none take a trailing attribute on the block's own line. (A code block is no exception: its opening line is the info string, so a `{…}` after the language word is info-string text, not an attribute - put the attributes on the line above the fence like any other block.)
+
 ## Inline elements
 
 An inline element lives inside a line of text.
@@ -74,11 +76,9 @@ The same `{…}` block is used in both positions:
 - `key=value` / `key="value"` - arbitrary attribute; quote when the value has spaces
 - `boolean` - a bare word becomes a value-less attribute
 
-## Special cases (the outliers)
+## The one outlier: list items
 
-A few elements don't follow the plain block rule, because the plain rule can't express what they need. These are the only exceptions - learn them once.
-
-### List items - attribute block abuts the marker
+Every block takes its attributes on the preceding line and every inline takes them trailing - with a single exception: a list item's attribute block **abuts its marker**.
 
 A `{…}` on the line before a list attaches to the **list**, not to an item. To attribute an individual `<li>` the attribute block must **abut the marker with no space** (`-{…}`), and the marker's required space follows it:
 
@@ -94,34 +94,7 @@ A `{…}` on the line before a list attaches to the **list**, not to an item. To
 
 This is a Carve addition (djot cannot attribute list items at all) and is the **only** way to target the `<li>` element itself. For task items the block abuts the marker before the checkbox: `-{.c} [ ] text`.
 
-### Code fences - leading line only
-
-A code fence's opening line is its **info string** (the language). An attribute block there would be parsed as part of that string, so code-block attributes must go on the **preceding** line:
-
-````carve
-{.numbered #snippet}
-``` js
-const x = 1;
-```
-````
-
-A `{…}` after the language word does **not** attach - it is treated as info-string content.
-
-### `:::` openers - type word vs class
-
-A `:::` opener is steered by a bare **type word**, not by a class:
-
-- `::: note` → an admonition (`<aside class="admonition note">`) for the eight canonical types; any other word → a generic `<div class="word">`.
-- For a purely presentational container, use the type-less form with a **preceding** attribute line:
-
-  ```carve
-  {.sidebar #s}
-  :::
-  Aside content.
-  :::
-  ```
-
-See [Examples → Admonitions](/examples#admonitions) for the recognized type words.
+(Aside: the `:::` *type word* that picks an admonition vs a generic div - e.g. `::: note` - is about block type, not attributes; a div takes its attributes on the preceding line like any block. See [Examples → Admonitions](/examples#admonitions).)
 
 ## Quick reference
 

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -78,27 +78,32 @@ The same `{…}` block is used in both positions:
 
 A few elements don't follow the plain block rule, because the plain rule can't express what they need. These are the only exceptions - learn them once.
 
-### List items - attributes go after the marker
+### List items - attribute block abuts the marker
 
-A `{…}` on the line before a list attaches to the **list**, not to an item. To attribute an individual `<li>` you put the attribute block **right after the marker**:
+A `{…}` on the line before a list attaches to the **list**, not to an item. To attribute an individual `<li>` the attribute block must **abut the marker with no space** (`-{…}`), and the marker's required space follows it:
 
 ```carve
-- {#first .done} finished item
+-{#first .done} finished item
 - ordinary item
 ```
 
-This is a Carve addition (djot cannot attribute list items at all) and is the **only** way to target the `<li>` element itself. The marker's space still follows the attribute block (`- {…} text`).
+**Whitespace is the discriminator** (normative):
+
+- `-{.c} text` - the `{.c}` abuts the marker, so it is part of the marker and attributes the `<li>` -> `<li class="c">text</li>`.
+- `- {.c} text` - a space before `{`, so the `{.c}` is ordinary item **content** (literal), not a li-attribute -> `<li>{.c} text</li>`.
+
+This is a Carve addition (djot cannot attribute list items at all) and is the **only** way to target the `<li>` element itself. For task items the block abuts the marker before the checkbox: `-{.c} [ ] text`.
 
 ### Code fences - leading line only
 
 A code fence's opening line is its **info string** (the language). An attribute block there would be parsed as part of that string, so code-block attributes must go on the **preceding** line:
 
-```carve
+````carve
 {.numbered #snippet}
 ``` js
 const x = 1;
 ```
-```
+````
 
 A `{…}` after the language word does **not** attach - it is treated as info-string content.
 
@@ -120,16 +125,16 @@ See [Examples → Admonitions](/examples#admonitions) for the recognized type wo
 
 ## Quick reference
 
-```carve
+````carve
 {#id .class}          ← block: line BEFORE the block
 # Heading
 
 text [span]{.c}       ← inline: directly AFTER, no space
 
-- {#item} list item   ← list item: after the marker
+-{#item} list item    ← list item: abuts the marker (no space!)
 
 {.x}                  ← code block: line BEFORE the fence
 ``` lang
 code
 ```
-```
+````

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -1,0 +1,135 @@
+# Block & inline elements (and attributes)
+
+Carve has two kinds of element, and **attributes attach to each kind in a different place**. Getting this one rule right removes almost all attribute confusion.
+
+| Kind | Attribute placement |
+|------|---------------------|
+| **Block** element | a `{…}` block on the line **immediately before** it |
+| **Inline** element | a `{…}` block **immediately after** it, with **no** space |
+
+This mirrors djot: block attributes lead the block; inline attributes trail the span. Carve keeps that rule uniform - there is no "trailing attribute" on a block line.
+
+## Block elements
+
+A block owns a rectangle of the document: it starts on its own line and is separated from its neighbors by structure (a blank line, a marker, a fence).
+
+- Paragraph
+- Heading - `# … ###### …`
+- Block quote - `> …`
+- List (bullet `-` / `*`, ordered `1.` / `1)`, task `- [ ]`) and its list items
+- Code block (fenced) - ` ``` `
+- Generic div / admonition / line-block - `::: …`
+- Table
+- Thematic break - `---`
+- Frontmatter - leading `---` block
+- Fenced comment - `%%%`
+
+### Attributing a block
+
+Put the attribute block on the line directly above it (no blank line in between):
+
+```carve
+{#install .featured}
+## Setup
+
+{.callout}
+::: note
+Read this first.
+:::
+```
+
+renders the heading as `<h2 id="install" class="featured">` and the admonition as `<aside class="admonition note callout">`.
+
+## Inline elements
+
+An inline element lives inside a line of text.
+
+- Emphasis `/…/`, strong `*…*`, underline `_…_`
+- Strikethrough `~…~`, highlight `=…=`, subscript `,…,`, superscript `^…^`
+- Inline code - `` `…` ``
+- Link `[…](…)`, reference link `[…][…]`, image `![…](…)`
+- Span `[…]{…}`, autolink `<…>`, footnote reference `[^…]`
+- Math, `:emoji:`, `@mention`, `#tag`
+
+### Attributing an inline
+
+Append the attribute block directly, with no space:
+
+```carve
+A [keyword]{.term #kw} and *bold text*{.lead} and `code`{.lang-js}.
+```
+
+A space before the `{…}` breaks the attachment - the braces are then literal text.
+
+## Attribute syntax
+
+The same `{…}` block is used in both positions:
+
+```carve
+{#the-id .class-a .class-b key="value" boolean}
+```
+
+- `#id` - element id (one per element)
+- `.class` - add a class (repeatable)
+- `key=value` / `key="value"` - arbitrary attribute; quote when the value has spaces
+- `boolean` - a bare word becomes a value-less attribute
+
+## Special cases (the outliers)
+
+A few elements don't follow the plain block rule, because the plain rule can't express what they need. These are the only exceptions - learn them once.
+
+### List items - attributes go after the marker
+
+A `{…}` on the line before a list attaches to the **list**, not to an item. To attribute an individual `<li>` you put the attribute block **right after the marker**:
+
+```carve
+- {#first .done} finished item
+- ordinary item
+```
+
+This is a Carve addition (djot cannot attribute list items at all) and is the **only** way to target the `<li>` element itself. The marker's space still follows the attribute block (`- {…} text`).
+
+### Code fences - leading line only
+
+A code fence's opening line is its **info string** (the language). An attribute block there would be parsed as part of that string, so code-block attributes must go on the **preceding** line:
+
+```carve
+{.numbered #snippet}
+``` js
+const x = 1;
+```
+```
+
+A `{…}` after the language word does **not** attach - it is treated as info-string content.
+
+### `:::` openers - type word vs class
+
+A `:::` opener is steered by a bare **type word**, not by a class:
+
+- `::: note` → an admonition (`<aside class="admonition note">`) for the eight canonical types; any other word → a generic `<div class="word">`.
+- For a purely presentational container, use the type-less form with a **preceding** attribute line:
+
+  ```carve
+  {.sidebar #s}
+  :::
+  Aside content.
+  :::
+  ```
+
+See [Examples → Admonitions](/examples#admonitions) for the recognized type words.
+
+## Quick reference
+
+```carve
+{#id .class}          ← block: line BEFORE the block
+# Heading
+
+text [span]{.c}       ← inline: directly AFTER, no space
+
+- {#item} list item   ← list item: after the marker
+
+{.x}                  ← code block: line BEFORE the fence
+``` lang
+code
+```
+```


### PR DESCRIPTION
## What

Adds `docs/blocks-and-attributes.md` (Reference sidebar) - a single page that explains:

- the two element kinds (**block** vs **inline**) with the full list of each;
- **where attributes attach**: block attributes on the line *before* the block; inline attributes *directly after* the span (no space);
- the `{#id .class key=value boolean}` attribute syntax;
- the **outliers** that don't follow the plain block rule:
  - **list items** - attribute block goes *after the marker* (`- {#id} text`); the only way to target the `<li>` (djot can't attribute items at all);
  - **code fences** - leading line only, because the opener is the info string;
  - **`:::` openers** - steered by a bare type word; presentational containers use a preceding attribute line.

## Why

Attribute placement was scattered across `examples.md` / `extensions.md` / grammar comments with no single reference, and the block-vs-inline distinction was implicit. This consolidates it.

## Note on the rule

The page states the **uniform djot-aligned rule**: block attributes lead the block, never trail the block line. This is the intended spec direction. The reference impls currently still accept a *trailing* `{…}` on some block openers (`# H {#id}`, `::: {.box}`) - tightening those to match this page is a planned follow-up (grammar + carve-php + carve-js). Inline trailing attributes and the list-item / code-fence outliers are already as documented.

Docs build is green (no dead links).
