### PR TITLE
docs: clarify core vs extensions / Tier 1-2-3

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -1009,10 +1009,11 @@ renders as
 - A label referenced twice keeps one number and gets a backlink per
   reference.
 
-> **Deferred.** The earlier *inline footnote* (`[^content]`) and
-> *sidenote* (`[>content]`) forms are reserved but **not yet
-> implemented** — they are ambiguous against the reference form and have
-> no djot equivalent. Use reference footnotes.
+> **Inline footnotes** (`^[content]` — a caret immediately before `[`) are
+> implemented and corpus-pinned (Tier-1, grammar PART 9 §16; see the *Inline
+> footnotes* examples). The note text is carried in place and numbered into the
+> same endnote pool as reference footnotes. **Sidenotes** (`[>content]`) remain
+> *reserved but not yet implemented* — margin notes with no djot equivalent.
 
 ### 4.12 Special Blocks (Admonitions)
 
@@ -1034,10 +1035,12 @@ This action cannot be undone.
 :::
 ```
 
-Carve renders a `:::` block by a **two-tier rule** on the type
-identifier (PART 9 §12):
+Carve renders a `:::` block by a **two-branch rule** on the type
+identifier (PART 9 §12). (This is a rendering-strategy split *within* the
+core `:::` mechanism — unrelated to the Tier-1/2/3 conformance tiers; both
+branches are Tier-1 core.)
 
-**Tier 1 — canonical admonition types** render as a semantic `<aside>`
+**Canonical admonition types** render as a semantic `<aside>`
 with the `admonition` marker class. The canonical set is `note`, `tip`,
 `warning`, `danger`, `info`, `success`, `example`, `quote`. The carve
 VitePress theme and most third-party themes ship CSS targeting these
@@ -1049,7 +1052,7 @@ exact class names:
 </aside>
 ```
 
