### PR TITLE
docs: code-block line numbers, titles, and highlighting

### DIFF
--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -298,9 +298,31 @@ async function highlightCode(): Promise<void> {
   }
 }
 
-// --- Code-block pill: on hover, show a top-right pill with the language and a
-// click-to-copy button. Runs after highlight so it covers Shiki blocks (tagged
-// with data-lang) and any plain `language-x` block left un-highlighted. ---
+function codePillIcon(kind: 'copy' | 'check'): SVGSVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.setAttribute('viewBox', '0 0 24 24')
+  svg.setAttribute('aria-hidden', 'true')
+  svg.setAttribute('focusable', 'false')
+  svg.classList.add('code-pill-icon')
+  const paths = kind === 'copy'
+    ? [
+        'M8 8h10v12H8z',
+        'M6 16H4V4h12v2',
+      ]
+    : [
+        'M20 6 9 17l-5-5',
+      ]
+  for (const d of paths) {
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    path.setAttribute('d', d)
+    svg.appendChild(path)
+  }
+  return svg
+}
+
+// --- Code-block chrome: on hover, show the language and a click-to-copy icon.
+// Runs after highlight so it covers Shiki blocks (tagged with data-lang) and
+// any plain `language-x` block left un-highlighted. ---
 function decorateCodeBlocks(): void {
   const root = outputEl.value
   if (!root) return
@@ -323,13 +345,14 @@ function decorateCodeBlocks(): void {
     btn.type = 'button'
     btn.className = 'code-pill-copy'
     btn.setAttribute('aria-label', 'Copy code')
-    btn.textContent = '📋'
+    btn.title = 'Copy code'
+    btn.replaceChildren(codePillIcon('copy'))
     btn.addEventListener('click', () => {
       const text = (code ?? pre).textContent ?? ''
       void navigator.clipboard?.writeText(text).then(() => {
-        btn.textContent = '✓'
+        btn.replaceChildren(codePillIcon('check'))
         setTimeout(() => {
-          btn.textContent = '📋'
+          btn.replaceChildren(codePillIcon('copy'))
         }, 1200)
       })
     })

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -686,43 +686,71 @@ html.dark .vp-code span[data-carve-highlight] {
   border-bottom: 1px dotted var(--vp-c-text-3);
 }
 
-/* Code-block pill (playground output): hover shows the language + a copy button
+/* Code-block chrome (playground output): hover shows the language + copy icon
    in the top-right corner. Decoration wired in Playground.vue. */
 .carve-render pre[data-pill] {
   position: relative;
 }
 .carve-render .code-pill {
   position: absolute;
-  top: 6px;
+  top: 8px;
   right: 8px;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   opacity: 0;
   transition: opacity 0.15s;
-  font-size: 12px;
-  line-height: 1.4;
+  font-size: 11px;
+  line-height: 1;
 }
 .carve-render pre[data-pill]:hover .code-pill,
 .carve-render .code-pill:focus-within {
   opacity: 1;
 }
 .carve-render .code-pill-lang {
-  background: rgba(127, 127, 127, 0.2);
+  display: inline-flex;
+  align-items: center;
+  height: 24px;
+  max-width: 10rem;
+  padding: 0 8px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  background: var(--vp-c-bg);
   color: var(--vp-c-text-2);
-  padding: 1px 8px;
-  border-radius: 999px;
+  font-family: var(--vp-font-family-mono, ui-monospace, monospace);
+  font-size: 11px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 .carve-render .code-pill-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
   cursor: pointer;
   border: 1px solid var(--vp-c-divider);
   background: var(--vp-c-bg);
   border-radius: 6px;
-  padding: 0 5px;
-  font-size: 12px;
+  color: var(--vp-c-text-2);
 }
-.carve-render .code-pill-copy:hover {
+.carve-render .code-pill-copy:hover,
+.carve-render .code-pill-copy:focus-visible {
   border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+.carve-render .code-pill-icon {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 /* Code-group (codeGroup extension): CSS-only radio tabs. The render emits

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -78,10 +78,6 @@ $new  = modern();     // [tl! ++]
 ```
 ````
 
-::: warning Not supported: the `lang #` info-string convention
-Markdown/djot tooling often writes `` ```php # `` or `` ```php {1,3-5} `` on the fence line to mark line numbers or ranges. In Carve that line is **not a fence** - after the language token, only an optional `"header"` and then an optional `[label]` are admitted. Use the preceding attribute line for renderer attributes and in-code annotations for highlighting.
-:::
-
 ## Inline elements
 
 An inline element lives inside a line of text.

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -40,15 +40,15 @@ Read this first.
 
 renders the heading as `<h2 class="featured">` inside `<section id="install">` (an explicit heading id hoists to the `<section>` wrapper, PART 9 §13) and the admonition as `<aside class="admonition note callout">`.
 
-This is uniform across every block - headings, block quotes, lists, code blocks, divs/admonitions, line-blocks, tables. They all take their attributes on the preceding line; none take a trailing attribute on the block's own line. (For a code block the fence line accepts only `lang [label]` - a `{…}` after the language word makes the line *not a fence at all*; the backticks then fall back to ordinary inline parsing. For a heading, a trailing `{…}` is ordinary inline text. Put the attributes on the line above, like any other block.)
+This is uniform across every block - headings, block quotes, lists, code blocks, divs/admonitions, line-blocks, tables. They all take their attributes on the preceding line; none take a trailing attribute on the block's own line. (For a code block the fence line accepts only structured metadata - `lang`, optional `"header"`, optional `[label]`, in that order. A trailing `{…}` after the language word makes the line *not a fence at all*; the backticks then fall back to ordinary inline parsing. For a heading, a trailing `{…}` is ordinary inline text. Put the attributes on the line above, like any other block.)
 
 ### Code blocks: line numbers, titles, and highlighting
 
-Because a code block takes its attributes on the preceding line, those attributes flow straight onto the rendered `<pre>`. A renderer can use them to switch on line numbers, a title, or highlighted lines - no special fence syntax is needed (and none exists: the fence word is a single token).
+Because a code block takes its attributes on the preceding line, those attributes flow straight onto the rendered `<pre>`. A renderer can use them to switch on line numbers or set other presentation hooks. The fence line has only the structured code metadata: language, optional quoted header, optional bracketed label.
 
 ````carve
-{.line-numbers title="src/app.php"}
-``` php
+{.line-numbers data-line-start="42"}
+```php "src/app.php" [Backend]
 $x = compute();
 return $x;
 ```
@@ -56,12 +56,22 @@ return $x;
 
 - `.line-numbers` asks the renderer for a line-number gutter.
 - `data-line-start="42"` (a plain `data-*` attribute) starts numbering at 42.
-- `title="…"` names the block; renderers typically surface it as a caption.
+- `"src/app.php"` is the code-block header; core carries it as `title` on the `<pre>`, and renderers typically surface it as a caption.
+- `[Backend]` is a grouping label; core ignores it, while a code-group extension can use it as the tab name.
 
-How *highlighting*, *diff*, and *focus* are expressed is a renderer concern, not Carve syntax. Renderers built on Torchlight read in-code annotations, so the signal lives in the code body and the single-token fence stays untouched:
+If the preceding attribute line also sets `title="…"`, that explicit attribute wins over the quoted opener header:
 
 ````carve
-``` php
+{title="shown title"}
+```php "fallback title"
+echo "ok";
+```
+````
+
+How *highlighting*, *diff*, and *focus* are expressed is a renderer concern, not Carve syntax. Renderers built on Torchlight read in-code annotations, so the signal lives in the code body and the fence metadata stays limited to `lang "header" [label]`:
+
+````carve
+```php
 $safe = clean($in);   // [tl! highlight]
 $old  = legacy();     // [tl! --]
 $new  = modern();     // [tl! ++]
@@ -69,7 +79,7 @@ $new  = modern();     // [tl! ++]
 ````
 
 ::: warning Not supported: the `lang #` info-string convention
-Markdown/djot tooling often writes `` ```php # `` or `` ```php {1,3-5} `` on the fence line to mark line numbers or ranges. In Carve that line is **not a fence** - the fence word is a single token, so a space and anything after it falls back to inline parsing. Use the preceding attribute line (and, for highlighting, in-code annotations) instead.
+Markdown/djot tooling often writes `` ```php # `` or `` ```php {1,3-5} `` on the fence line to mark line numbers or ranges. In Carve that line is **not a fence** - after the language token, only an optional `"header"` and then an optional `[label]` are admitted. Use the preceding attribute line for renderer attributes and in-code annotations for highlighting.
 :::
 
 ## Inline elements

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -42,6 +42,36 @@ renders the heading as `<h2 class="featured">` inside `<section id="install">` (
 
 This is uniform across every block - headings, block quotes, lists, code blocks, divs/admonitions, line-blocks, tables. They all take their attributes on the preceding line; none take a trailing attribute on the block's own line. (For a code block the fence line accepts only `lang [label]` - a `{…}` after the language word makes the line *not a fence at all*; the backticks then fall back to ordinary inline parsing. For a heading, a trailing `{…}` is ordinary inline text. Put the attributes on the line above, like any other block.)
 
+### Code blocks: line numbers, titles, and highlighting
+
+Because a code block takes its attributes on the preceding line, those attributes flow straight onto the rendered `<pre>`. A renderer can use them to switch on line numbers, a title, or highlighted lines - no special fence syntax is needed (and none exists: the fence word is a single token).
+
+````carve
+{.line-numbers title="src/app.php"}
+``` php
+$x = compute();
+return $x;
+```
+````
+
+- `.line-numbers` asks the renderer for a line-number gutter.
+- `data-line-start="42"` (a plain `data-*` attribute) starts numbering at 42.
+- `title="…"` names the block; renderers typically surface it as a caption.
+
+How *highlighting*, *diff*, and *focus* are expressed is a renderer concern, not Carve syntax. Renderers built on Torchlight read in-code annotations, so the signal lives in the code body and the single-token fence stays untouched:
+
+````carve
+``` php
+$safe = clean($in);   // [tl! highlight]
+$old  = legacy();     // [tl! --]
+$new  = modern();     // [tl! ++]
+```
+````
+
+::: warning Not supported: the `lang #` info-string convention
+Markdown/djot tooling often writes `` ```php # `` or `` ```php {1,3-5} `` on the fence line to mark line numbers or ranges. In Carve that line is **not a fence** - the fence word is a single token, so a space and anything after it falls back to inline parsing. Use the preceding attribute line (and, for highlighting, in-code annotations) instead.
+:::
+
 ## Inline elements
 
 An inline element lives inside a line of text.

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -143,7 +143,7 @@ text [span]{.c}       ← inline: directly AFTER, no space
 -{#item} list item    ← list item: abuts the marker (no space!)
 
 {.x}                  ← code block: line BEFORE the fence
-``` lang
+```lang
 code
 ```
 ````

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1754,7 +1754,7 @@ Content begins here.
 
 :::
 
-The space between `---` and the format token is optional — `---toml` and `--- toml` are both accepted (the no-space form is canonical), matching the optional space on a code fence (` ```php ` / ` ``` php `).
+The space between `---` and the format token is optional — `---toml` and `--- toml` are both accepted (the no-space form is canonical), matching code fences: ` ```php ` is canonical, though a space after the fence is accepted for compatibility.
 
 ::: compare
 


### PR DESCRIPTION
Documents the practical recipe for code-block line numbers, titles, and highlighting on the Blocks & Attributes page.

## What

- A code block takes its attributes on the **preceding line**, and those attributes flow onto the rendered `<pre>`; a renderer uses them for a line-number gutter (`.line-numbers`), a start offset (`data-line-start`), or a title.
- **Highlight / diff / focus** are a renderer concern, not Carve syntax. Renderers built on Torchlight read in-code annotations (the signal lives in the code body, so the single-token fence stays untouched).
- A warning callout: the Markdown/djot `lang #` / `lang {1,3-5}` info-string convention is **not a fence** in Carve - the fence word is a single token.

## Why

The capability already existed but was undocumented, so users assumed it was missing or reached for the djot info-string convention that silently breaks (renders as a paragraph). Closes the gap with no grammar change.

Corpus-safe (only `docs/examples.md` feeds the corpus) and `docs:build` passes locally.