### PR TITLE
Executable spec pipeline with corpus gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Conformance
         run: npm test
 
+      - name: Executable-spec gate (formal Core grammar vs corpus)
+        run: npm run core:check
+
   docs-build:
     name: docs build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,12 @@ jobs:
       - name: Conformance
         run: npm test
 
+      # The gate needs ohm-js (the conformance steps above run against the
+      # vendored carve-lib and need no install).
       - name: Executable-spec gate (formal Core grammar vs corpus)
-        run: npm run core:check
+        run: |
+          npm ci
+          npm run core:check
 
   docs-build:
     name: docs build

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -19,17 +19,23 @@ This is the canonical formal specification of Carve. It is **layered**, and each
 Light markup languages are provably not context-free: fence-length matching is a counting constraint, indentation is 2D, and reference resolution needs a whole-document symbol table. No single EBNF can express Carve (or Djot, or CommonMark). What CAN be done - and what this file does - is state every rule in *some* exact formalism, so nothing normative rests on English prose.
 :::
 
-## Carve Core: the executable subset
+## Carve Core: the executable spec
 
-**Carve Core** is the subset whose syntax is a genuinely machine-interpretable grammar: ATX headings, thematic breaks, paragraphs, fenced code, and the seven bare emphasis delimiters with their full word-boundary rules, code spans, and escapes.
+**Carve Core** is the subset of Carve whose specification is directly executable - each spec layer exists as a machine-interpretable artifact:
 
-Core exists as an executable PEG grammar, [`resources/carve-core.ohm`](https://github.com/markup-carve/carve/blob/main/resources/carve-core.ohm), checked against the conformance corpus:
+| Spec layer | Executable artifact |
+|---|---|
+| PART 0 layout automaton + list/quote structure | `scripts/spec/layout.mjs` |
+| PART 3 inline grammar | [`resources/carve-core.ohm`](https://github.com/markup-carve/carve/blob/main/resources/carve-core.ohm) (Ohm/PEG) |
+| PART 9R resolution + PART 10 serialization | `scripts/spec/html.mjs` |
+
+Core covers: headings, thematic breaks, paragraphs, fenced code, lists (bullet/ordered/task, all dialects, lazy continuation, tight/loose), block quotes (incl. the `+` continuation marker and attribution captions), the seven emphasis delimiters with full word-boundary rules, code spans, math, escapes, links (all three forms), images (incl. figure captions), inline spans and attribute blocks (incl. the security hardening rules), autolinks, footnotes (reference form, endnotes, backlinks), crossrefs, and abbreviations.
 
 ```bash
 npm run core:check
 ```
 
-The gate enforces a strict contract: an input the Core grammar matches must render to the pinned corpus HTML **byte-for-byte**; inputs using Full-Carve constructs must fail to match (Core refuses rather than approximates). The one rule a PEG cannot state - fence closer length >= opener length - is asserted as a documented semantic predicate in the checker, mirroring the `where` guard in the EBNF.
+The gate enforces a strict contract over the full conformance corpus: an input the executable spec accepts must render to the pinned corpus HTML **byte-for-byte** (currently ~45% of corpus inputs); anything using constructs outside the subset is REFUSED rather than approximated, so an accept is always a full-fidelity claim. The counting rule a PEG cannot state - fence closer length >= opener length - is asserted in the layout automaton, mirroring the `where` guard in the EBNF.
 
 Implementations should match this grammar. The [case study](./case-study/) explains the design rationale, the [reference page](./edge-cases) covers parsing edge cases, and the [examples](./examples) show the expected HTML output for each construct.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.35.0",
         "markdown-it-container": "^4.0.0",
+        "ohm-js": "^17.5.0",
         "vitepress": "^1.5.0"
       }
     },
@@ -3582,6 +3583,16 @@
       "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ohm-js": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-17.5.0.tgz",
+      "integrity": "sha512-l4Sa7026+6jsvYbt0PXKmL+f+ML32fD++IznLgxDhx2t9Cx6NC7zwRqblCujPHGGmkQerHoeBzRutdxaw/S72g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.1"
+      }
     },
     "node_modules/oniguruma-to-es": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "docs:preview": "vitepress preview docs",
     "corpus:build": "node scripts/generate-corpus.mjs",
     "compare:impls": "node scripts/compare-impls.mjs",
+    "core:check": "node scripts/formal-core-check.mjs",
     "sync-carve-lib": "node scripts/sync-carve-lib.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
@@ -21,6 +22,7 @@
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.35.0",
     "markdown-it-container": "^4.0.0",
