### PR TITLE
Docs: fix cross-document contradictions and external comparison claims

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -14,10 +14,18 @@ turning your content into a JavaScript program.
 |---------------------------------|:---:|:----:|:---:|:---:|
 | Formal, normative grammar       | ⚠️ spec, ambiguous edges |  ✅   | ❌ (md + JSX) | ✅ EBNF |
 | Consistent inline rules         | ❌ |  ✅   | ❌ | ✅ |
-| No-backtracking parse guarantee | ❌ |  ✅   | ❌ | ✅ |
+| No-backtracking parse guarantee | ❌ |  ✅   | ❌ | ✅ \* |
 | Markdown-familiar syntax        | ✅ |  ⚠️  | ✅ | ⚠️ |
-| Paragraph interruption (no blank line) | ✅ | ❌ | ✅ | ✅ |
+| Paragraph interruption (no blank line) | ✅ | ❌ | ✅ | ✅ \*\* |
 | Feature completeness/consistency | ❌ | ❌ | ❌ | ✅ |
+
+\* Inline parsing is single-pass with a delimiter stack; at the block level a
+fence / `:::` opener uses a bounded forward scan for a matching closer
+(closer lookahead, not backtracking) - see
+[Technical Rationale](/technical-rationale).
+\*\* Like Markdown for bullets, quotes, headings, tables and closed fences;
+ordered-list markers deliberately never interrupt (no CommonMark `1.`-only
+heuristic).
 
 ## Authoring features
 
@@ -29,12 +37,12 @@ turning your content into a JavaScript program.
 | Math | 🧩 | ✅ | 🧩 | ✅ |
 | Definition lists | 🧩 | ✅ | 🧩 | ✅ |
 | Admonitions / callouts | 🧩 | ⚠️ via div | 🧩 component | ✅ native |
-| Attributes `{.class #id}` | ❌ | ✅ | ⚠️ JSX props | ✅ |
-| Generic divs / spans | ❌ | ✅ | ⚠️ components | ✅ |
+| Attributes `{.class #id}` | 🧩 (Pandoc, markdown-it-attrs) | ✅ | ⚠️ JSX props | ✅ |
+| Generic divs / spans | 🧩 (Pandoc fenced divs / spans) | ✅ | ⚠️ components | ✅ |
 | Smart typography | 🧩 | ✅ | 🧩 | ✅ |
 | Editorial / critic markup | ❌ | ❌ | ❌ | ✅ |
 | Frontmatter | ⚠️ tooling | ❌ | 🧩 | ✅ |
-| Emoji `:name:` | 🧩 | ⚠️ | 🧩 | ✅ |
+| Emoji shortcodes | 🧩 | ⚠️ | 🧩 | 🧩 `:emoji[…]` extension |
 
 ## Docs & cross-referencing
 
@@ -48,9 +56,9 @@ turning your content into a JavaScript program.
 
 | | Markdown | Djot | MDX | **Carve** |
 |---|:---:|:---:|:---:|:---:|
-| Safe with untrusted input | ❌ raw HTML | ✅ | ❌ executes JS | ✅ raw off by default |
+| Safe with untrusted input | ⚠️ raw HTML on by default (sanitize modes exist) | ✅ | ❌ executes JS | ✅ raw off by default |
 | Embeds live components / JS | ❌ | ❌ | ✅ (its purpose) | ❌ by design |
-| Independent implementations | many, divergent | 1 reference + ports | JS-only | **php · js · rs, conformance-tested** |
+| Independent implementations | many, divergent | several (js, lua, rust, go) | JS-only | **php · js · rs, conformance-tested** |
 | Shared spec test corpus | ❌ | ⚠️ | ❌ | ✅ |
 
 ## When to pick which

