### PR TITLE
Docs: fix stale bullet interrupt+nesting claims, stale raw syntax, wrong spec refs

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -423,11 +423,11 @@ heuristic Djot removed, so Carve keeps both on the blank-line rule. (`+` is the
 continuation marker, not a bullet.) Inside an existing list item, indentation
 alone still nests a sublist.
 
-A bullet opens a list at **any indentation**, not only at column 0: a `- `/`* `
-marker is always a bullet, so an indented one opens a list at the top level or
-nests inside an existing item. The leading indentation becomes the new list's
-base column. This keeps the bullet rule uniform - an indented bullet opens a
-list whether it stands at the top level or nests inside an existing item.
+A bullet opens a list at **any indentation** at the top level, not only at
+column 0: a `- `/`* ` line is always a bullet, so even an indented one opens a
+list rather than becoming indented code (unlike CommonMark). The leading
+indentation becomes the new list's base column. (Nesting *inside* an existing
+item is gated by the content column - see below.)
 
 ```
   - item        →  a list (indented; no column-0 requirement)
@@ -456,22 +456,30 @@ How a deeper marker inside an open list item is read - this is sub-list nesting,
 a different axis from the §10 paragraph rule (no list marker interrupts a
 paragraph; both need a blank line):
 
-- **A bullet (unordered/task) opens a sub-list at any indent** past the parent's
-  base:
-  ```
-  - a
-    - b          →  nested
-  ```
-- **An ordered marker is gated by the content column.**
-  One **at or past** it opens a sub-list; one **below** it is lazy paragraph text
-  that folds into the item:
-  ```
-  1. a
-     1. b         →  nested  (column 3 = content column)
+A **list marker** (bullet or ordered) is **gated by the content column** - and
+bullet and ordered behave identically here. A marker **at or past** the parent's
+content column opens a sub-list; one **below** it is lazy paragraph text that
+folds into the item:
 
-  1. a
-    1. b          →  "1. b" is lazy text of item a  (column 2, below it)
-  ```
+```
+- a
+  - b          →  nested            (column 2 = content column)
+
+- a
+ - b           →  "- b" is lazy text of item a   (column 1, below it)
+
+1. a
+   1. b        →  nested            (column 3 = content column)
+
+1. a
+  1. b         →  "1. b" is lazy text of item a  (column 2, below it)
+```
+
+Every *other* block opener (quote, heading, fence, table) does nest at any
+indent past the parent's base column - those are unambiguous as blocks and never
+fold as lazy text. (Rule B's "a bullet opens a list at any indentation" is about
+the **top level** - no column-0 requirement, unlike CommonMark - not about
+sub-list nesting depth.)
 
 Carve does not require a blank line before a sub-list (unlike djot); indentation
 alone nests it. Structure comes from indentation only; the literal marker numbers

--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -412,33 +412,31 @@ Ordered lists support **decimal, alphabetic (`a.`/`A.`), and roman
 fixes the dialect, the `<ol type>`, and `start`; a marker outside that
 dialect (or the other delimiter) starts a new list (PART 9 §11).
 
-Unlike the other blocks, an ordered-list marker does **not** interrupt a
-paragraph (the §10 paragraph rule): an ordered list — `1.`, `2.`, `1985.`, `a.`,
-`i.`, any value — needs a blank line before it. An ordered marker is too common
-in prose ("step 2.", "version 1985.", "upgrade to 1. today"), and the only way
-to allow it would be the CommonMark `1.`-only heuristic Djot removed; Carve
-keeps ordered lists on the blank-line rule instead. (Bullets `- `/`* `,
-being unambiguous, do interrupt; `+` is the continuation marker, not a bullet.)
-Inside an existing list item, indentation
+Unlike the other blocks, a **list marker does not interrupt a paragraph** (the
+§10 paragraph rule): a list — bullet (`- `/`* `, task) or ordered (`1.`, `2.`,
+`1985.`, `a.`, `i.`, any value) — needs a blank line before it. Both marker
+classes behave identically here. An ordered marker is too common in prose
+("step 2.", "version 1985.", "upgrade to 1. today") to interrupt, and a
+hard-wrapped prose line that happens to begin with a bullet should not silently
+become a list; the only way to allow either would be the CommonMark `1.`-only
+heuristic Djot removed, so Carve keeps both on the blank-line rule. (`+` is the
+continuation marker, not a bullet.) Inside an existing list item, indentation
 alone still nests a sublist.
 
 A bullet opens a list at **any indentation**, not only at column 0: a `- `/`* `
-marker is always a bullet, so an indented one opens a list (at the top level) or
-interrupts an open paragraph just like a column-0 marker. The leading indentation
-becomes the new list's base column. This keeps the bullet rule uniform across
-contexts - an indented bullet opens a list whether it follows a paragraph, stands
-at the top level, or nests inside an existing item.
+marker is always a bullet, so an indented one opens a list at the top level or
+nests inside an existing item. The leading indentation becomes the new list's
+base column. This keeps the bullet rule uniform - an indented bullet opens a
+list whether it stands at the top level or nests inside an existing item.
 
 ```