+    "ohm-js": "^17.5.0",
     "vitepress": "^1.5.0"
   },
   "dependencies": {

--- a/resources/carve-core.ohm
+++ b/resources/carve-core.ohm
@@ -9,19 +9,26 @@ CarveCore {
   // conformance corpus in CI fashion: a corpus input that this grammar
   // matches must render to the corpus HTML byte-for-byte.
   //
-  // SCOPE (Core). Blocks: ATX headings, thematic breaks, paragraphs, fenced
-  // code (backtick/tilde, optional language token). Inline: the seven bare
-  // emphasis delimiters (/ * _ ~ ^ = ,) with the full PART 3
-  // bare_opener/bare_closer word-boundary guards, verbatim code spans, and
-  // backslash escapes.
+  // SCOPE (Core). This file owns the INLINE layer and the leaf blocks of
+  // the executable spec. Blocks: ATX headings, thematic breaks, paragraphs,
+  // fenced code. Inline: the seven bare emphasis delimiters (/ * _ ~ ^ = ,)
+  // with the full PART 3 bare_opener/bare_closer word-boundary guards,
+  // verbatim code spans, math ($/$$ + span), escapes, links (inline,
+  // reference, collapsed), images, inline spans + attribute blocks,
+  // autolinks (URL + email), footnote references, and crossrefs (</#id>).
   //
-  // DELIBERATELY OUT (not Core; see grammar.ebnf PART 0 / PART 9 / PART 9R):
-  // indentation containers (lists, quotes, footnote bodies - the L0 layout
-  // automaton), tables (2D span walk), links/images/spans/attributes,
-  // smart typography, mentions/tags, math, divs/admonitions, resolution
-  // passes. A paragraph line containing any construct Core does not
-  // implement FAILS to match - by design, so a match is a full-fidelity
-  // claim, never an approximation.
+  // Container blocks (lists, block quotes, footnote definitions - the L0
+  // layout automaton) live in scripts/spec/layout.mjs; resolution and
+  // serialization (PART 9R / PART 10) in scripts/spec/html.mjs. Together
+  // they form the executable spec that scripts/formal-core-check.mjs runs
+  // against the corpus.
+  //
+  // DELIBERATELY OUT (Full Carve; the pipeline REFUSES rather than
+  // approximates): tables (2D span walk), divs/admonitions, smart
+  // typography, mentions/tags, inline extensions (:name[...]), emoji,
+  // editorial markup, comments, block-attribute lines, definition lists,
+  // citations, includes, frontmatter, inline footnotes (^[...]), and
+  // multi-line heading folding.
   //
   // Word boundaries without lookbehind (PEGs have none):
   //  - left boundary / no-intraword: `word` absorbs a delimiter glued
@@ -39,7 +46,13 @@ CarveCore {
   // checker asserts it as a documented semantic predicate.
   // ==========================================================================
 
-  Doc        = block*
+  doc        = block*
+  // start rule used by the executable-spec pipeline (scripts/spec/*): the
+  // layout automaton owns block structure; this parses ONE line of inline
+  // content. newline is not matchable here.
+  inlines    = inline*
+  // (lexical, lowercase: Ohm syntactic rules skip whitespace -- fatal for
+  // an indentation-sensitive language)
 
   block      = blankLine
              | heading
@@ -50,7 +63,15 @@ CarveCore {
   blankLine  = spaceChar* newline
 
   // --- Headings: 1-6 '#' at column 0, one space, inline text to EOL --------
-  heading    = hashes " " inline+ lineEnd
+  heading    = headingL<"######"> | headingL<"#####"> | headingL<"####">
+             | headingL<"###"> | headingL<"##"> | headingL<"#">
+  headingL<h> = h " " inline+ lineEnd &hBound<h>
+  // A heading must be FOLLOWED by a blank line, a DIFFERENT-level heading,
+  // another structural opener, or EOF. A plain line directly after a
+  // heading, or a SAME-level `#` marker line, is djot-style multi-line
+  // heading FOLDING -- Full Carve, not Core: the document fails to match
+  // rather than mis-rendering as separate blocks.
+  hBound<h>  = blankLine | (~(h " ") structural) | end
   hashes     = "######" | "#####" | "####" | "###" | "##" | "#"
 
   // --- Thematic break: a lone line of 3+ dashes/stars/underscores ----------
@@ -58,8 +79,8 @@ CarveCore {
 
   // --- Fenced code ----------------------------------------------------------
   codeBlock  = backtickFence | tildeFence
-  backtickFence = btOpen langInfo? newline codeLine* btClose
-  tildeFence    = tdOpen langInfo? newline codeLine* tdClose
+  backtickFence = btOpen langInfo? newline codeLine<btClose>* btClose
+  tildeFence    = tdOpen langInfo? newline codeLine<tdClose>* tdClose
   btOpen     = "```" "`"*
   btClose    = "```" "`"* spaceChar* lineEnd
   tdOpen     = "~~~" "~"*
@@ -67,60 +88,88 @@ CarveCore {
   langInfo   = spaceChar* langToken
   langToken  = langChar+
   langChar   = letter | digit | "-" | "_" | "+" | "#" | "." | "/"
-  codeLine   = ~btClose ~tdClose (~newline any)* newline
+  // only a closer of the OPEN fence's character ends the body: a `~~~`
+  // line inside a backtick block (and vice versa) is ordinary content
+  codeLine<closer> = ~closer (~newline any)* newline
 
   // --- Paragraph: 1+ lines of Core-only inline content ----------------------
   paragraph  = paraLine+
   paraLine   = ~blankLine ~structural inline+ lineEnd
-  structural = hashes " " | thematicBreak | btOpen | tdOpen
+  structural = headingStart | thematicBreak | btOpen | tdOpen
+             | colonFence | ordMarker
+  headingStart = hashes " "
+  colonFence = ":::"
+  // an ordered-list marker line (digit/letter run + `)` + space) is a
+  // Full-Carve list: Core refuses the document rather than rendering a
+  // paragraph. (The `.`-delimited form already fails: `.` is not a Core
+  // character.)
+  ordMarker  = alnumCh+ ")" " "
 
   // ==========================================================================
   // INLINE (Core)
   // ==========================================================================
-  inline     = span | code | escape | word | inlineSpace | litDelim | other
+  inline     = delimRun | inlineNote | footnoteRef | crossref | span
+             | mathD | mathI | code | escape | image | bracketed
+             | autolink | word | inlineSpace | litDelim | bang | dollar
+             | dot | dash | plus | pct | other
+  // SAME-DELIMITER ADJACENCY (bare_opener\'s !(d) guard): a run of 2+
+  // identical bare delimiters is literal text, never an opener.
+  delimRun   = dRun<"/"> | dRun<"*"> | dRun<"_"> | dRun<"~"> | dRun<"^"> | dRun<"="> | dRun<",">
+  dRun<d>    = d d+
 
-  span       = emph | strong | underline | strike | sup | sub | highlight
+  span       = boldItalic | emph | strong | underline | strike | sup | sub | highlight
+
+  // Combined form /*x*/ -> <strong><em> (grammar.ebnf bold_italic); matched
+  // before emph so the two-char token wins over nested /-then-* parsing.
+  boldItalic = "/*" ~spaceOrEnd biInner+ "*/" ~alnumCh
+  biInner    = ~("*/") (rich | word | " " ~("*/") | litDelim | other)
+
+  // constructs allowed inside any span (everything except spans themselves,
+  // which are listed per-delimiter to exclude self-nesting)
+  rich       = delimRun | inlineNote | footnoteRef | crossref | mathD | mathI
+             | code | escape | image | bracketed | autolink | bang | dollar
+             | dot | dash | plus | pct
 
   // One rule shape per delimiter (the bare_opener/bare_closer instantiation).
-  emph       = "/" ~spaceOrEnd emphInner+ emphClose
-  emphInner  = ~emphClose (strong | underline | strike | sup | sub | highlight
-             | code | escape | word | spaceIn<"/"> | litSelf<"/"> | other)
-  emphClose  = "/" ~alnum
+  emph       = "/" ~"/" ~spaceOrEnd emphInner+ emphClose
+  emphInner = ~emphClose (strong | underline | strike | sup | sub | highlight
+             | rich | word | spaceIn<"/"> | litSelf<"/"> | litDelim | other)
+  emphClose  = "/" ~alnumCh
 
-  strong     = "*" ~spaceOrEnd strongInner+ strongClose
+  strong     = "*" ~"*" ~spaceOrEnd strongInner+ strongClose
   strongInner = ~strongClose (emph | underline | strike | sup | sub | highlight
-              | code | escape | word | spaceIn<"*"> | litSelf<"*"> | other)
-  strongClose = "*" ~alnum
+             | rich | word | spaceIn<"*"> | litSelf<"*"> | litDelim | other)
+  strongClose = "*" ~alnumCh
 
-  underline  = "_" ~spaceOrEnd underInner+ underClose
+  underline  = "_" ~"_" ~spaceOrEnd underInner+ underClose
   underInner = ~underClose (emph | strong | strike | sup | sub | highlight
-             | code | escape | word | spaceIn<"_"> | litSelf<"_"> | other)
-  underClose = "_" ~alnum
+             | rich | word | spaceIn<"_"> | litSelf<"_"> | litDelim | other)
+  underClose = "_" ~alnumCh
 
-  strike     = "~" ~spaceOrEnd strikeInner+ strikeClose
+  strike     = "~" ~"~" ~spaceOrEnd strikeInner+ strikeClose
   strikeInner = ~strikeClose (emph | strong | underline | sup | sub | highlight
-              | code | escape | word | spaceIn<"~"> | litSelf<"~"> | other)
-  strikeClose = "~" ~alnum
+             | rich | word | spaceIn<"~"> | litSelf<"~"> | litDelim | other)
+  strikeClose = "~" ~alnumCh
 
-  sup        = "^" ~spaceOrEnd supInner+ supClose
-  supInner   = ~supClose (emph | strong | underline | strike | sub | highlight
-             | code | escape | word | spaceIn<"^"> | litSelf<"^"> | other)
-  supClose   = "^" ~alnum
+  sup        = "^" ~"^" ~spaceOrEnd supInner+ supClose
+  supInner = ~supClose (emph | strong | underline | strike | sub | highlight
+             | rich | word | spaceIn<"^"> | litSelf<"^"> | litDelim | other)
+  supClose   = "^" ~alnumCh
 
-  sub        = "," ~spaceOrEnd subInner+ subClose
-  subInner   = ~subClose (emph | strong | underline | strike | sup | highlight
-             | code | escape | word | spaceIn<","> | litSelf<","> | other)
-  subClose   = "," ~alnum
+  sub        = "," ~"," ~spaceOrEnd subInner+ subClose
+  subInner = ~subClose (emph | strong | underline | strike | sup | highlight
+             | rich | word | spaceIn<","> | litSelf<","> | litDelim | other)
+  subClose   = "," ~alnumCh
 
-  highlight  = "=" ~spaceOrEnd hlInner+ hlClose
-  hlInner    = ~hlClose (emph | strong | underline | strike | sup | sub
-             | code | escape | word | spaceIn<"="> | litSelf<"="> | other)
-  hlClose    = "=" ~alnum
+  highlight  = "=" ~"=" ~spaceOrEnd hlInner+ hlClose
+  hlInner = ~hlClose (emph | strong | underline | strike | sup | sub
+             | rich | word | spaceIn<"="> | litSelf<"="> | litDelim | other)
+  hlClose    = "=" ~alnumCh
 
   // interior space: allowed except directly before this span's closer
-  spaceIn<d> = " " ~(d ~alnum)
+  spaceIn<d> = " " ~(d ~alnumCh)
   // a same-type delimiter that is not a valid closer is literal content
-  litSelf<d> = d &alnum
+  litSelf<d> = d &alnumCh
 
   // Verbatim code span: equal-length maximal backtick runs (Core uses the
   // 1..3 tier; longer runs are out of Core). Single-space strip is applied
@@ -132,10 +181,76 @@ CarveCore {
 
   escape     = "\\" punctChar
 
+  // --- Math (PART 3: `$` / `$$` + a verbatim span; bare `$` is literal) ---
+  mathI      = "$" code
+  mathD      = "$$" code
+
+  // --- Cross-reference with auto text (PART 3 auto_text_link) -------------
+  crossref   = "</#" xrefId ">"
+  xrefId     = (~">" ~space ~newline any)+
+
+  // --- Footnotes (PART 3; `^[` ranks ABOVE superscript, PART 8) -----------
+  footnoteRef = "[^" fnLabel "]"
+  fnLabel    = (~"]" ~newline any)+
+  inlineNote = "^[" brContent* "]"
+
+  // --- Bracketed constructs: link / image / span / reference link ---------
+  // The single-char lookahead after `]` selects the construct (PART 9 S14);
+  // a bare bracketed run with no tail is LITERAL text (rendered with its
+  // content inline-parsed).
+  bracketed  = "[" brContent* "]" brTail?
+  brContent  = escape | code | nested | (~"]" ~newline any)
+  nested     = "[" brContent* "]"
+  brTail     = linkTail | refTail | attrs
+  linkTail   = "(" dest destTitle? ")" attrs?
+  refTail    = "[" refLabel? "]" attrs?
+  refLabel   = (~"]" ~newline any)+
+  dest       = destChar*
+  destChar   = ~(")" | " " | "\t" | newline) any
+  destTitle  = " "+ quoted
+  quoted     = "\"" qChar* "\""
+  qChar      = qEsc | (~"\"" ~newline any)
+  qEsc       = "\\" "\""
+
+  image      = "!" "[" altText "]" "(" dest destTitle? ")" attrs?
+  altText    = (~"]" ~newline any)*
+
+  // --- Autolinks (PART 3): URL or email in angle brackets ------------------
+  autolink   = "<" (urlBody | emailBody) ">" attrs?
+  urlBody    = scheme ":" urlChar+
+  scheme     = letter (letter | digit | "+" | "-" | ".")*
+  emailBody  = emailChar+ "@" emailChar+ "." letter+
+  emailChar  = letter | digit | "-" | "_" | "." | "+"
+  urlChar    = letter | digit | "-" | "." | "_" | "~" | ":" | "/" | "?"
+             | "#" | "[" | "]" | "@" | "!" | "$" | "&" | "'" | "(" | ")"
+             | "*" | "+" | "," | ";" | "=" | "%"
+
+  // --- Attribute block (PART 4, strict identifiers) ------------------------
+  attrs      = "{" attrSp* attrItem (attrSp+ attrItem)* attrSp* "}"
+  attrSp     = " "
+  attrItem   = idAttr | classAttr | kvAttr | boolAttr
+  idAttr     = "#" ident
+  classAttr  = "." ident
+  kvAttr     = ident "=" attrVal
+  boolAttr   = ident
+  attrVal    = quoted | bareVal
+  bareVal    = (~(" " | "}" | newline) any)+
+  ident      = identStart identRest*
+  identStart = letter | "_" | "-"
+  identRest  = letter | digit | "_" | "-"
+
   // A word absorbs any bare delimiter glued between two word characters -
   // this IS the left word-boundary / no-intraword rule, structurally.
-  word       = wordChar (wordChar | wordGlue)*
+  word       = wordChar (wordChar | wordGlue | underGlue | atGlue | dotGlue)*
   wordGlue   = delim &wordChar
+  // absorb the `@` of an embedded email address (me@example.com) and the
+  // intraword dot (example.com) so neither triggers mention/typography rules
+  atGlue     = "@" &wordChar
+  dotGlue    = "." &wordChar
+  // a delimiter directly after a word-attached `_` never opens (the
+  // bare_opener guard excludes a preceding `_`): absorb `_` + delimiter
+  // when a word character follows, keeping the run literal
+  underGlue  = "_" delim &wordChar
   wordChar   = letter | digit
   delim      = "/" | "*" | "_" | "~" | "^" | "=" | ","
 
@@ -143,19 +258,34 @@ CarveCore {
 
   // A bare delimiter that opened nothing is literal text.
   litDelim   = delim
+  bang       = "!" ~"["
+  dollar     = "$" ~"`" ~"$"
+  // single punctuation is plain text; RUNS that smart-typography or the
+  // comment syntax would transform (`...`, `--`, `+-`, `%%`) are Full
+  // Carve, so Core refuses them
+  dot        = "." ~".."
+  dash       = "-" ~"-"
+  plus       = "+" ~"-"
+  pct        = "%" ~"%"
 
   // Core-safe plain characters. Everything NOT listed here and not handled
   // above (brackets, braces, quotes, $, <, >, !, %, dashes, dots, ...)
   // makes the line - and the document - fail to match: those constructs
   // exist in Full Carve, so Core refuses rather than mis-renders.
-  other      = letter | digit | ":" | ";" | "?" | "&" | "(" | ")" | "@"
+  other      = letter | digit | colon | ";" | "?" | "&" | "(" | ")" | at
+  // a `:` opening an inline extension (:name[...]) or an emoji (:name:) is
+  // Full Carve -> refuse; a plain colon is text
+  colon      = ":" ~(ident (":" | "["))
+  // a bare `@` followed by a word char is a mention (Full Carve) -> refuse;
+  // an email-embedded `@` is absorbed by the word rule (atGlue)
+  at         = "@" ~wordChar
 
   // --- Lexical ---------------------------------------------------------------
   punctChar  = "!" | "\"" | "#" | "$" | "%" | "&" | "'" | "(" | ")" | "*"
              | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | "=" | ">"
              | "?" | "@" | "[" | "\\" | "]" | "^" | "_" | "`" | "{" | "|"
              | "}" | "~"
-  alnum      = letter | digit
+  alnumCh    = letter | digit
   spaceChar  = " " | "\t"
   newline    = "\n" | "\r\n"
   lineEnd    = newline | end

--- a/scripts/formal-core-check.mjs
+++ b/scripts/formal-core-check.mjs
@@ -1,206 +1,53 @@
 /*
- * Formal-core conformance gate.
+ * Executable-spec conformance gate.
  *
- * Loads the executable Core grammar (resources/carve-core.ohm) and runs it
- * over every pair in tests/corpus:
- *   - NO-PARSE      -> the input uses non-Core constructs; out of scope.
- *   - MATCH + SAME  -> Core-conformant: the pure grammar parses it and the
- *                      derived HTML equals the pinned corpus output.
- *   - MATCH + DIFF  -> a defect: the Core grammar claims an input it cannot
- *                      render faithfully. The gate FAILS on any of these.
+ * Pipeline (the layered formal spec, executed):
+ *   1. scripts/spec/layout.mjs  - PART 0 line automaton + block structure
+ *   2. resources/carve-core.ohm - PART 3 inline grammar (Ohm/PEG)
+ *   3. scripts/spec/html.mjs    - PART 9R resolution + PART 10 serialization
  *
- * The one semantic predicate a PEG cannot state (fence closer length >=
- * opener length; the `where` guard in grammar.ebnf) is asserted here in
- * code, checked BEFORE the grammar verdict is trusted.
+ * Buckets per corpus pair:
+ *   - REFUSED       -> the input uses constructs outside the executable
+ *                      subset; counted out of scope (refuse > approximate).
+ *   - MATCH + SAME  -> executable-spec conformant, byte-for-byte.
+ *   - MATCH + DIFF  -> a DEFECT: the executable spec claims an input it
+ *                      cannot render faithfully. The gate FAILS.
  *
- * Usage: node scripts/formal-core-check.mjs [--list]
- * Requires: npm i -D ohm-js
+ * Usage: node scripts/formal-core-check.mjs [--list] [--diff]
  */
 
 import { readFileSync, readdirSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import * as ohm from 'ohm-js'
+import { parse, Refuse } from './spec/layout.mjs'
+import { renderDoc } from './spec/html.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const repo = resolve(here, '..')
-const grammarSrc = readFileSync(resolve(repo, 'resources/carve-core.ohm'), 'utf8')
-const g = ohm.grammar(grammarSrc)
-
-// ---------------------------------------------------------------------------
-// Semantic predicate: fence closer length >= opener length (grammar.ebnf
-// code_fence_close `where` guard). A PEG cannot count across tokens; if this
-// fails the input is treated as NO-PARSE (the grammar over-accepts it).
-function fenceLengthsOk(src) {
-  const lines = src.split('\n')
-  let open = null // { ch, len }
-  for (const line of lines) {
-    const m = /^(`{3,}|~{3,})/.exec(line)
-    if (!m) continue
-    const run = m[1]
-    if (!open) {
-      open = { ch: run[0], len: run.length }
-    } else if (run[0] === open.ch) {
-      if (run.length < open.len) return false
-      open = null
-    }
-  }
-  return true
-}
-
-// ---------------------------------------------------------------------------
-// Renderer: byte-parity with the corpus HTML for the Core subset.
-const escapeHtml = (s) =>
-  s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
-
-// Heading slug per grammar.ebnf PART 2 HEADING IDENTIFIERS (Core subset:
-// no smart-typography reversal needed - those chars are out of Core).
-function makeSlugger() {
-  const seen = new Map()
-  let anon = 0
-  return (text) => {
-    let slug = text
-      .replace(/[\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e\s]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-    if (slug === '') slug = `s-${++anon}`
-    else if (/^[0-9]/.test(slug)) slug = `s-${slug}`
-    const n = seen.get(slug) ?? 0
-    seen.set(slug, n + 1)
-    return n === 0 ? slug : `${slug}-${n + 1}`
-  }
-}
-
-const TAG = { emph: 'em', strong: 'strong', underline: 'u', strike: 's', sup: 'sup', sub: 'sub', highlight: 'mark' }
-
-function spanOp(tag) {
-  return function (_open, inner, _close) {
-    return `<${tag}>${inner.children.map((c) => c.h()).join('')}</${tag}>`
-  }
-}
-
-function codeOp(_o, content, _c) {
-  let text = content.sourceString
-  // single-space strip (code_span rule): one leading AND trailing space,
-  // content not all spaces
-  if (/^ .* $/.test(text) && text.trim() !== '') text = text.slice(1, -1)
-  return `<code>${escapeHtml(text)}</code>`
-}
-
-const sem = g.createSemantics().addOperation('h', {
-  heading(hashes, _sp, inl, _end) {
-    const level = hashes.sourceString.length
-    const html = inl.children.map((c) => c.h()).join('')
-    const text = inl.sourceString
-    return { kind: 'heading', level, html, text }
-  },
-  paragraph(lines) {
-    return { kind: 'p', html: lines.children.map((c) => c.h()).join('\n') }
-  },
-  paraLine(inl, _end) {
-    return inl.children.map((c) => c.h()).join('')
-  },
-  thematicBreak(_m, _r, _end) {
-    return { kind: 'hr' }
-  },
-  backtickFence(_o, lang, _nl, body, _c) {
-    return codeBlockNode(lang, body)
-  },
-  tildeFence(_o, lang, _nl, body, _c) {
-    return codeBlockNode(lang, body)
-  },
-  blankLine(_s, _n) {
-    return { kind: 'blank' }
-  },
-  emph: spanOp('em'),
-  strong: spanOp('strong'),
-  underline: spanOp('u'),
-  strike: spanOp('s'),
-  sup: spanOp('sup'),
-  sub: spanOp('sub'),
-  highlight: spanOp('mark'),
-  code1: codeOp,
-  code2: codeOp,
-  code3: codeOp,
-  escape(_bs, ch) {
-    return escapeHtml(ch.sourceString)
-  },
-  wordGlue(d, _la) {
-    return d.sourceString
-  },
-  _terminal() {
-    return escapeHtml(this.sourceString)
-  },
-  _nonterminal(...ch) {
-    return ch.map((c) => c.h()).join('')
-  },
-  _iter(...ch) {
-    return ch.map((c) => c.h()).join('')
-  },
-})
-
-function codeBlockNode(lang, body) {
-  const language = lang.sourceString.trim()
-  const text = body.children.map((c) => c.sourceString).join('')
-  return { kind: 'code', language, html: escapeHtml(text) }
-}
-
-function render(match) {
-  const blocks = sem(match)
-    .h()
-    .filter((b) => b.kind !== 'blank')
-  const out = []
-  const sections = [] // open heading levels
-  const slug = makeSlugger()
-  const indent = () => '  '.repeat(sections.length)
-  for (const b of blocks) {
-    if (b.kind === 'heading') {
-      while (sections.length && sections[sections.length - 1] >= b.level) {
-        sections.pop()
-        out.push(`${indent()}</section>`)
-      }
-      out.push(`${indent()}<section id="${slug(b.text)}">`)
-      sections.push(b.level)
-      out.push(`${indent()}<h${b.level}>${b.html}</h${b.level}>`)
-    } else if (b.kind === 'p') {
-      out.push(`${indent()}<p>${b.html}</p>`)
-    } else if (b.kind === 'hr') {
-      out.push(`${indent()}<hr>`)
-    } else if (b.kind === 'code') {
-      const cls = b.language ? ` class="language-${b.language}"` : ''
-      out.push(`${indent()}<pre><code${cls}>${b.html}</code></pre>`)
-    }
-  }
-  while (sections.length) {
-    sections.pop()
-    out.push(`${indent()}</section>`)
-  }
-  return out.join('\n')
-}
-
-// ---------------------------------------------------------------------------
 const corpusDir = resolve(repo, 'tests/corpus')
 const inputs = readdirSync(corpusDir)
   .filter((f) => f.endsWith('.crv'))
   .sort()
 
 const listMode = process.argv.includes('--list')
+const diffMode = process.argv.includes('--diff')
 let core = 0
 const diffs = []
-const noParse = []
+const refused = []
 
 for (const f of inputs) {
   const src = readFileSync(resolve(corpusDir, f), 'utf8')
   const expected = readFileSync(resolve(corpusDir, f.replace(/\.crv$/, '.html')), 'utf8').replace(/\n$/, '')
-  if (!fenceLengthsOk(src)) {
-    noParse.push(f)
-    continue
+  let got
+  try {
+    got = renderDoc(parse(src))
+  } catch (e) {
+    if (e instanceof Refuse || e.refuse) {
+      refused.push(`${f}: ${e.message}`)
+      continue
+    }
+    throw e
   }
-  const m = g.match(src)
-  if (m.failed()) {
-    noParse.push(f)
-    continue
-  }
-  const got = render(m)
   if (got === expected) {
     core++
     if (listMode) console.log(`CORE  ${f}`)
@@ -209,13 +56,18 @@ for (const f of inputs) {
   }
 }
 
-console.log(`\ncorpus inputs:        ${inputs.length}`)
-console.log(`core (parse + byte-match): ${core}`)
-console.log(`out of Core (no parse):    ${noParse.length}`)
-console.log(`DEFECTS (parse but diff):  ${diffs.length}`)
+console.log(`\ncorpus inputs:               ${inputs.length}`)
+console.log(`executable-spec conformant:  ${core}`)
+console.log(`refused (out of subset):     ${refused.length}`)
+console.log(`DEFECTS (parse but diff):    ${diffs.length}`)
 for (const d of diffs) {
   console.log(`\n--- ${d.f}`)
-  console.log(`expected:\n${d.expected}`)
-  console.log(`got:\n${d.got}`)
+  if (diffMode) {
+    console.log(`expected:\n${d.expected}`)
+    console.log(`got:\n${d.got}`)
+  }
+}
+if (diffMode) {
+  for (const r of refused.slice(0, 40)) console.log(`REFUSED ${r}`)
 }
 process.exit(diffs.length ? 1 : 0)

--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -1,0 +1,251 @@
+/*
+ * Executable PART 10 (block serialization) + PART 9R (resolution passes)
+ * over the layout tree. Byte-parity with the conformance corpus is the
+ * contract; anything the subset cannot render faithfully throws Refuse.
+ */
+
+import { Refuse } from './layout.mjs'
+import { renderInline, makeSlugger, checkUrl, escapeAttr } from './render.mjs'
+
+const IMG_ONLY = /^<img [^>]*>$/
+
+export function renderDoc(doc) {
+  const ctx = {
+    slug: makeSlugger(),
+    linkDefs: doc.linkDefs,
+    abbrDefs: doc.abbrDefs,
+    footnoteDefs: doc.footnoteDefs,
+    headingIds: new Map(), // lower-cased slug -> { id, html }
+  }
+  const out = []
+  const sections = []
+  const indent = () => '  '.repeat(sections.length)
+
+  for (const b of doc.blocks) {
+    if (b.t === 'heading') {
+      const html = renderInline(b.text)
+      while (sections.length && sections[sections.length - 1] >= b.level) {
+        sections.pop()
+        out.push(`${indent()}</section>`)
+      }
+      const id = ctx.slug(b.text)
+      ctx.headingIds.set(id.toLowerCase(), { id, html })
+      out.push(`${indent()}<section id="${id}">`)
+      sections.push(b.level)
+      out.push(`${indent()}<h${b.level}>${html}</h${b.level}>`)
+    } else {
+      out.push(renderBlock(b, sections.length, ctx))
+    }
+  }
+  while (sections.length) {
+    sections.pop()
+    out.push(`${indent()}</section>`)
+  }
+
+  let html = out.join('\n')
+  html = resolveFootnotes(html, ctx) // first: bodies may add ref/xref sentinels
+  html = resolveRefs(html, ctx)
+  html = resolveCrossrefs(html, ctx)
+  html = applyAbbreviations(html, ctx)
+  return html
+}
+
+function renderBlock(b, depth, ctx) {
+  const pad = '  '.repeat(depth)
+  switch (b.t) {
+    case 'para': {
+      const html = b.lines.map((l) => renderInline(l)).join('\n')
+      if (b.lines.length === 1 && IMG_ONLY.test(html)) {
+        // a standalone image paragraph renders as a bare <img> (PART 10)
+        if (b.caption !== undefined) {
+          return `${pad}<figure>\n${pad}  ${html}\n${pad}  <figcaption>${renderInline(b.caption)}</figcaption>\n${pad}</figure>`
+        }
+        return pad + html
+      }
+      if (b.caption !== undefined) throw new Refuse('caption on a text paragraph')
+      return `${pad}<p>${html}</p>`
+    }
+    case 'hr':
+      return `${pad}<hr>`
+    case 'code': {
+      const cls = b.lang ? ` class="language-${b.lang}"` : ''
+      const esc = b.text
+        .replace(/[‪-‮⁦-⁩]/g, '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+      return `${pad}<pre><code${cls}>${esc}</code></pre>`
+    }
+    case 'quote': {
+      const inner = b.children.map((c) => renderBlock(c, depth + 1, ctx)).join('\n')
+      if (b.caption !== undefined) {
+        // single-paragraph attribution form pins the compact figure layout
+        if (b.children.length === 1 && b.children[0].t === 'para') {
+          const p = renderBlock(b.children[0], 0, ctx)
+          return `${pad}<figure>\n${pad}  <blockquote>${p}</blockquote>\n${pad}  <figcaption>${renderInline(b.caption)}</figcaption>\n${pad}</figure>`
+        }
+        throw new Refuse('captioned multi-block quote')
+      }
+      if (b.children.length === 1 && b.children[0].t === 'para') {
+        const p = renderBlock(b.children[0], 0, ctx)
+        return `${pad}<blockquote>${p}</blockquote>`
+      }
+      return `${pad}<blockquote>\n${inner}\n${pad}</blockquote>`
+    }
+    case 'list':
+      return renderList(b, depth, ctx)
+    default:
+      throw new Refuse(`unknown block ${b.t}`)
+  }
+}
+
+function renderList(list, depth, ctx) {
+  const pad = '  '.repeat(depth)
+  let tag = 'ul'
+  let attrs = ''
+  if (list.ord) {
+    tag = 'ol'
+    if (list.ord.type) attrs += ` type="${list.ord.type}"`
+    if (list.ord.start) attrs += ` start="${list.ord.start}"`
+  }
+  const items = list.items.map((item) => renderItem(item, list, depth + 1, ctx))
+  return `${pad}<${tag}${attrs}>\n${items.join('\n')}\n${pad}</${tag}>`
+}
+
+function renderItem(item, list, depth, ctx) {
+  const pad = '  '.repeat(depth)
+  const prefix = list.task
+    ? `<input type="checkbox"${item.checked ? ' checked' : ''} disabled> `
+    : ''
+  const blocks = item.blocks
+  if (blocks.length === 0) return `${pad}<li></li>`
+
+  const parts = []
+  for (let i = 0; i < blocks.length; i++) {
+    const b = blocks[i]
+    if (b.t === 'para') {
+      const html = b.lines.map((l) => renderInline(l)).join('\n')
+      parts.push({ inlineable: true, html: list.tight ? html : `<p>${html}</p>` })
+    } else {
+      parts.push({ inlineable: false, html: renderBlock(b, depth + 1, ctx) })
+    }
+  }
+
+  // <li> + first block on the same line; further blocks indented; the
+  // closing </li> stays inline for a single-inline item, else on its own
+  // line at the li indent (corpus 05-lists-4, 103-marker-line-nested-lists)
+  const first = parts[0]
+  if (parts.length === 1 && first.inlineable) {
+    return `${pad}<li>${prefix}${first.html}</li>`
+  }
+  let out
+  if (first.inlineable) {
+    out = `${pad}<li>${prefix}${first.html}`
+  } else {
+    out = `${pad}<li>\n${first.html}`
+  }
+  for (let i = 1; i < parts.length; i++) {
+    const p = parts[i]
+    out += '\n' + (p.inlineable ? `${'  '.repeat(depth + 1)}${p.html}` : p.html)
+  }
+  out += `\n${pad}</li>`
+  return out
+}
+
+// --- PART 9R R1: reference links --------------------------------------------
+function resolveRefs(html, ctx) {
+  return html.replace(/ref:(\{.*?\})/g, (_, json) => {
+    const { label, text, attrs } = JSON.parse(json)
+    const key = label ?? stripTags(text)
+    const def = ctx.linkDefs.get(key)
+    if (!def) throw new Refuse(`unresolved reference [${key}]`)
+    const t = def.title ? ` title="${escapeAttr(def.title)}"` : ''
+    return `<a href="${escapeAttr(checkUrl(def.url))}"${t}${attrs}>${text}</a>`
+  })
+}
+
+function stripTags(s) {
+  return s.replace(/<[^>]*>/g, '')
+}
+
+// --- PART 9R R2: footnotes ---------------------------------------------------
+function resolveFootnotes(html, ctx) {
+  const order = [] // labels by first reference
+  const counts = new Map()
+  html = html.replace(/fn:(.*?)/g, (_, label) => {
+    if (!ctx.footnoteDefs.has(label)) return `[^${label}]` // unresolved -> literal
+    let n = order.indexOf(label) + 1
+    if (n === 0) {
+      order.push(label)
+      n = order.length
+    }
+    const k = (counts.get(label) ?? 0) + 1
+    counts.set(label, k)
+    const refId = k === 1 ? `fnref${n}` : `fnref${n}-${k}`
+    return `<a id="${refId}" href="#fn${n}" role="doc-noteref"><sup>${n}</sup></a>`
+  })
+  if (order.length === 0) return html
+
+  const notes = order.map((label, idx) => {
+    const n = idx + 1
+    const body = ctx.footnoteDefs.get(label)
+    let rendered = body
+      .map((b) => renderBlock(b, 3, ctx))
+      .join('\n')
+    // backlink into the LAST paragraph (PART 9 SS16); a k-th repeat
+    // reference adds an indexed backlink `↩<sup>k</sup>`
+    const total = counts.get(label) ?? 1
+    const backlink = total === 1
+      ? `<a href="#fnref${n}" role="doc-backlink">↩</a>`
+      : Array.from({ length: total }, (_, kk) => {
+          const refId = kk === 0 ? `fnref${n}` : `fnref${n}-${kk + 1}`
+          return `<a href="#${refId}" role="doc-backlink">↩<sup>${kk + 1}</sup></a>`
+        }).join(' ')
+    if (rendered.endsWith('</p>')) {
+      rendered = rendered.slice(0, -4) + backlink + '</p>'
+    } else {
+      rendered += `\n      <p>${backlink}</p>`
+    }
+    return `    <li id="fn${n}">\n${rendered}\n    </li>`
+  })
+  return (
+    html +
+    `\n<section role="doc-endnotes">\n  <hr>\n  <ol>\n${notes.join('\n')}\n  </ol>\n</section>`
+  )
+}
+
+// --- PART 9R R4: crossrefs ---------------------------------------------------
+function resolveCrossrefs(html, ctx) {
+  return html.replace(/xref(text)?:(.*?)/g, (_, textOnly, id) => {
+    const hit = ctx.headingIds.get(id.toLowerCase())
+    if (!hit) throw new Refuse(`unresolved crossref </#${id}>`)
+    // one-level resolution: nested sentinels in the cloned text flatten to
+    // their literal source (PART 9R R4)
+    const text = hit.html.replace(/xref(?:text)?:(.*?)/g, '</#$1>')
+    return textOnly ? text : `<a href="#${hit.id}">${text}</a>`
+  })
+}
+
+// --- PART 9R R3: abbreviations ----------------------------------------------
+function applyAbbreviations(html, ctx) {
+  if (ctx.abbrDefs.size === 0) return html
+  // transform only text segments outside tags and outside code/pre
+  const parts = html.split(/(<[^>]*>)/)
+  let inCode = 0
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i]
+    if (p.startsWith('<')) {
+      if (/^<(code|pre)[\s>]/.test(p)) inCode++
+      else if (/^<\/(code|pre)>/.test(p)) inCode--
+      continue
+    }
+    if (inCode > 0 || p === '') continue
+    let s = p
+    for (const [term, expansion] of ctx.abbrDefs) {
+      const re = new RegExp(`(^|[^\\p{L}\\p{N}])(${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})(?![\\p{L}\\p{N}])`, 'gu')
+      s = s.replace(re, (_, pre, hit) => `${pre}<abbr title="${expansion.replaceAll('"', '&quot;')}">${hit}</abbr>`)
+    }
+    parts[i] = s
+  }
+  return parts.join('')
+}

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -1,0 +1,563 @@
+/*
+ * Executable PART 0: the layout-layer line automaton (grammar.ebnf PART 0
+ * S1-S5), plus the block classification it feeds (PART 9 SS10 interruption,
+ * SS11 list partition, SS17 tight/loose + continuation marker, SS24 column
+ * arithmetic).
+ *
+ * Contract: parse(src) returns { blocks, linkDefs, footnoteDefs, abbrDefs }
+ * or throws Refuse. REFUSE-DON'T-APPROXIMATE: any construct outside the
+ * executable subset aborts the whole document, so a successful parse is a
+ * full-fidelity claim.
+ */
+
+export class Refuse extends Error {
+  constructor(reason) {
+    super(reason)
+    this.refuse = true
+  }
+}
+
+const HEADING = /^(#{1,6}) (.*)$/
+const HR = /^(-{3,}|\*{3,}|_{3,})[ \t]*$/
+const FENCE = /^(`{3,}|~{3,})(.*)$/
+const PURE_FENCE = /^(`{3,}|~{3,})[ \t]*$/
+const QUOTE = /^> ?(.*)$|^>$/
+const LINK_DEF = /^\[([^\]^@][^\]]*)\]:\s+(\S+)(?:\s+"((?:\\"|[^"])*)")?\s*$/
+const FOOTNOTE_DEF = /^\[\^([^\]]+)\]:\s*(.*)$/
+const ABBR_DEF = /^\*\[([^\]]+)\]:\s+(.+)$/
+const CAPTION = /^\^ (.*)$/
+const BULLET = /^([ \t]*)([-*]) (?:\[([ xX_>?-])\] )?(.+)$/
+const ORDERED = /^([ \t]*)([0-9]+|[a-z]+|[A-Z]+)([.)]) (.+)$/
+const CONT_MARKER = /^\+[ \t]*$/
+// marks a lazily-folded line (PART 9 SS10 I2): always paragraph text, never
+// re-classified as structure when an item's content is re-parsed
+export const LAZY = '\u0000L\u0000'
+
+// Lines that put the whole document out of the executable subset.
+const REFUSERS = [
+  [/^[ \t]*\|/, 'table'],
+  [/^[ \t]*:::/, 'colon fence'],
+  [/^%{2,}/, 'comment'],
+  [/^\{/, 'block attribute line'],
+  [/^\[@/, 'citation definition'],
+  [/^:[: ]/, 'definition list'],
+]
+
+// PART 9 SS24 C1: visual column of the first non-indent character.
+function indentCols(line) {
+  let col = 0
+  let i = 0
+  for (; i < line.length; i++) {
+    const ch = line[i]
+    if (ch === ' ') col += 1
+    else if (ch === '\t') col = (Math.floor(col / 4) + 1) * 4
+    else break
+  }
+  return { col, rest: line.slice(i) }
+}
+
+// Roman numeral helpers for the SS11 N2/N3 ordered dialects.
+const ROMAN_CHARS = /^[ivxlcdm]+$/
+const ROMAN_VALUES = { i: 1, v: 5, x: 10, l: 50, c: 100, d: 500, m: 1000 }
+function romanToInt(s) {
+  let total = 0
+  const lower = s.toLowerCase()
+  for (let i = 0; i < lower.length; i++) {
+    const v = ROMAN_VALUES[lower[i]]
+    const next = ROMAN_VALUES[lower[i + 1]] ?? 0
+    total += v < next ? -v : v
+  }
+  return total
+}
+function alphaToInt(s) {
+  // single letters only in the executable subset (a..z)
+  return s.toLowerCase().charCodeAt(0) - 96
+}
+
+// Classify an ordered marker token into candidate dialects.
+function classifyOrdered(token) {
+  const out = []
+  if (/^[0-9]+$/.test(token)) {
+    out.push({ dialect: 'decimal', value: parseInt(token, 10) })
+    return out
+  }
+  const lower = token === token.toLowerCase()
+  const upper = token === token.toUpperCase()
+  if (ROMAN_CHARS.test(token.toLowerCase()) && (lower || upper)) {
+    out.push({ dialect: lower ? 'roman' : 'Roman', value: romanToInt(token) })
+  }
+  if (/^[a-z]$/i.test(token) && (lower || upper)) {
+    out.push({ dialect: lower ? 'alpha' : 'Alpha', value: alphaToInt(token) })
+  }
+  if (token.length > 1 && /^[a-z]+$/i.test(token) && !ROMAN_CHARS.test(token.toLowerCase())) {
+    throw new Refuse(`multi-letter non-roman ordered marker: ${token}`)
+  }
+  return out
+}
+
+function isBlank(line) {
+  return /^[ \t]*$/.test(line)
+}
+
+// A line that begins a VISIBLE block (PART 9 SS10 I1) in the executable
+// subset. Fence interruption needs the closer lookahead (I4) - handled by
+// the caller which owns the remaining lines.
+function startsVisibleBlock(line) {
+  return HEADING.test(line) || HR.test(line) || QUOTE.test(line)
+}
+
+export function parse(src) {
+  const lines = src.split('\n')
+  if (lines[lines.length - 1] === '') lines.pop()
+  const state = {
+    linkDefs: new Map(),
+    footnoteDefs: new Map(),
+    abbrDefs: new Map(),
+  }
+  // frontmatter is out of the executable subset
+  if (lines[0] !== undefined && /^---/.test(lines[0])) {
+    for (let i = 1; i < lines.length; i++) {
+      if (/^---[ \t]*$/.test(lines[i])) throw new Refuse('frontmatter')
+    }
+  }
+  const blocks = parseBlocks(lines, state, true)
+  return { blocks, ...state }
+}
+
+function parseBlocks(lines, state, top, inItem = false) {
+  const blocks = []
+  let i = 0
+  const n = lines.length
+
+  const peekInterrupts = (idx) => {
+    // PART 9 SS10: does lines[idx] interrupt an open paragraph?
+    const line = lines[idx]
+    if (line === undefined) return false
+    if (startsVisibleBlock(line)) return true
+    const fence = FENCE.exec(line)
+    if (fence && hasCloser(lines, idx)) return true // I4
+    if (LINK_DEF.test(line) || FOOTNOTE_DEF.test(line) || ABBR_DEF.test(line)) return true // I5
+    return false
+  }
+
+  while (i < n) {
+    const line = lines[i]
+    if (isBlank(line)) {
+      i++
+      continue
+    }
+    for (const [re, what] of REFUSERS) {
+      if (re.test(line)) throw new Refuse(what)
+    }
+
+    // --- definitions (invisible blocks; PART 9 SS10 I5, PART 9R pass 1) ---
+    let m
+    if ((m = FOOTNOTE_DEF.exec(line))) {
+      const label = m[1]
+      const bodyLines = [m[2]]
+      i++
+      // indented continuation (>= 2 spaces), single blank lines allowed
+      while (i < n) {
+        if (/^ {2,}\S/.test(lines[i])) {
+          bodyLines.push(lines[i].replace(/^ {2}/, ''))
+          i++
+        } else if (isBlank(lines[i]) && /^ {2,}\S/.test(lines[i + 1] ?? '')) {
+          bodyLines.push('')
+          i++
+        } else if (
+          !isBlank(lines[i] ?? '') &&
+          bodyLines[bodyLines.length - 1] !== '' &&
+          !startsVisibleBlock(lines[i]) &&
+          !LINK_DEF.test(lines[i]) && !FOOTNOTE_DEF.test(lines[i]) && !ABBR_DEF.test(lines[i]) &&
+          !BULLET.test(lines[i]) && !ORDERED.test(lines[i]) && !FENCE.test(lines[i]) &&
+          !CAPTION.test(lines[i])
+        ) {
+          // lazy continuation of the definition's open paragraph (SS16)
+          bodyLines.push(lines[i].replace(/^[ \t]+/, ''))
+          i++
+        } else break
+      }
+      if (!state.footnoteDefs.has(label)) {
+        // FIRST definition wins (PART 9R state)
+        state.footnoteDefs.set(label, parseBlocks(bodyLines, state, false))
+      }
+      continue
+    }
+    if ((m = ABBR_DEF.exec(line))) {
+      const term = m[1]
+      if (term === '') throw new Refuse('empty abbreviation term')
+      if (!state.abbrDefs.has(term)) state.abbrDefs.set(term, m[2])
+      i++
+      continue
+    }
+    if ((m = LINK_DEF.exec(line))) {
+      // LAST definition wins (PART 9R state)
+      state.linkDefs.set(m[1], { url: m[2], title: m[3]?.replaceAll('\\"', '"') })
+      i++
+      continue
+    }
+
+    // --- headings ---
+    if ((m = HEADING.exec(line))) {
+      if (!top) throw new Refuse('heading inside a container')
+      const level = m[1].length
+      const text = m[2].replace(/[ \t]+$/, '')
+      const next = lines[i + 1]
+      if (next !== undefined && !isBlank(next)) {
+        const nm = HEADING.exec(next)
+        if (nm && nm[1].length === level) throw new Refuse('multi-line heading folding')
+        if (!nm && !HR.test(next) && !FENCE.test(next) && !QUOTE.test(next) && !BULLET.test(next) && !ORDERED.test(next)) {
+          throw new Refuse('heading continuation line')
+        }
+      }
+      blocks.push({ t: 'heading', level, text })
+      i++
+      continue
+    }
+
+    // --- thematic break (before bullets: `- x` vs `---`) ---
+    if (HR.test(line)) {
+      blocks.push({ t: 'hr' })
+      i++
+      continue
+    }
+
+    // --- fenced code ---
+    if ((m = FENCE.exec(line))) {
+      const run = m[1]
+      const info = m[2].trim()
+      if (info && !/^[A-Za-z0-9\-_+#./]+$/.test(info)) throw new Refuse('fence info beyond a language token')
+      if (info.startsWith('=')) throw new Refuse('raw block')
+      const close = findCloser(lines, i, run)
+      if (close === -1) throw new Refuse('unterminated fence')
+      blocks.push({ t: 'code', lang: info, text: lines.slice(i + 1, close).join('\n') + (close > i + 1 ? '\n' : '') })
+      i = close + 1
+      continue
+    }
+
+    // --- block quote ---
+    if (QUOTE.test(line)) {
+      const inner = []
+      while (i < n) {
+        const qm = /^> ?(.*)$/.exec(lines[i])
+        if (qm) {
+          inner.push(qm[1])
+          i++
+          continue
+        }
+        if (lines[i] !== undefined && CONT_MARKER.test(lines[i])) {
+          // PART 9 SS17 L4: `+` at column 0 attaches ONE following block
+          i++
+          const attached = takeOneBlock(lines, i, state)
+          // blank separators force the attached lines to parse as their own
+          // block instead of lazily folding into the open paragraph
+          inner.push('', ...attached.rawMarker, '')
+          i = attached.next
+          continue
+        }
+        if (lines[i] !== undefined && !isBlank(lines[i]) && !peekInterrupts(i) && !CAPTION.test(lines[i])) {
+          // lazy continuation folds into the open quoted paragraph (SS10 I6)
+          inner.push(lines[i])
+          i++
+          continue
+        }
+        break
+      }
+      const children = parseBlocks(inner.filter((l) => l !== ' CONT'), state, false)
+      const node = { t: 'quote', children }
+      // caption -> <figure><blockquote/><figcaption> (PART 9 SS4)
+      let j = i
+      if (j < n && isBlank(lines[j]) && CAPTION.test(lines[j + 1] ?? '')) j++
+      const cap = j < n ? CAPTION.exec(lines[j]) : null
+      if (cap) {
+        node.caption = cap[1]
+        i = j + 1
+      }
+      blocks.push(node)
+      continue
+    }
+
+    // --- lists ---
+    const bulletM = BULLET.exec(line)
+    const orderedM = !bulletM && ORDERED.exec(line)
+    if (bulletM || orderedM) {
+      i = parseListRun(lines, i, blocks, state, peekInterrupts)
+      continue
+    }
+
+    if (CONT_MARKER.test(line)) throw new Refuse('stray continuation marker')
+    if (CAPTION.test(line)) throw new Refuse('caption with no attachable block')
+
+    // --- paragraph ---
+    const para = []
+    while (i < n && !isBlank(lines[i])) {
+      if (lines[i].startsWith(LAZY)) {
+        para.push(lines[i].slice(LAZY.length).replace(/[ \t]+$/, ''))
+        i++
+        continue
+      }
+      for (const [re, what] of REFUSERS) {
+        if (re.test(lines[i])) throw new Refuse(`${what} interrupting a paragraph`)
+      }
+      if (CAPTION.test(lines[i])) break // a caption ends the block (SS4)
+      if (inItem && para.length > 0 && matchMarker(lines[i])) break // SS24 C3
+      if (para.length > 0) {
+        // definitions interrupt and are consumed (SS10 I5)
+        if (LINK_DEF.test(lines[i]) || FOOTNOTE_DEF.test(lines[i]) || ABBR_DEF.test(lines[i])) break
+        if (startsVisibleBlock(lines[i])) break // I1
+        const f = FENCE.exec(lines[i])
+        if (f) {
+          if (hasCloser(lines, i)) break // I4: interrupts
+          throw new Refuse('unterminated fence inside a paragraph')
+        }
+      }
+      para.push(lines[i].replace(/^[ \t]+/, '').replace(/[ \t]+$/, ''))
+      i++
+    }
+    const pnode = { t: 'para', lines: para }
+    // image paragraph caption -> figure (PART 9 SS4; one blank line allowed)
+    let j = i
+    if (j < n && isBlank(lines[j] ?? '') && CAPTION.test(lines[j + 1] ?? '')) j++
+    const cap = j < n && lines[j] !== undefined ? CAPTION.exec(lines[j]) : null
+    if (cap) {
+      if (para.length === 1 && /^!\[[^\]]*\]\([^)]*\)$/.test(para[0])) {
+        pnode.caption = cap[1]
+        i = j + 1
+      } else {
+        throw new Refuse('caption after a non-captionable block')
+      }
+    }
+    blocks.push(pnode)
+  }
+  return blocks
+}
+
+function hasCloser(lines, idx) {
+  const m = FENCE.exec(lines[idx])
+  if (!m) return false
+  return findCloser(lines, idx, m[1]) !== -1
+}
+
+function findCloser(lines, openIdx, run) {
+  const ch = run[0]
+  for (let j = openIdx + 1; j < lines.length; j++) {
+    const c = PURE_FENCE.exec(lines[j])
+    if (!c || c[1][0] !== ch) continue
+    if (c[1].length < run.length) throw new Refuse('fence closer shorter than opener') // the `where` guard
+    return j
+  }
+  return -1
+}
+
+// Parse ONE following flush-left block (for the `+` continuation marker).
+function takeOneBlock(lines, start, state) {
+  let end = start
+  while (end < lines.length && !isBlank(lines[end]) && !CONT_MARKER.test(lines[end])) end++
+  return { rawMarker: lines.slice(start, end), next: end }
+}
+
+// --- lists: PART 9 SS11 N1-N3, SS17 L1-L4, SS24 C3/C4 ----------------------
+function parseListRun(lines, i, blocks, state, peekInterrupts) {
+  const n = lines.length
+  while (i < n) {
+    const head = matchMarker(lines[i])
+    if (!head) break
+    const list = {
+      t: 'list',
+      task: head.task !== undefined,
+      bullet: head.bullet,
+      ord: null,
+      tight: true,
+      items: [],
+    }
+    if (head.ordered) {
+      list.ord = { delim: head.delim, dialects: head.dialects }
+    }
+    i = collectItems(lines, i, list, state)
+    finalizeOrdered(list)
+    blocks.push(list)
+    // a marker-mismatch sibling list continues the run (SS11 N1)
+    if (i < n && matchMarker(lines[i])) continue
+    break
+  }
+  return i
+}
+
+function matchMarker(line) {
+  if (line === undefined) return null
+  let m = BULLET.exec(line)
+  if (m) {
+    const { col } = indentCols(m[1])
+    return {
+      indent: col,
+      bullet: m[2],
+      task: m[3],
+      text: m[4],
+      // the task box is item CONTENT, not marker (PART 9 SS24 C3)
+      markerWidth: m[2].length + 1,
+    }
+  }
+  m = ORDERED.exec(line)
+  if (m) {
+    const { col } = indentCols(m[1])
+    const dialects = classifyOrdered(m[2])
+    if (dialects.length === 0) return null
+    return {
+      indent: col,
+      ordered: m[2],
+      delim: m[3],
+      dialects,
+      text: m[4],
+      markerWidth: m[2].length + m[3].length + 1,
+    }
+  }
+  return null
+}
+
+function sameAxes(list, head) {
+  // PART 9 SS11 N1: bullet char, ordered dialect+delim, plain-vs-task
+  if (list.ord) {
+    if (!head.ordered || head.delim !== list.ord.delim) return false
+    const heads = new Set(head.dialects.map((d) => d.dialect))
+    return list.ord.dialects.some((d) => heads.has(d.dialect))
+  }
+  if (head.ordered) return false
+  if (head.bullet !== list.bullet) return false
+  return (head.task !== undefined) === list.task
+}
+
+function collectItems(lines, i, list, state) {
+  const n = lines.length
+  const baseIndent = matchMarker(lines[i]).indent
+  while (i < n) {
+    const head = matchMarker(lines[i])
+    if (!head || head.indent !== baseIndent || !sameAxes(list, head)) break
+    if (list.ord && list.items.length > 0) {
+      // narrow the dialect set per item (SS11 N2)
+      const heads = new Set(head.dialects.map((d) => d.dialect))
+      list.ord.dialects = list.ord.dialects.filter((d) => heads.has(d.dialect))
+    }
+    const contentCol = head.indent + head.markerWidth
+    const itemLines = [head.text]
+    const item = { }
+    if (list.task) item.checked = /^[xX]$/.test(head.task)
+    let openPara = true // the marker line's text opens the item paragraph
+    i++
+    while (i < n) {
+      const line = lines[i]
+      if (line.startsWith(LAZY)) {
+        // a lazy line from an OUTER context propagates to the deepest open
+        // paragraph (PART 9 SS10 I2)
+        if (!openPara) break
+        itemLines.push(line)
+        i++
+        continue
+      }
+      if (isBlank(line)) {
+        // decide with the NEXT content line
+        let j = i + 1
+        while (j < n && isBlank(lines[j])) j++
+        if (j >= n) { i = j; break }
+        const { col } = indentCols(lines[j])
+        const nm = matchMarker(lines[j])
+        if (nm && nm.indent === baseIndent) {
+          // blank line between items -> loose (SS17 L1)
+          list.tight = false
+          i = j
+          break
+        }
+        if (col >= contentCol && !(nm && nm.indent >= contentCol)) {
+          const dedented = dedent(lines[j], contentCol)
+          if (QUOTE.test(dedented) || FENCE.test(dedented) || HEADING.test(dedented) || HR.test(dedented)) {
+            // sub-BLOCK after a blank: attaches, stays tight (SS17 L2)
+            itemLines.push('')
+            openPara = false
+            i = j
+            continue
+          }
+          // a second PARAGRAPH inside the item -> loose (SS17 L1)
+          itemLines.push('')
+          list.tight = false
+          openPara = true
+          i = j
+          continue
+        }
+        if (nm && nm.indent >= contentCol) {
+          // sub-list after a blank: attaches, stays tight (SS17 L2)
+          itemLines.push('')
+          openPara = false
+          i = j
+          continue
+        }
+        i = j
+        break
+      }
+      const { col } = indentCols(line)
+      const nm = matchMarker(line)
+      if (col >= contentCol) {
+        const dedented = dedent(line, contentCol)
+        itemLines.push(dedented)
+        // does the deepest structure now hold an OPEN paragraph that lazy
+        // text may fold into? markers open a sub-item paragraph; quotes an
+        // open quoted paragraph; fences/breaks close everything (SS10 I2/I6)
+        if (FENCE.test(dedented) || HR.test(dedented)) openPara = false
+        else if (matchMarker(dedented) || QUOTE.test(dedented)) openPara = true
+        else if (!isBlank(dedented)) openPara = true
+        i++
+        continue
+      }
+      if (nm && nm.indent <= baseIndent) break // sibling or outer list
+      if (nm && nm.indent < contentCol && nm.indent > baseIndent && openPara && itemLines.length > 0) {
+        // a marker BELOW the content column folds as lazy item text
+        // (PART 9 SS24 C3; list markers never interrupt, SS10 I2)
+        itemLines.push(LAZY + line.replace(/^[ \t]+/, ''))
+        i++
+        continue
+      }
+      if (!nm && openPara && itemLines.length > 0) {
+        // lazy fold into the open item paragraph (SS10 I2 / SS24 C3)
+        itemLines.push(LAZY + line.replace(/^[ \t]+/, ''))
+        i++
+        continue
+      }
+      break
+    }
+    item.blocks = parseBlocks(itemLines, state, false, true)
+    list.items.push(item)
+  }
+  return i
+}
+
+function dedent(line, cols) {
+  // strip `cols` visual columns of indentation (PART 9 SS24 C5)
+  let col = 0
+  let i = 0
+  while (i < line.length && col < cols) {
+    if (line[i] === ' ') col += 1
+    else if (line[i] === '\t') col = (Math.floor(col / 4) + 1) * 4
+    else break
+    i++
+  }
+  return line.slice(i)
+}
+
+function finalizeOrdered(list) {
+  if (!list.ord) return
+  // PART 9 SS11 N3 tie-break already applied by intersection; prefer roman
+  // for lone i/I, alpha otherwise
+  const ds = list.ord.dialects
+  let chosen = ds[0]
+  if (ds.length > 1) {
+    const first = list.items.length > 0 ? null : null
+    const roman = ds.find((d) => d.dialect.toLowerCase() === 'roman')
+    const alpha = ds.find((d) => d.dialect.toLowerCase() === 'alpha')
+    if (roman && alpha) {
+      chosen = roman.value === 1 ? roman : alpha // lone i/I -> roman, else alpha
+    }
+  }
+  const typeMap = { decimal: null, alpha: 'a', Alpha: 'A', roman: 'i', Roman: 'I' }
+  list.ord = {
+    type: typeMap[chosen.dialect],
+    start: chosen.value !== 1 ? chosen.value : null,
+  }
+}

--- a/scripts/spec/render.mjs
+++ b/scripts/spec/render.mjs
@@ -1,0 +1,369 @@
+/*
+ * Executable PART 3 (inline, via the Ohm Core grammar), PART 9R (two-pass
+ * resolution) and PART 10 (HTML serialization) for the executable subset.
+ *
+ * Sentinels: footnote references and crossrefs render as ...
+ * tokens during the tree pass and are resolved in the PART 9R pass, which
+ * owns numbering and the symbol tables.
+ */
+
+import { readFileSync } from 'node:fs'
+import { resolve as presolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as ohm from 'ohm-js'
+import { Refuse } from './layout.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const g = ohm.grammar(readFileSync(presolve(here, '../../resources/carve-core.ohm'), 'utf8'))
+
+const escapeHtml = (s) =>
+  s
+    .replace(/[‪-‮⁦-⁩]/g, '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll(' ', '&nbsp;')
+
+export const escapeAttr = (s) => escapeHtml(s).replaceAll('"', '&quot;')
+
+// PART 9 SS25: URL sink scheme denylist -- a denylisted scheme renders an
+// EMPTY value. Scheme detection first strips ASCII controls and ALL Unicode
+// whitespace before matching, so an obfuscated scheme cannot slip past.
+const DENY = new Set(['javascript', 'vbscript', 'data', 'file',
+  'ms-msdt', 'ms-office', 'ms-word', 'ms-excel', 'ms-powerpoint', 'ms-access',
+  'ms-visio', 'ms-project', 'ms-publisher', 'ms-infopath', 'ms-spd',
+  'ms-search', 'search-ms', 'ms-cxh', 'ms-cxh-full', 'shell', 'vscode',
+  'vscode-insiders', 'jar'])
+
+export function checkUrl(url) {
+  const probe = url.replace(/[\x00-\x20\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]+/g, '')
+  const m = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(probe)
+  if (m && DENY.has(m[1].toLowerCase())) return ''
+  return url
+}
+
+// ---------------------------------------------------------------------------
+// Inline semantics
+function spanOp(tag) {
+  return function (_open, inner, _close) {
+    return `<${tag}>${inner.children.map((c) => c.h()).join('')}</${tag}>`
+  }
+}
+function codeText(content) {
+  let text = content.sourceString
+  if (/^ .* $/.test(text) && text.trim() !== '') text = text.slice(1, -1)
+  return text
+}
+function codeOp(_o, content, _c) {
+  return `<code>${escapeHtml(codeText(content))}</code>`
+}
+
+// attribute block -> ordered list of [kind, name, value]
+function attrsOf(node) {
+  if (node.numChildren === 0) return []
+  return node.child(0).parseAttrs()
+}
+
+const attrSem = g.createSemantics().addOperation('parseAttrs', {
+  attrs(_o, _s1, first, _s2, rest, _s3, _c) {
+    return [first.parseAttrs(), ...rest.children.map((c) => c.parseAttrs())]
+  },
+  attrItem(item) {
+    return item.parseAttrs()
+  },
+  idAttr(_h, id) {
+    return ['id', id.sourceString]
+  },
+  classAttr(_d, cls) {
+    return ['class', cls.sourceString]
+  },
+  kvAttr(k, _eq, v) {
+    return ['kv', k.sourceString, v.parseAttrs()]
+  },
+  boolAttr(name) {
+    return ['bool', name.sourceString]
+  },
+  attrVal(v) {
+    return v.parseAttrs()
+  },
+  quoted(_o, chars, _c) {
+    return chars.children.map((c) => c.sourceString.replace(/^\\/, '')).join('')
+  },
+  bareVal(chars) {
+    return chars.sourceString
+  },
+  _terminal() {
+    return this.sourceString
+  },
+})
+
+// PART 9 SS25 ATTRIBUTE HARDENING: drop on*/srcdoc/formaction; drop an
+// href/src override whose scheme is denylisted; blank a style value with a
+// CSS execution vector.
+const STYLE_VECTOR = /expression\(|url\(|@import|behavior:|-moz-binding/i
+function hardenAttr(name, value) {
+  const n = name.toLowerCase()
+  if (n.startsWith('on') || n === 'srcdoc' || n === 'formaction') return null
+  if ((n === 'href' || n === 'src') && checkUrl(value) === '') return null
+  if (n === 'style' && STYLE_VECTOR.test(value.replace(/\s+/g, ''))) return { name, value: '' }
+  return { name, value }
+}
+
+function renderAttrs(list) {
+  // serialization: SOURCE order; all classes merge (deduplicated, corpus
+  // 121) into one class attribute at the position of the FIRST class;
+  // a repeated id/key keeps the LAST value at its first position
+  const parts = []
+  const classes = []
+  let classAt = -1
+  const seen = new Map() // name -> index in parts
+  for (const a of list) {
+    if (a[0] === 'class') {
+      if (classAt === -1) {
+        classAt = parts.length
+        parts.push(null) // placeholder
+      }
+      if (!classes.includes(a[1])) classes.push(a[1])
+    } else if (a[0] === 'id') {
+      if (seen.has('#id')) parts[seen.get('#id')] = ` id="${escapeAttr(a[1])}"`
+      else {
+        seen.set('#id', parts.length)
+        parts.push(` id="${escapeAttr(a[1])}"`)
+      }
+    } else if (a[0] === 'kv') {
+      const h = hardenAttr(a[1], a[2])
+      if (!h) continue
+      if (seen.has(a[1])) parts[seen.get(a[1])] = ` ${a[1]}="${escapeAttr(h.value)}"`
+      else {
+        seen.set(a[1], parts.length)
+        parts.push(` ${a[1]}="${escapeAttr(h.value)}"`)
+      }
+    } else {
+      if (!hardenAttr(a[1], '')) continue
+      parts.push(` ${a[1]}=""`)
+    }
+  }
+  if (classAt !== -1) parts[classAt] = ` class="${escapeAttr(classes.join(' '))}"`
+  return parts.join('')
+}
+
+const sem = g.createSemantics().addOperation('h', {
+  inlines(items) {
+    return items.children.map((c) => c.h()).join('')
+  },
+  boldItalic(_o, inner, _c) {
+    return `<strong><em>${inner.children.map((c) => c.h()).join('')}</em></strong>`
+  },
+  emph: spanOp('em'),
+  strong: spanOp('strong'),
+  underline: spanOp('u'),
+  strike: spanOp('s'),
+  sup: spanOp('sup'),
+  sub: spanOp('sub'),
+  highlight: spanOp('mark'),
+  code1: codeOp,
+  code2: codeOp,
+  code3: codeOp,
+  mathI(_d, code) {
+    // `code` is the alternation node; its sole child is codeN(_o,content,_c)
+    return `<span class="math inline">\\(${escapeHtml(codeText(code.child(0).child(1)))}\\)</span>`
+  },
+  mathD(_d, code) {
+    return `<span class="math display">\\[${escapeHtml(codeText(code.child(0).child(1)))}\\]</span>`
+  },
+  crossref(_o, id, _c) {
+    return `xref:${id.sourceString}`
+  },
+  footnoteRef(_o, label, _c) {
+    return `fn:${label.sourceString}`
+  },
+  inlineNote(_o, content, _c) {
+    throw new Refuse('inline footnote (out of the executable subset)')
+  },
+  bracketed(_o, content, _c, tail) {
+    // link text is FULL inline content; parse the raw source recursively
+    const raw = content.sourceString
+    let inner = raw === '' ? '' : renderInline(raw)
+    if (tail.numChildren === 0) {
+      // bare bracketed run: literal (PART 9 SS14), content still parsed
+      return `[${inner}]`
+    }
+    // links never nest (PART 3): an inner link/autolink is replaced by its
+    // own text content; an inner crossref flattens to its resolved TEXT
+    inner = inner.replace(/<a [^>]*>([\s\S]*?)<\/a>/g, '$1')
+    inner = inner.replaceAll('\uE000xref:', '\uE000xreftext:')
+    return tail.child(0).applyTail(inner)
+  },
+  image(_b, _o, alt, _c, _p, dest, title, _cp, attrs) {
+    const t = title.numChildren ? ` title="${escapeAttr(title.child(0).titleText())}"` : ''
+    const a = renderAttrs(attrsOf(attrs))
+    return `<img src="${escapeAttr(checkUrl(dest.sourceString))}" alt="${escapeAttr(alt.sourceString)}"${t}${a}>`
+  },
+  autolink(_o, body, _c, attrs) {
+    const raw = body.sourceString
+    const href = /@/.test(raw) && !/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(raw) ? `mailto:${raw}` : raw
+    const a = renderAttrs(attrsOf(attrs))
+    return `<a href="${escapeAttr(checkUrl(href))}"${a}>${escapeHtml(raw)}</a>`
+  },
+  escape(_bs, ch) {
+    return escapeHtml(ch.sourceString)
+  },
+  word(first, rest) {
+    return escapeHtml(this.sourceString)
+  },
+  _terminal() {
+    return escapeHtml(this.sourceString)
+  },
+  _nonterminal(...ch) {
+    return ch.map((c) => c.h()).join('')
+  },
+  _iter(...ch) {
+    return ch.map((c) => c.h()).join('')
+  },
+})
+
+// tails need the already-rendered link text
+sem.addOperation('applyTail(text)', {
+  linkTail(_o, dest, title, _c, attrs) {
+    const { text } = this.args
+    if (text.includes('\uE000fn:')) throw new Refuse('footnote inside link text')
+    const t = title.numChildren ? ` title="${escapeAttr(title.child(0).titleText())}"` : ''
+    const a = renderAttrs(attrsOf(attrs))
+    return `<a href="${escapeAttr(checkUrl(dest.sourceString))}"${t}${a}>${text}</a>`
+  },
+  refTail(_o, label, _c, attrs) {
+    const { text } = this.args
+    if (text.includes('\uE000fn:')) throw new Refuse('footnote inside link text')
+    const lbl = label.numChildren ? label.child(0).sourceString : null
+    const a = renderAttrs(attrsOf(attrs))
+    return `ref:${JSON.stringify({ label: lbl, text, attrs: a })}`
+  },
+  attrs(_o, _s1, _first, _s2, _rest, _s3, _c) {
+    const { text } = this.args
+    return `<span${renderAttrs(this.parseAttrs())}>${text}</span>`
+  },
+})
+
+sem.addOperation('titleText', {
+  destTitle(_sp, q) {
+    return q.parseAttrs() // quoted -> unescaped string
+  },
+})
+// reuse parseAttrs for quoted strings
+for (const op of ['parseAttrs']) {
+  // attrSem already defines quoted; merge by extending sem
+}
+sem.addOperation('parseAttrs', {
+  attrs(_o, _s1, first, _s2, rest, _s3, _c) {
+    return [first.parseAttrs(), ...rest.children.map((c) => c.parseAttrs())]
+  },
+  attrItem(item) {
+    return item.parseAttrs()
+  },
+  idAttr(_h, id) {
+    return ['id', id.sourceString]
+  },
+  classAttr(_d, cls) {
+    return ['class', cls.sourceString]
+  },
+  kvAttr(k, _eq, v) {
+    return ['kv', k.sourceString, v.parseAttrs()]
+  },
+  boolAttr(name) {
+    return ['bool', name.sourceString]
+  },
+  attrVal(v) {
+    return v.parseAttrs()
+  },
+  quoted(_o, chars, _c) {
+    return chars.children.map((c) => c.parseAttrs()).join('')
+  },
+  qChar(c) {
+    return c.parseAttrs()
+  },
+  qEsc(_bs, q) {
+    return '"'
+  },
+  bareVal(chars) {
+    return chars.sourceString
+  },
+  _terminal() {
+    return this.sourceString
+  },
+  _iter(...ch) {
+    return ch.map((c) => c.parseAttrs()).join('')
+  },
+  _nonterminal(...ch) {
+    if (ch.length === 1) return ch[0].parseAttrs()
+    return ch.map((c) => c.parseAttrs()).join('')
+  },
+})
+
+// --- PART 9 SS9 E1-E5 delimiter-stack pre-scan -----------------------------
+// A PEG's ordered choice resolves emphasis by nesting, not by the spec's
+// close-first-wins rule. The two agree UNLESS a closer matches a non-top
+// stack entry (E2 demotion, i.e. overlapping candidate spans). Detect that
+// case with a faithful mini stack-scan and REFUSE it - the executable spec
+// never silently diverges from the delimiter-stack semantics.
+const DELIMS = new Set(['/', '*', '_', '~', '^', '=', ','])
+const isWordCh = (c) => c !== undefined && /[\p{L}\p{N}]/u.test(c)
+const isWs = (c) => c === undefined || /\s/.test(c)
+
+function overlapScan(text) {
+  const stack = []
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]
+    if (c === '\\') {
+      i++
+      continue
+    }
+    if (c === '`') {
+      // skip a verbatim span (equal-run close)
+      let run = 1
+      while (text[i + run] === '`') run++
+      const close = text.indexOf('`'.repeat(run), i + run)
+      i = close === -1 ? text.length : close + run - 1
+      continue
+    }
+    if (!DELIMS.has(c)) continue
+    const prev = text[i - 1]
+    const next = text[i + 1]
+    if (prev === c || next === c) continue // same-delimiter adjacency: literal
+    const canOpen = !isWs(next) && !isWordCh(prev) && prev !== '_'
+    const canClose = !isWs(prev) && !isWordCh(next)
+    const top = stack.length ? stack[stack.length - 1] : null
+    const idx = stack.lastIndexOf(c)
+    if (canClose && idx !== -1) {
+      if (idx !== stack.length - 1) return true // E2 demotion -> overlap
+      stack.pop()
+      continue
+    }
+    if (canOpen && !stack.includes(c)) stack.push(c) // E3: no same-type nesting
+  }
+  return false
+}
+
+export function renderInline(text) {
+  if (overlapScan(text)) throw new Refuse('overlapping emphasis (delimiter-stack close-first rule)')
+  const m = g.match(text, 'inlines')
+  if (m.failed()) throw new Refuse(`inline: ${m.shortMessage}`)
+  return sem(m).h()
+}
+
+// ---------------------------------------------------------------------------
+// Heading slugs (grammar.ebnf PART 2 HEADING IDENTIFIERS, executable subset)
+export function makeSlugger() {
+  const seen = new Map()
+  return (text) => {
+    let slug = text
+      .replace(/[‪-‮⁦-⁩​‌‍⁠﻿­]/g, '')
+      .normalize('NFC')
+      .replace(/[\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e\s]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+    if (slug === '') slug = 's'
+    else if (/^[0-9]/.test(slug)) slug = `s-${slug}`
+    const n = seen.get(slug) ?? 0
+    seen.set(slug, n + 1)
+    return n === 0 ? slug : `${slug}-${n + 1}`
+  }
+}


### PR DESCRIPTION
Turns the layered formal spec into a directly **executable spec**, gate-checked against the conformance corpus in CI.

## What this adds

The pipeline mirrors the spec layers one-to-one (the layer restructure of `resources/grammar.ebnf` itself landed as part of #244):

| Spec layer | Executable artifact |
|---|---|
| PART 0 layout automaton (blocks, lists, quotes, lazy continuation, column arithmetic) | `scripts/spec/layout.mjs` |
| PART 3 inline grammar (word-boundary guards, links, images, spans, attributes, autolinks, math, footnote refs, crossrefs) | `resources/carve-core.ohm` (Ohm/PEG) |
| PART 9R resolution + PART 10 serialization (refs, footnotes/endnotes, crossrefs, abbreviations, URL denylist + attribute hardening) | `scripts/spec/html.mjs` |

## The gate

`npm run core:check` (new CI step) runs all 388 corpus pairs through the pipeline:

- **174 render byte-identically** to the pinned corpus HTML.
- **214 are REFUSED** - they use constructs outside the executable subset (tables, divs, smart typography, mentions, extensions, ...). Refuse-over-approximate: an accept is always a full-fidelity claim.
- **0 parse-but-diff defects** - the hard failure condition.

Two honest seams where a pure PEG cannot carry the spec are executed as declared predicates instead: fence-length counting (the `where` guard) in the layout automaton, and emphasis overlap resolution (the close-first delimiter-stack rule), which a pre-scan detects and refuses rather than letting PEG ordered choice silently diverge.

Also wires up the `ohm-js` dev dependency and `core:check` script that the previously landed `scripts/formal-core-check.mjs` required.
