### PR TITLE
Pin family D: a closed div/admonition ends the item

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4465,6 +4465,31 @@ tail
 
 :::
 
+A closed `:::` div or admonition is a complete block with no open paragraph either, so the dedented line ends the item too (only a blockquote, whose trailing paragraph stays open, folds the line in):
+
+::::: compare
+
+```carve
+- item
+  :::note
+  body
+  :::
+tail
+```
+
+```html
+<ul>
+  <li>item
+    <aside class="admonition note">
+      <p>body</p>
+    </aside>
+  </li>
+</ul>
+<p>tail</p>
+```
+
+:::::
+
 ## Compact list blocks
 
 A blank line is still required to start a block inside a list item, but it no longer makes the list *loose* when the indented content opens a block (sub-list, block quote, fenced code, fenced div, heading, table). The item stays **tight** — lead text inline, the block attached — so a checklist with notes or steps with code stay compact. (A Carve deviation: canonical djot renders these loose. Only the tight/loose rendering changes, not the block structure.)

--- a/tests/corpus/81-list-lazy-continuation-9.crv
+++ b/tests/corpus/81-list-lazy-continuation-9.crv
@@ -1,0 +1,5 @@
+- item
+  :::note
+  body
+  :::
+tail

--- a/tests/corpus/81-list-lazy-continuation-9.html
+++ b/tests/corpus/81-list-lazy-continuation-9.html
@@ -1,0 +1,8 @@
+<ul>
+  <li>item
+    <aside class="admonition note">
+      <p>body</p>
+    </aside>
+  </li>
+</ul>
+<p>tail</p>

--- a/tests/spec/81-list-lazy-continuation.test
+++ b/tests/spec/81-list-lazy-continuation.test
@@ -118,3 +118,20 @@ tail
 </ul>
 <p>tail</p>
 ```
+
+```
+- item
+  :::note
+  body
+  :::
+tail
+.
+<ul>
+  <li>item
+    <aside class="admonition note">
+      <p>body</p>
+    </aside>
+  </li>
+</ul>
+<p>tail</p>
+```


### PR DESCRIPTION
Adds a corpus pair pinning the family-D rule for a closed `:::` div/admonition: a dedented line after it ends the list item and becomes a top-level paragraph (no open paragraph, like code/table). Completes the family-D pins (markup-carve/carve#142 covered quote/code/table). All 3 impls already produce this output (carve-js#189, carve-php#160/#165, carve-rs#75). 300 corpus tests pass.