### PR TITLE
docs: correct migrate-from-markdown guide (fence rule + syntax fixes)

### DIFF
--- a/docs/migrate-from-markdown.md
+++ b/docs/migrate-from-markdown.md
@@ -23,29 +23,29 @@ The table below covers the constructs you use most often. Items marked **same** 
 
 | Construct | Markdown | Carve | Notes |
 |---|---|---|---|
-| Headings | `# H1` through `###### H6` | same | |
+| Headings | `# H1` through `###### H6` | same | A trailing `{#id}` is **not** an attribute (see below) |
 | Links | `[text](url)` | same | |
 | Reference links | `[text][ref]` / `[ref]: url` | same | |
 | Images | `![alt](src)` | same | |
 | Inline code | `` `code` `` | same | |
+| Fenced code | `` `code fence` `` with a language | same | No-space info string is canonical; a space is also accepted |
 | Blockquotes | `> text` | same | Carve adds captions (see below) |
-| Unordered lists | `- item` or `* item` | same | |
+| Unordered lists | `- item` or `* item` | same | Carve bullets are `-`/`*`; a Markdown `+` bullet is not a Carve bullet |
 | Ordered lists | `1. item` | same | |
 | Task lists | `- [ ] todo` / `- [x] done` | same | |
-| Thematic break | `---` | same | |
+| Thematic break | `---` | same | Contiguous `---`, `***`, or `___` (no spaced forms) |
 | **Italic** | `*italic*` or `_italic_` | `/italic/` | **Changed** - see below |
 | **Bold** | `**bold**` or `__bold__` | `*bold*` | **Changed** - see below |
-| **Bold + italic** | `***both***` | `/*both*/` or `*text*` inside `/…/` | **Changed** |
+| **Bold + italic** | `***both***` | `/*both*/` | **Changed** |
 | Underline | (not standard) | `_underline_` | Carve adds this |
 | Strikethrough | `~~strike~~` (GFM) | `~strike~` | Single tilde in Carve |
-| Fenced code language | ` ```python ` (no space) | ` ``` python ` (space required) | **Changed** - see below |
-| Tables | GFM pipe tables with `\|---\|` separator row | `\|=` header cells, no separator row | **Changed** - see below |
-| Footnotes | `[^label]` + `[^label]: text` (GFM ext.) | same | |
-| Raw HTML | Inline and block, on by default | Disabled by default | See below |
+| Tables | GFM pipe tables with a `\|---\|` row | `\|=` header cells | **Changed** - see below (GFM delimiter row also accepted) |
+| Footnotes | `[^label]` + `[^label]: text` (GFM ext.) | same | Plus inline `^[...]` |
+| Raw HTML | Inline and block, on by default | Bare tags are literal; explicit `=html` passthrough only | See below |
 
 ## Emphasis: the most important change
 
-Carve swaps the roles of `*` and `_` compared to Markdown. This is the one change that will catch you most often.
+Carve uses `/` for italic and `*` for bold - unlike Markdown's `*`/`**`. And `_`, which is italic in Markdown, means underline in Carve. This is the one change that will catch you most often.
 
 ::: code-group
 
@@ -77,31 +77,20 @@ The mnemonic: `/` leans like italics, `*` is strong like bold.
 
 ## Fenced code blocks
 
-The fence token and closing fence are the same as Markdown. The only difference is a **required space** between the fence and the language tag:
+Fenced code blocks work like Markdown for the common case - a language directly after the fence, no space, which is the canonical Carve form:
 
-::: code-group
-
-```md [Markdown]
+````md
 ```python
 def hello():
     print("hello")
 ```
-```
+````
 
-```carve [Carve]
-``` python
-def hello():
-    print("hello")
-```
-```
-
-:::
-
-Carve's grammar requires the space so that ` ```python ` is unambiguous with the extension syntax. Without it, the language tag is silently treated as plain text.
+Carve is lenient about the leading space: a space after the fence (the Djot style) is also accepted and parses identically. One difference worth knowing: Carve's info string is structured - an optional language token, then an optional `"title"`, then an optional `[label]` - rather than free-form text. For everyday `language`-only fences there is nothing to migrate.
 
 ## Tables
 
-GFM tables use a separator row (`|---|`) to mark the header. Carve uses `|=` on header cells instead and has no separator row:
+GFM tables use a delimiter row (`|---|`) to mark the header. Carve's native, canonical form marks header cells with `|=` and needs no delimiter row:
 
 ::: code-group
 
