### PR TITLE
Add shared profile parity battery

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -141,3 +141,13 @@ Presets: **`unrestricted`** (all schemes/hosts), **`internalOnly`**
   markup.
 - Parity is byte-checked against `carve-php` via golden fixtures (the presets
   and the resolution rule above are the shared source of truth).
+
+## Parity battery
+
+`tests/profile-fixtures.json` is the **shared golden battery**: a set of
+`{carve, profile, html}` fixtures rendered by carve-php (the reference) covering
+the four presets, the disallowed-node actions, and the link policy. carve-js and
+carve-rs assert their own profile output against this file (comparing
+trailing-newline-insensitively, since renderers differ on a trailing `\n`), so a
+profile divergence in any implementation is caught. Regenerate with
+`tests/gen-profile-fixtures.php` from a carve-php checkout.

--- a/tests/gen-profile-fixtures.php
+++ b/tests/gen-profile-fixtures.php
@@ -1,0 +1,32 @@
+<?php
+// Generates tests/profile-fixtures.json -- the shared profile parity battery.
+// Run from a carve-php checkout: `php tests/gen-profile-fixtures.php > tests/profile-fixtures.json`
+// (adjust the require path to your carve-php vendor/autoload.php). carve-php is
+// the reference; carve-js and carve-rs assert their profile output against this
+// file (trailing-newline-insensitive). See docs/profiles.md.
+require getenv('CARVE_PHP_AUTOLOAD') ?: 'vendor/autoload.php';
+use Carve\CarveConverter;
+use Carve\Profile;
+use Carve\LinkPolicy;
+
+// name => [carve input, profile factory closure, profile id string for impls]
+$cases = [
+  'full-unchanged'      => ["Text with *bold* and a [link](/a).", fn()=>Profile::full(), 'full'],
+  'article-raw-denied'  => ["Para.\n\n```=html\n<b>x</b>\n```\n", fn()=>Profile::article(), 'article'],
+  'article-raw-inline'  => ["A `<b>x</b>`{=html} end.", fn()=>Profile::article(), 'article'],
+  'comment-heading'     => ["# Heading\n\nBody text.", fn()=>Profile::comment(), 'comment'],
+  'comment-image'       => ["See ![alt text](/pic.png) here.", fn()=>Profile::comment(), 'comment'],
+  'comment-table'       => ["| a | b |\n| c | d |\n", fn()=>Profile::comment(), 'comment'],
+  'comment-link-rel'    => ["A [site](https://example.com) link.", fn()=>Profile::comment(), 'comment'],
+  'comment-basic-fmt'   => ["*Bold*, _em_, `code`, ~~del~~.", fn()=>Profile::comment(), 'comment'],
+  'minimal-link-denied' => ["A [site](https://example.com) link.", fn()=>Profile::minimal(), 'minimal'],
+  'minimal-heading'     => ["# H\n\nText.", fn()=>Profile::minimal(), 'minimal'],
+  'minimal-list'        => ["- one\n- two\n", fn()=>Profile::minimal(), 'minimal'],
+];
+
+$out = [];
+foreach ($cases as $name => [$carve, $factory, $pid]) {
+    $conv = new CarveConverter(profile: $factory());
+    $out[$name] = ['carve' => $carve, 'profile' => $pid, 'html' => $conv->convert($carve)];
+}
+echo json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";

--- a/tests/profile-fixtures.json
+++ b/tests/profile-fixtures.json
@@ -1,0 +1,57 @@
+{
+    "full-unchanged": {
+        "carve": "Text with *bold* and a [link](/a).",
+        "profile": "full",
+        "html": "<p>Text with <strong>bold</strong> and a <a href=\"/a\">link</a>.</p>\n"
+    },
+    "article-raw-denied": {
+        "carve": "Para.\n\n```=html\n<b>x</b>\n```\n",
+        "profile": "article",
+        "html": "<p>Para.</p>\n<p>&lt;b&gt;x&lt;/b&gt;</p>\n"
+    },
+    "article-raw-inline": {
+        "carve": "A `<b>x</b>`{=html} end.",
+        "profile": "article",
+        "html": "<p>A &lt;b&gt;x&lt;/b&gt; end.</p>\n"
+    },
+    "comment-heading": {
+        "carve": "# Heading\n\nBody text.",
+        "profile": "comment",
+        "html": "<p># Heading</p>\n<p>Body text.</p>\n"
+    },
+    "comment-image": {
+        "carve": "See ![alt text](/pic.png) here.",
+        "profile": "comment",
+        "html": "<p>See [img: alt text] here.</p>\n"
+    },
+    "comment-table": {
+        "carve": "| a | b |\n| c | d |\n",
+        "profile": "comment",
+        "html": "<p>a | b<br>\nc | d</p>\n"
+    },
+    "comment-link-rel": {
+        "carve": "A [site](https://example.com) link.",
+        "profile": "comment",
+        "html": "<p>A <a href=\"https://example.com\" rel=\"nofollow ugc\">site</a> link.</p>\n"
+    },
+    "comment-basic-fmt": {
+        "carve": "*Bold*, _em_, `code`, ~~del~~.",
+        "profile": "comment",
+        "html": "<p><strong>Bold</strong>, <u>em</u>, <code>code</code>, ~~del~~.</p>\n"
+    },
+    "minimal-link-denied": {
+        "carve": "A [site](https://example.com) link.",
+        "profile": "minimal",
+        "html": "<p>A site link.</p>\n"
+    },
+    "minimal-heading": {
+        "carve": "# H\n\nText.",
+        "profile": "minimal",
+        "html": "<p># H</p>\n<p>Text.</p>\n"
+    },
+    "minimal-list": {
+        "carve": "- one\n- two\n",
+        "profile": "minimal",
+        "html": "<ul>\n  <li>one</li>\n  <li>two</li>\n</ul>\n"
+    }
+}


### PR DESCRIPTION
A canonical `tests/profile-fixtures.json` (11 `{carve, profile, html}` fixtures rendered by carve-php) covering the four presets, the disallowed-node actions, and the link policy. carve-js and carve-rs assert their profile output against it (trailing-newline-insensitive), locking profile parity beyond per-impl unit tests. Verified: all 11 match php / carve-js (#195) / carve-rs today. Includes the generator + a Parity-battery section in the Profiles Contract.