--- a/docs/dismissed-syntax.md
+++ b/docs/dismissed-syntax.md
@@ -66,7 +66,7 @@ See [[https://example.com/intro | the introduction]] for details.
 - URL-first order is less natural for reading
 - Would need special handling to avoid conflicts
 
-**Decision:** For wiki-style internal links, use collapsed reference syntax `[Page Name][]` instead, which is unambiguous.
+**Decision:** For wiki-style internal links, use collapsed reference syntax `[Page Name][]` instead, which is unambiguous. (A `[[Page Name]]` *heading-reference* form - text-first, no URL - exists as a separate opt-in extension; the rejection here is the URL-first `[[url | text]]` core syntax.)
 
 ---
 
@@ -132,7 +132,7 @@ This is _italic_ text.
 | Alice | 30  |
 ```
 
-**Why rejected:**
+**Why rejected as the primary mechanism:**
 - Extra row adds noise
 - Alignment markers (`:--:`) are cryptic
 - Creole's `|=` is cleaner and more explicit
@@ -140,7 +140,12 @@ This is _italic_ text.
   a *cell*, it also expresses **row headers** (a `<th>` in a body row) - which a
   separator row cannot. See [Tables → Row Headers](./case-study/syntax#row-headers).
 
-**Decision:** `|=` prefix marks header cells directly, no separator row needed.
+**Decision:** `|=` prefix marks header cells directly; no separator row is
+*needed*. **Later amendment:** the GFM separator row *is* accepted as a
+compatibility alias - a delimiter row as the second line of a table marks the
+first row as the header and sets column alignment (pinned by corpus
+`09-tables-3`), so pasted Markdown tables keep working. `|=` remains the
+canonical Carve form and the only way to express row headers.
 
 ---
 

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -29,7 +29,7 @@ opt-in for share-safe URL fragments.
 **Why.** We first mirrored Djot's case-preserving rule. It broke cross-references:
 `# Getting Started` produced the id `Getting-Started`, so a `</#getting-started>`
 reference no longer resolved - the reference and the id differed only in case.
-Lowercasing makes ids and the common `</#id>` / `[[Heading]]` references
+Lowercasing makes ids and the common `</#id>` / `[Heading][]` references
 case-insensitive with **no special lookup logic** - the universal
 GitHub / Hugo / Jekyll / MDN convention authors already expect for anchors.
 
@@ -163,8 +163,9 @@ These aren't divergences - Djot has no equivalent - but they're why Carve exists
 as more than restyled Djot:
 
 - **Cross-references** - `</#id>` auto-fills its link text from the target heading.
-- **Implicit heading references** - `[[Heading]]` resolves to a heading with no
-  separate `[label]: url` definition.
+- **Implicit heading references** - `[Heading][]` resolves to a heading with no
+  separate `[label]: url` definition (the wiki-style `[[Heading]]` form is a
+  separate opt-in extension, not core syntax).
 - **Tables with rowspan / colspan / multi-line cells** and captions on images,
   quotes, and tables.
 - **Native admonitions**, editorial/critic markup, `@mentions`, and `#tags`.

--- a/docs/markup-languages.md
+++ b/docs/markup-languages.md
@@ -17,28 +17,28 @@ syntaxes together instead.
 | Markdown                       | John Gruber            | 2004 | Simplicity, email-style      |
 | Creole                         | WikiCreole             | 2007 | Wiki standardization         |
 | CommonMark                     | John MacFarlane et al. | 2014 | Standardized Markdown        |
-| GitHub Flavored Markdown (GFM) | GitHub                 | 2017 | Extended CommonMark          |
+| GitHub Flavored Markdown (GFM) | GitHub                 | 2017 (formal spec; the flavor dates to ~2009) | Extended CommonMark |
 | Gemtext                        | Solderpunk             | 2019 | Minimalism (Gemini protocol) |
 | Djot                           | John MacFarlane        | 2022 | Predictable parsing          |
 | Carve                          | Mark Scherer           | 2026 | Simple & predictable parsing |
 
 ## Feature Comparison
 
-| Feature | Markdown | CommonMark | GFM | Djot | AsciiDoc | reST |
-|---------|----------|------------|-----|------|----------|------|
-| Strong | `**text**` | `**text**` | `**text**` | `*text*` | `*text*` | `**text**` |
-| Emphasis | `*text*` | `*text*` | `*text*` | `_text_` | `_text_` | `*text*` |
-| Code inline | `` `code` `` | `` `code` `` | `` `code` `` | `` `code` `` | `` `+code+` `` | ``` ``code`` ``` |
-| Strikethrough | - | - | `~~text~~` | - | `[.line-through]#text#` | - |
-| Highlight | - | - | - | `{=text=}` | `#text#` | - |
-| Subscript | - | - | - | `{~text~}` | `~text~` | - |
-| Superscript | - | - | - | `{^text^}` | `^text^` | - |
-| Tables | varies | - | `\| col \|` | `\| col \|` | `\|===` | directives |
-| Task lists | - | - | `- [x]` | `- [x]` | `* [x]` | - |
-| Footnotes | varies | - | - | `[^1]` | `footnote:[]` | `[1]_` |
-| Attributes | - | - | - | `{.class #id}` | `[.class]` | `:class:` |
-| Divs/Admonitions | - | - | - | `:::` | `====` | `.. note::` |
-| Smart quotes | varies | - | - | auto | auto | - |
+| Feature | Markdown | CommonMark | GFM | Djot | AsciiDoc | reST | **Carve** |
+|---------|----------|------------|-----|------|----------|------|-----------|
+| Strong | `**text**` | `**text**` | `**text**` | `*text*` | `*text*` | `**text**` | `*text*` |
+| Emphasis | `*text*` | `*text*` | `*text*` | `_text_` | `_text_` | `*text*` | `/text/` |
+| Code inline | `` `code` `` | `` `code` `` | `` `code` `` | `` `code` `` | `` `code` `` | ``` ``code`` ``` | `` `code` `` |
+| Strikethrough | - | - | `~~text~~` | - | `[.line-through]#text#` | - | `~text~` |
+| Highlight | - | - | - | `{=text=}` | `#text#` | - | `=text=` |
+| Subscript | - | - | - | `{~text~}` | `~text~` | - | `,text,` |
+| Superscript | - | - | - | `{^text^}` | `^text^` | - | `^text^` |
+| Tables | varies | - | `\| col \|` | `\| col \|` | `\|===` | directives | `\| col \|` + spans |
+| Task lists | - | - | `- [x]` | `- [x]` | `* [x]` | - | `- [x]` |
+| Footnotes | varies | - | `[^1]` (deployed; not in the formal spec) | `[^1]` | `footnote:[]` | `[1]_` | `[^1]`, `^[inline]` |
+| Attributes | - | - | - | `{.class #id}` | `[.class]` | `:class:` | `{.class #id}` |
+| Divs/Admonitions | - | - | - | `:::` | `====` | `.. note::` | `::: note` |
+| Smart quotes | varies | - | - | auto | explicit (`` "`text`" ``) | - | auto |
 
 **Notes on the Djot column:**
 
@@ -50,7 +50,7 @@ syntaxes together instead.
 ### Headings
 
 ```
-# Markdown/CommonMark/GFM/Djot
+# Markdown/CommonMark/GFM/Djot/Carve
 
 = AsciiDoc Level 1
 == AsciiDoc Level 2
@@ -65,12 +65,12 @@ Title
 ### Links
 
 ```
-[text](url)                    # Markdown/CommonMark/GFM/Djot
+[text](url)                    # Markdown/CommonMark/GFM/Djot/Carve
 https://url[text]              # AsciiDoc
 `text <url>`_                  # reST
 [[url][text]]                  # Org Mode
 "text":url                     # Textile
-[[url|text]]                   # MediaWiki
+[[Page|text]] / [url text]     # MediaWiki (internal page / external URL)
 [[url|text]]                   # Creole
 => url text                    # Gemtext
 ```
@@ -78,7 +78,7 @@ https://url[text]              # AsciiDoc
 ### Images
 
 ```
-![alt](src)                    # Markdown/CommonMark/GFM/Djot
+![alt](src)                    # Markdown/CommonMark/GFM/Djot/Carve
 image::src[alt]                # AsciiDoc
 .. image:: src                 # reST
    :alt: alt text
@@ -91,7 +91,7 @@ image::src[alt]                # AsciiDoc
 ### Code Blocks
 
 ````
-```language                    # Markdown/GFM/Djot
+```language                    # Markdown/GFM/Djot/Carve
 code
 ```
 
@@ -111,7 +111,7 @@ code
 ### Lists
 
 ```
-- item                         # Markdown/CommonMark/GFM/Djot
+- item                         # Markdown/CommonMark/GFM/Djot/Carve
 * item                         # AsciiDoc/Org Mode
 - item                         # reST (with blank lines)
 * item                         # Textile/MediaWiki/Creole
@@ -183,12 +183,13 @@ code
 |----------|-------------------|-----------|
 | Gemtext | Trivial | ~1 page |
 | Creole | Simple | ~10 pages |
-| Markdown | Ambiguous | ~1 page (original) |
-| CommonMark | Complex | ~600 rules |
-| Djot | Moderate | ~200 rules |
+| Markdown | Ambiguous | informal syntax essay, no formal spec |
+| CommonMark | Complex | large prose spec, ~650 conformance examples |
+| Djot | Moderate | compact prose spec + reference implementation |
 | GFM | Complex | CommonMark + extensions |
 | AsciiDoc | Complex | Large spec |
 | reST | Complex | Large spec |
+| Carve | Moderate | EBNF grammar + semantic constraints + executable corpus |
 
 ## Recommendations
 


### PR DESCRIPTION
## What

Audit follow-up (C/D-class items from the spec soundness audit): fixes cross-document contradictions and factually wrong claims about other markup languages. No normative changes - docs only.

## Internal contradictions

- **Emoji**: comparison table said native; dismissed-syntax.md rejects shortcodes and the corpus pins `:rocket:` as literal. Table now says extension (`:emoji[...]`).
- **GFM separator row**: dismissed-syntax.md still recorded a flat rejection, but the spec adopted the delimiter row as a compatibility alias (corpus `09-tables-3`). Entry now records the amendment; the header-cell prefix stays canonical.
- **Implicit heading refs**: three docs told three stories. Core = collapsed reference (`[Heading][]`, verified: the double-bracket form is literal in core); the double-bracket form is an opt-in extension. All three docs now agree.
- **No-backtracking claim**: comparison table now carries the fence closer-lookahead caveat from technical-rationale.md; the paragraph-interruption row notes the ordered-marker exception.

## External claims

- markup-languages.md: GFM footnotes exist (deployed since 2021, outside the formal spec); modern AsciiDoc inline code is backticks, typographic quotes are explicit not auto; MediaWiki double brackets are internal-only (external links use single brackets); invented "rule counts" for CommonMark/Djot replaced with accurate spec descriptions; GFM year notes the flavor predates the 2017 spec.
- comparison.md: Markdown attributes + divs/spans are plugin-available (Pandoc, markdown-it-attrs), not absent; untrusted-input cell acknowledges sanitize modes; Djot has several independent implementations.
- markup-languages.md now includes Carve itself in the feature/complexity tables and example labels.
