### PR TITLE
docs(demo): simpler display-math example (Euler's identity)

### DIFF
--- a/docs/.vitepress/examples/demo.crv
+++ b/docs/.vitepress/examples/demo.crv
@@ -132,7 +132,7 @@ Inline math uses a dollar before a code span: $`e = mc^2`.
 
 Display math uses a double dollar:
 
-$$`\int_0^\infty e^{-x^2}\,dx = \frac{\sqrt{\pi}}{2}`
+$$`e^{i\pi} + 1 = 0`
 
 A fenced `math` block is the GFM-style block form (mathBlock extension):
 

--- a/tests/examples/demo.html
+++ b/tests/examples/demo.html
@@ -125,7 +125,7 @@ list:
     <h2>Math</h2>
     <p>Inline math uses a dollar before a code span: <span class="math inline">\(e = mc^2\)</span>.</p>
     <p>Display math uses a double dollar:</p>
-    <p><span class="math display">\[\int_0^\infty e^{-x^2}\,dx = \frac{\sqrt{\pi}}{2}\]</span></p>
+    <p><span class="math display">\[e^{i\pi} + 1 = 0\]</span></p>
     <p>A fenced <code>math</code> block is the GFM-style block form (mathBlock extension):</p>
     <pre><code class="language-math">\sum_{k=1}^{n} k = \frac{n(n+1)}{2}
 </code></pre>


### PR DESCRIPTION
The demo's display equation was the Gaussian integral - wide enough to overflow the rendered pane and needlessly complex for a feature demo. Swap it for the compact `e^{i\pi}+1=0` (distinct from the inline `e=mc^2` above). No overflow; snapshot regenerated.