@@ -114,31 +103,34 @@ GFM tables use a separator row (`|---|`) to mark the header. Carve uses `|=` on 
 
 ```carve [Carve]
 |= Name   |= Role   |
-| Alice   | Editor  |
+| Alice   | Author  |
 | Bob     | Editor  |
 ```
 
 :::
 
-Carve tables also support cell spanning:
+For convenience, Carve also accepts a GFM `|---|` delimiter row as a second line, so a pasted Markdown table still renders - but `|=` is the canonical form the converter emits.
+
+Carve tables also support cell spanning and multi-line cells:
 
 ```carve
 |= Name        |= Q1 |= Q2 |
-| Alice        | 42  | ^   |
-| Bob and Carol| <   | 17  |
+| Alice         | 42  | 17  |
+| Bob           | 9   | ^   |
+| Carol and Dan | <   | 21  |
 ```
 
-- `<` merges with the cell to the left (colspan)
-- `^` merges with the cell above (rowspan)
-- `+` extends a span in both directions
+- `<` merges with the nearest available cell to its left (colspan)
+- `^` merges with the nearest available cell above (rowspan)
+- `+` begins a continuation row: each non-empty cell is appended to the corresponding cell in the row above (multi-line cells), not a span
 
 ## Blockquote captions
 
-Carve blockquotes work the same as Markdown, but you can add a caption with a `^` line immediately after the closing block:
+Carve blockquotes work the same as Markdown, but you can add a caption with a `^` line immediately after the quote:
 
 ```carve
 > The art of being wise is the art of knowing what to overlook.
-^ William James, *The Principles of Psychology*
+^ William James, /The Principles of Psychology/
 ```
 
 The same caption syntax works after images and fenced code blocks.
@@ -154,52 +146,50 @@ These Carve features have no Markdown equivalent. They do not collide with Markd
 This is a note admonition.
 :::
 
-::: tip
-Use admonitions for callouts and warnings.
-:::
-
 ::: warning
 Dangerous operation ahead.
 :::
-
-::: danger
-This will delete your data.
-:::
 ```
 
-Any label works: `::: info`, `::: important`, `::: caution`, or your own custom names via extensions.
+The Tier-1 canonical types - `note`, `tip`, `warning`, `danger`, `info`, `success`, `example`, `quote` - render as admonition `<aside>` callouts. Any other `:::` name (e.g. `important`, `caution`, or your own) renders as a generic typed `<div>` (class `name`), or as a registered extension if one claims that name.
 
 ### Attributes
 
-Attach `{#id .class key="value"}` to any block or inline element:
+Attach `{#id .class key="value"}` to inline elements directly, and to block elements via a standalone line **before** the block:
 
 ```carve
-# Heading with an anchor {#custom-id}
+A [span]{.highlight} with a class, or an attributed [link](/url){.cta}.
 
-A [link]{.highlight} with a class.
-
-::: note {#important-note .callout}
-This note has an id and a class.
+{#custom-id .callout}
+::: note
+This note has an id and a class, set by the line above it.
 :::
 ```
+
+A `{...}` written at the **end of a heading line is literal text**, not an attribute (a deliberate Djot-strict choice). To give a heading a custom id, put the attribute on the preceding line:
+
+```carve
+{#intro}
+## Introduction
+```
+
+Without an explicit id, headings still get an auto-generated id from their text (case is preserved; a leading digit gets an `s-` prefix). Lowercasing and ASCII-folding are available as opt-in transforms.
 
 ### Math
 
 ::: code-group
 
 ```carve [Inline]
-Einstein's famous equation is $`E = mc^2`$.
+Einstein's famous equation is $`E = mc^2`.
 ```
 
-```carve [Block]
-``` math
-\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}
-```
+```carve [Display]
+$$`\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}`
 ```
 
 :::
 
-### Inline footnotes
+### Footnotes
 
 Carve supports both reference-style and inline footnotes:
 
@@ -211,52 +201,46 @@ Reference-style[^1] and inline^[This is the footnote content.] both work.
 
 ### Citations
 
-```carve
-Recent work[@smith2023] shows promising results.
+Citations are a Tier-2 extension (enable the citations extension). Cite with `[@key]` and define entries in-document with `[@key]:` lines. The generated reference list is appended at the document end, or injected wherever you place a `::: references` block:
 
-::: bibliography
-[smith2023]: Smith, J. (2023). *Example Paper*. Journal of Examples.
-:::
+```carve
+Recent work [@smith2023] shows promising results.
+
+[@smith2023]: Smith, J. (2023). /Example Paper/. Journal of Examples.
 ```
 
 ### Cross-references
 
 ```carve
-## Introduction {#intro}
+{#intro}
+## Introduction
 
-See [the introduction](#intro) or the numbered reference </#intro>.
+See [the introduction](#intro) or the cross-reference </#intro>.
 ```
 
