### PR TITLE
feat: pin smart-quote flanking after a non-breaking space

### DIFF
--- a/docs/.vitepress/carve-lib/parse.js
+++ b/docs/.vitepress/carve-lib/parse.js
@@ -2779,7 +2779,7 @@ function allocateDashes(n) {
     return '—'.repeat(em) + '–'.repeat(en);
 }
 const isAlnum = (ch) => /[A-Za-z0-9]/.test(ch);
-const isQuoteOpenContext = (prev) => prev === '' || /[\s([{\-–—/]/.test(prev) || prev === '“' || prev === '‘';
+const isQuoteOpenContext = (prev) => prev === '' || /[\s([{\-–—/]/.test(prev) || prev === '“' || prev === '‘' || prev === '\ue000';
 /**
  * Recognize one smart-typography construct at `text[i]`.
  * `prev` is the character immediately before (for contextual quotes).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -3064,6 +3064,20 @@ A backslash before a space produces a non-breaking space.
 
 :::
 
+A non-breaking space counts as whitespace for smart-quote flanking, so a quote that follows one opens (exactly as it would after an ordinary space).
+
+::: compare
+
+```carve
+say\ 'twas a fine\ "day"
+```
+
+```html
+<p>say&nbsp;‘twas a fine&nbsp;“day”</p>
+```
+
+:::
+
 ## Raw inline
 
 A verbatim span tagged `{=format}` passes through when the format

--- a/tests/corpus/49-non-breaking-space-2.crv
+++ b/tests/corpus/49-non-breaking-space-2.crv
@@ -1,0 +1,1 @@
+say\ 'twas a fine\ "day"

--- a/tests/corpus/49-non-breaking-space-2.html
+++ b/tests/corpus/49-non-breaking-space-2.html
@@ -1,0 +1,1 @@
+<p>say&nbsp;‘twas a fine&nbsp;“day”</p>

--- a/tests/spec/49-non-breaking-space.test
+++ b/tests/spec/49-non-breaking-space.test
@@ -5,3 +5,9 @@ Non-breaking space
 .
 <p>10&nbsp;kg</p>
 ```
+
+```
+say\ 'twas a fine\ "day"
+.
+<p>say&nbsp;‘twas a fine&nbsp;“day”</p>
+```


### PR DESCRIPTION
A non-breaking space (literal U+00A0 or the escaped `\ ` form) now counts as whitespace for smart-quote flanking, so a quote that immediately follows one **opens** - exactly as it would after an ordinary space.

This was a pre-existing 3-way divergence: each implementation treated *one* of the two NBSP forms (literal vs escaped) as a word boundary and the other as a word character, in different directions. The only internally-consistent and typographically-correct rule is "NBSP is whitespace for flanking", so all three converge on it.

Pinned via a new `49-non-breaking-space-2` corpus pair:

```carve
say\ 'twas a fine\ "day"
```
```html
<p>say&nbsp;‘twas a fine&nbsp;“day”</p>
```

Companion PRs in carve-js / carve-php / carve-rs implement the rule and bump this spec.