-text
-  - item       →  a paragraph, then a list (the bullet interrupts)
-
-  - a           →  a list (no column-0 requirement)
+  - item        →  a list (indented; no column-0 requirement)
 ```
 
-Ordered markers, by contrast, never interrupt a paragraph at any indentation
-(they keep the blank-line rule above); a marker requires a single space after it
-(`- x`, not a tab), since the space is a syntax delimiter, not indentation.
+A marker requires a single space after it (`- x`, not a tab), since the space is
+a syntax delimiter, not indentation. Directly under a line of prose with no
+blank line, though, a bullet does not start a list - it folds into the paragraph
+like any list marker (the §10 rule above).
 
 **Auto-numbering:**
 ```
@@ -454,15 +452,17 @@ marker: `- ` / `* ` → column 2, `1. ` → 3, `10. ` → 4. A **task** item's c
 is content, not marker, so its content column is the **bullet width (2)**, not
 the full `- [x] ` width.
 
-How a deeper marker is read follows the §10 interrupt rule:
+How a deeper marker inside an open list item is read - this is sub-list nesting,
+a different axis from the §10 paragraph rule (no list marker interrupts a
+paragraph; both need a blank line):
 
-- **Unordered and task markers interrupt**, so an indented one always opens a
-  sub-list, at any indent past the parent's base:
+- **A bullet (unordered/task) opens a sub-list at any indent** past the parent's
+  base:
   ```
   - a
     - b          →  nested
   ```
-- **Ordered markers do not interrupt**, so they are gated by the content column.
+- **An ordered marker is gated by the content column.**
   One **at or past** it opens a sub-list; one **below** it is lazy paragraph text
   that folds into the item:
   ```
@@ -1162,24 +1162,24 @@ Useful for:
 ### 4.15 Raw/Passthrough Content
 
 ~~~
-```raw html
+```=html
 <div class="custom">
   <p>Raw HTML here</p>
 </div>
 ```
 
-```raw latex
+```=latex
 \begin{equation}
   E = mc^2
 \end{equation}
 ```
 ~~~
 
-Inline raw passthrough is the inline parallel of the `raw` block: a code
-span tagged with `{=format}`. The verbatim content is emitted unescaped
-when the format matches the output, and dropped otherwise. Any *other*
-trailing `{…}` on a code span is a generic attribute block, not raw
-passthrough (PART 9 §20).
+A raw block opens with `=FORMAT` (a leading `=` immediately followed by the
+format name). Inline raw passthrough is its inline parallel: a code span tagged
+with `{=format}`. The verbatim content is emitted unescaped when the format
+matches the output, and dropped otherwise. Any *other* trailing `{…}` on a code
+span is a generic attribute block, not raw passthrough (PART 9 §20).
 
 ```
 Use `<br>`{=html} to force a break, and `\foo`{=latex} is dropped in HTML.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -23,9 +23,9 @@ turning your content into a JavaScript program.
 fence / `:::` opener uses a bounded forward scan for a matching closer
 (closer lookahead, not backtracking) - see
 [Technical Rationale](/technical-rationale).