-`</#id>` inserts an auto-numbered cross-reference that updates when you add or remove numbered blocks.
+`</#id>` inserts a cross-reference to the target: generated link text for a heading, or an auto-updating number ("Figure 3", "Table 2", "Listing 1", "Equation 4") for a *numbered-caption* target - a figure, table, listing, or equation whose caption carries a number placeholder.
 
 ### Extension syntax
 
-The `:name[content]` (inline) and `::: name` (block) syntax is available for custom extensions without touching core grammar. An unknown name renders as a plain span or div, so documents remain readable even without the extension registered.
+The `:name[content]` (inline) and `::: name` (block) syntax is available for custom extensions without touching core grammar. An unknown inline `:name[content]` renders as a generic inline extension (class `ext-name`, content closing at the first `]`); an unknown `::: name` block renders as a generic typed div - so documents stay readable even without the extension registered.
 
 ## Raw HTML
 
-Carve disables raw HTML by default for security. Inline `<span>` and block `<div>` tags in your source will be passed through as literal text rather than HTML.
+Bare `<span>` and `<div>` tags in your source are **always literal text** in Carve - they are never interpreted as HTML. This is the key safety difference from Markdown, which passes raw HTML through by default.
 
-To enable raw HTML output (for trusted content only):
+When you genuinely want verbatim HTML, use the explicit raw constructs - a ```` ```=html ```` block or `` `...`{=html} `` inline. These passthrough constructs are on by default for trusted content. For untrusted input, turn the passthrough off so even those are escaped:
 
-::: code-group
-
-```ts [carve-js]
+```ts
 import { carveToHtml } from '@markup-carve/carve'
 
-const html = carveToHtml(source, { rawHtml: true })
+// Untrusted input: disable the explicit raw-HTML passthrough.
+const html = carveToHtml(source, { allowRawHtml: false })
 ```
 
-```php [carve-php]
-use Carve\CarveConverter;
-
-$html = (new CarveConverter(['rawHtml' => true]))->convert($source);
-```
-
-:::
+The equivalent switch exists per engine (carve-rs `Options::with_raw_html(false)`, etc.). See [Security](/security) for the full model.
 
 ::: warning Trust boundary
-Only enable `rawHtml` for content you control. For user-generated content, leave it off and use Carve's native constructs instead.
+Bare tags are safe (literal) regardless. The setting above only governs the explicit ```` ```=html ```` / `{=html}` passthrough - leave it disabled for user-generated content.
 :::
 
 ## Migration checklist
@@ -264,9 +248,9 @@ Only enable `rawHtml` for content you control. For user-generated content, leave
 When moving a document from Markdown to Carve:
 
 - [ ] Run `carve migrate --from markdown` for a first-pass conversion
-- [ ] Review all emphasis: `*italic*` → `/italic/`, `**bold**` → `*bold*`
+- [ ] Review all emphasis: `*italic*` -> `/italic/`, `**bold**` -> `*bold*`
 - [ ] Check `_underline_` occurrences - these render as `<u>` in Carve, not `<em>`
-- [ ] Add a space after fenced code fence tokens: ` ```python ` not ` ```python`
-- [ ] Convert GFM table separator rows to `|=` header cells
+- [ ] Convert GFM table delimiter rows to `|=` header cells
 - [ ] Replace `~~strike~~` with `~strike~` (single tilde)
-- [ ] Decide on raw HTML: remove it, replace with Carve constructs, or enable `rawHtml`
+- [ ] Move any heading `{#id}` onto the line above the heading (trailing is literal)
+- [ ] Decide on raw HTML: bare `<tags>` become literal text, so replace them with Carve constructs (or use the explicit `{=html}` passthrough for trusted content; disable it with `allowRawHtml: false` for untrusted input)


### PR DESCRIPTION
Fixes numerous incorrect Carve syntax claims and broken VitePress fence nesting in the merged migration guide (#232).

Every Carve example was re-verified against `resources/grammar.ebnf` through 6 rounds of codex review (final pass: "No invalid Carve syntax found, no fenced-block nesting issue"). Docs build is clean and the rendered page was verified (proper code blocks + code-group tabs, zero stray text).

Key corrections: fenced-code no-space form is canonical (the guide wrongly said a space is required); a trailing heading `{#id}` is literal text (custom id goes on a preceding line); citations use `[@key]:` defs and `::: references`; correct admonition canonical types; raw-HTML is `allowRawHtml` with passthrough on by default; and 4-backtick wrappers for the examples that show literal triple-backtick fences.
