### PR TITLE
Executable spec: full corpus coverage (388/388)

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -29,13 +29,13 @@ Light markup languages are provably not context-free: fence-length matching is a
 | PART 3 inline grammar | [`resources/carve-core.ohm`](https://github.com/markup-carve/carve/blob/main/resources/carve-core.ohm) (Ohm/PEG) |
 | PART 9R resolution + PART 10 serialization | `scripts/spec/html.mjs` |
 
-Core covers: headings, thematic breaks, paragraphs, fenced code, lists (bullet/ordered/task, all dialects, lazy continuation, tight/loose), block quotes (incl. the `+` continuation marker and attribution captions), the seven emphasis delimiters with full word-boundary rules, code spans, math, escapes, links (all three forms), images (incl. figure captions), inline spans and attribute blocks (incl. the security hardening rules), autolinks, footnotes (reference form, endnotes, backlinks), crossrefs, and abbreviations.
+The executable spec covers the full conformant core: block structure (headings incl. multi-line folding and section wrapping, lists with every ordered dialect, quotes, tables with the span walk, fenced code and colon fences, definition lists, comments, frontmatter, block-attribute lines), the complete inline layer (emphasis with word-boundary guards, links, images, spans, attributes with the security hardening rules, autolinks, math, extensions, mentions/tags, editorial markup, smart typography, footnotes incl. inline notes, crossrefs, raw passthrough), and the resolution passes (references, footnote numbering and endnotes placement, numbered captions, abbreviations).
 
 ```bash
 npm run core:check
 ```
 
-The gate enforces a strict contract over the full conformance corpus: an input the executable spec accepts must render to the pinned corpus HTML **byte-for-byte** (currently ~45% of corpus inputs); anything using constructs outside the subset is REFUSED rather than approximated, so an accept is always a full-fidelity claim. The counting rule a PEG cannot state - fence closer length >= opener length - is asserted in the layout automaton, mirroring the `where` guard in the EBNF.
+The gate demands byte-identical HTML for **every pair in the conformance corpus - currently 388/388**. Rules a pure PEG cannot state are executed as declared predicates in the layout automaton (fence-length counting, the `where` guards) or as a pre-scan (the emphasis close-first delimiter-stack rule), so the pipeline never silently diverges from the delimiter-stack semantics.
 
 Implementations should match this grammar. The [case study](./case-study/) explains the design rationale, the [reference page](./edge-cases) covers parsing edge cases, and the [examples](./examples) show the expected HTML output for each construct.
 

--- a/resources/carve-core.ohm
+++ b/resources/carve-core.ohm
@@ -108,10 +108,12 @@ CarveCore {
   // ==========================================================================
   // INLINE (Core)
   // ==========================================================================
-  inline     = delimRun | inlineNote | footnoteRef | crossref | span
-             | mathD | mathI | code | escape | image | bracketed
-             | autolink | word | inlineSpace | litDelim | bang | dollar
-             | dot | dash | plus | pct | lt | gt | other
+  inline     = arrow | symbol | delimRun | inlineNote | footnoteRef | crossref | extension | mention | tag
+             | editorial | forcedSpan | span
+             | mathD | mathI | codeA | nbspEsc | hardBreak | escape | image | bracketed
+             | autolink | word | spComment | inlineSpace | litDelim | bang | dollar
+             | ellipsis | dashRun | dot | dash | plus | pct | lt | gt
+             | dquote | squote | hash | looseAttrs | nl | other | anyChar
   // SAME-DELIMITER ADJACENCY (bare_opener\'s !(d) guard): a run of 2+
   // identical bare delimiters is literal text, never an opener.
   delimRun   = dRun<"/"> | dRun<"*"> | dRun<"_"> | dRun<"~"> | dRun<"^"> | dRun<"="> | dRun<",">
@@ -121,47 +123,49 @@ CarveCore {
 
   // Combined form /*x*/ -> <strong><em> (grammar.ebnf bold_italic); matched
   // before emph so the two-char token wins over nested /-then-* parsing.
-  boldItalic = "/*" ~spaceOrEnd biInner+ "*/" ~alnumCh
+  boldItalic = "/*" ~spaceOrEnd biInner+ "*/" ~alnumCh attrs?
   biInner    = ~("*/") (rich | word | " " ~("*/") | litDelim | other)
 
   // constructs allowed inside any span (everything except spans themselves,
   // which are listed per-delimiter to exclude self-nesting)
-  rich       = delimRun | inlineNote | footnoteRef | crossref | mathD | mathI
-             | code | escape | image | bracketed | autolink | bang | dollar
+  rich       = arrow | symbol | delimRun | inlineNote | footnoteRef | crossref | extension | mention | tag
+             | editorial | forcedSpan | mathD | mathI
+             | codeA | escape | image | bracketed | autolink | bang | dollar
+             | ellipsis | dashRun | dquote | squote
              | dot | dash | plus | pct
 
   // One rule shape per delimiter (the bare_opener/bare_closer instantiation).
-  emph       = "/" ~"/" ~spaceOrEnd emphInner+ emphClose
+  emph       = "/" ~"/" ~spaceOrEnd emphInner+ emphClose attrs?
   emphInner = ~emphClose (strong | underline | strike | sup | sub | highlight
              | rich | word | spaceIn<"/"> | litSelf<"/"> | litDelim | other)
   emphClose  = "/" ~alnumCh
 
-  strong     = "*" ~"*" ~spaceOrEnd strongInner+ strongClose
+  strong     = "*" ~"*" ~spaceOrEnd strongInner+ strongClose attrs?
   strongInner = ~strongClose (emph | underline | strike | sup | sub | highlight
              | rich | word | spaceIn<"*"> | litSelf<"*"> | litDelim | other)
   strongClose = "*" ~alnumCh
 
-  underline  = "_" ~"_" ~spaceOrEnd underInner+ underClose
+  underline  = "_" ~"_" ~spaceOrEnd underInner+ underClose attrs?
   underInner = ~underClose (emph | strong | strike | sup | sub | highlight
              | rich | word | spaceIn<"_"> | litSelf<"_"> | litDelim | other)
   underClose = "_" ~alnumCh
 
-  strike     = "~" ~"~" ~spaceOrEnd strikeInner+ strikeClose
+  strike     = "~" ~"~" ~spaceOrEnd strikeInner+ strikeClose attrs?
   strikeInner = ~strikeClose (emph | strong | underline | sup | sub | highlight
              | rich | word | spaceIn<"~"> | litSelf<"~"> | litDelim | other)
   strikeClose = "~" ~alnumCh
 
-  sup        = "^" ~"^" ~spaceOrEnd supInner+ supClose
+  sup        = "^" ~"^" ~spaceOrEnd supInner+ supClose attrs?
   supInner = ~supClose (emph | strong | underline | strike | sub | highlight
              | rich | word | spaceIn<"^"> | litSelf<"^"> | litDelim | other)
   supClose   = "^" ~alnumCh
 
-  sub        = "," ~"," ~spaceOrEnd subInner+ subClose
+  sub        = "," ~"," ~spaceOrEnd subInner+ subClose attrs?
   subInner = ~subClose (emph | strong | underline | strike | sup | highlight
              | rich | word | spaceIn<","> | litSelf<","> | litDelim | other)
   subClose   = "," ~alnumCh
 
-  highlight  = "=" ~"=" ~spaceOrEnd hlInner+ hlClose
+  highlight  = "=" ~"=" ~spaceOrEnd hlInner+ hlClose attrs?
   hlInner = ~hlClose (emph | strong | underline | strike | sup | sub
              | rich | word | spaceIn<"="> | litSelf<"="> | litDelim | other)
   hlClose    = "=" ~alnumCh
@@ -174,25 +178,73 @@ CarveCore {
   // Verbatim code span: equal-length maximal backtick runs (Core uses the
   // 1..3 tier; longer runs are out of Core). Single-space strip is applied
   // by the renderer per the code_span rule.
-  code       = code3 | code2 | code1
+  codeA      = rawInline | codeAttrd
+  codeAttrd  = code attrs?
+  code       = code3 | code2 | code1 | codeU
+  // UNCLOSED RUN (PART 3 code_span): an opener with no equal-run closer
+  // ahead opens a verbatim span to the END OF BLOCK; opaque; no
+  // single-space strip
+  codeU      = "\u0060" "\u0060"* any*
   code1      = "`" (~"`" any)+ "`" ~"`"
   code2      = "``" (~"``" any)+ "``" ~"`"
   code3      = "```" (~"```" any)+ "```" ~"`"
 
   escape     = "\\" punctChar
+  // escaped SPACE is a non-breaking space; a backslash at END OF LINE is a
+  // hard break (PART 3)
+  nbspEsc    = "\\" " "
+  hardBreak  = "\\" &(newline | end)
+
+  // --- Mentions and tags (PART 9 SS7): name = letters/digits/_/- with
+  // INTERIOR dots; a trailing dot is punctuation. Word boundary on the
+  // left is enforced by the word rule's atGlue/hashGlue absorption.
+  mention    = "@" tagName
+  tag        = "#" tagName
+  tagName    = tagChar+ (tagDot tagChar+)*
+  tagChar    = letter | digit | "_" | "-"
+  tagDot     = "." &tagChar
 
   // --- Math (PART 3: `$` / `$$` + a verbatim span; bare `$` is literal) ---
-  mathI      = "$" code
-  mathD      = "$$" code
+  mathI      = "$" code attrs?
+  mathD      = "$$" code attrs?
 
   // --- Cross-reference with auto text (PART 3 auto_text_link) -------------
   crossref   = "</#" xrefId ">"
   xrefId     = (~">" ~space ~newline any)+
 
   // --- Footnotes (PART 3; `^[` ranks ABOVE superscript, PART 8) -----------
-  footnoteRef = "[^" fnLabel "]"
+  footnoteRef = "[^" fnLabel "]" attrs?
   fnLabel    = (~"]" ~newline any)+
-  inlineNote = "^[" brContent* "]"
+  inlineNote = "^[" brContent* "]" attrs?
+
+  // --- Forced intraword spans {X...X} (PART 9 SS22) and editorial markup.
+  // A same-type delimiter inside a forced span is literal until the `X}`
+  // closer; other constructs nest normally.
+  forcedSpan = forced<"/"> | forced<"*"> | forced<"_"> | forced<"~">
+             | forced<"^"> | forced<","> | forced<"=">
+  forced<d>  = "{" d fInner<d>* d "}" attrs?
+  fInner<d>  = ~(d "}") (rich | span | word | spComment | inlineSpace | litDelim
+             | bang | dollar | ellipsis | dashRun | dot | dash | plus | pct
+             | lt | gt | dquote | squote | hash | other)
+
+  // editorial: {+ins+} {-del-} {~old~>new~} {# comment #} (+ the doubled
+  // {++...++} / {--...--} forms whose extra marker chars stay literal)
+  editorial  = edSub | edIns | edDel | edComment
+  edIns      = "{+" (~"+}" edChar)* "+}" attrs?
+  edDel      = "{-" (~"-}" edChar)* "-}" attrs?
+  edSub      = "{~" (~"~>" ~"~}" edChar)* "~>" (~"~}" edChar)* "~}" attrs?
+  edComment  = "{#" (~"#}" edChar)* "#}" attrs?
+  edChar     = ~newline any
+
+  // raw inline passthrough: a code span whose trailing block is EXACTLY
+  // {=format} (PART 9 SS20)
+  rawInline  = code "{=" ident "}"
+
+  // --- Inline extensions: :name[content] -> ext span (PART 8 rank 9);
+  // content ends at the FIRST unescaped "]" (corpus 16-5)
+  extension  = ":" extName "[" extContent "]" attrs?
+  extName    = identStart identRest*
+  extContent = (escape | (~"]" ~newline any))*
 
   // --- Bracketed constructs: link / image / span / reference link ---------
   // The single-char lookahead after `]` selects the construct (PART 9 S14);
@@ -201,13 +253,16 @@ CarveCore {
   bracketed  = "[" brContent* "]" brTail?
   brContent  = escape | code | nested | (~"]" ~newline any)
   nested     = "[" brContent* "]"
-  brTail     = linkTail | refTail | attrs
+  brTail     = linkTail | refTail | attrs | emptyAttrs
   linkTail   = "(" dest destTitle? ")" attrs?
   refTail    = "[" refLabel? "]" attrs?
   refLabel   = (~"]" ~newline any)+
   dest       = destChar*
   destChar   = ~(")" | " " | "\t" | newline) any
-  destTitle  = " "+ quoted
+  destTitle  = " "+ (quoted | squoted)
+  squoted    = "'" sqChar* "'"
+  sqChar     = sqEsc | (~"'" ~newline any)
+  sqEsc      = "\\" "'"
   quoted     = "\"" qChar* "\""
   qChar      = qEsc | (~"\"" ~newline any)
   qEsc       = "\\" "\""
@@ -229,13 +284,14 @@ CarveCore {
 
   // --- Attribute block (PART 4, strict identifiers) ------------------------
   attrs      = "{" attrSp* attrItem (attrSp+ attrItem)* attrSp* "}"
-  attrSp     = " "
+  emptyAttrs = "{" " "* "}"
+  attrSp     = " " | "\n"
   attrItem   = idAttr | classAttr | kvAttr | boolAttr
   idAttr     = "#" ident
   classAttr  = "." ident
   kvAttr     = ident "=" attrVal
   boolAttr   = ident
-  attrVal    = quoted | bareVal
+  attrVal    = quoted | squoted | bareVal
   bareVal    = (~(" " | "}" | newline) any)+
   ident      = identStart identRest*
   identStart = letter | "_" | "-"
@@ -243,12 +299,15 @@ CarveCore {
 
   // A word absorbs any bare delimiter glued between two word characters -
   // this IS the left word-boundary / no-intraword rule, structurally.
-  word       = wordChar (wordChar | wordGlue | underGlue | atGlue | dotGlue)*
+  word       = wordChar (wordChar | wordGlue | underGlue | atGlue | hashGlue | dotGlue | pctGlue)*
   wordGlue   = delim &wordChar
-  // absorb the `@` of an embedded email address (me@example.com) and the
-  // intraword dot (example.com) so neither triggers mention/typography rules
+  // absorb the `@`/`#` glued between word chars (me@example.com, a#b) and
+  // the intraword dot so none triggers mention/tag/typography rules
   atGlue     = "@" &wordChar
+  hashGlue   = "#" &wordChar
   dotGlue    = "." &wordChar
+  // a %-run glued to a word is literal (50%%, a%%b) - never a comment
+  pctGlue    = "%" "%"* &(wordChar | " " | end)
   // a delimiter directly after a word-attached `_` never opens (the
   // bare_opener guard excludes a preceding `_`): absorb `_` + delimiter
   // when a word character follows, keeping the run literal
@@ -256,6 +315,9 @@ CarveCore {
   wordChar   = letter | digit
   delim      = "/" | "*" | "_" | "~" | "^" | "=" | ","
 
+  // a whitespace-preceded %% consumes the rest of the LINE (SS21); the
+  // space itself is consumed too
+  spComment  = " " "%%" (~newline any)*
   inlineSpace = " "
 
   // A bare delimiter that opened nothing is literal text.
@@ -269,6 +331,18 @@ CarveCore {
   // text (HTML-escaped by the renderer)
   lt         = "<"
   gt         = ">"
+  // SMART TYPOGRAPHY (PART 9 SS8). Multi-char patterns are consumed as
+  // tokens; the open/close decision for quotes uses the previous source
+  // character in the SEMANTICS (deterministic single-char lookbehind).
+  arrow      = "<->" | "->" | "<-" | "=>" | "!=" | "<=" | ">=" | "+-"
+  symbol     = "(c)" | "(r)" | "(tm)"
+  ellipsis   = "..."
+  dashRun    = "-" "-"+
+  dquote     = "\""
+  squote     = "'"
+  // a bare `#` (not a tag opener: followed by space/colon/dot/end) is
+  // literal - needed for caption number placeholders and prose
+  hash       = "#" &(" " | ":" | "." | newline | end)
   dot        = "." ~".."
   dash       = "-" ~"-"
   plus       = "+" ~"-"
@@ -279,9 +353,18 @@ CarveCore {
   // makes the line - and the document - fail to match: those constructs
   // exist in Full Carve, so Core refuses rather than mis-renders.
   other      = letter | digit | colon | ";" | "?" | "&" | "(" | ")" | at
+  // catch-all: any remaining character is literal text (HTML-escaped; the
+  // Trojan-Source bidi strip happens in escapeHtml). Constructs are all
+  // tried first, so this only sees genuinely plain characters.
+  anyChar    = ~newline any
+  // paragraphs are inline-parsed as ONE text with embedded soft breaks
+  nl         = "\n"
+  // a valid-shaped attribute block with no abutting carrier is LITERAL
+  // text (PART 9 SS14/SS15); an invalid payload still refuses
+  looseAttrs = attrs
   // a `:` opening an inline extension (:name[...]) or an emoji (:name:) is
   // Full Carve -> refuse; a plain colon is text
-  colon      = ":" ~(ident (":" | "["))
+  colon      = ":" ~(ident "[")
   // a bare `@` followed by a word char is a mention (Full Carve) -> refuse;
   // an email-embedded `@` is absorbed by the word rule (atGlue)
   at         = "@" ~wordChar

--- a/scripts/formal-core-check.mjs
+++ b/scripts/formal-core-check.mjs
@@ -68,6 +68,6 @@ for (const d of diffs) {
   }
 }
 if (diffMode) {
-  for (const r of refused.slice(0, 40)) console.log(`REFUSED ${r}`)
+  for (const r of refused.slice(0, 400)) console.log(`REFUSED ${r}`)
 }
 process.exit(diffs.length ? 1 : 0)

--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -4,8 +4,8 @@
  * contract; anything the subset cannot render faithfully throws Refuse.
  */
 
-import { Refuse } from './layout.mjs'
-import { renderInline, makeSlugger, checkUrl, escapeAttr, parseAttrBlock } from './render.mjs'
+import { Refuse, TIER1 } from './layout.mjs'
+import { renderInline, makeSlugger, checkUrl, escapeAttr, parseAttrBlock, renderBlockAttrs } from './render.mjs'
 
 const IMG_ONLY = /^<img [^>]*>$/
 
@@ -16,6 +16,8 @@ export function renderDoc(doc) {
     abbrDefs: doc.abbrDefs,
     footnoteDefs: doc.footnoteDefs,
     headingIds: new Map(), // lower-cased slug -> { id, html }
+    captionSeq: new Map(), // caption label word -> counter (R5)
+    captionIds: new Map(), // lower-cased id -> "Label N" (R4)
   }
   const out = []
   const sections = []
@@ -28,13 +30,30 @@ export function renderDoc(doc) {
         sections.pop()
         out.push(`${indent()}</section>`)
       }
-      const id = ctx.slug(b.text)
+      // an explicit {#id} from a preceding attribute line lands on the
+      // <section> (PART 9 SS13/SS15); remaining attrs go on the <h*>
+      let id = null
+      let hAttrs = ''
+      if (b.battrs) {
+        const rest = []
+        for (const list of b.battrs) {
+          const keep = []
+          for (const a of list) {
+            if (a[0] === 'id') id = a[1]
+            else keep.push(a)
+          }
+          if (keep.length) rest.push(keep)
+        }
+        hAttrs = renderBlockAttrs(rest)
+      }
+      if (id === null) id = ctx.slug(b.text.replace(/<\/#[^>]*>/g, '').replace(/[ \t]+$/, ''))
       ctx.headingIds.set(id.toLowerCase(), { id, html })
-      out.push(`${indent()}<section id="${id}">`)
+      out.push(`${indent()}<section id="${escapeAttr(id)}">`)
       sections.push(b.level)
-      out.push(`${indent()}<h${b.level}>${html}</h${b.level}>`)
+      out.push(`${indent()}<h${b.level}${hAttrs}>${html}</h${b.level}>`)
     } else {
-      out.push(renderBlock(b, sections.length, ctx))
+      const r = renderBlock(b, sections.length, ctx)
+      if (r !== null) out.push(r)
     }
   }
   while (sections.length) {
@@ -52,50 +71,160 @@ export function renderDoc(doc) {
 
 function renderBlock(b, depth, ctx) {
   const pad = '  '.repeat(depth)
+  const ba = b.battrs ? renderBlockAttrs(b.battrs) : ''
   switch (b.t) {
     case 'para': {
-      const html = b.lines.map((l) => renderInline(l)).join('\n')
+      const html = renderInline(b.lines.join('\n'))
       if (b.lines.length === 1 && IMG_ONLY.test(html)) {
         // a standalone image paragraph renders as a bare <img> (PART 10)
         if (b.caption !== undefined) {
-          return `${pad}<figure>\n${pad}  ${html}\n${pad}  <figcaption>${renderInline(b.caption)}</figcaption>\n${pad}</figure>`
+          const id = / id="([^"]*)"/.exec(ba)?.[1]
+          const cap = numberCaption(b.caption, ctx, id)
+          return `${pad}<figure${ba}>\n${pad}  ${html}\n${pad}  <figcaption>${renderInline(cap)}</figcaption>\n${pad}</figure>`
         }
-        return pad + html
+        return pad + (ba ? html.replace('<img ', `<img${ba} `.replace(/ $/, ' ')) : html)
       }
-      if (b.caption !== undefined) throw new Refuse('caption on a text paragraph')
-      return `${pad}<p>${html}</p>`
+      if (b.caption !== undefined) {
+        const id = / id="([^"]*)"/.exec(ba)?.[1]
+        const cap = numberCaption(b.caption, ctx, id)
+        return `${pad}<figure${ba}>\n${pad}  <p>${html}</p>\n${pad}  <figcaption>${renderInline(cap)}</figcaption>\n${pad}</figure>`
+      }
+      return `${pad}<p${ba}>${html}</p>`
     }
     case 'hr':
-      return `${pad}<hr>`
+      return `${pad}<hr${ba}>`
     case 'code': {
       const cls = b.lang ? ` class="language-${b.lang}"` : ''
+      const title = b.title != null && !/ title="/.test(ba) ? ` title="${escapeAttr(b.title)}"` : ''
+      if (b.caption !== undefined) {
+        const id = / id="([^"]*)"/.exec(ba)?.[1]
+        const cap = numberCaption(b.caption, ctx, id)
+        const esc0 = b.text
+          .replace(/[\u202A-\u202E\u2066-\u2069]/g, '')
+          .replaceAll('&', '&amp;')
+          .replaceAll('<', '&lt;')
+          .replaceAll('>', '&gt;')
+        return `${pad}<figure${ba}>\n${pad}  <pre${title}><code${cls}>${esc0}</code></pre>\n${pad}  <figcaption>${renderInline(cap)}</figcaption>\n${pad}</figure>`
+      }
       const esc = b.text
         .replace(/[‪-‮⁦-⁩]/g, '')
         .replaceAll('&', '&amp;')
         .replaceAll('<', '&lt;')
         .replaceAll('>', '&gt;')
-      return `${pad}<pre><code${cls}>${esc}</code></pre>`
+      return `${pad}<pre${title}${ba}><code${cls}>${esc}</code></pre>`
     }
     case 'quote': {
-      const inner = b.children.map((c) => renderBlock(c, depth + 1, ctx)).join('\n')
+      const inner = b.children.map((c) => renderBlock(c, depth + 1, ctx)).filter((x) => x !== null).join('\n')
       if (b.caption !== undefined) {
         // single-paragraph attribution form pins the compact figure layout
         if (b.children.length === 1 && b.children[0].t === 'para') {
           const p = renderBlock(b.children[0], 0, ctx)
-          return `${pad}<figure>\n${pad}  <blockquote>${p}</blockquote>\n${pad}  <figcaption>${renderInline(b.caption)}</figcaption>\n${pad}</figure>`
+          return `${pad}<figure${ba}>\n${pad}  <blockquote>${p}</blockquote>\n${pad}  <figcaption>${renderInline(b.caption)}</figcaption>\n${pad}</figure>`
         }
         throw new Refuse('captioned multi-block quote')
       }
       if (b.children.length === 1 && b.children[0].t === 'para') {
         const p = renderBlock(b.children[0], 0, ctx)
-        return `${pad}<blockquote>${p}</blockquote>`
+        return `${pad}<blockquote${ba}>${p}</blockquote>`
       }
-      return `${pad}<blockquote>\n${inner}\n${pad}</blockquote>`
+      return `${pad}<blockquote${ba}>\n${inner}\n${pad}</blockquote>`
     }
     case 'list':
       return renderList(b, depth, ctx)
     case 'table':
       return renderTable(b, depth, ctx)
+    case 'colon-div': {
+      const pad2 = '  '.repeat(depth)
+      const tag = b.type !== null && TIER1.has(b.type) ? 'aside' : 'div'
+      let attrStr
+      if (b.type === null) {
+        // generic div: attribute-line attrs apply verbatim in SOURCE order
+        attrStr = b.battrs ? renderBlockAttrs(b.battrs) : ''
+      } else {
+        // typed block: the type class leads; attribute-line classes merge
+        // into it, everything else follows in source order (PART 9 SS15)
+        const baseCls = TIER1.has(b.type) ? ['admonition', b.type] : [b.type]
+        const extra = []
+        const rest = []
+        for (const list of b.battrs ?? []) {
+          const keep = []
+          for (const a of list) {
+            if (a[0] === 'class') extra.push(a[1])
+            else keep.push(a)
+          }
+          if (keep.length) rest.push(keep)
+        }
+        attrStr = ` class="${[...baseCls, ...extra].join(' ')}"` + renderBlockAttrs(rest)
+      }
+      const open = `${pad2}<${tag}${attrStr}>`
+      const closeTag = `</${tag}>`
+      const parts = []
+      if (b.title !== null) parts.push(`${pad2}  <p class="admonition-title">${renderInline(b.title)}</p>`)
+      if (b.label !== null) parts.push(`${pad2}  <p class="div-label">${renderInline(b.label)}</p>`)
+      for (const c of b.children) parts.push(renderBlock(c, depth + 1, ctx))
+      if (parts.length === 0) {
+        // empty body: a bare div collapses to one line break; a typed block
+        // keeps its empty body line (both corpus/oracle-pinned)
+        if (b.type === null) return `${open}\n${pad2}${closeTag}`
+        return `${open}\n\n${pad2}${closeTag}`
+      }
+      return `${open}\n${parts.join('\n')}\n${pad2}${closeTag}`
+    }
+    case 'line-block': {
+      const pad2 = '  '.repeat(depth)
+      // stanzas split on blank lines; soft breaks harden; leading spaces
+      // serialize as NBSP entities (PART 9 SS23)
+      const stanzas = []
+      let cur = []
+      for (const l of b.lines) {
+        if (/^[ \t]*$/.test(l)) {
+          if (cur.length) stanzas.push(cur)
+          cur = []
+        } else cur.push(l)
+      }
+      if (cur.length) stanzas.push(cur)
+      const ps = stanzas.map((st) => {
+        const rendered = st.map((l) => {
+          const m = /^( *)(.*)$/.exec(l)
+          return '&nbsp;'.repeat(m[1].length) + renderInline(m[2].replace(/[ \t]+$/, ''))
+        })
+        return `${pad2}  <p>${rendered.join('<br>\n')}</p>`
+      })
+      return `${pad2}<div class="line-block">\n${ps.join('\n')}\n${pad2}</div>`
+    }
+    case 'hardbreaks': {
+      const pad2 = '  '.repeat(depth)
+      // direct paragraph children harden their soft breaks; nested blocks
+      // keep normal behavior (PART 9 SS23)
+      const parts = b.children.map((c) => {
+        if (c.t === 'para') {
+          const html = renderInline(c.lines.join('\n')).replaceAll('\n', '<br>\n')
+          return `${'  '.repeat(depth + 1)}<p>${html}</p>`
+        }
+        return renderBlock(c, depth + 1, ctx)
+      })
+      if (parts.length === 0) return `${pad2}<div class="hardbreaks"></div>`
+      return `${pad2}<div class="hardbreaks">\n${parts.join('\n')}\n${pad2}</div>`
+    }
+    case 'deflist': {
+      const rows = b.items.map((it) =>
+        it.dt !== undefined ? `${pad}  <dt>${renderInline(it.dt)}</dt>` : `${pad}  <dd>${renderInline(it.dd)}</dd>`
+      )
+      return `${pad}<dl>\n${rows.join('\n')}\n${pad}</dl>`
+    }
+    case 'raw':
+      // PART 9 SS20: verbatim for the html target, dropped otherwise
+      return b.format === 'html' ? b.text.split('\n').map((l) => pad + l).join('\n') : null
+    case 'heading': {
+      // a heading inside a container: no section wrapper (SS13 wraps
+      // top-level headings only); the id lands on the <h*> itself
+      const html = renderInline(b.text)
+      const id = ctx.slug(b.text.replace(/<\/#[^>]*>/g, '').replace(/[ \t]+$/, ''))
+      ctx.headingIds.set(id.toLowerCase(), { id, html })
+      return `${pad}<h${b.level} id="${escapeAttr(id)}">${html}</h${b.level}>`
+    }
+    case 'footnotes-placement':
+      return '\uE000fnplacement\uE001'
     default:
       throw new Refuse(`unknown block ${b.t}`)
   }
@@ -104,7 +233,7 @@ function renderBlock(b, depth, ctx) {
 function renderList(list, depth, ctx) {
   const pad = '  '.repeat(depth)
   let tag = 'ul'
-  let attrs = ''
+  let attrs = list.battrs ? renderBlockAttrs(list.battrs) : ''
   if (list.ord) {
     tag = 'ol'
     if (list.ord.type) attrs += ` type="${list.ord.type}"`
@@ -116,11 +245,17 @@ function renderList(list, depth, ctx) {
 
 function renderItem(item, list, depth, ctx) {
   const pad = '  '.repeat(depth)
+  let liAttrs = ''
+  if (item.attrs) {
+    const parsed = parseAttrBlock(item.attrs)
+    if (parsed === null) throw new Refuse('invalid list-item attribute block')
+    liAttrs = parsed
+  }
   const prefix = list.task
     ? `<input type="checkbox"${item.checked ? ' checked' : ''} disabled> `
     : ''
   const blocks = item.blocks
-  if (blocks.length === 0) return `${pad}<li></li>`
+  if (blocks.length === 0) return `${pad}<li${liAttrs}></li>`
 
   const parts = []
   for (let i = 0; i < blocks.length; i++) {
@@ -138,13 +273,13 @@ function renderItem(item, list, depth, ctx) {
   // line at the li indent (corpus 05-lists-4, 103-marker-line-nested-lists)
   const first = parts[0]
   if (parts.length === 1 && first.inlineable) {
-    return `${pad}<li>${prefix}${first.html}</li>`
+    return `${pad}<li${liAttrs}>${prefix}${first.html}</li>`
   }
   let out
   if (first.inlineable) {
-    out = `${pad}<li>${prefix}${first.html}`
+    out = `${pad}<li${liAttrs}>${prefix}${first.html}`
   } else {
-    out = `${pad}<li>\n${first.html}`
+    out = `${pad}<li${liAttrs}>\n${first.html}`
   }
   for (let i = 1; i < parts.length; i++) {
     const p = parts[i]
@@ -154,9 +289,23 @@ function renderItem(item, list, depth, ctx) {
   return out
 }
 
+// PART 9R R5: the FIRST bare `#` in a caption's top-level text is a number
+// placeholder; each label word draws from its own sequence. An id on the
+// captioned block registers the "Label N" text for crossrefs (R4).
+function numberCaption(text, ctx, id) {
+  const m = /^(\S+)([^#]*?)(?<!\\)#(?=[\s:.]|$)/.exec(text)
+  if (!m) return text
+  const label = m[1]
+  const n = (ctx.captionSeq.get(label) ?? 0) + 1
+  ctx.captionSeq.set(label, n)
+  if (id) ctx.captionIds.set(id.toLowerCase(), `${label} ${n}`)
+  return text.replace(/(?<!\\)#(?=[\s:.]|$)/, String(n))
+}
+
 // --- tables: PART 9 SS5 T5 span walk + serialization -------------------------
 function renderTable(node, depth, ctx) {
   const pad = '  '.repeat(depth)
+  const ba = node.battrs ? renderBlockAttrs(node.battrs) : ''
   const rows = node.rows
   // resolve span markers (T5): row-major; consumed positions are skipped in
   // the output; a marker with no reachable origin renders as an EMPTY cell
@@ -229,8 +378,11 @@ function renderTable(node, depth, ctx) {
       .join('')
     return `<tr${ra}>${cells}</tr>`
   }
-  const out = [`${pad}<table>`]
-  if (node.caption !== undefined) out.push(`${pad}  <caption>${renderInline(node.caption)}</caption>`)
+  const out = [`${pad}<table${ba}>`]
+  if (node.caption !== undefined) {
+    const id = / id="([^"]*)"/.exec(ba)?.[1]
+    out.push(`${pad}  <caption>${renderInline(numberCaption(node.caption, ctx, id))}</caption>`)
+  }
   const bodyStart = headCount
   if (headCount > 0) {
     const headRows = rows.slice(0, headCount).map((row, r) => renderRow(row, r)).join('')
@@ -251,7 +403,7 @@ function resolveRefs(html, ctx) {
     const { label, text, attrs } = JSON.parse(json)
     const key = label ?? stripTags(text)
     const def = ctx.linkDefs.get(key)
-    if (!def) throw new Refuse(`unresolved reference [${key}]`)
+    if (!def) return `[${text}][${label ?? ''}]` // unresolved -> literal (R1)
     const t = def.title ? ` title="${escapeAttr(def.title)}"` : ''
     return `<a href="${escapeAttr(checkUrl(def.url))}"${t}${attrs}>${text}</a>`
   })
@@ -263,9 +415,19 @@ function stripTags(s) {
 
 // --- PART 9R R2: footnotes ---------------------------------------------------
 function resolveFootnotes(html, ctx) {
+  const placement = html.includes('\uE000fnplacement\uE001')
   const order = [] // labels by first reference
   const counts = new Map()
-  html = html.replace(/fn:(.*?)/g, (_, label) => {
+  const inlineNotes = [] // rendered content per anonymous note, by number
+  html = html.replace(/(fn|note):([\s\S]*?)\u0002(.*?)/g, (_, kind, payload, attrs) => {
+    if (kind === 'note') {
+      // an inline note draws a fresh number from the SAME sequence (R2)
+      order.push({ inline: inlineNotes.length })
+      inlineNotes.push(payload)
+      const n = order.length
+      return `<a id="fnref${n}" href="#fn${n}" role="doc-noteref"${attrs}><sup>${n}</sup></a>`
+    }
+    const label = payload
     if (!ctx.footnoteDefs.has(label)) return `[^${label}]` // unresolved -> literal
     let n = order.indexOf(label) + 1
     if (n === 0) {
@@ -275,16 +437,21 @@ function resolveFootnotes(html, ctx) {
     const k = (counts.get(label) ?? 0) + 1
     counts.set(label, k)
     const refId = k === 1 ? `fnref${n}` : `fnref${n}-${k}`
-    return `<a id="${refId}" href="#fn${n}" role="doc-noteref"><sup>${n}</sup></a>`
+    return `<a id="${refId}" href="#fn${n}" role="doc-noteref"${attrs}><sup>${n}</sup></a>`
   })
-  if (order.length === 0) return html
+  if (order.length === 0) return html.replace(/\uE000fnplacement\uE001\n?/g, '')
 
   const notes = order.map((label, idx) => {
     const n = idx + 1
-    const body = ctx.footnoteDefs.get(label)
-    let rendered = body
-      .map((b) => renderBlock(b, 3, ctx))
-      .join('\n')
+    let rendered
+    if (typeof label === 'object') {
+      rendered = `      <p>${inlineNotes[label.inline]}</p>`
+    } else {
+      const body = ctx.footnoteDefs.get(label)
+      rendered = body
+        .map((b) => renderBlock(b, 3, ctx))
+        .join('\n')
+    }
     // backlink into the LAST paragraph (PART 9 SS16); a k-th repeat
     // reference adds an indexed backlink `↩<sup>k</sup>`
     const total = counts.get(label) ?? 1
@@ -301,20 +468,24 @@ function resolveFootnotes(html, ctx) {
     }
     return `    <li id="fn${n}">\n${rendered}\n    </li>`
   })
-  return (
-    html +
-    `\n<section role="doc-endnotes">\n  <hr>\n  <ol>\n${notes.join('\n')}\n  </ol>\n</section>`
-  )
+  const section = `<section role="doc-endnotes">\n  <hr>\n  <ol>\n${notes.join('\n')}\n  </ol>\n</section>`
+  if (placement) return html.replace('\uE000fnplacement\uE001', section).replace(/\uE000fnplacement\uE001\n?/g, '')
+  return html + '\n' + section
 }
 
 // --- PART 9R R4: crossrefs ---------------------------------------------------
 function resolveCrossrefs(html, ctx) {
   return html.replace(/xref(text)?:(.*?)/g, (_, textOnly, id) => {
     const hit = ctx.headingIds.get(id.toLowerCase())
-    if (!hit) throw new Refuse(`unresolved crossref </#${id}>`)
+    if (!hit) {
+      const cap = ctx.captionIds.get(id.toLowerCase())
+      if (cap) return textOnly ? cap : `<a href="#${id}">${cap}</a>`
+      // unresolved: literal source text (PART 9 SS19)
+      return `&lt;/#${id}&gt;`
+    }
     // one-level resolution: nested sentinels in the cloned text flatten to
     // their literal source (PART 9R R4)
-    const text = hit.html.replace(/xref(?:text)?:(.*?)/g, '</#$1>')
+    const text = hit.html.replace(/xref(?:text)?:(.*?)/g, '')
     return textOnly ? text : `<a href="#${hit.id}">${text}</a>`
   })
 }

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -10,6 +10,10 @@
  * full-fidelity claim.
  */
 
+import { parseAttrList } from './render.mjs'
+
+export { TIER1 }
+
 export class Refuse extends Error {
   constructor(reason) {
     super(reason)
@@ -22,12 +26,12 @@ const HR = /^(-{3,}|\*{3,}|_{3,})[ \t]*$/
 const FENCE = /^(`{3,}|~{3,})(.*)$/
 const PURE_FENCE = /^(`{3,}|~{3,})[ \t]*$/
 const QUOTE = /^> ?(.*)$|^>$/
-const LINK_DEF = /^\[([^\]^@][^\]]*)\]:\s+(\S+)(?:\s+"((?:\\"|[^"])*)")?\s*$/
+const LINK_DEF = /^\[([^\]^@][^\]]*)\]:\s+(\S+)(?:\s+"((?:\\"|[^"])*)")?(?:\s.*)?$/
 const FOOTNOTE_DEF = /^\[\^([^\]]+)\]:\s*(.*)$/
 const ABBR_DEF = /^\*\[([^\]]+)\]:\s+(.+)$/
 const CAPTION = /^\^ (.*)$/
-const BULLET = /^([ \t]*)([-*]) (?:\[([ xX_>?-])\] )?(.+)$/
-const ORDERED = /^([ \t]*)([0-9]+|[a-z]+|[A-Z]+)([.)]) (.+)$/
+const BULLET = /^([ \t]*)([-*])(\{[^}]*\})? (?:\[([ xX_>?-])\] )?(.+)$/
+const ORDERED = /^([ \t]*)([0-9]+|[a-z]+|[A-Z]+)([.)])(\{[^}]*\})? (.+)$/
 const CONT_MARKER = /^\+[ \t]*$/
 // marks a lazily-folded line (PART 9 SS10 I2): always paragraph text, never
 // re-classified as structure when an item's content is re-parsed
@@ -35,11 +39,7 @@ export const LAZY = '\u0000L\u0000'
 
 // Lines that put the whole document out of the executable subset.
 const REFUSERS = [
-  [/^[ \t]*:::/, 'colon fence'],
-  [/^%{2,}/, 'comment'],
-  [/^\{/, 'block attribute line'],
   [/^\[@/, 'citation definition'],
-  [/^:[: ]/, 'definition list'],
 ]
 
 // PART 9 SS24 C1: visual column of the first non-indent character.
@@ -150,7 +150,53 @@ export function interruptingRow(line) {
   return splitRow(line) !== null
 }
 
-const CONT_ROW = /^\+[ \t]*\|.*\|[ \t]*$/ // strict: must close with a pipe
+const COLON_FENCE = /^(:{3,})(.*)$/
+const COLON_CLOSER = /^(:{3,})[ \t]*$/
+const TIER1 = new Set(['note', 'tip', 'warning', 'danger', 'info', 'success', 'example', 'quote'])
+
+// parse a `:::` opener tail (STRICT, PART 9 SS12): type word, optional
+// quoted title, optional [label]; a bare pipe / backslash selects the
+// line-block / hard-break block; anything else (inline attrs, digit-first
+// type, ...) makes the line an ordinary paragraph line. null = not a fence.
+function parseColonOpener(tail) {
+  let s = tail
+  const out = { type: null, title: null, label: null, mode: 'div' }
+  if (/^[ \t]*$/.test(s)) return out // bare generic div
+  s = s.replace(/^[ \t]+/, '')
+  if (/^\|[ \t]*$/.test(s)) return { ...out, mode: 'line-block' }
+  if (/^\\[ \t]*$/.test(s)) return { ...out, mode: 'hardbreaks' }
+  const ty = /^([A-Za-z_-][A-Za-z0-9_-]*)/.exec(s)
+  if (ty) {
+    out.type = ty[1]
+    s = s.slice(ty[0].length)
+  }
+  const qt = /^[ \t]+"([^"]*)"/.exec(s)
+  if (qt) {
+    out.title = qt[1]
+    s = s.slice(qt[0].length)
+  }
+  const lb = /^[ \t]*\[([^\]]*)\]/.exec(s)
+  if (lb) {
+    out.label = lb[1]
+    s = s.slice(lb[0].length)
+  }
+  if (!/^[ \t]*$/.test(s)) return null // trailing junk -> paragraph
+  if (!out.type && !out.title && out.label === null && tail.trim() !== '') return null
+  return out
+}
+
+function findColonCloser(lines, openIdx, len) {
+  for (let j = openIdx + 1; j < lines.length; j++) {
+    const c = COLON_CLOSER.exec(lines[j])
+    if (c && c[1].length >= len) return j
+  }
+  return -1
+}
+
+const COMMENT_LINE = /^[ \t]*%%(?!%)/
+const COMMENT_FENCE = /^[ \t]*(%{3,})[ \t]*$/
+
+const CONT_ROW = /^\+.*\|[ \t]*$/ // `+` replaces the leading pipe; must close with one
 const DELIM_CELL = /^[ \t]*:?-+:?[ \t]*$/
 
 // classify one raw cell segment
@@ -185,6 +231,62 @@ function parseCell(seg) {
   return cell
 }
 
+// PART 9 SS15: try to read one-or-more attribute blocks starting at
+// lines[i] (adjacent blocks on one line merge; one block may wrap lines; a
+// blank line inside the braces invalidates). Returns { lists, next } or null.
+function tryAttrLine(lines, i) {
+  let text = lines[i]
+  if (text === undefined || text[0] !== '{') return null
+  const lists = []
+  let pos = 0
+  let li = i
+  while (true) {
+    // skip whitespace
+    while (pos < text.length && (text[pos] === ' ' || text[pos] === '\t')) pos++
+    if (pos >= text.length) break
+    if (text[pos] !== '{') return null // trailing junk -> not an attr line
+    // find the matching close brace, possibly across lines; a `}` inside a
+    // quoted value is content, not the closer (corpus 64-6)
+    let buf = ''
+    let j = pos
+    let line = text
+    let found = false
+    while (!found) {
+      let inQuote = false
+      let close = -1
+      for (let k = j; k < line.length; k++) {
+        const ch = line[k]
+        if (ch === '\\' && inQuote) {
+          k++
+          continue
+        }
+        if (ch === '"') inQuote = !inQuote
+        else if (ch === '}' && !inQuote) {
+          close = k
+          break
+        }
+      }
+      if (close !== -1) {
+        buf += line.slice(j, close + 1)
+        pos = close + 1
+        text = line
+        found = true
+        break
+      }
+      buf += line.slice(j) + '\n'
+      li++
+      if (li >= lines.length || isBlank(lines[li])) return null // A5
+      line = lines[li]
+      j = 0
+    }
+    const list = parseAttrList(buf)
+    if (list === null) return null // A6: not an attribute list
+    lists.push(list)
+  }
+  if (lists.length === 0) return null
+  return { lists, next: li + 1 }
+}
+
 function isBlank(line) {
   return /^[ \t]*$/.test(line)
 }
@@ -204,10 +306,14 @@ export function parse(src) {
     footnoteDefs: new Map(),
     abbrDefs: new Map(),
   }
-  // frontmatter is out of the executable subset
-  if (lines[0] !== undefined && /^---/.test(lines[0])) {
-    for (let i = 1; i < lines.length; i++) {
-      if (/^---[ \t]*$/.test(lines[i])) throw new Refuse('frontmatter')
+  // frontmatter (PART 1): consumed; renders nothing. The closer-lookahead
+  // guard: with no closing --- the line is an ordinary thematic break.
+  if (lines[0] !== undefined && /^---(\s|[A-Za-z0-9]+\s*$|$)/.test(lines[0])) {
+    for (let j = 1; j < lines.length; j++) {
+      if (/^---[ \t]*$/.test(lines[j])) {
+        lines.splice(0, j + 1)
+        break
+      }
     }
   }
   const blocks = parseBlocks(lines, state, true)
@@ -225,11 +331,24 @@ function parseBlocks(lines, state, top, inItem = false) {
     if (line === undefined) return false
     if (startsVisibleBlock(line)) return true
     if (interruptingRow(line)) return true
+    {
+      const cf = COLON_FENCE.exec(line)
+      if (cf && parseColonOpener(cf[2]) && findColonCloser(lines, idx, cf[1].length) !== -1) return true
+    }
     const fence = FENCE.exec(line)
     if (fence && hasCloser(lines, idx)) return true // I4
     if (LINK_DEF.test(line) || FOOTNOTE_DEF.test(line) || ABBR_DEF.test(line)) return true // I5
     return false
   }
+
+  const pending = [] // PART 9 SS15: collected attribute lists, float forward
+  const flushAttrs = (node) => {
+    if (pending.length) {
+      node.battrs = (node.battrs ?? []).concat(pending.splice(0))
+    }
+    return node
+  }
+  const push = (node) => blocks.push(flushAttrs(node))
 
   while (i < n) {
     const line = lines[i]
@@ -237,8 +356,38 @@ function parseBlocks(lines, state, top, inItem = false) {
       i++
       continue
     }
+    if (line[0] === '{') {
+      const al = tryAttrLine(lines, i)
+      if (al) {
+        pending.push(...al.lists) // A1/A2: collect, render nothing
+        i = al.next
+        continue
+      }
+      // not a valid attribute line: ordinary paragraph content (A6)
+    }
     for (const [re, what] of REFUSERS) {
       if (re.test(line)) throw new Refuse(what)
+    }
+
+    // --- comments (SS21; invisible) ---
+    {
+      const cfm = COMMENT_FENCE.exec(line)
+      if (cfm) {
+        // %%% block: consumed to the EXACT-length closer (the `where`
+        // guard: len(close) = len(open); corpus 91 nested fences)
+        let j = i + 1
+        for (; j < n; j++) {
+          const c = COMMENT_FENCE.exec(lines[j])
+          if (c && c[1].length === cfm[1].length) break
+        }
+        if (j >= n) throw new Refuse('unterminated comment block')
+        i = j + 1
+        continue
+      }
+      if (COMMENT_LINE.test(line)) {
+        i++
+        continue
+      }
     }
 
     // --- definitions (invisible blocks; PART 9 SS10 I5, PART 9R pass 1) ---
@@ -290,25 +439,34 @@ function parseBlocks(lines, state, top, inItem = false) {
 
     // --- headings ---
     if ((m = HEADING.exec(line))) {
-      if (!top) throw new Refuse('heading inside a container')
       const level = m[1].length
-      const text = m[2].replace(/[ \t]+$/, '')
-      const next = lines[i + 1]
-      if (next !== undefined && !isBlank(next)) {
-        const nm = HEADING.exec(next)
-        if (nm && nm[1].length === level) throw new Refuse('multi-line heading folding')
-        if (!nm && !HR.test(next) && !FENCE.test(next) && !QUOTE.test(next) && !BULLET.test(next) && !ORDERED.test(next)) {
-          throw new Refuse('heading continuation line')
-        }
-      }
-      blocks.push({ t: 'heading', level, text })
+      const strip = (s) => s.replace(/(^|[ \t])%%(?!%).*$/, '').replace(/[ \t]+$/, '')
+      const parts = [strip(m[2])]
       i++
+      // MULTI-LINE HEADINGS (PART 2): a same-# marker line or a plain text
+      // line folds into the heading; a blank line or any block opener ends it
+      while (i < n && !isBlank(lines[i])) {
+        const cm = HEADING.exec(lines[i])
+        if (cm && cm[1].length === level) {
+          parts.push(strip(cm[2]))
+          i++
+          continue
+        }
+        if (cm) break // different # count: a new heading
+        const l = lines[i]
+        if (HR.test(l) || FENCE.test(l) || QUOTE.test(l) || BULLET.test(l) || ORDERED.test(l) ||
+            COLON_FENCE.test(l) || CAPTION.test(l) || l[0] === '|' || l[0] === '{' ||
+            COMMENT_LINE.test(l) || COMMENT_FENCE.test(l)) break
+        parts.push(strip(l))
+        i++
+      }
+      push({ t: 'heading', level, text: parts.join('\n') })
       continue
     }
 
     // --- thematic break (before bullets: `- x` vs `---`) ---
     if (HR.test(line)) {
-      blocks.push({ t: 'hr' })
+      push({ t: 'hr' })
       i++
       continue
     }
@@ -316,14 +474,99 @@ function parseBlocks(lines, state, top, inItem = false) {
     // --- fenced code ---
     if ((m = FENCE.exec(line))) {
       const run = m[1]
-      const info = m[2].trim()
-      if (info && !/^[A-Za-z0-9\-_+#./]+$/.test(info)) throw new Refuse('fence info beyond a language token')
-      if (info.startsWith('=')) throw new Refuse('raw block')
-      const close = findCloser(lines, i, run)
-      if (close === -1) throw new Refuse('unterminated fence')
-      blocks.push({ t: 'code', lang: info, text: lines.slice(i + 1, close).join('\n') + (close > i + 1 ? '\n' : '') })
-      i = close + 1
+      const info = parseFenceInfo(m[2])
+      if (info && info.lang.startsWith('=')) {
+        const close = findCloser(lines, i, run)
+        if (close !== -1) {
+          push({ t: 'raw', format: info.lang.slice(1), text: lines.slice(i + 1, close).join('\n') })
+          i = close + 1
+          continue
+        }
+      }
+      const close = info ? findCloser(lines, i, run) : -1
+      if (close !== -1) {
+        const node = {
+          t: 'code',
+          lang: info.lang,
+          title: info.title,
+          text: lines.slice(i + 1, close).join('\n') + (close > i + 1 ? '\n' : ''),
+        }
+        i = close + 1
+        let j = i
+        if (j < n && isBlank(lines[j] ?? '') && CAPTION.test(lines[j + 1] ?? '')) j++
+        const cap = j < n && lines[j] !== undefined ? CAPTION.exec(lines[j]) : null
+        if (cap) {
+          node.caption = cap[1] // a captioned code block is a LISTING (SS4)
+          i = j + 1
+        }
+        push(node)
+        continue
+      }
+      if (info) {
+        // valid opener, no closer: at BLOCK START the code runs to the end
+        // of the container (oracle-verified; corpus 80)
+        push({
+          t: 'code',
+          lang: info.lang,
+          title: info.title,
+          text: lines.slice(i + 1).join('\n') + '\n',
+        })
+        i = n
+        continue
+      }
+      // INVALID-FENCE FALLBACK: ordinary paragraph text (the backtick run
+      // becomes an inline verbatim span)
+    }
+
+    // --- definition lists (:: term / :  def) ---
+    if (/^::?[ ]/.test(line) && !/^:::/.test(line)) {
+      const node = { t: 'deflist', items: [] }
+      while (i < n) {
+        let dm
+        if ((dm = /^:: (.*)$/.exec(lines[i] ?? ''))) node.items.push({ dt: dm[1].trim() })
+        else if ((dm = /^: {2}(.*)$/.exec(lines[i] ?? ''))) node.items.push({ dd: dm[1].trim() })
+        else break
+        i++
+      }
+      if (node.items.length === 0) throw new Refuse('malformed definition list')
+      push(node)
       continue
+    }
+
+    // --- colon fences: admonitions / divs / line block / hard-break block
+    // (PART 9 SS12, SS23) ---
+    {
+      const cf = COLON_FENCE.exec(line)
+      if (cf) {
+        const opener = parseColonOpener(cf[2])
+        const close = opener ? findColonCloser(lines, i, cf[1].length) : -1
+        if (opener && close !== -1) {
+          const body = lines.slice(i + 1, close)
+          i = close + 1
+          if (opener.mode === 'line-block') {
+            push({ t: 'line-block', lines: body })
+          } else if (opener.mode === 'hardbreaks') {
+            push({ t: 'hardbreaks', children: parseBlocks(body, state, false) })
+          } else if (opener.type === 'footnotes') {
+            // placement directive: relocates the endnotes section
+            if (body.some((l) => !isBlank(l))) throw new Refuse('non-empty ::: footnotes body')
+            push({ t: 'footnotes-placement' })
+          } else if (opener.type === 'toc') {
+            throw new Refuse('::: toc directive')
+          } else {
+            push({
+              t: 'colon-div',
+              type: opener.type,
+              title: opener.title,
+              label: opener.label,
+              children: parseBlocks(body, state, false),
+            })
+          }
+          continue
+        }
+        // invalid opener or no closer: ordinary paragraph text (falls
+        // through to the paragraph collector)
+      }
     }
 
     // --- tables (PART 9 SS5) ---
@@ -334,10 +577,11 @@ function parseBlocks(lines, state, top, inItem = false) {
         if (l === undefined || isBlank(l)) break
         if (CONT_ROW.test(l)) {
           // T6: continuation row - joins per column onto the row above
-          const sr = splitRow(l.replace(/^\+[ \t]*/, '|'))
+          const sr = splitRow('|' + l.slice(1))
           if (!sr) break
           if (node.rows.length === 0) throw new Refuse('table begins with a continuation row')
           const prev = node.rows[node.rows.length - 1]
+          if (prev.cells.every((c) => c.header)) break // needs a BODY row (corpus 113)
           sr.cells.forEach((seg, ci) => {
             const add = seg.trim()
             const cell = prev.cells[ci]
@@ -395,21 +639,41 @@ function parseBlocks(lines, state, top, inItem = false) {
         node.caption = cap[1]
         i = j + 1
       }
-      blocks.push(node)
+      push(node)
       continue
     }
-    if (CONT_ROW.test(line)) throw new Refuse('continuation row outside a table')
+    // a stray `+ ... |` line is ordinary paragraph text (corpus 113)
 
     // --- block quote ---
     if (QUOTE.test(line)) {
       const inner = []
+      let openFence = null // run string of a fence opened inside the quote
+      let prevBlank = true // fences open only at BLOCK START (I4 otherwise)
+      let qOpenPara = false // does the quote currently end in an open paragraph?
+      const trackFence = (l) => {
+        if (openFence) {
+          const c = PURE_FENCE.exec(l)
+          if (c && c[1][0] === openFence[0] && c[1].length >= openFence.length) openFence = null
+          qOpenPara = false
+          return
+        }
+        const f = FENCE.exec(l)
+        const isOpener = !!(f && prevBlank && parseFenceInfo(f[2]))
+        if (isOpener) openFence = f[1]
+        prevBlank = isBlank(l)
+        if (isBlank(l) || HEADING.test(l) || HR.test(l) || isOpener ||
+            COLON_FENCE.test(l) || l[0] === '|' || l[0] === '{') qOpenPara = false
+        else qOpenPara = true
+      }
       while (i < n) {
         const qm = /^> ?(.*)$/.exec(lines[i])
         if (qm) {
           inner.push(qm[1])
+          trackFence(qm[1])
           i++
           continue
         }
+        if (openFence) break // the innermost open block is verbatim (S2)
         if (lines[i] !== undefined && CONT_MARKER.test(lines[i])) {
           // PART 9 SS17 L4: `+` at column 0 attaches ONE following block
           i++
@@ -420,7 +684,7 @@ function parseBlocks(lines, state, top, inItem = false) {
           i = attached.next
           continue
         }
-        if (lines[i] !== undefined && !isBlank(lines[i]) && !peekInterrupts(i) && !CAPTION.test(lines[i])) {
+        if (lines[i] !== undefined && qOpenPara && !isBlank(lines[i]) && !peekInterrupts(i) && !CAPTION.test(lines[i])) {
           // lazy continuation folds into the open quoted paragraph (SS10 I6)
           inner.push(lines[i])
           i++
@@ -438,15 +702,15 @@ function parseBlocks(lines, state, top, inItem = false) {
         node.caption = cap[1]
         i = j + 1
       }
-      blocks.push(node)
+      push(node)
       continue
     }
 
     // --- lists ---
-    const bulletM = BULLET.exec(line)
-    const orderedM = !bulletM && ORDERED.exec(line)
-    if (bulletM || orderedM) {
+    if (matchMarker(line)) {
+      const before = blocks.length
       i = parseListRun(lines, i, blocks, state, peekInterrupts)
+      if (pending.length && blocks.length > before) flushAttrs(blocks[before])
       continue
     }
 
@@ -460,7 +724,6 @@ function parseBlocks(lines, state, top, inItem = false) {
       }
       throw new Refuse('stray continuation marker')
     }
-    if (CAPTION.test(line)) throw new Refuse('caption with no attachable block')
 
     // --- paragraph ---
     const para = []
@@ -473,7 +736,9 @@ function parseBlocks(lines, state, top, inItem = false) {
       for (const [re, what] of REFUSERS) {
         if (re.test(lines[i])) throw new Refuse(`${what} interrupting a paragraph`)
       }
-      if (CAPTION.test(lines[i])) break // a caption ends the block (SS4)
+      if (para.length > 0 && CAPTION.test(lines[i])) break // a caption ends the block (SS4); an orphan `^ ` line is literal text
+      if (lines[i][0] === '{' && tryAttrLine(lines, i)) break // SS15 A1 / SS10 I5
+      if (COMMENT_LINE.test(lines[i]) || COMMENT_FENCE.test(lines[i])) break // SS10 I5
       if (inItem && CONT_MARKER.test(lines[i])) break // SS17 L4
       if (inItem && para.length > 0 && matchMarker(lines[i])) break // SS24 C3
       if (para.length > 0) {
@@ -481,11 +746,12 @@ function parseBlocks(lines, state, top, inItem = false) {
         if (LINK_DEF.test(lines[i]) || FOOTNOTE_DEF.test(lines[i]) || ABBR_DEF.test(lines[i])) break
         if (startsVisibleBlock(lines[i])) break // I1
         if (interruptingRow(lines[i])) break // I1: valid table row
-        const f = FENCE.exec(lines[i])
-        if (f) {
-          if (hasCloser(lines, i)) break // I4: interrupts
-          throw new Refuse('unterminated fence inside a paragraph')
+        {
+          const cf = COLON_FENCE.exec(lines[i])
+          if (cf && parseColonOpener(cf[2]) && findColonCloser(lines, i, cf[1].length) !== -1) break // I1/I4
         }
+        const f = FENCE.exec(lines[i])
+        if (f && parseFenceInfo(f[2]) && hasCloser(lines, i)) break // I4: interrupts
       }
       para.push(lines[i].replace(/^[ \t]+/, '').replace(/[ \t]+$/, ''))
       i++
@@ -496,14 +762,14 @@ function parseBlocks(lines, state, top, inItem = false) {
     if (j < n && isBlank(lines[j] ?? '') && CAPTION.test(lines[j + 1] ?? '')) j++
     const cap = j < n && lines[j] !== undefined ? CAPTION.exec(lines[j]) : null
     if (cap) {
-      if (para.length === 1 && /^!\[[^\]]*\]\([^)]*\)$/.test(para[0])) {
+      if (para.length === 1 && (/^!\[[^\]]*\]\([^)]*\)(\{[^}]*\})?$/.test(para[0]) || /^\$\$`.*`$/.test(para[0]))) {
         pnode.caption = cap[1]
         i = j + 1
-      } else {
-        throw new Refuse('caption after a non-captionable block')
       }
+      // a caption after a non-captionable block stays literal paragraph
+      // text (handled by the paragraph collector on the next pass)
     }
-    blocks.push(pnode)
+    push(pnode)
   }
   return blocks
 }
@@ -519,10 +785,36 @@ function findCloser(lines, openIdx, run) {
   for (let j = openIdx + 1; j < lines.length; j++) {
     const c = PURE_FENCE.exec(lines[j])
     if (!c || c[1][0] !== ch) continue
-    if (c[1].length < run.length) throw new Refuse('fence closer shorter than opener') // the `where` guard
+    if (c[1].length < run.length) continue // shorter run: content (the `where` guard)
     return j
   }
   return -1
+}
+
+// CODE-FENCE INFO STRING (PART 2): language token, then an optional quoted
+// "header", then an optional [label], in that fixed order. Returns
+// { lang, title, label } or null on any other shape (INVALID-FENCE
+// FALLBACK: the line is not a fence).
+function parseFenceInfo(raw) {
+  let s = raw.trim()
+  const out = { lang: '', title: null, label: null }
+  const lm = /^([A-Za-z0-9\-_+#.=/]+)/.exec(s)
+  if (lm) {
+    out.lang = lm[1]
+    s = s.slice(lm[0].length)
+  }
+  const tm = /^[ \t]*"([^"]*)"/.exec(s)
+  if (tm) {
+    out.title = tm[1]
+    s = s.slice(tm[0].length)
+  }
+  const lb = /^[ \t]*\[([^\]]*)\]/.exec(s)
+  if (lb) {
+    out.label = lb[1]
+    s = s.slice(lb[0].length)
+  }
+  if (!/^[ \t]*$/.test(s)) return null
+  return out
 }
 
 // Parse ONE following flush-left block (for the `+` continuation marker).
@@ -562,18 +854,21 @@ function parseListRun(lines, i, blocks, state, peekInterrupts) {
 function matchMarker(line) {
   if (line === undefined) return null
   let m = BULLET.exec(line)
+  if (m && m[3] && m[3].replace(/[{} ]/g, '') !== '' && parseAttrList(m[3]) === null) m = null
   if (m) {
     const { col } = indentCols(m[1])
     return {
       indent: col,
       bullet: m[2],
-      task: m[3],
-      text: m[4],
+      attrs: m[3] ?? null, // marker-glued item attribute block (SS15 ext)
+      task: m[4],
+      text: m[5],
       // the task box is item CONTENT, not marker (PART 9 SS24 C3)
       markerWidth: m[2].length + 1,
     }
   }
   m = ORDERED.exec(line)
+  if (m && m[4] && m[4].replace(/[{} ]/g, '') !== '' && parseAttrList(m[4]) === null) m = null
   if (m) {
     const { col } = indentCols(m[1])
     const dialects = classifyOrdered(m[2])
@@ -582,8 +877,9 @@ function matchMarker(line) {
       indent: col,
       ordered: m[2],
       delim: m[3],
+      attrs: m[4] ?? null,
       dialects,
-      text: m[4],
+      text: m[5],
       markerWidth: m[2].length + m[3].length + 1,
     }
   }
@@ -616,6 +912,7 @@ function collectItems(lines, i, list, state) {
     const contentCol = head.indent + head.markerWidth
     const itemLines = [head.text]
     const item = { }
+    if (head.attrs && head.attrs.replace(/[{} ]/g, '') !== '') item.attrs = head.attrs
     if (list.task) item.checked = /^[xX]$/.test(head.task)
     let openPara = true // the marker line's text opens the item paragraph
     i++
@@ -665,8 +962,9 @@ function collectItems(lines, i, list, state) {
         const { col } = indentCols(lines[j])
         const nm = matchMarker(lines[j])
         if (nm && nm.indent === baseIndent) {
-          // blank line between items -> loose (SS17 L1)
-          list.tight = false
+          // blank line between ITEMS of this list -> loose (SS17 L1); a
+          // following DIFFERENT list is a sibling and loosens nothing
+          if (sameAxes(list, nm)) list.tight = false
           i = j
           break
         }
@@ -704,7 +1002,7 @@ function collectItems(lines, i, list, state) {
         // does the deepest structure now hold an OPEN paragraph that lazy
         // text may fold into? markers open a sub-item paragraph; quotes an
         // open quoted paragraph; fences/breaks close everything (SS10 I2/I6)
-        if (FENCE.test(dedented) || HR.test(dedented)) openPara = false
+        if (FENCE.test(dedented) || HR.test(dedented) || COLON_FENCE.test(dedented)) openPara = false
         else if (dedented[0] === '|' || CONT_ROW.test(dedented)) openPara = false
         else if (matchMarker(dedented) || QUOTE.test(dedented)) openPara = true
         else if (!isBlank(dedented)) openPara = true
@@ -719,7 +1017,7 @@ function collectItems(lines, i, list, state) {
         i++
         continue
       }
-      if (!nm && openPara && itemLines.length > 0 && !startsVisibleBlock(line) && !interruptingRow(line)) {
+      if (!nm && openPara && itemLines.length > 0 && !startsVisibleBlock(line) && !interruptingRow(line) && !COLON_FENCE.test(line)) {
         // lazy fold into the open item paragraph (SS10 I2 / SS24 C3)
         itemLines.push(LAZY + line.replace(/^[ \t]+/, ''))
         i++

--- a/scripts/spec/render.mjs
+++ b/scripts/spec/render.mjs
@@ -24,7 +24,7 @@ const escapeHtml = (s) =>
     .replaceAll('>', '&gt;')
     .replaceAll(' ', '&nbsp;')
 
-export const escapeAttr = (s) => escapeHtml(s).replaceAll('"', '&quot;')
+export const escapeAttr = (s) => escapeHtml(s).replaceAll('"', '&quot;').replaceAll("'", '&apos;')
 
 // PART 9 SS25: URL sink scheme denylist -- a denylisted scheme renders an
 // EMPTY value. Scheme detection first strips ASCII controls and ALL Unicode
@@ -45,8 +45,9 @@ export function checkUrl(url) {
 // ---------------------------------------------------------------------------
 // Inline semantics
 function spanOp(tag) {
-  return function (_open, inner, _close) {
-    return `<${tag}>${inner.children.map((c) => c.h()).join('')}</${tag}>`
+  return function (_open, inner, _close, attrs) {
+    const a = renderAttrs(attrsOf(attrs))
+    return `<${tag}${a}>${inner.children.map((c) => c.h()).join('')}</${tag}>`
   }
 }
 function codeText(content) {
@@ -151,8 +152,9 @@ const sem = g.createSemantics().addOperation('h', {
   inlines(items) {
     return items.children.map((c) => c.h()).join('')
   },
-  boldItalic(_o, inner, _c) {
-    return `<strong><em>${inner.children.map((c) => c.h()).join('')}</em></strong>`
+  boldItalic(_o, inner, _c, attrs) {
+    const a = renderAttrs(attrsOf(attrs))
+    return `<strong${a}><em>${inner.children.map((c) => c.h()).join('')}</em></strong>`
   },
   emph: spanOp('em'),
   strong: spanOp('strong'),
@@ -164,26 +166,50 @@ const sem = g.createSemantics().addOperation('h', {
   code1: codeOp,
   code2: codeOp,
   code3: codeOp,
-  mathI(_d, code) {
-    // `code` is the alternation node; its sole child is codeN(_o,content,_c)
-    return `<span class="math inline">\\(${escapeHtml(codeText(code.child(0).child(1)))}\\)</span>`
+  codeU(_o, _r, content) {
+    // unclosed run: verbatim to end of block, trailing whitespace stripped,
+    // NO single-space strip
+    return `<code>${escapeHtml(content.sourceString.replace(/\s+$/, ''))}</code>`
   },
-  mathD(_d, code) {
-    return `<span class="math display">\\[${escapeHtml(codeText(code.child(0).child(1)))}\\]</span>`
+  nl(_n) {
+    return '\n'
+  },
+  codeA(alt) {
+    return alt.h()
+  },
+  codeAttrd(code, attrs) {
+    const a = renderAttrs(attrsOf(attrs))
+    if (a === '') return code.h()
+    return code.h().replace('<code>', `<code${a}>`)
+  },
+  mathI(_d, code, attrs) {
+    // `code` is the alternation node; its sole child is codeN(_o,content,_c)
+    return mathSpan('inline', code, attrs)
+  },
+  mathD(_d, code, attrs) {
+    return mathSpan('display', code, attrs)
   },
   crossref(_o, id, _c) {
     return `xref:${id.sourceString}`
   },
-  footnoteRef(_o, label, _c) {
-    return `fn:${label.sourceString}`
+  footnoteRef(_o, label, _c, attrs) {
+    const a = renderAttrs(attrsOf(attrs))
+    return `fn:${label.sourceString}\u0002${a}`
   },
-  inlineNote(_o, content, _c) {
-    throw new Refuse('inline footnote (out of the executable subset)')
+  inlineNote(_o, content, _c, attrs) {
+    // anonymous note: content renders now; numbering happens in PART 9R.
+    // Footnote/crossref recognition is DISABLED inside a note (SS16); a
+    // nested sentinel would also break the sentinel framing, so refuse.
+    const inner = renderInline(content.sourceString, '[')
+    if (inner.includes('\uE000')) throw new Refuse('nested construct in an inline note')
+    if (content.sourceString.trim() === '') throw new Refuse('empty inline note')
+    const a = renderAttrs(attrsOf(attrs))
+    return `\uE000note:${inner}\u0002${a}\uE001`
   },
   bracketed(_o, content, _c, tail) {
     // link text is FULL inline content; parse the raw source recursively
     const raw = content.sourceString
-    let inner = raw === '' ? '' : renderInline(raw)
+    let inner = raw === '' ? '' : renderInline(raw, '[')
     if (tail.numChildren === 0) {
       // bare bracketed run: literal (PART 9 SS14), content still parsed
       return `[${inner}]`
@@ -207,6 +233,91 @@ const sem = g.createSemantics().addOperation('h', {
   },
   escape(_bs, ch) {
     return escapeHtml(ch.sourceString)
+  },
+  nbspEsc(_bs, _sp) {
+    return '&nbsp;'
+  },
+  hardBreak(_bs, _la) {
+    return '<br>'
+  },
+  mention(_a, name) {
+    return `<span class="mention"><strong>@${escapeHtml(name.sourceString)}</strong></span>`
+  },
+  tag(_h, name) {
+    return `<span class="tag"><strong>#${escapeHtml(name.sourceString)}</strong></span>`
+  },
+  forcedSpan(f) {
+    return f.h()
+  },
+  forced(_ob, d, inner, _d2, _cb, attrs) {
+    const tag = { '/': 'em', '*': 'strong', _: 'u', '~': 's', '^': 'sup', ',': 'sub', '=': 'mark' }[d.sourceString]
+    const a = renderAttrs(attrsOf(attrs))
+    return `<${tag}${a}>${inner.children.map((c) => c.h()).join('')}</${tag}>`
+  },
+  edIns(_o, content, _c, attrs) {
+    return `<ins${renderAttrs(attrsOf(attrs))}>${renderInline(content.sourceString, '{')}</ins>`
+  },
+  edDel(_o, content, _c, attrs) {
+    return `<del${renderAttrs(attrsOf(attrs))}>${renderInline(content.sourceString, '{')}</del>`
+  },
+  edSub(_o, oldC, _ar, newC, _c, attrs) {
+    const a = renderAttrs(attrsOf(attrs))
+    return `<del${a}>${renderInline(oldC.sourceString, '{')}</del><ins${a}>${renderInline(newC.sourceString, '{')}</ins>`
+  },
+  edComment(_o, content, _c, attrs) {
+    // comment content is verbatim (spaces preserved)
+    return `<span class="critic-comment"${renderAttrs(attrsOf(attrs))}>${escapeHtml(content.sourceString)}</span>`
+  },
+  rawInline(code, _ob, fmt, _cb) {
+    // PART 9 SS20: emitted UNESCAPED for the html format, dropped otherwise
+    const text = codeText(code.child(0).child(1))
+    return fmt.sourceString === 'html' ? text : ''
+  },
+  extension(_c, name, _o, content, _cl, attrs) {
+    const n = name.sourceString
+    const inner = renderInline(content.sourceString, '[')
+    const extra = attrsOf(attrs).filter((a) => a[0] === 'class').map((a) => a[1])
+    const rest = attrsOf(attrs).filter((a) => a[0] !== 'class')
+    // the kbd extension renders its own element (attrs apply to it);
+    // everything else is the generic ext-<name> span
+    if (n === 'kbd') {
+      const cls = extra.length ? ` class="${escapeAttr(extra.join(' '))}"` : ''
+      return `<kbd${cls}${renderAttrs(rest)}>${inner}</kbd>`
+    }
+    const cls = [`ext-${n}`, ...extra].join(' ')
+    return `<span class="${cls}"${renderAttrs(rest)}>${inner}</span>`
+  },
+  spComment(_sp, _pp, _rest) {
+    return ''
+  },
+  arrow(tok) {
+    return { '<->': '\u2194', '->': '\u2192', '<-': '\u2190', '=>': '\u21d2', '!=': '\u2260', '<=': '\u2264', '>=': '\u2265', '+-': '\u00b1' }[tok.sourceString]
+  },
+  symbol(tok) {
+    return { '(c)': '\u00a9', '(r)': '\u00ae', '(tm)': '\u2122' }[tok.sourceString]
+  },
+  ellipsis(_e) {
+    return '\u2026'
+  },
+  dashRun(_a, _b) {
+    // PART 9 SS8: a run of n hyphens -> em/en dash mix (djot algorithm):
+    // n%3==0 all em; n%2==0 all en; else one em + (n-3)/2 en
+    const n = this.sourceString.length
+    if (n % 3 === 0) return '\u2014'.repeat(n / 3)
+    if (n % 2 === 0) return '\u2013'.repeat(n / 2)
+    return '\u2014' + '\u2013'.repeat((n - 3) / 2)
+  },
+  dquote(_q) {
+    return smartQuote(this, '\u201c', '\u201d', false)
+  },
+  squote(_q) {
+    return smartQuote(this, '\u2018', '\u2019', true)
+  },
+  hash(_h, _la) {
+    return '#'
+  },
+  looseAttrs(a) {
+    return escapeHtml(a.sourceString) // standalone block is literal text
   },
   word(first, rest) {
     return escapeHtml(this.sourceString)
@@ -242,11 +353,21 @@ sem.addOperation('applyTail(text)', {
     const { text } = this.args
     return `<span${renderAttrs(this.parseAttrs())}>${text}</span>`
   },
+  emptyAttrs(_o, _sp, _c) {
+    const { text } = this.args
+    return `<span>${text}</span>`
+  },
 })
 
 sem.addOperation('titleText', {
   destTitle(_sp, q) {
-    return q.parseAttrs() // quoted -> unescaped string
+    return q.titleText()
+  },
+  quoted(_o, chars, _c) {
+    return chars.children.map((c) => c.sourceString.replace(/^\\/, '')).join('')
+  },
+  squoted(_o, chars, _c) {
+    return chars.children.map((c) => c.sourceString.replace(/^\\/, '')).join('')
   },
 })
 // reuse parseAttrs for quoted strings
@@ -277,6 +398,9 @@ sem.addOperation('parseAttrs', {
   },
   quoted(_o, chars, _c) {
     return chars.children.map((c) => c.parseAttrs()).join('')
+  },
+  squoted(_o, chars, _c) {
+    return chars.children.map((c) => c.sourceString.replace(/^\\/, '')).join('')
   },
   qChar(c) {
     return c.parseAttrs()
@@ -343,6 +467,33 @@ function overlapScan(text) {
   return false
 }
 
+// math attrs merge into the base `math inline|display` class (PART 9 SS18);
+// key/value and boolean attributes go through the SAME hardening path as
+// every other carrier (PART 9 SS25)
+function mathSpan(kind, code, attrs) {
+  const wrap = kind === 'inline' ? ['\\(', '\\)'] : ['\\[', '\\]']
+  const list = attrsOf(attrs)
+  const classes = ['math', kind, ...list.filter((a) => a[0] === 'class').map((a) => a[1])]
+  let rest = ''
+  for (const a of list) {
+    if (a[0] === 'id') rest += ` id="${escapeAttr(a[1])}"`
+    else if (a[0] === 'kv') {
+      const h = hardenAttr(a[1], a[2])
+      if (h) rest += ` ${a[1]}="${escapeAttr(h.value)}"`
+    } else if (a[0] === 'bool') {
+      if (hardenAttr(a[1], '')) rest += ` ${a[1]}=""`
+    }
+  }
+  const inner = code.child(0)
+  // codeU (unclosed run) carries its content in a different child slot
+  const body = escapeHtml(
+    inner.ctorName === 'codeU'
+      ? inner.child(2).sourceString.replace(/\s+$/, '')
+      : codeText(inner.child(1))
+  )
+  return `<span class="${classes.join(' ')}"${rest}>${wrap[0]}${body}${wrap[1]}</span>`
+}
+
 // parse a standalone `{...}` attribute block (table row/cell attrs);
 // returns the serialized attribute string or null when invalid
 export function parseAttrBlock(text) {
@@ -351,7 +502,80 @@ export function parseAttrBlock(text) {
   return renderAttrs(attrSem(m).parseAttrs())
 }
 
-export function renderInline(text) {
+// raw parsed attr list ([kind, name, value?] tuples) or null when invalid
+export function parseAttrList(text) {
+  const m = g.match(text, 'attrs')
+  if (m.failed()) return null
+  return attrSem(m).parseAttrs()
+}
+
+// PART 9 SS15 A3 merge for BLOCK attribute lines: first-appearance position,
+// last value wins for id/key, classes ACCUMULATE in source order (no dedup)
+export function renderBlockAttrs(lists) {
+  const parts = []
+  const classes = []
+  let classAt = -1
+  const seen = new Map()
+  for (const list of lists) {
+    for (const a of list) {
+      if (a[0] === 'class') {
+        if (classAt === -1) {
+          classAt = parts.length
+          parts.push(null)
+        }
+        classes.push(a[1])
+      } else if (a[0] === 'id') {
+        if (seen.has('#id')) parts[seen.get('#id')] = ` id="${escapeAttr(a[1])}"`
+        else {
+          seen.set('#id', parts.length)
+          parts.push(` id="${escapeAttr(a[1])}"`)
+        }
+      } else if (a[0] === 'kv') {
+        const h = hardenAttr(a[1], a[2])
+        if (!h) continue
+        if (seen.has(a[1])) parts[seen.get(a[1])] = ` ${a[1]}="${escapeAttr(h.value)}"`
+        else {
+          seen.set(a[1], parts.length)
+          parts.push(` ${a[1]}="${escapeAttr(h.value)}"`)
+        }
+      } else {
+        if (!hardenAttr(a[1], '')) continue
+        parts.push(` ${a[1]}=""`)
+      }
+    }
+  }
+  if (classAt !== -1) parts[classAt] = ` class="${escapeAttr(classes.join(' '))}"`
+  return parts.join('')
+}
+
+// quote-context decision (PART 9 SS8): OPENING after whitespace or an
+// opening context character; CLOSING otherwise (incl. start of input -
+// corpus 37-3 pins a line-initial pair as two closers). A single quote
+// directly before a digit is always an apostrophe ('70s, '24).
+const QUOTE_OPEN_PREV = new Set([' ', '\t', '=', ':', '-', '/', '(', '[', '{'])
+function smartQuote(node, open, close, single) {
+  const src = node.source.sourceString
+  const at = node.source.startIdx
+  const prev = at > 0 ? src[at - 1] : quotePrevCtx
+  const next = src[at + 1] ?? ''
+  if (single && /[0-9]/.test(next) && !/[\p{L}\p{N}]/u.test(prev)) return close // apostrophe
+  if (QUOTE_OPEN_PREV.has(prev) && prev !== '') return open
+  return close
+}
+
+let quotePrevCtx = '' // preceding character for recursive inline parses
+
+export function renderInline(text, prevCtx = '') {
+  const saved = quotePrevCtx
+  quotePrevCtx = prevCtx
+  try {
+    return renderInlineInner(text)
+  } finally {
+    quotePrevCtx = saved
+  }
+}
+
+function renderInlineInner(text) {
   if (overlapScan(text)) throw new Refuse('overlapping emphasis (delimiter-stack close-first rule)')
   const m = g.match(text, 'inlines')
   if (m.failed()) throw new Refuse(`inline: ${m.shortMessage}`)
@@ -369,7 +593,7 @@ export function makeSlugger() {
       .replace(/[\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e\s]+/g, '-')
       .replace(/^-+|-+$/g, '')
     if (slug === '') slug = 's'
-    else if (/^[0-9]/.test(slug)) slug = `s-${slug}`
+    else if (/^\p{N}/u.test(slug)) slug = `s-${slug}`
     const n = seen.get(slug) ?? 0
     seen.set(slug, n + 1)
     return n === 0 ? slug : `${slug}-${n + 1}`


### PR DESCRIPTION
Completes the executable spec: the gate now demands - and gets - **byte-identical HTML for all 388 conformance-corpus pairs**, zero refusals, zero divergence defects.

## Coverage added

| Layer | New |
|---|---|
| Layout automaton | colon fences (two-tier admonitions, quoted titles, `[label]`, generic divs, line blocks, hard-break blocks, `::: footnotes` placement), block-attribute lines (full collect/float/merge semantics, quote-aware multi-line scan), definition lists, comments (line + exact-length block fences), frontmatter, code-fence header/label info, raw blocks, multi-line heading folding, headings in containers, captioned code/math figures (numbered LISTING/EQUATION), block-start unterminated fences |
| Inline grammar | forced intraword spans, editorial markup, inline extensions (kbd mapping), mentions/tags, smart typography (arrows, symbols, dash runs, ellipsis, context-decided quotes), inline footnotes, raw inline passthrough, NBSP escapes, hard breaks, single-quoted titles/values, literal catch-all |
| Resolution | unresolved refs/crossrefs render literal, per-label numbered-caption sequences feeding crossref targets, shared footnote sequence for inline notes, one-level crossref flattening |

## Verification

- Gate: **388/388 byte-exact** (was 213 after the tables PR)
- Full test suite green; docs build green
- **Differential run beyond the corpus**: 567 generated inputs (corpus-pair concatenations + crafted edges) against the current vendored carve-lib reference - **zero divergences**
- Review findings fixed during development: math-attribute hardening bypass, footnote-placement sentinel collision, cross-sibling list-tightness leak, unclosed-verbatim in math spans

With this, every layer of the formal spec is executable and CI-enforced: PART 0 layout automaton, the inline PEG, and the PART 9R resolution passes agree with the reference implementation on the entire pinned contract.
