### PR TITLE
docs(extensions): catalog the Details Tier-3 disclosure extension

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -25,10 +25,19 @@ core-and-default-on everywhere and its default output is corpus-pinned.
   corpus-pinned, but per grammar PART 9 §19 a processor MAY disable them.
 - Tier 2: configuration over Tier-1 syntax — mention/tag→URL, emoji glyph map,
   locale smart-quote sets, bare-URL autolinking, and citations (§4).
-- Tier 3 (non-exhaustive): Mermaid, Tabs, CodeGroup, TableOfContents,
+- Tier 3 (non-exhaustive): Mermaid, Tabs, CodeGroup, Details, TableOfContents,
   HeadingPermalinks, HeadingLevelShift, ExternalLinks, DefaultAttributes,
   Wikilinks, SemanticSpan, and the opt-in heading-id transforms
   (LowercaseHeadingIds, AsciiHeadingIds).
+
+  `Details` is a pure renderer extension over the existing `:::details`
+  admonition (no new syntax): it emits the HTML5 `<details>/<summary>`
+  disclosure widget instead of the default `<div class="details">`. The
+  **quoted** title becomes the `<summary>` (a title-less block falls back to
+  `<summary>Details</summary>`); `{open}` on the opener carries through as
+  `<details open>`. Disabled, the block renders as the ordinary admonition
+  div, so documents stay readable. See the per-impl `docs/extensions.md` in
+  carve-js / carve-php / carve-rs.
 
 Inline and sidenote footnotes are **not** Tier 3. They are deferred core
 reserved syntax (`[^…]` inline, `[>…]` sidenote; `resources/grammar.ebnf`


### PR DESCRIPTION
Adds the Details extension to the Tier-3 catalog in `docs/extensions.md` - a pure renderer extension over the existing `:::details` admonition that emits the HTML5 `<details>`/`<summary>` disclosure widget. Quoted title becomes the `<summary>`; `{open}` carries through; disabled it renders as the ordinary admonition div. Implements the spec side of #161; carve-js already ships it, carve-php and carve-rs implementations are in flight.