### PR TITLE
docs: citation enrichment (typed locators, integral, data-*), ecosystem expansion

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -296,7 +296,25 @@ Smith [@smith2020] and others [see @jones2019, p. 4] agree.
 ```
 
 - **Forms:** `[@key]`, `[@key, p. 33]` (locator), `[see @key]` (prefix),
-  `[@a; @b]` (multiple), `[-@key]` (suppress author).
+  `[@a; @b]` (multiple), `[-@key]` (suppress author in author-date mode).
+- **Integral (author-in-text):** a single leading `+` after `[` marks the
+  whole cluster integral: `[+@smith2020]`, `[+see @smith2020, p. 12]`.
+  Wraps the rendered citation in
+  `<span class="citation" data-cite-mode="integral">`. Mode is group-level;
+  there is no per-item integral flag.
+- **Typed locators:** the locator after `,` is parsed into a CSL `{label,
+  value}` pair. Recognized labels include `p.` / `pp.` (page), `chap.`
+  (chapter), `sec.` / `§` (section), `vol.` (volume), `no.` (issue), and
+  more (full vocabulary in `../extensions.md` §4.2). A leading digit defaults
+  to `page`. Trailing separators (`,`, `&`, `-`, `.`) are trimmed from the
+  value; the remainder is the suffix. Examples:
+  - `[@key, p. 12]` - label `page`, value `12`
+  - `[@key, chap. 3, conclusion]` - label `chapter`, value `3`, suffix `conclusion`
+  - `[@key, 42]` - label `page` (default), value `42`
+- **`data-*` on anchors:** `data-cite-key`, `data-suppress-author`,
+  `data-cite-prefix`, `data-locator-label`, `data-locator`, `data-suffix`
+  (each only when present). This gives a host CSL processor the structure it
+  needs without any Carve-side style resolution.
 - **Output** is processor-configured: numbered (default) renders `[1]` with an
   ordered references list; author-date renders `(Smith 2020)`. The `{author=
   year=}` attributes feed author-date and are optional for numbered.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -19,6 +19,18 @@ the bar for "a Carve implementation" is **Tier-1 core** (native syntax) - see
 | [carve-php](https://github.com/markup-carve/carve-php) | PHP | Forked from djot-php; Carve syntax implemented, corpus passing. Powers the [PHP sandbox](https://sandbox.dereuromark.de/sandbox/carve) and wp-carve. |
 | [carve-wasm](https://github.com/markup-carve/carve-wasm) | WASM | Browser/Node bindings for carve-rs. *Early.* |
 
+## Language bindings
+
+Higher-level bindings and satellite packages that wrap one of the reference implementations.
+
+| Project | Language | Notes |
+|---|---|---|
+| [carve-go](https://github.com/markup-carve/carve-go) | Go | Pure-Go module via wazero + WASI over carve-rs. |
+| [carve-py](https://github.com/markup-carve/carve-py) | Python | PyO3 bindings over carve-rs. Enables MkDocs, Pelican, and other Python pipelines. |
+| [carve-rb](https://github.com/markup-carve/carve-rb) | Ruby | Native gem via magnus over carve-rs. |
+| [carve-components](https://github.com/markup-carve/carve-components) | React / Vue | UI components for rendering Carve markup in the browser. |
+| [carve-wysiwyg](https://github.com/markup-carve/carve-wysiwyg) | TypeScript | WYSIWYG editor / live sandbox (Tiptap + carve-grammars). |
+
 ## Editor support
 
 Syntax highlighting, structural editing, and diagnostics inside editors.
@@ -26,16 +38,27 @@ Syntax highlighting, structural editing, and diagnostics inside editors.
 | Project | Target | Status |
 |---|---|---|
 | [vscode-carve](https://github.com/markup-carve/vscode-carve) | VS Code | Highlighting, snippets, live preview. |
+| [emacs-carve](https://github.com/markup-carve/emacs-carve) | Emacs | Major mode for `.crv`/`.carve` files. |
+| [vim-carve](https://github.com/markup-carve/vim-carve) | Vim / Neovim | Syntax highlighting + tree-sitter grammar. |
+| [sublime-carve](https://github.com/markup-carve/sublime-carve) | Sublime Text | Syntax package for `.crv`/`.carve`. |
+| [helix-carve](https://github.com/markup-carve/helix-carve) | Helix | Editor support for Carve. |
+| [intellij-carve](https://github.com/markup-carve/intellij-carve) | JetBrains IDEs | Highlighting, live preview, and export for IntelliJ, PhpStorm, etc. |
 | [zed-carve](https://github.com/markup-carve/zed-carve) | Zed | Editor support. |
 | [tree-sitter-carve](https://github.com/markup-carve/tree-sitter-carve) | Tree-sitter | Grammar for highlighting and structural editing. |
 | [carve-lsp](https://github.com/markup-carve/carve-lsp) | LSP | Language server - syntax diagnostics, Djot/Markdown collision hints. *Early.* |
 
-## Integrations
+## Framework integrations
 
 Carve embedded in another tool or framework.
 
 | Project | Host | Status |
 |---|---|---|
+| [mkdocs-carve](https://github.com/markup-carve/mkdocs-carve) | MkDocs | Plugin: renders `.crv`/`.carve` pages in MkDocs documentation sites. |
+| [jekyll-carve](https://github.com/markup-carve/jekyll-carve) | Jekyll | Converter plugin for `.crv`/`.carve` pages. |
+| [eleventy-carve](https://github.com/markup-carve/eleventy-carve) | Eleventy (11ty) | Plugin for processing Carve source files. |
+| [astro-carve](https://github.com/markup-carve/astro-carve) | Astro | Integration for importing `.carve`/`.crv` pages. |
+| [symfony-carve](https://github.com/markup-carve/symfony-carve) | Symfony | Bundle to render Carve markup to HTML via carve-php. |
+| [symfony-carve-demo](https://github.com/markup-carve/symfony-carve-demo) | Symfony | Demo app showcasing the symfony-carve bundle. |
 | [wp-carve](https://github.com/markup-carve/wp-carve) | WordPress | Plugin on the carve-php engine - live preview, multi-format paste, REST API. |
 | [carve-grammars](https://github.com/markup-carve/carve-grammars) | Tiptap | Editor kit and Carve serializer. |
 | [vite-plugin-carve](https://github.com/markup-carve/vite-plugin-carve) | Vite | Import `.carve` / `.crv` documents as rendered HTML. *Early.* |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -290,17 +290,58 @@ Grammar: `resources/grammar.ebnf` PART 9 §22. Narrative: `case-study/syntax.md`
   those tails is claimed. This is exactly the gap core leaves (core declines
   tail-less brackets), so citations never hijack core syntax.
 - Items are `;`-separated; each is `[prefix] [-] @key [, locator]`. The leading
-  `-` suppresses the author in author-date mode.
+  `-` suppresses the author in author-date mode (per item).
+- A single leading `+` immediately after `[` marks the whole cluster as
+  **integral** (author-in-text): `[+@smith2020]`, `[+see @smith2020, p. 12]`.
+  Mode is a group property - there is no per-item integral flag. Vocabulary
+  matches CSL / Citum `CitationMode` (`integral` / `non-integral`).
 - Definitions are in-document, one per line, footnote-style:
   `[@key]: {author= year=}? entry`. The optional `{author= year=}` feeds
   author-date output; its quotes may be straight or smart (the typographic
   pass runs over entry prose). A leading `@` label is reserved from reference
   definitions in core (parallels `[^...]:` precedence).
 
-### 4.2 Lifecycle
+### 4.2 Typed Locators
+
+The locator text after the first `,` in an item is parsed into a structured
+`{label, value}` pair plus a trailing suffix, so a host CSL processor receives
+the same data it would from Pandoc.
+
+**Matching rules:**
+
+- Canonical labels (longest-match, boundary rule - a term matches only when
+  followed by end-of-locator, whitespace, a digit, `§`, or `¶`):
+
+  | Label | Abbreviations |
+  |---|---|
+  | book | bk. |
+  | chapter | chap., chaps. |
+  | column | |
+  | figure | |
+  | folio | |
+  | issue | no. |
+  | line | l., ll. |
+  | note | n., nn. |
+  | opus | |
+  | page | p., pp. |
+  | paragraph | para., ¶ |
+  | part | |
+  | section | sec., § |
+  | sub verbo | s.v. |
+  | verse | v., vv. |
+  | volume | vol. |
+
+- A leading digit with no preceding label defaults to `page`.
+- The value runs to end-of-locator or the next `;`; trailing `,`, `&`, `-`,
+  `.` are trimmed. The remainder (after the value) is the **suffix**.
+- An unrecognized locator string is emitted as-is (no label, no value split).
+
+### 4.3 Lifecycle
 
 - **Matcher** (inline): claims `[...@key...]` per the rule above, producing a
-  `citation-group` node carrying its verbatim `raw` source.
+  `citation-group` node carrying its verbatim `raw` source and the parsed
+  integral flag, suppress-author flags, prefixes, locator labels/values, and
+  suffixes.
 - **afterParse**: collects and removes `[@key]:` definition lines; resets
   per-document state so a reused extension instance does not leak across runs.
 - **beforeRender**: numbers cited+defined keys in first-citation order and
@@ -311,15 +352,39 @@ Grammar: `resources/grammar.ebnf` PART 9 §22. Narrative: `case-study/syntax.md`
   list (`<ol class="references">` numbered, sorted `<ul class="references">`
   author-date).
 
-### 4.3 Conformance (pinned in `tests/corpus-optional`)
+### 4.4 HTML data-\* contract
 
-- `citations-numbered`, `citations-author-date`: the five forms, the references
-  list, and the `{author= year=}` author-date path.
+Each rendered citation anchor carries the following `data-*` attributes, in
+canonical order, emitting only the attributes that apply for the item:
+
+| Attribute | Value |
+|---|---|
+| `data-cite-key` | the citation key |
+| `data-suppress-author` | `"true"` when `-` was present |
+| `data-cite-prefix` | flattened plain-text prefix (when present) |
+| `data-locator-label` | parsed label name (when a label was matched) |
+| `data-locator` | parsed locator value (when present) |
+| `data-suffix` | flattened plain-text suffix (when present) |
+
+An integral cluster wraps all its items in:
+
+```html
+<span class="citation" data-cite-mode="integral">…</span>
+```
+
+### 4.5 Conformance (pinned in `tests/corpus-optional`)
+
+- `citations-numbered`, `citations-author-date`: the base forms, the references
+  list, and the `{author= year=}` author-date path (corpus cases 05-06).
 - Failure modes are pinned too: a group with any undefined key renders verbatim;
   `[@k]{...}` is a span, not a citation; a `;` inside a locator falls back to
-  literal text.
+  literal text (cases 07-09).
+- **Enrichment** (cases 13-24): typed locators (label match, boundary rule,
+  default-page, value trim, suffix), integral cluster marker (`[+@key]`),
+  per-item suppress-author, group-marker disambiguation vs. per-item flags,
+  and trailing-comma edge case.
 
-### 4.4 Undefined (impls MAY differ; NOT corpus-pinned)
+### 4.6 Undefined (impls MAY differ; NOT corpus-pinned)
 
 - Same-author-year disambiguation letters (`2020a` / `2020b`) are out of scope
   for v1; the bare year is emitted.
@@ -390,7 +455,7 @@ no-cell-row defer, and the thead/tbody rowspan clamp).
 
 Render a reference list from citation keys resolved against an external
 CSL-JSON source (issue #199). This is the external-data follow-up the Citations
-extension (§4) explicitly deferred (§4.4): §4 resolves `@key` against in-document
+extension (§4) explicitly deferred (§4.6): §4 resolves `@key` against in-document
 `[@key]:` definitions only; this extension adds a document-level bibliography
 pool. Off by default; enable per processor. Depends on Citations (§4) being
 enabled - it reuses the same `citation-group` nodes, numbering, and
@@ -421,7 +486,7 @@ enabled - it reuses the same `citation-group` nodes, numbering, and
 - A cited `@key` resolves against, in order: (a) an in-document `[@key]:`
   definition (§4), then (b) the CSL-JSON pool. An in-document definition wins on
   collision, so a document can override or supplement an external entry locally.
-- Only **cited** keys enter the reference list (the §4.4 rule holds: no
+- Only **cited** keys enter the reference list (the §4.6 rule holds: no
   `nocite`-style force-include of uncited entries).
 - Numbering is unchanged from §4: cited+resolved keys are numbered in
   first-citation order.
@@ -498,7 +563,7 @@ merge is a host concern, not pinned here.
 - BibTeX (`.bib`) ingestion - convert to CSL-JSON upstream.
 - Arbitrary `.csl` style rendering (the renderer-plugin point above).
 - Same-author-year disambiguation letters (`2020a` / `2020b`), inherited from
-  §4.4 - the bare year is emitted.
+  §4.6 - the bare year is emitted.
 
 ## 7. Glossary (Tier-3)
 

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -142,6 +142,12 @@ extension_profile_note=this run compares default/no-opt-in output. Use --corpus=
 
 Optional raw output:
 
+> **Note:** the snapshot below is from 2026-06-19 (4 optional corpus pairs).
+> The optional corpus has since grown to 24 pairs (citations-numbered enrichment
+> cases 13-24 for typed locators, integral marker, and suppress-author; code
+> callouts cases 10-12; trailing-comma case 24). Regenerate with
+> `npm run compare:impls -- --corpus=optional` to get current counts.
+
 ```text
 Implementation summary
 profile=optional/opt-in corpus=optional corpus_pairs=4

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -981,6 +981,30 @@ footnote_definition = "[^", footnote_label, "]:", space, inline_content, newline
    references list; author-date (configuration) emits `(Author Year)` + an
    alphabetical list. The references list is appended at document end or
    injected into a `::: references` block.
+
+   INTEGRAL MARKER (issue #226): a single leading `+` immediately after `[`
+   marks the whole citation cluster as integral (author-in-text). The `+` is
+   a group-level flag - there is no per-item integral mode. An integral cluster
+   is wrapped in `<span class="citation" data-cite-mode="integral">…</span>`.
+   The vocabulary (`integral` / `non-integral`) matches CSL / Citum `CitationMode`.
+   Example: `[+@smith2020]`, `[+see @smith2020, p. 12]`.
+
+   TYPED LOCATORS (issue #226): the locator text after the first `,` in an item
+   is parsed into a citeproc `{label, value}` structure plus a trailing suffix.
+   Longest-match, boundary rule: a term matches only when followed by end-of-locator,
+   whitespace, a digit, `§`, or `¶`. On a leading digit with no preceding term,
+   the default label is `page`. Trailing `,`, `&`, `-`, `.` are trimmed from the
+   value; the remainder is the suffix. Canonical labels with recognized abbreviations:
+     book (bk.) | chapter (chap., chaps.) | column | figure | folio |
+     issue (no.) | line (l., ll.) | note (n., nn.) | opus | page (p., pp.) |
+     paragraph (para., ¶) | part | section (sec., §) | sub verbo (s.v.) |
+     verse (v., vv.) | volume (vol.)
+
+   DATA-* HTML CONTRACT (issue #226): each citation anchor carries, in order,
+   only the attributes that apply: `data-cite-key`, `data-suppress-author`,
+   `data-cite-prefix`, `data-locator-label`, `data-locator`, `data-suffix`.
+   Prefix and suffix are flattened plain text.
+
    Undefined behavior (impls MAY differ, NOT corpus-pinned): same-author-year
    disambiguation letters (e.g. `2020a` / `2020b`) are out of scope for v1 -
    the bare year is emitted. A `;` inside a locator is not supported (it splits
@@ -989,7 +1013,8 @@ footnote_definition = "[^", footnote_label, "]:", space, inline_content, newline
    undefined key renders the verbatim source; a `[@k]{...}` is a span, not a
    citation; a `[@k, a; b]` with a `;` in the locator is literal text.
    Pinned in tests/corpus-optional (features citations-numbered /
-   citations-author-date and the failure-mode cases). *)
+   citations-author-date and the failure-mode cases, plus typed-locator,
+   integral, and suppress-author enrichment cases 13-24). *)
 citation_group = '[', ['+'], citation_item, {';', citation_item}, ']' ;
 citation_item = [inline_content], ['-'], '@', citation_key, [',', space, inline_content] ;
 (* A single leading `+` immediately after `[` sets the whole citation cluster to


### PR DESCRIPTION
## Summary

Documentation debt from PR #226 (citation enrichment) and ecosystem growth:

- `docs/extensions.md` §4: full normative prose for what #226 shipped - typed locator vocabulary (label table, boundary rule, value-trim, suffix), group-level integral marker (`[+@key]`), per-item suppress-author (`-@key`), and the `data-*` HTML contract table; subsections renumbered (4.2 Typed Locators, 4.3 Lifecycle, 4.4 HTML contract, 4.5 Conformance, 4.6 Undefined); §6 xrefs updated accordingly
- `docs/case-study/syntax.md` §4.3: adds `[+@key]` integral form and typed locator examples alongside the existing citation forms; documents `data-*` attribute surface
- `resources/grammar.ebnf` §22: adds corpus case numbers 13-24 to the pinned conformance note
- `docs/implementation-comparison.md`: annotates the stale `corpus_pairs=4` raw output with a note that the optional corpus is now 24 pairs
- `docs/ecosystem.md`: adds 15 org repos missing from the previous listing, grouped into a new Language bindings section (carve-go, carve-py, carve-rb, carve-components, carve-wysiwyg) and expanded editor/framework tables (emacs-carve, vim-carve, sublime-carve, helix-carve, intellij-carve; mkdocs-carve, jekyll-carve, eleventy-carve, astro-carve, symfony-carve, symfony-carve-demo)

Tests: 415 pass, 2 skipped (same 2 skipped as before; 21 new optional corpus cases from the rebase of origin/main now passing).