### PR TITLE
docs: lead with the online-first, graceful-degradation principle

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -5,9 +5,9 @@ description: Try Carve in 30 seconds, then render it in your own project.
 
 # Get Started
 
-## What Carve is built for
+## Interactive online, readable offline
 
-**Interactive online, readable offline.** Carve is built for the interactive web first: the [Playground](/playground), live preview, and hydration extensions (Mermaid, D2, Graphviz, Vega-Lite, Chart.js, math, tabs, details) render rich, interactive output when JavaScript is present. But interactivity is an enhancement, never a requirement — Carve only ever emits the marker element, and the client library hydrates it.
+One of Carve's design principles: it targets the interactive web first. The [Playground](/playground), live preview, and hydration extensions (Mermaid, D2, Graphviz, Vega-Lite, Chart.js, math, tabs, details) render rich, interactive output when JavaScript is present. But interactivity is an enhancement, never a requirement — Carve only ever emits the marker element, and the client library hydrates it.
 
 With no JavaScript — RSS readers, email, `curl`, archived pages, PDF, Markdown or terminal exports — every construct degrades to self-describing semantic HTML: a `mermaid` fence renders as `<pre class="mermaid">` showing its source, `:::details` is a native `<details>`, `list-table` is a real `<table>`, captions are `<figure>` / `<figcaption>`. The document is always whole; online just makes it richer. See [Graceful Degradation](/graceful-degradation) for the exact per-construct rules.
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -5,6 +5,12 @@ description: Try Carve in 30 seconds, then render it in your own project.
 
 # Get Started
 
+## What Carve is built for
+
+**Interactive online, readable offline.** Carve is built for the interactive web first: the [Playground](/playground), live preview, and hydration extensions (Mermaid, D2, Graphviz, Vega-Lite, Chart.js, math, tabs, details) render rich, interactive output when JavaScript is present. But interactivity is an enhancement, never a requirement — Carve only ever emits the marker element, and the client library hydrates it.
+
+With no JavaScript — RSS readers, email, `curl`, archived pages, PDF, Markdown or terminal exports — every construct degrades to self-describing semantic HTML: a `mermaid` fence renders as `<pre class="mermaid">` showing its source, `:::details` is a native `<details>`, `list-table` is a real `<table>`, captions are `<figure>` / `<figcaption>`. The document is always whole; online just makes it richer. See [Graceful Degradation](/graceful-degradation) for the exact per-construct rules.
+
 ## 1. Try it now — no install
 
 The fastest path is the **[Playground](/playground)**: type Carve on the left, watch the HTML render live on the right. Nothing to set up.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -9,7 +9,7 @@ description: Try Carve in 30 seconds, then render it in your own project.
 
 One of Carve's design principles: it targets the interactive web first. The [Playground](/playground), live preview, and hydration extensions (Mermaid, D2, Graphviz, Vega-Lite, Chart.js, math, tabs, details) render rich, interactive output when JavaScript is present. But interactivity is an enhancement, never a requirement — Carve only ever emits the marker element, and the client library hydrates it.
 
-With no JavaScript — RSS readers, email, `curl`, archived pages, PDF, Markdown or terminal exports — every construct degrades to self-describing semantic HTML: a `mermaid` fence renders as `<pre class="mermaid">` showing its source, `:::details` is a native `<details>`, `list-table` is a real `<table>`, captions are `<figure>` / `<figcaption>`. The document is always whole; online just makes it richer. See [Graceful Degradation](/graceful-degradation) for the exact per-construct rules.
+With no JavaScript — RSS readers, email, `curl`, archived pages, PDF, Markdown or terminal exports — every construct degrades to self-describing semantic HTML: a `mermaid` fence renders as `<pre class="mermaid">` showing its source, `:::details` is a native `<details>`, `list-table` is a real `<table>`, captions are `<figure>` / `<figcaption>`. The document is always whole; online just makes it richer.
 
 ## 1. Try it now — no install
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,16 +20,14 @@ hero:
       link: https://github.com/markup-carve
 
 features:
-  - title: Interactive Online, Readable Offline
-    details: "Built for the interactive web first — diagrams, math, charts and tabs hydrate into rich output online. With no JavaScript every block degrades to clean semantic HTML: a Mermaid fence still shows its source, <details> stays native, tables stay tables."
-    link: /graceful-degradation
-    linkText: How it degrades
   - title: Visual Mnemonics
     details: "/italic/ slashes lean, *bold* asterisks are heavy, _underline_ sits below, ~strikethrough~ runs through. Syntax that looks like its output."
   - title: Linear-Time Rigor
     details: "Djot-style linear-time parsing with no backtracking and unambiguous rules (Djot is the markup Carve builds on), extended with captions, abbreviations, and social conventions."
   - title: Ten-Second Rule
     details: Learnable in 10 seconds for basic use. Memorable after 10 days without practice. Unambiguous within 10 characters of context.
+  - title: Interactive Online, Readable Offline
+    details: "Built for the interactive web first — diagrams, math, charts and tabs hydrate into rich output online. With no JavaScript every block degrades to clean semantic HTML: a Mermaid fence still shows its source, <details> stays native, tables stay tables."
   - title: Captions Everywhere
     details: One ^ prefix adds captions to images, blockquotes, and tables — emitting semantic figure / figcaption / caption HTML.
   - title: Friendly Tables

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,10 @@ hero:
       link: https://github.com/markup-carve
 
 features:
+  - title: Interactive Online, Readable Offline
+    details: "Built for the interactive web first — diagrams, math, charts and tabs hydrate into rich output online. With no JavaScript every block degrades to clean semantic HTML: a Mermaid fence still shows its source, <details> stays native, tables stay tables."
+    link: /graceful-degradation
+    linkText: How it degrades
   - title: Visual Mnemonics
     details: "/italic/ slashes lean, *bold* asterisks are heavy, _underline_ sits below, ~strikethrough~ runs through. Syntax that looks like its output."
   - title: Linear-Time Rigor


### PR DESCRIPTION
Makes Carve's core positioning - **interactive on the web first, fully readable without JavaScript** - visible where readers land first.

## What

- **Hero feature card** (`docs/index.md`): a new "Interactive Online, Readable Offline" card, placed first, linking to the Graceful Degradation page.
- **Get Started** (`docs/get-started.md`): a short "What Carve is built for" section at the top stating the principle - hydration extensions light up online; with no JS every block degrades to self-describing semantic HTML - and pointing to the per-construct rules.

## Why

The repo already has a `graceful-degradation` page, but it reads as a normative per-render-target rule. Nothing on the landing surfaces frames it as a top-level goal. These two additions state the goal up front and link down to the detailed rules - no duplication.

Full docs test suite green (352 tests).