-**Tier 2 — any other (custom) type** renders as a generic block-level
+**Custom types — any other type** render as a generic block-level
 `<div>` carrying the verbatim type as its class. This is the carve
 fenced-div primitive that the block-extension mechanism (§4.20) builds
 on (`::: tabs`, `::: mermaid`, `::: codepen` → `<div class="tabs">`
@@ -1086,10 +1089,10 @@ synthesize a default title from the type name; `::: note` without `"…"`
 produces no title element at all.
 
 > **Design note — a conscious exception.** Whether `::: x` renders as an
-> `<aside>` (Tier 1) or a `<div>` (Tier 2) depends on whether `x` is in
+> `<aside>` (canonical) or a `<div>` (custom) depends on whether `x` is in
 > the canonical set — i.e. the *meaning* of the construct is
 > context-dependent, in mild tension with Design Principle 1 ("one
-> syntax, one meaning"). This is deliberate: both tiers share the same
+> syntax, one meaning"). This is deliberate: both branches share the same
 > `<div>`-shaped fenced-container primitive, and the canonical names are
 > a curated styling convention layered on top, not a separate syntax.
 > The *parse* is never ambiguous (every `::: word` is a fenced block);
@@ -1123,7 +1126,7 @@ A div with attributes.
 </div>
 ```
 
-So `::: word` is a typed block (Tier 1 admonition / Tier 2 div); bare
+So `::: word` is a typed block (canonical admonition / custom div); bare
 `:::` or `::: {…}` is a generic `<div>` (PART 9 §12).
 
 **Nesting by fence length.** A fence is a run of three or more colons. A

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -7,6 +7,11 @@ description: Every Carve construct on one scannable page.
 
 The whole syntax, one page. Carve's mnemonic: **the markup looks like its output**.
 
+Everything here is **core** (Tier-1) — on by default, identical across every
+implementation — except rows marked **✦**, which are opt-in extensions
+(Tier-2/3) you enable in your processor. Look any feature up in the
+[feature → tier table](/extensions#feature-tiers-quick-reference).
+
 ## Inline
 
 | Write | Get | Mnemonic |
@@ -27,7 +32,7 @@ The whole syntax, one page. Carve's mnemonic: **the markup looks like its output
 | `![alt](img.jpg)` | image | |
 | `[^1]` / `^[inline note]` | footnote | reference / inline form |
 | `[span]{.class}` | span | `{…}` adds class, id, or attributes |
-| `:youtube[ID]` | extension | `:type[content]{attrs}` |
+| `:youtube[ID]` ✦ | extension | `:type[content]{attrs}` — syntax is core; the handler is opt-in |
 | `@user` `#tag` | mention / tag | social conventions |
 | `\*literal\*` | escape | backslash + any ASCII punctuation |
 | `--` `---` `...` `->` `(c)` | – — … → © | smart typography |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -31,20 +31,20 @@ PART 9 §19); Tier-2 / Tier-3 are off until enabled.
 
 | Feature | Tier | Default | Disable? |
 |---|---|---|---|
-| Headings, paragraphs, lists, task lists, blockquotes, thematic breaks | <Badge type="tip" text="1 · core" /> | on | no |
-| Tables (incl. rowspan/colspan/alignment), fenced code, inline code | <Badge type="tip" text="1 · core" /> | on | no |
-| Emphasis family (`/` `*` `_` `~` `^` `,` `=`), links, images, `<…>` autolinks | <Badge type="tip" text="1 · core" /> | on | no |
-| Attributes `{.class #id k=v}`, generic divs / spans, captions / figures | <Badge type="tip" text="1 · core" /> | on | no |
-| Admonitions (8 canonical types), definition lists, verse `::: \|` | <Badge type="tip" text="1 · core" /> | on | no |
-| Math `$…$` / `$$…$$`, footnotes `[^id]` + inline `^[…]`, abbreviations | <Badge type="tip" text="1 · core" /> | on | no |
-| Cross-references `</#id>` + numbered cross-refs, editorial / critic markup | <Badge type="tip" text="1 · core" /> | on | no |
-| Frontmatter, comments, raw blocks / inline `=format` | <Badge type="tip" text="1 · core" /> | on | no |
-| The extension **syntax** `:name[…]` (inline) and `::: name` (block) | <Badge type="tip" text="1 · core" /> | on | no — the *handlers* are Tier-2/3 |
-| Smart typography, `@mention`, `#tag`, `:emoji:` parsing | <Badge type="tip" text="1 · core" /> | on | **yes** (§19) |
-| Citations `[@key]`, bare-URL autolinking | <Badge type="info" text="2" /> | off | — |
-| Mention/tag → URL templates, emoji glyph map, locale smart-quote sets | <Badge type="info" text="2" /> | off | — |
-| Mermaid / FencedRender, MathBlock, ListTable, Details, Spoiler, Tabs, CodeGroup | <Badge type="warning" text="3" /> | off | — |
-| TableOfContents, HeadingPermalinks / LevelShift, ExternalLinks, Wikilinks, SemanticSpan, Lowercase/AsciiHeadingIds | <Badge type="warning" text="3" /> | off | — |
+| Headings, paragraphs, lists, task lists, blockquotes, thematic breaks | <Badge type="tip" text="core" /> | on | no |
+| Tables (incl. rowspan/colspan/alignment), fenced code, inline code | <Badge type="tip" text="core" /> | on | no |
+| Emphasis family (`/` `*` `_` `~` `^` `,` `=`), links, images, `<…>` autolinks | <Badge type="tip" text="core" /> | on | no |
+| Attributes `{.class #id k=v}`, generic divs / spans, captions / figures | <Badge type="tip" text="core" /> | on | no |
+| Admonitions (8 canonical types), definition lists, verse `::: \|` | <Badge type="tip" text="core" /> | on | no |
+| Math `$…$` / `$$…$$`, footnotes `[^id]` + inline `^[…]`, abbreviations | <Badge type="tip" text="core" /> | on | no |
+| Cross-references `</#id>` + numbered cross-refs, editorial / critic markup | <Badge type="tip" text="core" /> | on | no |
+| Frontmatter, comments, raw blocks / inline `=format` | <Badge type="tip" text="core" /> | on | no |
+| The extension **syntax** `:name[…]` (inline) and `::: name` (block) | <Badge type="tip" text="core" /> | on | no — the *handlers* are Tier-2/3 |
+| Smart typography, `@mention`, `#tag`, `:emoji:` parsing | <Badge type="tip" text="core" /> | on | **yes** (§19) |
+| Citations `[@key]`, bare-URL autolinking | <Badge type="info" text="standard" /> | off | — |
+| Mention/tag → URL templates, emoji glyph map, locale smart-quote sets | <Badge type="info" text="standard" /> | off | — |
+| Mermaid / FencedRender, MathBlock, ListTable, Details, Spoiler, Tabs, CodeGroup | <Badge type="warning" text="extension" /> | off | — |
+| TableOfContents, HeadingPermalinks / LevelShift, ExternalLinks, Wikilinks, SemanticSpan, Lowercase/AsciiHeadingIds | <Badge type="warning" text="extension" /> | off | — |
 
 A `:name[…]` / `::: name` whose word has no registered handler renders via the
 generic fallback (`<span>` / `<div class="name">`), so a document using an

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -17,6 +17,40 @@ implementation realizes.
 Invariant: a feature's tier is identical in every language; a Tier-1 feature is
 core-and-default-on everywhere and its default output is corpus-pinned.
 
+> The same split is described as MUST / SHOULD / MAY in
+> [`native-features-analysis.md`](./native-features-analysis): **MUST** = Tier-1
+> core (not disableable); **SHOULD** = Tier-1 default-on but a processor MAY
+> turn it off (the four shorthands below); **MAY** = Tier-2 / Tier-3. Same model,
+> two vocabularies.
+
+### Feature tiers (quick reference)
+
+The one place to answer "is feature X core or an extension?". "Disable?" is
+whether a conformant processor may turn a default-on feature off (grammar
+PART 9 §19); Tier-2 / Tier-3 are off until enabled.
+
+| Feature | Tier | Default | Disable? |
+|---|---|---|---|
+| Headings, paragraphs, lists, task lists, blockquotes, thematic breaks | 1 · core | on | no |
+| Tables (incl. rowspan/colspan/alignment), fenced code, inline code | 1 · core | on | no |
+| Emphasis family (`/` `*` `_` `~` `^` `,` `=`), links, images, `<…>` autolinks | 1 · core | on | no |
+| Attributes `{.class #id k=v}`, generic divs / spans, captions / figures | 1 · core | on | no |
+| Admonitions (8 canonical types), definition lists, verse `::: \|` | 1 · core | on | no |
+| Math `$…$` / `$$…$$`, footnotes `[^id]` + inline `^[…]`, abbreviations | 1 · core | on | no |
+| Cross-references `</#id>` + numbered cross-refs, editorial / critic markup | 1 · core | on | no |
+| Frontmatter, comments, raw blocks / inline `=format` | 1 · core | on | no |
+| The extension **syntax** `:name[…]` (inline) and `::: name` (block) | 1 · core | on | no — the *handlers* are Tier-2/3 |
+| Smart typography, `@mention`, `#tag`, `:emoji:` parsing | 1 · core | on | **yes** (§19) |
+| Citations `[@key]`, bare-URL autolinking | 2 | off | — |
+| Mention/tag → URL templates, emoji glyph map, locale smart-quote sets | 2 | off | — |
+| Mermaid / FencedRender, MathBlock, ListTable, Details, Spoiler, Tabs, CodeGroup | 3 | off | — |
+| TableOfContents, HeadingPermalinks / LevelShift, ExternalLinks, Wikilinks, SemanticSpan, Lowercase/AsciiHeadingIds | 3 | off | — |
+
+A `:name[…]` / `::: name` whose word has no registered handler renders via the
+generic fallback (`<span>` / `<div class="name">`), so a document using an
+unknown extension word still parses and stays readable — only its *rendering*
+differs by processor. The narrative below details each tier.
+
 - Tier 1: corpus categories 01–88 (admonitions, footnotes, cross-references,
   list-item attributes, `::: |` verse, `<…>` autolinks, the
   `:name[…]` / `::: name` extension syntax). Recognized `:::` type words

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -31,20 +31,20 @@ PART 9 §19); Tier-2 / Tier-3 are off until enabled.
 
 | Feature | Tier | Default | Disable? |
 |---|---|---|---|
