### PR TITLE
docs: one-line quoted title and [label] forms on container fences

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -256,6 +256,17 @@
   font-size: 0.8rem;
   margin-bottom: 0.4rem;
 }
+/* The graceful-degradation floor for an unconsumed grouping [label]: a small
+   muted caption, visually distinct from the admonition-title heading line so
+   the two opener tokens don't read as the same thing. */
+.carve-render .div-label {
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: var(--vp-c-text-2);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.4rem;
+}
 .carve-render .admonition.note,
 .carve-render .admonition.info {
   border-left-color: var(--vp-c-note-1, var(--vp-c-brand-1));

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -104,6 +104,19 @@ Two strictness rules to know:
 - The header must use **straight double quotes**. An unquoted trailing word (`::: note Custom Title`) or typographic quotes (`::: note “Custom”`, the kind word processors and CMS text filters substitute) make the line *not a fence at all* - the whole block degrades to a literal paragraph. If you see raw `:::` lines in your output, check the quotes first.
 - The quoted opener header is the only thing that produces the visible `<p class="admonition-title">`. A `title="…"` key on the preceding attribute line is an ordinary HTML `title` attribute (a hover tooltip) like on any block - a different channel, not a fallback spelling.
 
+#### Title vs. label - which one do I want?
+
+Both tokens can end up visible, so the distinction is *role*, not visibility:
+
+| | `"Title"` (header) | `[Label]` (grouping id) |
+|---|---|---|
+| Role | caption **of** the block's content | name **for** the block among siblings |
+| Standalone block | `<p class="admonition-title">` heading line | `<p class="div-label">` caption (the graceful-degradation floor - authored text never vanishes) |
+| tabs / code-group active | stays **inside** the panel | moves **out** to the tab button; the fallback caption disappears |
+| details extension | becomes the `<summary>` | ignored (details has no group to name) |
+
+Rules of thumb: a standalone admonition wants quotes; a panel in a group wants brackets; use both to have a named tab whose panel also carries a visible heading (`::: tab "Install on Linux" [Linux]`). A title never feeds the tab name - if a tab has no `[label]`, the name falls back to the deprecated `{label="…"}` attribute or first inner heading, then to `Tab N`.
+
 ## Inline elements
 
 An inline element lives inside a line of text.

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -40,7 +40,7 @@ Read this first.
 
 renders the heading as `<h2 class="featured">` inside `<section id="install">` (an explicit heading id hoists to the `<section>` wrapper, PART 9 §13) and the admonition as `<aside class="admonition note callout">`.
 
-This is uniform across every block - headings, block quotes, lists, code blocks, divs/admonitions, line-blocks, local hard-break blocks, tables. They all take their attributes on the preceding line; none take a trailing attribute on the block's own line. (For a code block the fence line accepts only structured metadata - `lang`, optional `"header"`, optional `[label]`, in that order. A trailing `{…}` after the language word makes the line *not a fence at all*; the backticks then fall back to ordinary inline parsing. For a heading, a trailing `{…}` is ordinary inline text. Put the attributes on the line above, like any other block.)
+This is uniform across every block - headings, block quotes, lists, code blocks, divs/admonitions, line-blocks, local hard-break blocks, tables. They all take their attributes on the preceding line; none take a trailing attribute on the block's own line. (For a code block the fence line accepts only structured metadata - `lang`, optional `"header"`, optional `[label]`, in that order. A `:::` container fence takes the same two metadata tokens after its type word - see [Container fences: titles and labels](#container-fences-titles-and-labels) below. A trailing `{…}` after the language word makes the line *not a fence at all*; the backticks then fall back to ordinary inline parsing. For a heading, a trailing `{…}` is ordinary inline text. Put the attributes on the line above, like any other block.)
 
 ### Code blocks: line numbers, titles, and highlighting
 
@@ -77,6 +77,32 @@ $old  = legacy();     // [tl! --]
 $new  = modern();     // [tl! ++]
 ```
 ````
+
+### Container fences: titles and labels
+
+A `:::` fence line takes the same two metadata tokens as a code fence, after the type word and in the same fixed order: an optional quoted `"header"` and an optional bracketed `[label]`. This is the one-line way to title an admonition or name a tab panel:
+
+```carve
+::: note "Custom Title"
+The quoted header becomes <p class="admonition-title">.
+:::
+
+:::: tabs
+::: tab [Overview]
+The [label] is the tab name (canonical; the older {label="…"} attribute
+and inner-heading conventions stay supported but are deprecated).
+:::
+::::
+
+::: tip "Pro Tip" [Build]
+Header and label together - header first, label second.
+:::
+```
+
+Two strictness rules to know:
+
+- The header must use **straight double quotes**. An unquoted trailing word (`::: note Custom Title`) or typographic quotes (`::: note “Custom”`, the kind word processors and CMS text filters substitute) make the line *not a fence at all* - the whole block degrades to a literal paragraph. If you see raw `:::` lines in your output, check the quotes first.
+- The quoted opener header is the only thing that produces the visible `<p class="admonition-title">`. A `title="…"` key on the preceding attribute line is an ordinary HTML `title` attribute (a hover tooltip) like on any block - a different channel, not a fallback spelling.
 
 ## Inline elements
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -78,9 +78,17 @@ code block
 <div>passed through when the output format matches</div>
 ```
 
-::: note                     (admonition: note tip warning danger
+::: note "Custom Title"      (admonition: note tip warning danger
 body                          info success example quote;
-:::                           any other word = <div class="word">)
+:::                           any other word = <div class="word">;
+                              optional "Title" -> admonition-title,
+                              must be straight-quoted - unquoted or
+                              curly-quoted text makes the line a
+                              plain paragraph)
+
+::: tab [Label]              (optional [Label] after the type = group
+body                          identifier, e.g. the tab name; same
+:::                           "Header" [Label] tokens as a code fence)
 
 :::: outer                   (longer fences nest shorter ones)
 ::: note

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1649,7 +1649,7 @@ Custom call-out.
 
 ::::
 
-A `[label]` after the type (and after any quoted header) is a grouping identifier — the same `[label]` token a code fence takes. Core ignores it on a standalone block; a group extension (e.g. tabs) uses it as the tab name. It is the canonical replacement for the older tabs `{label="…"}` / inner-heading convention (both stay supported, deprecated). The `selected` default-tab marker is not a label — it stays a boolean attribute on the preceding `{…}` line.
+A `[label]` after the type (and after any quoted header) is a grouping identifier — the same `[label]` token a code fence takes. Core ignores it on a standalone block; a group extension (e.g. tabs) uses it as the tab name. It is the canonical replacement for the older tabs `{label="…"}` / inner-heading convention (both stay supported, deprecated). The `selected` default-tab marker is not a label — it stays a boolean attribute on the preceding `{…}` line. Title and label never trade places: under a group extension the quoted header stays inside the panel as its `admonition-title` line while the `[label]` moves out to the tab button (and the standalone `div-label` caption disappears); a header is never used as the tab name.
 
 :::: compare
 

--- a/docs/migrate-from-markdown.md
+++ b/docs/migrate-from-markdown.md
@@ -153,6 +153,16 @@ Dangerous operation ahead.
 
 The Tier-1 canonical types - `note`, `tip`, `warning`, `danger`, `info`, `success`, `example`, `quote` - render as admonition `<aside>` callouts. Any other `:::` name (e.g. `important`, `caution`, or your own) renders as a generic typed `<div>` (class `name`), or as a registered extension if one claims that name.
 
+A custom title goes in **straight double quotes** after the type:
+
+```carve
+::: tip "Custom Title"
+The quoted header renders as the admonition's title.
+:::
+```
+
+If you come from VitePress or Docusaurus, note the difference: their unquoted form (`::: tip Custom Title`) is **not** a fence in Carve - the whole block degrades to a literal paragraph. Quote the title. The same happens when a CMS "smart quote" filter converts your straight quotes to typographic ones (`::: tip “Custom”`) before Carve parses the text - if you see raw `:::` lines in your output, check the quotes.
+
 ### Attributes
 
 Attach `{#id .class key="value"}` to inline elements directly, and to block elements via a standalone line **before** the block:


### PR DESCRIPTION
Docs action item from #252.

The one-line quoted `"header"` + `[label]` tokens on `:::` container fences (shipped spec-side in #201) were documented only in examples.md - the cheat sheet and blocks-and-attributes still read as if a preceding `{title="..."}` line were the only spelling, which is exactly the gap that led to #252.

- **cheatsheet.md**: `:::` entry now shows `::: note "Custom Title"` and `::: tab [Label]`, with the straight-quote strictness note.
- **blocks-and-attributes.md**: new "Container fences: titles and labels" section covering both tokens, the fixed order, and the two degradation traps (unquoted trailing text, typographic quotes from CMS smart-quote filters); cross-linked from the fence-metadata paragraph.
- **migrate-from-markdown.md**: admonition section now maps the VitePress/Docusaurus unquoted habit (`::: tip Custom Title`) to the quoted Carve form and warns about smart-quote mangling.

Deliberately documents `{title="..."}` on an admonition as a plain HTML `title` attribute (tooltip), per grammar PART 9 rule 12b - the quoted opener header is the only source of `<p class="admonition-title">`. carve-js and carve-rs conform; carve-php currently promotes the attribute to a visible title, which is a separate divergence to fix php-side.


**Second commit** (title-vs-label deep dive): adds a role table to the container-fence section (title = caption of the block's content, stays inside under extensions; label = the block's name among siblings, moves to group chrome), states that a header never feeds the tab name, notes the same rule in examples.md, and styles the `.div-label` graceful-degradation caption in the reference theme (it previously rendered indistinguishable from body text while `admonition-title` had full styling). Companion behavior fixes: carve-js#314 / carve-php#326 (tabs dropped the quoted title from panels).