### PR TITLE
docs: fix task/sub-list nesting prose to match symmetric interruption

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -648,7 +648,7 @@ An ordered child *below* the content column does not nest: an ordered marker doe
 
 :::
 
-A task item's content column is the bullet width (2), since the checkbox is content, not marker, so a child indented to column 2 nests. (Unordered and task markers interrupt, §10, so they nest at any indent past the base, regardless of the content column.)
+A task item's content column is the bullet width (2), since the checkbox is content, not marker, so a child indented to column 2 nests. A marker indented below the content column folds in as lazy continuation rather than nesting; no list marker interrupts (§10), so only a marker at or past the content column opens a sub-list.
 
 ::: compare
 


### PR DESCRIPTION
The Lists section had a parenthetical that predates the symmetric interruption rule:

> A task item's content column is the bullet width (2) [...]. (Unordered and task markers interrupt, §10, so they nest at any indent past the base, regardless of the content column.)

After section 10 became symmetric, no list marker interrupts a paragraph. A marker indented *below* the parent content column folds in as lazy continuation rather than nesting; only a marker at or past the content column opens a sub-list. The old parenthetical ("interrupt", "any indent past the base, regardless of the content column") contradicts that, and also contradicts the section 10 prose later in the same file ("neither a bullet nor an ordered marker interrupts").

Verified against carve-rs:

```
- a
 - b
```

folds into one item (`- b` is below the content column), it does not nest. A child at column 2 (`- a` / `  - b`) does nest.

Prose-only change; the corpus and spec mirror are unchanged (the generator ignores prose lines).