-\*\* Like Markdown for bullets, quotes, headings, tables and closed fences;
-ordered-list markers deliberately never interrupt (no CommonMark `1.`-only
-heuristic).
+\*\* Like Markdown for quotes, headings, tables and closed fences; list markers
+(both bullet and ordered) deliberately never interrupt a paragraph - a list
+needs a blank line (no CommonMark `1.`-only heuristic).
 
 ## Authoring features
 

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -136,25 +136,38 @@ block marker - a `-`/`*` bullet, `>` quote, `#` heading, a `|` table row, or a
 fence - stays part of the paragraph; the block needs a blank line before it.
 
 **Carve:** a **visible** block interrupts an open paragraph with no blank line
-before it - the Markdown / CommonMark rule. Ordered lists are the main exception:
-they still need a blank line (an ordered marker in prose is too common to treat
-as a list); fence and `:::` closers and bare images are also excluded (PART 9 §10).
+before it - the Markdown / CommonMark rule. The exception is **list markers**:
+neither a bullet (`-`/`*`, task) nor an ordered marker interrupts a paragraph -
+a list still needs a blank line before it (matching Djot). Both list-marker
+classes behave identically here; fence and `:::` closers and bare images are
+also excluded (PART 9 §10).
+
+```
+intro
+# Heading
+
+Djot:   <p>intro\n# Heading</p>                  (one paragraph)
+Carve:  <p>intro</p><h1>Heading</h1>             (paragraph + heading)
+```
+
+A list marker is the exception - it does NOT interrupt:
 
 ```
 intro
 - item
 
-Djot:   <p>intro\n- item</p>                    (one paragraph)
-Carve:  <p>intro</p><ul><li>item</li></ul>      (paragraph + list)
+Carve:  <p>intro\n- item</p>                     (one paragraph; add a blank line to start a list)
 ```
 
 **Why.** Djot's blank-line rule is hard-wrap-safe, but it surprises authors
-coming from Markdown more often than it helps: a list or heading written
+coming from Markdown more often than it helps: a heading or quote written
 directly under a line of prose silently stayed prose. Carve follows the
-near-universal Markdown expectation and accepts the cost - a hard-wrapped prose
-line that happens to begin with a marker becomes a block. Escape the marker
-(`\- item`) or add a blank line to keep it prose. This is Carve's largest
-block-level break from Djot, and the reason the project frames itself as
+near-universal Markdown expectation for those blocks. Lists keep Djot's
+blank-line rule on purpose: an ordered marker is common in prose ("see step
+2.") and a hard-wrapped line that happens to begin with a bullet should not
+silently become a list. Escape a marker (`\# H`, `\- item`) or add a blank line
+to control it. This block-interruption rule is one of Carve's larger
+block-level breaks from Djot, and part of why the project frames itself as
 post-Markdown rather than post-Djot.
 
 ## What Carve adds on top (not breaks)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2417,7 +2417,7 @@ text
 :::
 
 A trailing attribute block on a reference attaches to the noteref `<a>`
-(grammar PART 9 §note). Only the reference where the author wrote the block
+(grammar PART 9 §16). Only the reference where the author wrote the block
 carries it.
 
 ::: compare

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -22,7 +22,7 @@ core-and-default-on everywhere and its default output is corpus-pinned.
   `:name[…]` / `::: name` extension syntax). Recognized `:::` type words
   (the eight admonitions + `line-block`) are catalogued in `examples.md`. Smart
   typography and `@mention` / `#tag` / `:emoji:` parsing are also default-on and
