### PR TITLE
feat: collect reference definitions inside containers

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2452,6 +2452,45 @@ Read the [intro][x]{.ext} first.
 
 :::
 
+"Anywhere in the document" includes inside a container: a reference definition
+written inside a blockquote or a list item is still an invisible block that is
+collected into the document-wide definition table, so a reference elsewhere
+resolves against it. The container keeps only its visible content (here, none).
+
+::: compare
+
+```carve
+> [ref]: /url
+
+See [it][ref].
+```
+
+```html
+<blockquote>
+
+</blockquote>
+<p>See <a href="/url">it</a>.</p>
+```
+
+:::
+
+::: compare
+
+```carve
+- [ref]: /url
+
+See [it][ref].
+```
+
+```html
+<ul>
+  <li></li>
+</ul>
+<p>See <a href="/url">it</a>.</p>
+```
+
+:::
+
 ## Collapsed reference link
 
 `[text][]` uses the link text as the label.

--- a/tests/corpus/34-reference-link-3.crv
+++ b/tests/corpus/34-reference-link-3.crv
@@ -1,0 +1,3 @@
+> [ref]: /url
+
+See [it][ref].

--- a/tests/corpus/34-reference-link-3.html
+++ b/tests/corpus/34-reference-link-3.html
@@ -1,0 +1,4 @@
+<blockquote>
+
+</blockquote>
+<p>See <a href="/url">it</a>.</p>

--- a/tests/corpus/34-reference-link-4.crv
+++ b/tests/corpus/34-reference-link-4.crv
@@ -1,0 +1,3 @@
+- [ref]: /url
+
+See [it][ref].

--- a/tests/corpus/34-reference-link-4.html
+++ b/tests/corpus/34-reference-link-4.html
@@ -1,0 +1,4 @@
+<ul>
+  <li></li>
+</ul>
+<p>See <a href="/url">it</a>.</p>

--- a/tests/spec/34-reference-link.test
+++ b/tests/spec/34-reference-link.test
@@ -15,3 +15,25 @@ Read the [intro][x]{.ext} first.
 .
 <p>Read the <a href="/intro" class="ext">intro</a> first.</p>
 ```
+
+```
+> [ref]: /url
+
+See [it][ref].
+.
+<blockquote>
+
+</blockquote>
+<p>See <a href="/url">it</a>.</p>
+```
+
+```
+- [ref]: /url
+
+See [it][ref].
+.
+<ul>
+  <li></li>
+</ul>
+<p>See <a href="/url">it</a>.</p>
+```


### PR DESCRIPTION
A reference definition written **inside a blockquote or list item** is an invisible block that is still collected into the document-wide definition table, so a reference elsewhere resolves against it. The container keeps only its visible content.

This matches the grammar (a `reference_definition` is a `block`, and blocks nest inside containers), CommonMark, and Djot. It was a pre-existing 3-way divergence: carve-js collected from anywhere (correct), carve-php lost list-item defs (consumed the line but didn't register), carve-rs only collected at top level.

New corpus pairs:
- `34-reference-link-3` (blockquote)
- `34-reference-link-4` (list item)

Companion PRs bring carve-php and carve-rs in line (carve-js already matched).