### PR TITLE
test: pin ::: footnotes placement in the main corpus

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7402,7 +7402,7 @@ A `::: footnotes` block flushes the endnotes section at that point instead of
 at the document end. All footnotes are included, even those referenced after
 the marker.
 
-::: compare
+:::: compare
 
 ```carve
 Intro[^a] and[^b].
@@ -7438,4 +7438,4 @@ More text.
 </section>
 ```
 
-:::
+::::

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7395,3 +7395,47 @@ leaving an empty `href`:
 ```
 
 :::
+
+## Footnotes placement
+
+A `::: footnotes` block flushes the endnotes section at that point instead of
+at the document end. All footnotes are included, even those referenced after
+the marker.
+
+::: compare
+
+```carve
+Intro[^a] and[^b].
+
+::: footnotes
+:::
+
+## After
+
+More text.
+
+[^a]: first note
+
+[^b]: second note
+```
+
+```html
+<p>Intro<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a>.</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>first note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>second note<a href="#fnref2" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+<section id="After">
+  <h2>After</h2>
+  <p>More text.</p>
+</section>
+```
+
+:::

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -751,10 +751,16 @@ the opt-in.
 
 ### 8b.3 Degradation & conformance
 
-Both degrade gracefully (a labeled `<div>` floor). Not corpus-pinned; the
-cross-impl contract is the byte-identical `<nav>`/endnotes fragment. Each
-implementation pins the window selection, id resolution, and degradation in its
-own suite.
+Both degrade gracefully (a labeled `<div>` floor).
+
+- **`::: footnotes`** is core and its full output is byte-identical across
+  implementations, so it is **corpus-pinned** in the main corpus
+  (`120-footnotes-placement`).
+- **`::: toc`** is a Tier-3 extension whose embedded output carries
+  per-implementation block indentation (like Glossary and Index), so it is
+  **not** corpus-pinned; the cross-impl contract is the byte-identical `<nav>`
+  list fragment, and each implementation pins the window selection, id
+  resolution, and degradation in its own suite.
 
 ## 9. HeadingNumbers (Tier-3)
 

--- a/tests/corpus/120-footnotes-placement.crv
+++ b/tests/corpus/120-footnotes-placement.crv
@@ -1,0 +1,12 @@
+Intro[^a] and[^b].
+
+::: footnotes
+:::
+
+## After
+
+More text.
+
+[^a]: first note
+
+[^b]: second note

--- a/tests/corpus/120-footnotes-placement.html
+++ b/tests/corpus/120-footnotes-placement.html
@@ -1,0 +1,16 @@
+<p>Intro<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a>.</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>first note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>second note<a href="#fnref2" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+<section id="After">
+  <h2>After</h2>
+  <p>More text.</p>
+</section>

--- a/tests/spec/120-footnotes-placement.test
+++ b/tests/spec/120-footnotes-placement.test
@@ -1,0 +1,33 @@
+Footnotes placement
+
+```
+Intro[^a] and[^b].
+
+::: footnotes
+:::
+
+## After
+
+More text.
+
+[^a]: first note
+
+[^b]: second note
+.
+<p>Intro<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a>.</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>first note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>second note<a href="#fnref2" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+<section id="After">
+  <h2>After</h2>
+  <p>More text.</p>
+</section>
+```


### PR DESCRIPTION
Adds `120-footnotes-placement` to the main spec corpus, pinning the endnotes-relocation output (byte-identical across carve-js / carve-php / carve-rs). Updates §8b.3: `::: footnotes` is corpus-pinned; `::: toc` stays per-impl (block-indentation divergence, like Glossary/Index).