### PR TITLE
docs: security comparison (Carve vs Markdown/djot/MDX) + fix comparison safety row

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -79,10 +79,15 @@ special cases.
 
 | | Markdown | Djot | MDX | **Carve** |
 |---|:---:|:---:|:---:|:---:|
-| Safe with untrusted input | ⚠️ raw HTML on by default (sanitize modes exist) | ✅ | ❌ executes JS | ✅ raw off by default |
+| Sanitization mandated by the spec | ❌ consumer's job | ❌ consumer's job | n/a | ✅ §25, corpus-pinned |
+| URL / attribute / DoS hardening by default | ❌ | ❌ | ❌ | ✅ always on |
+| Raw HTML default | ⚠️ on (libs vary) | ⚠️ on | runs JS | ⚠️ on, one-flag opt-out / safe mode |
 | Embeds live components / JS | ❌ | ❌ | ✅ (its purpose) | ❌ by design |
 | Independent implementations | many, divergent | several (js, lua, rust, go) | JS-only | **php · js · rs, conformance-tested** |
 | Shared spec test corpus | ❌ | ⚠️ | ❌ | ✅ |
+
+See [Security → How Carve compares on security](/security#how-carve-compares-on-security)
+for the detailed breakdown and caveats.
 
 ## When to pick which
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -160,6 +160,50 @@ does not launder an attack:
   responsible for inserting it into a trusted context and for the surrounding
   Content-Security-Policy.
 
+## How Carve compares on security
+
+Most lightweight-markup ecosystems treat sanitization as the *consumer's* job:
+the format says nothing about safety, and you are expected to bolt on a
+sanitizer (or pick a "safe mode") yourself. Carve is unusual in that the
+baseline defenses on this page are **part of the specification** (grammar
+PART 9 §25), **pinned by the shared corpus**, and **enforced identically by all
+three implementations** with no configuration.
+
+| | Spec mandates sanitization? | URL scheme filtering | Attribute hardening | Raw HTML default | DoS bounds in spec |
+|---|:---:|:---:|:---:|:---:|:---:|
+| **Carve** | **yes** (§25, corpus-pinned, 3 impls) | always-on denylist | always-on (incl. extension wrappers, CSS-escape decoding) | **on, one-flag opt-out / safe mode** | yes (linear-time, depth caps) |
+| CommonMark / markdown-it / marked | no | none (consumer's job) | no attribute model | on (libs vary; `markdown-it` defaults off) | no |
+| GitHub GFM | no - platform sanitizer | via GitHub's separate allowlist | via GitHub's sanitizer | sanitized server-side | no |
+| Djot (Carve's parent) | no | none mandated | none mandated | on | no |
+| MDX | n/a - compiles to JS | n/a | n/a | executes code | no |
+
+What this means in practice for **untrusted input**:
+
+- Carve out of the box blanks dangerous URL schemes (`javascript:`/`vbscript:`/
+  `data:`/`file:`), drops `on*`/`srcdoc`/`formaction` and script-bearing CSS,
+  bounds resources, and strips terminal-control bytes from the Markdown / plain
+  / ANSI renderers - **without you wiring up a sanitizer**. Stock Markdown and
+  reference Djot do none of this; you must add a sanitizer or use a host that
+  sanitizes (as GitHub does).
+- The safety is *guaranteed by the spec and tested across implementations*, so
+  carve-php, carve-js and carve-rs all behave the same - you do not inherit a
+  different security posture by switching implementation.
+
+::: warning One thing you must still configure
+**Raw HTML is on by default.** ` ```=html ` blocks and `` `…`{=html} `` inline
+raw are emitted verbatim unless you disable raw passthrough (or run a safe
+mode). For untrusted input, turn raw HTML off - the URL, attribute, and DoS
+defenses above are always on, but raw passthrough is the one switch you own.
+:::
+
+::: tip Defense in depth still applies
+Carve's URL/CSS hardening is a **denylist** of known-dangerous constructs, not a
+full allowlist sanitizer. For genuinely hostile input that may carry arbitrary
+attributes, keep running the rendered HTML through a DOM sanitizer (e.g.
+DOMPurify) under a Content-Security-Policy. `SafeMode` / `Profile` add
+allowlist-style policies on top (see below).
+:::
+
 ## Beyond the baseline: SafeMode and Profiles
 
 The baseline on this page - the URL scheme denylist, the attribute name/value


### PR DESCRIPTION
Adds a **"How Carve compares on security"** section to `docs/security.md`: a table contrasting Carves spec-mandated, corpus-pinned, cross-impl security baseline (URL denylist, attribute hardening, DoS bounds, non-HTML control-stripping) with CommonMark / markdown-it / marked, GitHub GFM, Djot, and MDX, plus the honest caveats:

- **Raw HTML is on by default** and must be opted out (or safe-moded) for untrusted input -- the one switch you own; URL/attr/DoS defenses are always on.
- The URL/CSS hardening is a **denylist**, not a full allowlist sanitizer -- keep DOMPurify + CSP as defense in depth for hostile arbitrary-attribute input.

Also corrects the `comparison.md` "Safety & ecosystem" table, which wrongly claimed Carve raw HTML was "off by default" (verified: all three impls emit ` ```=html ` verbatim by default) and overstated Djot as "safe with untrusted input" (Djot, like CommonMark, leaves sanitization to the consumer). Links the comparison table to the new security section.

Docs build passes.