### PR TITLE
test(corpus): pin [@key,] trailing-comma citation (#227)

### DIFF
--- a/tests/corpus-optional/24-citations-trailing-comma.crv
+++ b/tests/corpus-optional/24-citations-trailing-comma.crv
@@ -1,0 +1,3 @@
+See [@smith2020,].
+
+[@smith2020]: Smith, J. (2020).

--- a/tests/corpus-optional/24-citations-trailing-comma.html
+++ b/tests/corpus-optional/24-citations-trailing-comma.html
@@ -1,0 +1,4 @@
+<p>See [<a data-cite-key="smith2020" href="#ref-smith2020">1</a>].</p>
+<ol class="references">
+  <li id="ref-smith2020">Smith, J. (2020).</li>
+</ol>

--- a/tests/corpus-optional/manifest.json
+++ b/tests/corpus-optional/manifest.json
@@ -115,6 +115,11 @@
       "slug": "23-citations-suppress-per-item",
       "feature": "citations-numbered",
       "description": "A '-' before @key in a non-integral group sets data-suppress-author per item."
+    },
+    {
+      "slug": "24-citations-trailing-comma",
+      "feature": "citations-numbered",
+      "description": "A trailing comma with no locator ([@key,]) is ignored - the item is a normal citation, not verbatim text (carve#227)."
     }
   ]
 }


### PR DESCRIPTION
Pins the canonical behavior for markup-carve/carve#227: `[@smith2020,]` (trailing comma, empty locator) renders as a normal citation, not verbatim text.

Adds optional-corpus case `24-citations-trailing-comma` + manifest entry (citations-numbered runner). Golden matches the carve-js oracle (incl. the `data-cite-key` attr from #223). carve-php already conformant; carve-rs aligned in carve-rs#174.