### PR TITLE
spec: {% ... %} is literal in all impls (drop php comment margin)

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1922,11 +1922,13 @@ EOF = (* end of file *) ;
       digit-first bare word is not a valid name (the block stays literal, as for
       any digit-first identifier). All impls support it (a carve extension
       beyond canonical djot, matching djot-php; corpus 95-boolean-attributes).
-      The boundary of "yields an attribute" still differs at the margins:
+      The boundary of "yields an attribute" still differs at one margin:
       carve-php additionally accepts colon-bearing keys/classes
-      (`{xml:lang="en"}`, `{.sm:hover}`) and comment-only blocks (`{% c %}`) as
-      spans, where carve-js treats those as literal. Use a plain
-      `.class` / `#id` / `key=value` / bare word for a portable span.
+      (`{xml:lang="en"}`, `{.sm:hover}`) as spans, where carve-js treats those
+      as literal. Use a plain `.class` / `#id` / `key=value` / bare word for a
+      portable span. (A `{% ... %}` block is NOT a comment in Carve -- comments
+      are `%%` / `%%%` only, PART 9 -- and a `%`-bearing attribute block is an
+      invalid attribute that renders literally in ALL impls.)
 
    15. BLOCK ATTRIBUTE LINES -- OPERATIONAL SEMANTICS (governs
       `block_attributes` in PART 2; matches djot). STATE: pending := the


### PR DESCRIPTION
carve-php previously accepted `{% c %}` as a comment-only span (silently deleting the content); grammar §14 listed that as a known carve-php margin. carve-php has now been fixed (markup-carve/carve-php#313) to treat `{% ... %}` literally, matching carve-js / carve-rs.

Update §14 to drop the `{% c %}` margin note: comments are `%%` / `%%%` only (PART 9), and a `%`-bearing attribute block is an invalid attribute that renders literally in **all** impls. The colon-key margin (`{xml:lang="en"}`) is unchanged - that one still differs in carve-php.