-  corpus-pinned, but per grammar PART 19 a processor MAY disable them.
+  corpus-pinned, but per grammar PART 9 §19 a processor MAY disable them.
 - Tier 2: configuration over Tier-1 syntax — mention/tag→URL, emoji glyph map,
   locale smart-quote sets, bare-URL autolinking.
 - Tier 3: Mermaid, Tabs, CodeGroup, TableOfContents, HeadingPermalinks,

--- a/docs/native-features-analysis.md
+++ b/docs/native-features-analysis.md
@@ -177,7 +177,7 @@ Conformance Core below for the full split):
 | Tier | Features | Disableable? |
 |------|----------|--------------|
 | **Core (MUST)** | captions, abbreviations, tables (rowspan/colspan/multi-line), autolinks, emphasis family, links, math, footnotes, crossrefs, the `:type[content]` extension *syntax* | **No.** Corpus-pinned; identical across implementations. Disabling one means the processor is no longer Carve-conformant. |
-| **Default-on (SHOULD)** | `@mention`, `#tag`, smart typography | **Yes.** On by default in the conformant core; a processor MAY disable them. Normative: `resources/grammar.ebnf` PART 19. |
+| **Default-on (SHOULD)** | `@mention`, `#tag`, smart typography | **Yes.** On by default in the conformant core; a processor MAY disable them. Normative: `resources/grammar.ebnf` PART 9 §19. |
 | **Out of core (MAY)** | includes (<code v-pre>{{ … }}</code>), the extension *registry* beyond the generic fallback, all "implementation extensions" above | **Yes / opt-in.** Processor-level; a conformant core MAY omit them entirely (e.g. leave <code v-pre>{{ … }}</code> literal). |
 
 Separately, **Profiles** (case-study spec §4.21) restrict which features are
@@ -216,7 +216,7 @@ feature-level boundary.
 
 ### SHOULD / configurable (on by default, a processor MAY disable)
 
