### PR TITLE
Add corpus case: marker resumes sub-list after lazy continuation

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -829,6 +829,31 @@ Intro
 
 :::
 
+After a lazy continuation line, a marker at the content column resumes the *same* sub-list rather than starting a new one (§10).
+
+::: compare
+
+```carve
+1. outer
+   1. inner
+lazy
+   2. sibling
+```
+
+```html
+<ol>
+  <li>outer
+    <ol>
+      <li>inner
+lazy</li>
+      <li>sibling</li>
+    </ol>
+  </li>
+</ol>
+```
+
+:::
+
 ## Task lists
 
 ::: compare

--- a/tests/corpus/05-lists-17.crv
+++ b/tests/corpus/05-lists-17.crv
@@ -1,0 +1,4 @@
+1. outer
+   1. inner
+lazy
+   2. sibling

--- a/tests/corpus/05-lists-17.html
+++ b/tests/corpus/05-lists-17.html
@@ -1,0 +1,9 @@
+<ol>
+  <li>outer
+    <ol>
+      <li>inner
+lazy</li>
+      <li>sibling</li>
+    </ol>
+  </li>
+</ol>

--- a/tests/spec/05-lists.test
+++ b/tests/spec/05-lists.test
@@ -185,3 +185,20 @@ Intro
   <figcaption>Steve Jobs</figcaption>
 </figure>
 ```
+
+```
+1. outer
+   1. inner
+lazy
+   2. sibling
+.
+<ol>
+  <li>outer
+    <ol>
+      <li>inner
+lazy</li>
+      <li>sibling</li>
+    </ol>
+  </li>
+</ol>
+```


### PR DESCRIPTION
Adds one spec corpus example for a list edge case the suite did not yet exercise.

## What

After a lazy continuation line, a marker at the content column resumes the *same* sub-list rather than starting a new one (section 10, paragraph interruption).

Input:

```
1. outer
   1. inner
lazy
   2. sibling
```

Expected:

```html
<ol>
  <li>outer
    <ol>
      <li>inner
lazy</li>
      <li>sibling</li>
    </ol>
  </li>
</ol>
```

## Why

The Lists prose already states the rule, but no corpus pair covered a marker resuming a nested list *after* a lazy line. carve-php and carve-js produce the output above; carve-rs currently splits the resumed marker into a separate ordered list with start=2, so this pair guards that divergence across implementations.

## Notes

- `docs/examples.md` is the source of truth; `tests/corpus/*` and `tests/spec/*` are regenerated via `npm run corpus:build`.
- Appended at the end of the Lists section so no existing examples renumber.
- Touches on the in-flight list-interruption work; this only adds coverage, no behavior or prose change.
