### PR TITLE
docs(extensions): catalog ListTable in the Tier-3 list

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -27,7 +27,9 @@ core-and-default-on everywhere and its default output is corpus-pinned.
   locale smart-quote sets, bare-URL autolinking, and citations (§4).
 - Tier 3 (non-exhaustive): Mermaid, MathBlock (a ` ```math ` fenced block →
   `<div class="math display">`, the GFM-style block form of Carve's `$…$`
-  math), Tabs, CodeGroup, Details, TableOfContents, HeadingPermalinks,
+  math), ListTable (a `::: list-table` div whose nested list renders as a real
+  HTML `<table>`; carve-php only), Tabs, CodeGroup, Details, TableOfContents,
+  HeadingPermalinks,
   HeadingLevelShift, ExternalLinks, DefaultAttributes, Wikilinks, SemanticSpan,
   and the opt-in heading-id transforms (LowercaseHeadingIds, AsciiHeadingIds).
 


### PR DESCRIPTION
carve-php shipped the `ListTable` Tier-3 extension (#195): a `::: list-table` div whose nested list renders as a real HTML `<table>`. Add it to the non-exhaustive Tier-3 catalog in `docs/extensions.md` for discoverability.

Tier-3 permits an extension to exist in a single implementation, so no carve-js / carve-rs partner is required.