### PR TITLE
docs(extensions): catalog FencedRender in the Tier-3 taxonomy

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -25,7 +25,9 @@ core-and-default-on everywhere and its default output is corpus-pinned.
   corpus-pinned, but per grammar PART 9 §19 a processor MAY disable them.
 - Tier 2: configuration over Tier-1 syntax — mention/tag→URL, emoji glyph map,
   locale smart-quote sets, bare-URL autolinking, and citations (§4).
-- Tier 3 (non-exhaustive): Mermaid, MathBlock (a ` ```math ` fenced block →
+- Tier 3 (non-exhaustive): FencedRender (a generic fenced-code-block factory
+  with Mermaid, D2, Graphviz, WaveDrom, ABC, Vega-Lite and Chart.js presets),
+  MathBlock (a ` ```math ` fenced block →
   `<div class="math display">`, the GFM-style block form of Carve's `$…$`
   math), ListTable (a `::: list-table` div whose nested list renders as a real
   HTML `<table>`, so cells can hold block content the pipe-table syntax cannot;
@@ -44,6 +46,19 @@ core-and-default-on everywhere and its default output is corpus-pinned.
   `<details open>`. Disabled, the block renders as the ordinary admonition
   div, so documents stay readable. See the per-impl `docs/extensions.md` in
   carve-js / carve-php / carve-rs.
+
+  `FencedRender` is the generic form of the Mermaid pattern: one configurable
+  renderer claims fenced code blocks by language word and emits a single
+  client-hydration element. In **text** mode (Mermaid, D2, Graphviz, WaveDrom,
+  ABC) the body is HTML-escaped inside `<pre class="lang">…</pre>`, with `&` and
+  `<` escaped but `>` preserved so arrow syntax (`-->`) survives; in **json**
+  mode (Vega-Lite, Chart.js) the body is emitted verbatim inside
+  `<div class="lang"><script type="application/json">…</script></div>`. The seven
+  named presets are one-liners, and any other client-rendered language needs no
+  new code - just a new instance with its fence word. Carve only emits the
+  marker element; loading the client library and hydrating it is the host's job.
+  Mermaid is one preset of this shape. In carve-php / carve-js / carve-rs; see
+  each impl's `docs/extensions.md` for the per-language client libraries.
 
   `MathBlock` renders a ` ```math ` fence as
   `<div class="math display">\[ … \]</div>` (body HTML-escaped). A preceding

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,9 +7,14 @@ tighten the policy.
 ## HTML is text, not markup
 
 Carve has no *implicit* raw-HTML passthrough. Authored bare `<` and `>` carry no
-special meaning and are escaped on output rather than interpreted. (Explicit,
-opt-in raw passthrough — `` ```=html `` blocks and `` `…`{=html} `` inline —
-does emit verbatim HTML and must be disabled for untrusted input; see Profiles.)
+special meaning and are escaped on output rather than interpreted.
+
+There is one *explicit*, author-opted raw passthrough - `` ```=html `` blocks
+and `` `…`{=html} `` inline - which emits verbatim HTML and is on by default
+(it is corpus-pinned). For UNTRUSTED input you MUST disable it: set
+`allowRawHtml: false` (carve-js) / `Options::with_raw_html(false)` (carve-rs) /
+enable `SafeMode` (carve-php), which escapes the raw content to text instead of
+emitting it.
 
 ```carve
 <script>alert(1)</script>
@@ -19,12 +24,13 @@ renders as the literal, inert text `&lt;script&gt;alert(1)&lt;/script&gt;`.
 This removes the entire class of injection that comes from Markdown/CommonMark
 passing raw HTML through to the output.
 
-## URL scheme sanitization (on by default)
+## URL scheme sanitization (always on)
 
-The HTML renderer filters the URL on every clickable sink - link `href` and
-image `src` - against a scheme allowlist. A URL whose scheme is not allowed
-collapses to an empty value, so the link text or image `alt` stays visible but
-the element is inert:
+The HTML renderer filters the URL on every clickable sink - link `href`, image
+`src`, and autolink - against a scheme **denylist**, unconditionally (no opt-in,
+no safe-mode required). A URL whose scheme is `javascript`, `vbscript`, `data`,
+or `file` collapses to an empty value, so the link text or image `alt` stays
+visible but the element is inert:
 
 | Input | Rendered |
 |---|---|