-| Headings, paragraphs, lists, task lists, blockquotes, thematic breaks | 1 · core | on | no |
-| Tables (incl. rowspan/colspan/alignment), fenced code, inline code | 1 · core | on | no |
-| Emphasis family (`/` `*` `_` `~` `^` `,` `=`), links, images, `<…>` autolinks | 1 · core | on | no |
-| Attributes `{.class #id k=v}`, generic divs / spans, captions / figures | 1 · core | on | no |
-| Admonitions (8 canonical types), definition lists, verse `::: \|` | 1 · core | on | no |
-| Math `$…$` / `$$…$$`, footnotes `[^id]` + inline `^[…]`, abbreviations | 1 · core | on | no |
-| Cross-references `</#id>` + numbered cross-refs, editorial / critic markup | 1 · core | on | no |
-| Frontmatter, comments, raw blocks / inline `=format` | 1 · core | on | no |
-| The extension **syntax** `:name[…]` (inline) and `::: name` (block) | 1 · core | on | no — the *handlers* are Tier-2/3 |
-| Smart typography, `@mention`, `#tag`, `:emoji:` parsing | 1 · core | on | **yes** (§19) |
-| Citations `[@key]`, bare-URL autolinking | 2 | off | — |
-| Mention/tag → URL templates, emoji glyph map, locale smart-quote sets | 2 | off | — |
-| Mermaid / FencedRender, MathBlock, ListTable, Details, Spoiler, Tabs, CodeGroup | 3 | off | — |
-| TableOfContents, HeadingPermalinks / LevelShift, ExternalLinks, Wikilinks, SemanticSpan, Lowercase/AsciiHeadingIds | 3 | off | — |
+| Headings, paragraphs, lists, task lists, blockquotes, thematic breaks | <Badge type="tip" text="1 · core" /> | on | no |
+| Tables (incl. rowspan/colspan/alignment), fenced code, inline code | <Badge type="tip" text="1 · core" /> | on | no |
+| Emphasis family (`/` `*` `_` `~` `^` `,` `=`), links, images, `<…>` autolinks | <Badge type="tip" text="1 · core" /> | on | no |
+| Attributes `{.class #id k=v}`, generic divs / spans, captions / figures | <Badge type="tip" text="1 · core" /> | on | no |
+| Admonitions (8 canonical types), definition lists, verse `::: \|` | <Badge type="tip" text="1 · core" /> | on | no |
+| Math `$…$` / `$$…$$`, footnotes `[^id]` + inline `^[…]`, abbreviations | <Badge type="tip" text="1 · core" /> | on | no |
+| Cross-references `</#id>` + numbered cross-refs, editorial / critic markup | <Badge type="tip" text="1 · core" /> | on | no |
+| Frontmatter, comments, raw blocks / inline `=format` | <Badge type="tip" text="1 · core" /> | on | no |
+| The extension **syntax** `:name[…]` (inline) and `::: name` (block) | <Badge type="tip" text="1 · core" /> | on | no — the *handlers* are Tier-2/3 |
+| Smart typography, `@mention`, `#tag`, `:emoji:` parsing | <Badge type="tip" text="1 · core" /> | on | **yes** (§19) |
+| Citations `[@key]`, bare-URL autolinking | <Badge type="info" text="2" /> | off | — |
+| Mention/tag → URL templates, emoji glyph map, locale smart-quote sets | <Badge type="info" text="2" /> | off | — |
+| Mermaid / FencedRender, MathBlock, ListTable, Details, Spoiler, Tabs, CodeGroup | <Badge type="warning" text="3" /> | off | — |
+| TableOfContents, HeadingPermalinks / LevelShift, ExternalLinks, Wikilinks, SemanticSpan, Lowercase/AsciiHeadingIds | <Badge type="warning" text="3" /> | off | — |
 
 A `:name[…]` / `::: name` whose word has no registered handler renders via the
 generic fallback (`<span>` / `<div class="name">`), so a document using an

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -53,6 +53,27 @@ $html = (new CarveConverter())->convert('/italic/, *bold*, and a heading');
 - **[Examples](/examples)** — Carve source next to the exact HTML it produces.
 - **[Case Study](/case-study/)** — the full design rationale and normative spec.
 
