### PR TITLE
docs: show all four QR formats as code-group tabs in the tutorial

### DIFF
--- a/docs/extension-tutorial.md
+++ b/docs/extension-tutorial.md
@@ -13,9 +13,18 @@ join, an SMS) is just a **payload convention**. That split - a pure
 *payload builder* in front of a *renderer* - is the shape most useful
 extensions take.
 
-The author writes:
+The author writes any of these - the type rides on the hyphenated fence info
+word (`qr-wifi`, `qr-sms`, …; bare `qr` is a URL):
 
+::: code-group
+
+````carve [URL]
+```qr
+https://example.com
+```
 ````
+
+````carve [WiFi]
 ```qr-wifi
 ssid: HomeNet
 password: hunter2
@@ -23,7 +32,27 @@ security: WPA
 ```
 ````
 
-and gets a scannable QR that joins the network.
+````carve [SMS]
+```qr-sms
+to: +15550100
+body: Running late, be there soon
+```
+````
+
+````carve [vCard]
+```qr-vcard
+name: Jane Doe
+org: ACME, Inc
+tel: +15550100
+email: jane@example.com
+url: https://example.com
+```
+````
+
+:::
+
+and gets a scannable QR for each - a link to open, a network to join, a text to
+send, a contact to save. Same extension, different payload convention (Step 1).
 
 ::: tip Tier
 Everything here is [Tier-3](./extensions#_1-feature-taxonomy): an app extension,


### PR DESCRIPTION
The "The author writes:" example at the top of the QR-code extension tutorial only showed the `qr-wifi` format. The intro names four payload conventions (a URL, a vCard, a WiFi join, an SMS), but only one was demonstrated.

Expand that example into a `::: code-group` with a tab per format - **URL**, **WiFi**, **SMS**, **vCard** - so the payload-convention idea (the `qr-{type}` hyphenated info word, detailed in Step 1) is visible up front. Each tab shows the exact author input the Step 2 builder consumes.

Docs-only; `vitepress build docs` passes and all four tabs render.
