### PR TITLE
security: make HTML hardening normative (grammar PART 9 §25) + corpus pins

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5971,3 +5971,113 @@ author chooses the layout by where they place the markers.
 ```
 
 :::
+
+## Security hardening
+
+Carve is safe by default: when it emits HTML for untrusted input, dangerous URL
+schemes, event-handler attributes, and script-bearing CSS are neutralized
+before serialization. These pairs pin that behavior (normative: grammar PART 9
+§25). The HTML renderer is the primary untrusted-output path; the rules below
+are always on and identical across implementations.
+
+A `javascript:` link destination is rejected, leaving an empty `href` (the link
+text is preserved):
+
+::: compare
+
+```carve
+[click here](javascript:stealCookies)
+```
+
+```html
+<p><a href="">click here</a></p>
+```
+
+:::
+
+An autolink with a dangerous scheme is blanked the same way:
+
+::: compare
+
+```carve
+<vbscript:msgbox>
+```
+
+```html
+<p><a href="">vbscript:msgbox</a></p>
+```
+
+:::
+
+An image whose source uses a dangerous scheme keeps its `alt` but drops the
+`src` value:
+
+::: compare
+
+```carve
+![logo](javascript:stealCookies)
+```
+
+```html
+<img src="" alt="logo">
+```
+
+:::
+
+An event-handler attribute (any `on*` name) is dropped entirely:
+
+::: compare
+
+```carve
+A [danger]{onclick="steal()"} span.
+```
+
+```html
+<p>A <span>danger</span> span.</p>
+```
+
+:::
+
+A `style` value containing a CSS `expression(` (or `url(`, `@import`,
+`behavior:`, `-moz-binding`) is blanked, keeping the harmless `style` slot:
+
+::: compare
+
+```carve
+A [danger]{style="x:expression(steal())"} span.
+```
+
+```html
+<p>A <span style="">danger</span> span.</p>
+```
+
+:::
+
+The `srcdoc` and `formaction` attribute names are dropped:
+
+::: compare
+
+```carve
+A [danger]{srcdoc="<script>"} span.
+```
+
+```html
+<p>A <span>danger</span> span.</p>
+```
+
+:::
+
+An attribute-block `href`/`src` override cannot reintroduce a dangerous scheme;
+the safe destination is kept and the override is ignored:
+
+::: compare
+
+```carve
+[safe](https://example.com){href="javascript:steal"}
+```
+
+```html
+<p><a href="https://example.com">safe</a></p>
+```
+
+:::

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -97,8 +97,13 @@ differs by processor. The narrative below details each tier.
   Mermaid is one preset of this shape. In carve-php / carve-js / carve-rs; see
   each impl's `docs/extensions.md` for the per-language client libraries.
 
-  Note: json mode emits a `<script type="application/json">`, which an HTML
-  sanitizer run *after* conversion usually strips. Every json-mode type has a
+  Note: json mode emits a `<script type="application/json">`. Because an HTML
+  parser ends *script data* on the literal `</script>` regardless of the
+  script's MIME type, a json-mode renderer **MUST** neutralize script-data
+  terminators in the body (rewrite `</` so `</script>`, `<!--`, and `<script`
+  cannot break out) before emitting -- a Tier-3 requirement mirroring the core
+  attribute hardening (grammar PART 9 §25). Even then, an HTML
+  sanitizer run *after* conversion usually strips the whole element. Every json-mode type has a
   non-script alternative: render that same language in **text mode** instead, so
   the config rides in a `<pre class="lang">` as escaped text and survives
   sanitizing (the host reads it from `textContent` rather than a script tag).

--- a/docs/security.md
+++ b/docs/security.md
@@ -163,9 +163,11 @@ does not launder an attack:
 ## Beyond the baseline: SafeMode and Profiles
 
 The baseline on this page - the URL scheme denylist, the attribute name/value
-hardening, and the raw-HTML escape switch - is the normative default: enforced
-by all three implementations (carve-php, carve-js, carve-rs) without any
-configuration. `SafeMode` / `Profile` are **optional, implementation-level**
+hardening, the raw-HTML escape switch, and the DoS resource bounds - is the
+normative default, mandated by the grammar (`resources/grammar.ebnf` PART 9 §25)
+and pinned by the corpus ("Security hardening" examples). It is enforced by all
+three implementations (carve-php, carve-js, carve-rs) without any configuration.
+`SafeMode` / `Profile` are **optional, implementation-level**
 policy objects that layer a broader surface ON TOP (scheme allowlists,
 domain allow/deny, `rel=nofollow`, feature restriction, nesting / length
 limits); that wider surface is documented in the

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1849,8 +1849,14 @@ EOF = (* end of file *) ;
         corpus pins the default-on behavior.
       - Includes (`{{ path }}`) are a PROCESSOR-LEVEL directive, NOT part
         of the core parser; a conformant core MAY leave `{{ … }}` literal.
-        An implementing processor MUST forbid path traversal outside the
-        project root, bound recursion depth, and treat includes as opt-in.
+        An implementing processor MUST treat includes as opt-in (off for
+        untrusted input) and MUST resolve include paths only to files under
+        the configured project root AFTER symlink resolution (rejecting
+        `..`-traversal and absolute paths that escape the root). It MUST NOT
+        fetch remote URLs unless an allowlist is explicitly configured, and
+        MUST bound BOTH recursion depth AND total expanded byte size to
+        prevent include-bomb amplification (a file that includes another N
+        times, transitively). See PART 9 §25 for the general security model.
 
    20. RAW PASSTHROUGH -- NORMATIVE (governs `raw_inline` in PART 3 and the
       semantics of `raw_block` in PART 2). The BLOCK form (```=FORMAT
@@ -1979,6 +1985,68 @@ EOF = (* end of file *) ;
         on a LIST-MARKER line the straddling tab's unconsumed columns are
         re-inserted as spaces, so sibling markers aligned with mixed
         tab/space indentation keep the same visual column and stay siblings.
+
+   25. SECURITY REQUIREMENTS -- NORMATIVE (HTML output target). These rules
+      bind any implementation that emits HTML for UNTRUSTED input. They were
+      previously stated only in docs/security.md (non-normative); they are
+      hoisted here so an implementation written to this grammar + the corpus
+      cannot be conformant yet a trivial XSS vector. The corpus pins
+      representative cases (docs/examples.md "Security hardening").
+      - URL SINK SCHEME DENYLIST. On every clickable URL sink -- link
+        destination (`href`), image source (`src`), and autolink -- an HTML
+        renderer MUST reject any URL whose scheme is `javascript`, `vbscript`,
+        `data`, or `file`, emitting an EMPTY value (`href=""` / `src=""`).
+        Scheme detection MUST first strip leading ASCII control characters,
+        spaces, tabs, and newlines (which browsers ignore when resolving a
+        scheme). A `data:` exception for images, if offered, MUST be opt-in.
+        An attribute-block `href`/`src` override (PART 4) MUST NOT reintroduce
+        a rejected scheme.
+      - ATTRIBUTE NAME/VALUE HARDENING. On EVERY rendered element -- including
+        elements emitted by extensions -- an HTML renderer MUST drop
+        attributes whose name begins with `on` (case-insensitive) and the
+        names `srcdoc` and `formaction`; MUST blank any attribute value whose
+        scheme (control/space-stripped) is `javascript`/`vbscript`/`data`/
+        `file`; and MUST blank any `style` value containing `expression(`,
+        `url(`, `@import`, `behavior:`, or `-moz-binding` (whitespace
+        collapsed first). This applies to author attribute blocks AND to
+        attributes an extension copies onto its wrapper element: an extension
+        MUST route authored attributes through the same hardening and MUST NOT
+        emit them raw.
+      - RAW PASSTHROUGH OPT-OUT. Raw blocks (```=FORMAT, PART 2) and raw
+        inline (`{=format}`, §20) emit verbatim UNESCAPED content. An
+        implementation MUST provide a mode in which raw passthrough is NOT
+        emitted and is instead escaped as literal text. Implementations SHOULD
+        make safe handling the default for untrusted input; a processor that
+        emits raw passthrough by default MUST document that its input is
+        trusted.
+      - URL TEMPLATE ENCODING. Any value taken from document content (mention
+        name, tag, citation key, crossref id) and substituted into a
+        configured URL template MUST be percent-encoded before substitution,
+        and the resulting URL MUST then pass the scheme denylist above.
+      - MATH + CODE are element TEXT, not raw HTML: their verbatim content MUST
+        be HTML-escaped (`&`,`<`,`>`) before wrapping (§18, PART 10 §6). They
+        are NOT a raw-HTML bypass.
+      - FRONTMATTER MUST be parsed with a SAFE loader -- no arbitrary object
+        instantiation and no custom-tag deserialization (e.g. no YAML
+        `!!`-tag object construction). Any frontmatter value later rendered
+        into output MUST be escaped per the output target's rules.
+      - RESOURCE BOUNDS (DoS). An implementation MUST parse and render any
+        input in time and space LINEAR in input size (within a constant
+        factor). It MUST enforce a FINITE nesting-depth cap for block and
+        inline containers (RECOMMENDED 100; an implementation MAY choose a
+        larger fixed cap), beyond which further openers degrade to literal
+        text rather than recursing. It MUST bound abbreviation, reference,
+        footnote, and crossref expansion so total work stays O(n): in
+        particular an empty abbreviation term is rejected, a reference is not
+        resolved by rescanning the whole output per occurrence, and a crossref
+        target is not cloned without bound. Recursive RENDER, RESOLVE, and
+        FILTER passes over a programmatically constructed tree MUST be subject
+        to the same finite ceiling, not only the parse path.
+      - NON-HTML TARGETS. The Markdown, plain-text, and terminal (ANSI)
+        renderers MUST NOT become injection vectors either: text, code, math,
+        AND URL values MUST be stripped of control characters before emission
+        to a terminal, and a Markdown link/image title MUST escape the `"`
+        that would otherwise terminate it.
 *)
 
 
@@ -2004,7 +2072,9 @@ EOF = (* end of file *) ;
    2. ATTRIBUTE QUOTING + ESCAPING. Attribute values are double-quoted.
       In an attribute value escape `&`->&amp;, `<`->&lt;, `>`->&gt;,
       `"`->&quot;, `'`->&apos;. In text/content escape `&`,`<`,`>` (NOT
-      quotes). No other entities are produced.
+      quotes). No other entities are produced. This describes only the
+      QUOTING of values that survive filtering: dangerous attribute names,
+      values, and URL schemes are dropped/blanked FIRST per PART 9 §25.
 
    3. VOID ELEMENTS are written WITHOUT a trailing slash: `<hr>`,
       `<img …>`, `<br>`. A hard break serializes as `<br>` + newline.

--- a/tests/corpus/106-security-hardening-2.crv
+++ b/tests/corpus/106-security-hardening-2.crv
@@ -1,0 +1,1 @@
+<vbscript:msgbox>

--- a/tests/corpus/106-security-hardening-2.html
+++ b/tests/corpus/106-security-hardening-2.html
@@ -1,0 +1,1 @@
+<p><a href="">vbscript:msgbox</a></p>

--- a/tests/corpus/106-security-hardening-3.crv
+++ b/tests/corpus/106-security-hardening-3.crv
@@ -1,0 +1,1 @@
+![logo](javascript:stealCookies)

--- a/tests/corpus/106-security-hardening-3.html
+++ b/tests/corpus/106-security-hardening-3.html
@@ -1,0 +1,1 @@
+<img src="" alt="logo">

--- a/tests/corpus/106-security-hardening-4.crv
+++ b/tests/corpus/106-security-hardening-4.crv
@@ -1,0 +1,1 @@
+A [danger]{onclick="steal()"} span.

--- a/tests/corpus/106-security-hardening-4.html
+++ b/tests/corpus/106-security-hardening-4.html
@@ -1,0 +1,1 @@
+<p>A <span>danger</span> span.</p>

--- a/tests/corpus/106-security-hardening-5.crv
+++ b/tests/corpus/106-security-hardening-5.crv
@@ -1,0 +1,1 @@
+A [danger]{style="x:expression(steal())"} span.

--- a/tests/corpus/106-security-hardening-5.html
+++ b/tests/corpus/106-security-hardening-5.html
@@ -1,0 +1,1 @@
+<p>A <span style="">danger</span> span.</p>

--- a/tests/corpus/106-security-hardening-6.crv
+++ b/tests/corpus/106-security-hardening-6.crv
@@ -1,0 +1,1 @@
+A [danger]{srcdoc="<script>"} span.

--- a/tests/corpus/106-security-hardening-6.html
+++ b/tests/corpus/106-security-hardening-6.html
@@ -1,0 +1,1 @@
+<p>A <span>danger</span> span.</p>

--- a/tests/corpus/106-security-hardening-7.crv
+++ b/tests/corpus/106-security-hardening-7.crv
@@ -1,0 +1,1 @@
+[safe](https://example.com){href="javascript:steal"}

--- a/tests/corpus/106-security-hardening-7.html
+++ b/tests/corpus/106-security-hardening-7.html
@@ -1,0 +1,1 @@
+<p><a href="https://example.com">safe</a></p>

--- a/tests/corpus/106-security-hardening.crv
+++ b/tests/corpus/106-security-hardening.crv
@@ -1,0 +1,1 @@
+[click here](javascript:stealCookies)

--- a/tests/corpus/106-security-hardening.html
+++ b/tests/corpus/106-security-hardening.html
@@ -1,0 +1,1 @@
+<p><a href="">click here</a></p>

--- a/tests/spec/106-security-hardening.test
+++ b/tests/spec/106-security-hardening.test
@@ -1,0 +1,43 @@
+Security hardening
+
+```
+[click here](javascript:stealCookies)
+.
+<p><a href="">click here</a></p>
+```
+
+```
+<vbscript:msgbox>
+.
+<p><a href="">vbscript:msgbox</a></p>
+```
+
+```
+![logo](javascript:stealCookies)
+.
+<img src="" alt="logo">
+```
+
+```
+A [danger]{onclick="steal()"} span.
+.
+<p>A <span>danger</span> span.</p>
+```
+
+```
+A [danger]{style="x:expression(steal())"} span.
+.
+<p>A <span style="">danger</span> span.</p>
+```
+
+```
+A [danger]{srcdoc="<script>"} span.
+.
+<p>A <span>danger</span> span.</p>
+```
+
+```
+[safe](https://example.com){href="javascript:steal"}
+.
+<p><a href="https://example.com">safe</a></p>
+```


### PR DESCRIPTION
Round-4 security audit (8 independent reviewers across spec + 3 impls) surfaced a **structural** hole: every concrete defense (URL scheme denylist, attribute name/value hardening, raw-HTML opt-out, DoS bounds) lived only in `docs/security.md`, which is **outside the spec's own normativity chain** (`grammar.ebnf` + the corpus). The grammar was silent on all four (it even mandates raw passthrough emitted *unescaped*), and the corpus had **zero** security pairs.

Net effect: an implementation written strictly to grammar + corpus could be fully conformant and a trivial XSS vector. The three impls are hardened by convention, not by contract. This PR closes that gap.

## Changes
- **`grammar.ebnf` — new normative `PART 9 §25` "Security Requirements (HTML target)":**
  - URL sink scheme denylist (`javascript`/`vbscript`/`data`/`file` blanked; control/space-stripped scheme detection; attribute override cannot reintroduce a rejected scheme).
  - Attribute name/value hardening (drop `on*`/`srcdoc`/`formaction`; blank dangerous-scheme values; blank CSS `expression(`/`url(`/`@import`/`behavior:`/`-moz-binding`) — explicitly **including attributes an extension copies onto its wrapper**.
  - Raw-passthrough opt-out; URL-template percent-encoding; math/code escaped-not-raw; safe frontmatter loading.
  - DoS bounds: linear time/space, finite nesting cap (recommended 100), bounded abbreviation/reference/footnote/crossref expansion, and the same ceiling on render/resolve/filter passes (not just parse).
  - Non-HTML renderer hygiene (control-strip + Markdown title escaping).
  - Cross-referenced from `PART 10 §2`.
- **`grammar.ebnf` §19 includes** — tightened: symlink-resolved root jail, no remote fetch without explicit allowlist, bound recursion depth **and** total expanded bytes (include-bomb).
- **`examples.md` — new "Security hardening" section → 7 corpus pairs** pinning the URL denylist, `on*`/`srcdoc`/`style` hardening, and override behavior against the reference implementation.
- **`extensions.md`** — json-mode `FencedRender` MUST neutralize `</script>` script-data terminators (Tier-3 requirement mirroring §25).
- **`security.md`** — the baseline is now backed by the normative grammar + corpus, not just prose.

Companion implementation PRs (carve-js / carve-php / carve-rs) fix the concrete bugs the same audit found (extension attr-hardening bypass, empty-abbreviation hang, O(n²)/OOM/SIGSEGV DoS, non-HTML renderer hygiene).