### PR TITLE
Draft: dogfood docs examples via vite-plugin-carve + .crv files

### DIFF
--- a/docs/.vitepress/theme/components/CarveExample.vue
+++ b/docs/.vitepress/theme/components/CarveExample.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+// Dogfood: render a real `.crv` example through @markup-carve/vite-plugin-carve.
+// The `source` (raw carve) and the default export (HTML rendered by the actual
+// carve parser at build time) come straight from the plugin - no hand-authored
+// expected HTML, and no `::: compare` markdown-it-container wrapper.
+const props = defineProps<{ name: string }>()
+
+const modules = import.meta.glob('../../../examples-live/*.crv', { eager: true }) as Record<
+  string,
+  { default: string; source: string }
+>
+
+const entry = Object.entries(modules).find(([path]) => path.endsWith(`/${props.name}.crv`))
+const source = entry ? entry[1].source.replace(/\n$/, '') : `(missing example: ${props.name}.crv)`
+const html = entry ? entry[1].default : ''
+</script>
+
+<template>
+  <div class="carve-example">
+    <div class="carve-example-pane">
+      <div class="carve-example-label">Carve source</div>
+      <pre class="carve-example-src"><code>{{ source }}</code></pre>
+    </div>
+    <div class="carve-example-pane">
+      <div class="carve-example-label">Rendered (live)</div>
+      <div class="carve-example-out" v-html="html" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.carve-example {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin: 1rem 0;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  overflow: hidden;
+}
+@media (max-width: 720px) {
+  .carve-example { grid-template-columns: 1fr; }
+}
+.carve-example-pane { padding: 0.75rem 1rem; }
+.carve-example-pane + .carve-example-pane { border-left: 1px solid var(--vp-c-divider); }
+.carve-example-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vp-c-text-2);
+  margin-bottom: 0.4rem;
+}
+.carve-example-src {
+  margin: 0;
+  background: var(--vp-c-bg-alt);
+  border-radius: 6px;
+  padding: 0.6rem 0.8rem;
+  font-size: 0.85em;
+  white-space: pre-wrap;
+}
+.carve-example-out :deep(aside.admonition),
+.carve-example-out :deep(div.line-block) {
+  margin: 0;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,11 +3,13 @@ import type { Theme } from 'vitepress'
 import './custom.css'
 import Playground from './components/Playground.vue'
 import DogfoodCarve from './components/DogfoodCarve.vue'
+import CarveExample from './components/CarveExample.vue'
 
 export default {
   extends: DefaultTheme,
   enhanceApp({ app }) {
     app.component('Playground', Playground)
     app.component('DogfoodCarve', DogfoodCarve)
+    app.component('CarveExample', CarveExample)
   },
 } satisfies Theme

--- a/docs/examples-live.md
+++ b/docs/examples-live.md
@@ -1,0 +1,38 @@
+---
+title: Live examples (dogfood)
+description: Carve examples rendered by the real parser via vite-plugin-carve.
+---
+
+# Live examples (dogfood proof-of-concept)
+
+These examples are **real `.crv` files** in `docs/examples-live/`, rendered to HTML by the actual carve parser at build time through [`@markup-carve/vite-plugin-carve`](https://github.com/markup-carve/vite-plugin-carve). The right column is *live output*, not hand-authored - so a parser regression breaks the docs build, and there is no `::: compare` markdown-it-container wrapper to collide with `:::` content.
+
+Compare with the hand-authored [examples page](/examples), where the HTML column is written by hand and wrapped in `::: compare`.
+
+## Admonitions
+
+<CarveExample name="admonition-note" />
+
+A quoted title renders as `<p class="admonition-title">`:
+
+<CarveExample name="admonition-tip-title" />
+
+An admonition may contain block children (a list here) - the `:::` body no longer breaks the page because there is no container wrapping it:
+
+<CarveExample name="admonition-tip-list" />
+
+A non-canonical type word is a generic `<div>`:
+
+<CarveExample name="admonition-hint" />
+
+## Line block
+
+Per-line layout preserved, leading whitespace as `&nbsp;`:
+
+<CarveExample name="line-block" />
+
+---
+
+::: tip How this works
+Each block above is `<CarveExample name="x" />`, which imports `docs/examples-live/x.crv`. The plugin gives `source` (raw carve) and the default export (rendered HTML). One `.crv` file is the single source of truth - no duplicated expected HTML.
+:::

--- a/docs/examples-live/admonition-hint.crv
+++ b/docs/examples-live/admonition-hint.crv
@@ -1,0 +1,3 @@
+::: hint "Heads up"
+Custom call-out.
+:::

--- a/docs/examples-live/admonition-note.crv
+++ b/docs/examples-live/admonition-note.crv
@@ -1,0 +1,3 @@
+::: note
+Heads up — this is important.
+:::

--- a/docs/examples-live/admonition-tip-list.crv
+++ b/docs/examples-live/admonition-tip-list.crv
@@ -1,0 +1,6 @@
+::: tip
+Quick steps:
+
+- read the docs
+- run the demo
+:::

--- a/docs/examples-live/admonition-tip-title.crv
+++ b/docs/examples-live/admonition-tip-title.crv
@@ -1,0 +1,3 @@
+::: tip "Pro Tip"
+Save early, save often.
+:::

--- a/docs/examples-live/line-block.crv
+++ b/docs/examples-live/line-block.crv
@@ -1,0 +1,4 @@
+::: line-block
+Roses are red,
+  Violets are blue.
+:::


### PR DESCRIPTION
**Draft / proof-of-concept** for dogfooding carve in the docs, per the discussion on the `:::` render bug.

## What this does

Renders real `.crv` example files through [`@markup-carve/vite-plugin-carve`](https://github.com/markup-carve/vite-plugin-carve) (already wired into the VitePress vite config) instead of the hand-authored `::: compare` blocks.

- New `docs/examples-live/*.crv` - the example **source of truth** (5 files: admonitions + a line block).
- New `CarveExample.vue` - imports a `.crv` by name via `import.meta.glob`, shows the `source` next to the default export (HTML rendered by the **actual carve parser** at build time).
- New `docs/examples-live.md` - the demo page using `<CarveExample name="..." />`.

## Why

- **No duplicated expected HTML.** Today each example hand-writes both the carve source *and* the expected HTML. Here the `.crv` is the single source; the HTML column is live output.
- **Dogfoods the parser.** A parser regression breaks the docs build.
- **Immune to the `::: compare` bug.** No markdown-it-container wrapper, so a `:::` in the body can't close the container early (the bug this PR is a reaction to). The independent byte contract still lives in `tests/corpus`.

## See it locally

```
npm run docs:dev
# open /carve/examples-live
```

## Open questions / scope

- The plugin bundles carve-js `main`, which doesn't have the line-block impl yet, so the `line-block` example renders as a generic `<div>` (no `&nbsp;`/breaks) until the plugin's carve is bumped. This is itself a useful finding: dogfooding surfaces version skew between the plugin's carve and the spec.
- This is one section as a taste. Full migration of `examples.md` would be a follow-up; the corpus generator still needs the `::: compare` form to produce `tests/corpus`, so either both coexist or the corpus pipeline moves to `.crv` files too.

Not for merge as-is - opening to look at the approach.
