### PR TITLE
test: regenerate stale quick.crv example snapshot

### DIFF
--- a/tests/examples/quick.html
+++ b/tests/examples/quick.html
@@ -1,4 +1,6 @@
 <section id="Plugin-Dogfood">
   <h1>Plugin Dogfood</h1>
   <p>This snippet is rendered from a <code>.crv</code> import by <strong>vite-plugin-carve</strong>.</p>
+  <p>Inline math like <span class="math inline">\(E = mc^2\)</span> and a display equation render with KaTeX:</p>
+  <p><span class="math display">\[\int_0^\infty e^{-x^2}\,dx = \frac{\sqrt{\pi}}{2}\]</span></p>
 </section>


### PR DESCRIPTION
The dogfood example docs/.vitepress/examples/quick.crv gained an inline + display math demo, but its rendered snapshot tests/examples/quick.html was not regenerated - leaving conformance red on main (commit 5321674f). This regenerates only that snapshot to match. Fixes the pre-existing main CI failure; no behavior change.