-- `@mention` and `#tag` shorthands, smart typography (grammar PART 19).
+- `@mention` and `#tag` shorthands, smart typography (grammar PART 9 §19).
 
 ### MAY / out of core (processor-level)
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -187,7 +187,7 @@ tilde_fence = '~', '~', '~', {'~'} ;
 
 code_fence_info = (language_info, [space+, label]) | label ;
 language_info = (letter | digit | '-' | '_' | '+' | '#' | '.' | '/')+ ;  (* a single token; the punctuation covers real language tags like c++, c#, f#, asp.net, text/html. May start with a digit. The `/` is normative across all impls (so `text/html`, `image/svg` are language tokens, not split). A token MUST NOT start with `=`: a leading `=` is the raw_block opener (above), not a language. *)
-label = '[', { any_char - ']' }, ']' ;  (* structured metadata, e.g. [Installation]; not part of the class *)
+label = '[', { character - ']' }, ']' ;  (* structured metadata, e.g. [Installation]; not part of the class *)
 code_content = (* any text until matching fence, preserved literally *) ;
 (* TABS IN CODE -- NORMATIVE. Literal tab characters in code content (fenced
    code blocks and inline code spans) are PRESERVED verbatim; a tab and N spaces
@@ -1445,8 +1445,8 @@ EOF = (* end of file *) ;
           an attribute block: the `]` and the `{...}` render literally. The
           inner bracket content is still inline-parsed, so `[*x*]{???}` ->
           `[<strong>x</strong>]{???}`.
-        - a name (id, class, or key) that is not a grammar `identifier` (line
-          905) is also unrecognized: a DIGIT-FIRST name (`{.123}`, `{#1}`,
+        - a name (id, class, or key) that is not a grammar `identifier` (the
+          `identifier` production) is also unrecognized: a DIGIT-FIRST name (`{.123}`, `{#1}`,
           `{2=v}`) or a name with a non-identifier character (`{.a!b}`).
           ONE invalid name makes the WHOLE block not an attribute block, even
           when mixed with valid attributes (`{.ok .1}`), so the run stays

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1738,18 +1738,21 @@ EOF = (* end of file *) ;
         indentation. `-<TAB>a` is NOT a list item (paragraph text).
       - CONTENT COLUMN. An item's content column is the visual column where
         its content starts (marker width + separator: `- ` -> 2, `1. ` -> 3,
-        `10. ` -> 4). An ORDERED child marker must reach the parent item's
-        content column to nest; below it, the line folds as lazy item text
-        (ordered markers never interrupt, §10). UNORDERED/TASK bullets and
-        every other block opener (quote, heading, fence, table, ...) nest at
-        ANY indent past the parent item's base column.
-      - RULE B (BULLETS AT ANY INDENT). A bullet (`-`/`*` + space + content)
-        opens a list at ANY indentation, uniformly in every context: at the
-        top level and nested in a list item. There is no column-0 restriction.
-        A bullet does NOT, however, interrupt an OPEN PARAGRAPH -- like an
-        ordered marker it needs a blank line before it (the symmetric §10 rule);
-        the "any indent" freedom is about WHERE a list may open, not about
-        breaking running prose.
+        `10. ` -> 4). A LIST-MARKER child -- a bullet (`-`/`*`, task) OR an
+        ordered marker -- must reach the parent item's content column to open a
+        sublist; below it, the line folds as lazy item text (list markers never
+        interrupt, §10). Bullet and ordered markers are SYMMETRIC here. Every
+        other block opener (quote, heading, fence, table, ...) nests at ANY
+        indent past the parent item's base column (those are unambiguous as
+        blocks and never fold as lazy text).
+      - RULE B (BULLETS AT ANY INDENT -- TOP LEVEL). A bullet (`-`/`*` + space +
+        content) opens a list at ANY indentation at the TOP LEVEL: there is no
+        column-0 restriction (unlike CommonMark, a `    - x` line is a list, not
+        indented code). An ordered marker behaves the same at the top level.
+        This "any indent" freedom is about WHERE a list may open at the top
+        level, NOT about sublist nesting depth (nesting follows the content-
+        column rule above) and NOT about interrupting an OPEN PARAGRAPH (a
+        marker needs a blank line before it -- the symmetric §10 rule).
       - DEDENT. When nested content is re-parsed, the container's structural
         indent is stripped by columns. A tab straddling the dedent boundary
         is consumed WHOLE on non-marker lines (Carve has no indent-sensitive


### PR DESCRIPTION
Spec/docs audit (codex passes + manual verification against actual impl behavior) found docs out of sync with the shipped grammar. Each finding was checked against `resources/grammar.ebnf` §10 and a live render before fixing.

## Paragraph interruption (the main one)
Several docs still described the old asymmetry "a bullet interrupts a paragraph, an ordered marker does not." Grammar §10 and all three impls now treat **both** list-marker classes identically: neither interrupts an open paragraph; a list needs a blank line. Verified: `intro\n- item` renders as a single paragraph.
- `divergence-from-djot.md` section 7 (rewrote the rule + flipped the example to a heading, which *does* interrupt)
- `comparison.md` footnote
- `case-study/syntax.md` (the paragraph-interruption claims; also reworded the **sub-list nesting** section so "interrupt" no longer collides with the §10 paragraph sense -- nesting is a separate axis and keeps its bullet/ordered distinction)

## Stale raw-block syntax
`case-study/syntax.md` still showed ```raw html / ```raw latex -- this file was missed when the `=FORMAT` change landed. Now ```=html / ```=latex.

## Wrong / dangling spec references
- "grammar PART 19" (no such part) -> `PART 9 §19`: `extensions.md`, `native-features-analysis.md` (x2)
- `examples.md` "PART 9 §note" -> `§16` (footnotes)
- `grammar.ebnf`: `label` production used an undefined `any_char` -> `character`; an attribute note cited a stale hardcoded line number -> the `identifier` production by name

No corpus change (the `examples.md` edit is prose only; 284 pairs unchanged; conformance green).

**Not included:** the GFM table delimiter-row gap -- there the docs are correct and the grammar production is incomplete; that needs a real production and is tracked separately.