+## 4. Core vs extensions
+
+Almost everything you write is **core** (Tier-1): headings, lists, tables,
+links, code, math, footnotes, admonitions, attributes, and the rest of the
+cheat sheet. Core is **on by default** and renders identically across every
+implementation — no configuration, no plugins.
+
+A few things are **opt-in**:
+
+- **Tier-2** — spec-defined but off by default, e.g. citations `[@key]`,
+  bare-URL autolinking, mention/tag → URL templates. Enable them in your
+  processor.
+- **Tier-3** — per-implementation extensions, e.g. Mermaid diagrams, a
+  collapsible `details` widget, `list-table`. Register the ones you want.
+
+The `:name[…]` (inline) and `::: name` (block) **syntax** is core, but whether a
+given `name` does something special depends on whether a handler is registered;
+an unknown one just renders as a plain span/div, so documents always stay
+readable. The full **[feature → tier table](/extensions#feature-tiers-quick-reference)**
+is the place to look up any feature.
+
 ## Build your own parser
 
 Carve's grammar is small and unambiguous. To implement it in another language, start from **[Build Your Own Implementation](/implementing-carve)** and the **[Formal Grammar](/grammar)**.

--- a/docs/native-features-analysis.md
+++ b/docs/native-features-analysis.md
@@ -172,7 +172,13 @@ These should remain implementation-specific, not part of Carve syntax:
 ## Disabling / Restricting Features
 
 Can a processor turn native features off? It depends on the tier (see
-Conformance Core below for the full split):
+Conformance Core below for the full split).
+
+> This MUST / SHOULD / MAY split is the same model as the Tier-1/2/3 taxonomy in
+> the normative [extensions contract](./extensions): **MUST** = Tier-1 core
+> (not disableable); **SHOULD** = Tier-1 default-on but a processor MAY disable
+> it; **MAY** = Tier-2 (spec-listed, off by default) / Tier-3 (per-impl). The
+> extensions contract has the consolidated feature → tier table.
 
 | Tier | Features | Disableable? |
 |------|----------|--------------|


### PR DESCRIPTION
Improves clarity of the core-vs-extension / Tier 1-2-3 model (from a docs audit):

1. **Feature → tier table** in extensions.md - one place to look up any feature's tier, default, and whether it's disableable.
2. **Stale fix** in syntax.md §4.11: inline footnotes `^[content]` are implemented + corpus-pinned (Tier-1); only sidenotes `[>…]` remain deferred.
3. **Reconcile two taxonomies**: cross-link the Tier-1/2/3 model and native-features-analysis.md's MUST/SHOULD/MAY framing (same model, two vocabularies).
4. **Core-vs-extensions primer** in get-started.md.
5. **Cheatsheet marker**: everything is core unless marked ✦ (opt-in), linking the table.
6. **De-overload "Tier"** in syntax.md §4.12: admonition rendering split renamed canonical/custom.

Doc-only; `docs:build` passes.