### PR TITLE
docs(extensions): ListTable shipped in all three impls

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -28,7 +28,10 @@ core-and-default-on everywhere and its default output is corpus-pinned.
 - Tier 3 (non-exhaustive): Mermaid, MathBlock (a ` ```math ` fenced block →
   `<div class="math display">`, the GFM-style block form of Carve's `$…$`
   math), ListTable (a `::: list-table` div whose nested list renders as a real
-  HTML `<table>`; carve-php only), Tabs, CodeGroup, Details, TableOfContents,
+  HTML `<table>`, so cells can hold block content the pipe-table syntax cannot;
+  `{header-rows}` / `{header-cols}` take a count or the boolean first-row/column
+  form, and `^` / `<` give pipe-table-parity rowspan / colspan; in carve-php,
+  carve-js and carve-rs), Tabs, CodeGroup, Details, TableOfContents,
   HeadingPermalinks,
   HeadingLevelShift, ExternalLinks, DefaultAttributes, Wikilinks, SemanticSpan,
   and the opt-in heading-id transforms (LowercaseHeadingIds, AsciiHeadingIds).


### PR DESCRIPTION
The Tier-3 catalog said ListTable was `carve-php only`, but carve-js and carve-rs both ship it now. Updates the entry to list all three impls and notes the header count/boolean forms and the `^`/`<` rowspan/colspan markers.