@@ -34,12 +40,16 @@ the element is inert:
 | `[ok](https://example.com)` | `<a href="https://example.com">ok</a>` |
 | `[rel](/docs/page)` | `<a href="/docs/page">rel</a>` |
 
-What always passes through:
+What passes through (denylist, not allowlist):
 
 - Relative URLs (no scheme), e.g. `/docs/page`, `page.crv`
 - Fragments, e.g. `#section`
 - Protocol-relative URLs, e.g. `//cdn.example.com/x`
-- Any scheme in the allowlist (default: `http`, `https`, `mailto`)
+- Any scheme NOT on the denylist, e.g. `http`, `https`, `mailto`, `tel`, `ftp`
+
+To tighten to a strict allowlist instead, pass `allowedUrlSchemes` (carve-js);
+to customize the denylist, pass `deniedUrlSchemes`. carve-php / carve-rs apply
+the same baseline; their safe-mode / profile layer can tighten it further.
 
 An attribute block cannot reintroduce a dangerous URL: a `{href=...}` or
 `{src=...}` override (in any letter case) is dropped in favor of the sanitized
@@ -93,7 +103,9 @@ Specifically, on every rendered element:
 - an attribute **value** whose scheme is `javascript`, `vbscript`, `data`, or
   `file` is blanked - scheme detection ignores the control/space characters a
   browser discards, so `java<TAB>script:` does not slip through;
-- a `style` value containing a CSS `expression(...)` is blanked.
+- a `style` value containing a script-bearing or fetching CSS construct -
+  `expression(...)`, `url(...)`, `@import`, `behavior:`, or `-moz-binding` - is
+  blanked (whitespace collapsed first to defeat evasion).
 
 All other attributes pass through with their values HTML-escaped (quotes
 included, so a value cannot break out of its attribute). This baseline is
@@ -117,9 +129,10 @@ identical across carve-php, carve-js and carve-rs.
 
 ## Relationship to the spec's SafeMode
 
-The case study describes a broader `SafeMode` / `Profile` link policy (scheme
-allow/deny lists, domain allow/deny, `rel=nofollow`, nesting and length limits).
-The scheme allowlist on this page is the part enforced today by the reference
-JavaScript implementation. The wider feature-restriction surface is documented
-in the [Syntax Specification](./case-study/syntax) and may land in
-implementations incrementally.
+The baseline on this page - the URL scheme denylist, the attribute name/value
+hardening, and the raw-HTML escape switch - is enforced by all three
+implementations (carve-php, carve-js, carve-rs) by default. `SafeMode` /
+`Profile` describe a broader, opt-in policy layered ON TOP (scheme allowlists,
+domain allow/deny, `rel=nofollow`, feature restriction, nesting / length
+limits); that wider surface is documented in the
+[Syntax Specification](./case-study/syntax) and may land incrementally.


### PR DESCRIPTION
The §1 Tier-3 taxonomy bullet listed a standalone `Mermaid` and never mentioned the generic **FencedRender** factory, even though it shipped across all three impls (carve-php #201, carve-js #221, carve-rs #112).

## What

- Name `FencedRender` (with its Mermaid / D2 / Graphviz / WaveDrom / ABC / Vega-Lite / Chart.js presets) in the Tier-3 bullet.
- Add a short explainer paragraph after the Details one: text vs json content modes, the seven presets, custom languages need no new code, and that the host loads the client library / hydrates the emitted marker. Mirrors the existing MathBlock / Details prose.

Contract-doc convention kept: FencedRender is Tier-3 and not corpus-pinned, so it is catalogued in §1 (like Mermaid/MathBlock/etc.) rather than given its own normative section; per-language client-library detail lives in each impl's `docs/extensions.md`.

Full test suite green (328 tests).