### PR TITLE
docs: ::: toc includes container-nested headings

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -724,9 +724,12 @@ preceding attribute line, never inline on the opener):
 - The author's `{#id .class}` is carried onto the `<nav>`; the directive-only
   `depth`/`from`/`to` keys are stripped from the output.
 - Entries link to each heading's resolved, dedup-aware id (so links match the
-  emitted `<section id>` anchors). **Scope: document-level (top-level) headings**
-  — headings nested inside containers (`::: note`, blockquotes) are excluded,
-  matching the standalone TOC extension in carve-js / carve-rs.
+  emitted heading anchors). **Every heading is included in document order**,
+  recursing into containers (`::: note`, blockquotes, divs) — those headings
+  render with id anchors, so they belong in the TOC. Footnote-definition
+  headings get no id and are excluded. (A heading inside a list item is subject
+  to the core list-interruption rules, which currently differ across engines;
+  the TOC faithfully reflects each engine's parse.)
 - The nested `<ul>` HTML is byte-identical to the standalone TOC extension
   (one tag per line).
 


### PR DESCRIPTION
Updates §8b.1: the placed TOC now includes headings nested in containers (`::: note`, blockquotes, divs) - they render with id anchors. Footnote-definition headings stay excluded. Companion to the impl PRs (carve-js #283, carve-php #289, carve-rs #182).