### PR TITLE
docs(versioning): define 0.1 stability scope

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -8,6 +8,33 @@ All Carve repositories use [Semantic Versioning](https://semver.org/) (`MAJOR.MI
 introduce breaking changes to grammar, output, or the extension API. Patch
 releases fix bugs without changing behavior.
 
+## Stability scope (0.1)
+
+What the 0.1 release guarantees, by tier (the line is drawn at the
+Tier-2 / Tier-3 seam):
+
+- **Tier-1 core** (emphasis, headings, links, lists, tables, code, blockquotes,
+  footnotes, math, admonitions, attributes, frontmatter, comments, autolinks,
+  raw blocks, heading ids, cross-references) and the always-on security model
+  (grammar PART 9 §25/§26) are **normative and stable** - corpus-pinned with
+  byte-parity across all three engines. Changes require a coordinated minor.
+- **Tier-2 standard extensions** (citations incl. typed-locator + integral
+  enrichment, bibliography, code callouts, glossary, index, heading numbers,
+  mentions/tags) are **stable and corpus-pinned** in 0.1. Their syntax and HTML
+  contract will not change without a minor bump.
+- **Tier-3 app-level extensions** (Mermaid, Tabs, table-of-contents, heading
+  permalinks, ColorSwatch, QR, static maps, and other host-dependent showcases)
+  ship and are documented, but are **not covered by the 0.1 stability
+  guarantee** - they may evolve in any release. Several depend on a host library
+  or service and so cannot be normatively corpus-pinned like core.
+- **Tooling** - the round-trip / reverse converters (Markdown / HTML / Djot /
+  BBCode to Carve, plus the `carve fmt` formatter) and the language server
+  (`carve-lsp`) - ships as part of the ecosystem but **versions independently**
+  of the spec tag (see Satellites below); it is not part of the lockstep core.
+
+In short: build on Tier-1 + Tier-2 with confidence; treat Tier-3 and the
+converters / LSP as available-but-evolving.
+
 ## Core lockstep
 
 The four core repositories advance together on every **minor** and **major** release:


### PR DESCRIPTION
Encodes the Tier-3 scope-cut decision (carve#65 P1, option B): Tier-1 core + Tier-2 standard extensions are the stable, corpus-pinned 0.1 guarantee; Tier-3 app-level extensions and the converters/LSP tooling ship but version/evolve independently and are not part of the 0.1 stability promise. Adds a `Stability scope (0.1)` section to VERSIONING.md.