### PR TITLE
docs: clarity polish (SafeMode framing, CriticMarkup scope, cross-refs)

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -4,6 +4,11 @@ How Carve compares to the markup languages you already know. The short version:
 Markdown's reach, Djot's consistency, web-native features by default - without
 turning your content into a JavaScript program.
 
+> This page is **Carve-centric**: a feature-by-feature take against Markdown,
+> Djot, and MDX. For a broader, neutral survey of the wider lightweight-markup
+> landscape (AsciiDoc, reStructuredText, Textile, and more), see
+> [Modern Markup Languages Comparison](./markup-languages).
+
 ::: tip Legend
 ✅ native &nbsp;·&nbsp; 🧩 plugin / extension needed &nbsp;·&nbsp; ⚠️ partial / convention &nbsp;·&nbsp; ❌ not available
 :::

--- a/docs/dismissed-syntax.md
+++ b/docs/dismissed-syntax.md
@@ -254,7 +254,11 @@ syntax — symbol-based, no English keyword, symmetric with the inline
 
 ---
 
-## CriticMarkup Integration
+## CriticMarkup: doubled-marker form (`{++added++}`)
+
+> The CriticMarkup *feature* was adopted - it is part of the spec (section 4.14)
+> with single-character markers. Only the **doubled-marker** form proposed
+> below was dismissed. It lives here to record that choice.
 
 **Proposed:**
 ```
@@ -262,7 +266,7 @@ This is {++added++} and {--removed--} text.
 This is {~~old~>new~~} replacement.
 ```
 
-**Status:** Included in spec (section 4.14), but with **single**-character markers (`{+added+}`, `{-removed-}`, `{~old~>new~}`); the doubled-marker form shown above was not adopted.
+**Status:** The feature is in the spec (section 4.14), but with **single**-character markers (`{+added+}`, `{-removed-}`, `{~old~>new~}`); the doubled-marker form shown above was not adopted.
 
 **Considerations:**
 - Useful for document review workflows

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ features:
   - title: Visual Mnemonics
     details: "/italic/ slashes lean, *bold* asterisks are heavy, _underline_ sits below, ~strikethrough~ runs through. Syntax that looks like its output."
   - title: Linear-Time Rigor
-    details: Djot-style linear-time parsing with no backtracking, unambiguous rules — extended with captions, abbreviations, and social conventions.
+    details: "Djot-style linear-time parsing with no backtracking and unambiguous rules (Djot is the markup Carve builds on), extended with captions, abbreviations, and social conventions."
   - title: Ten-Second Rule
     details: Learnable in 10 seconds for basic use. Memorable after 10 days without practice. Unambiguous within 10 characters of context.
   - title: Captions Everywhere

--- a/docs/markup-languages.md
+++ b/docs/markup-languages.md
@@ -1,6 +1,9 @@
 # Modern Markup Languages Comparison
 
-A comparison of lightweight markup languages available today.
+A broad, neutral survey of the lightweight markup languages available today.
+
+> For a focused, Carve-centric comparison against Markdown, Djot, and MDX, see
+> [Carve vs Markdown, Djot & MDX](./comparison).
 
 ## Overview
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -160,12 +160,13 @@ does not launder an attack:
   responsible for inserting it into a trusted context and for the surrounding
   Content-Security-Policy.
 
-## Relationship to the spec's SafeMode
+## Beyond the baseline: SafeMode and Profiles
 
 The baseline on this page - the URL scheme denylist, the attribute name/value
-hardening, and the raw-HTML escape switch - is enforced by all three
-implementations (carve-php, carve-js, carve-rs) by default. `SafeMode` /
-`Profile` describe a broader, opt-in policy layered ON TOP (scheme allowlists,
+hardening, and the raw-HTML escape switch - is the normative default: enforced
+by all three implementations (carve-php, carve-js, carve-rs) without any
+configuration. `SafeMode` / `Profile` are **optional, implementation-level**
+policy objects that layer a broader surface ON TOP (scheme allowlists,
 domain allow/deny, `rel=nofollow`, feature restriction, nesting / length
 limits); that wider surface is documented in the
 [Syntax Specification](./case-study/syntax) and may land incrementally.


### PR DESCRIPTION
Low-priority clarity items from the full-docs re-audit (follow-up to #191/#192/#193).

- **security.md** - heading `Relationship to the spec's SafeMode` read as if SafeMode were normative. Reframed to `Beyond the baseline: SafeMode and Profiles`; the page baseline is the normative default, SafeMode/Profile are optional implementation-level policy layered on top.
- **dismissed-syntax.md** - the CriticMarkup entry sat in a *dismissal* doc but its status said "Included in spec". Scoped the heading to the dismissed **doubled-marker** form and added a note that the feature itself was adopted (single markers, section 4.14).
- **index.md** - glossed the first `Djot` mention on the home page (it was used before being introduced); dropped an em dash.
- **comparison.md / markup-languages.md** - cross-linked the two overlapping comparison pages and stated each page's scope (Carve-centric vs broad neutral survey).

Docs build passes.