### PR TITLE
spec: pin title attribute vs quoted opener header as separate channels

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1669,6 +1669,26 @@ Save early, save often.
 
 ::::
 
+The quoted opener header is the only source of the visible `admonition-title` paragraph. A `title="…"` key on the preceding attribute line is an ordinary HTML `title` attribute on the wrapper (a hover tooltip) — a separate channel, not a fallback spelling, and it never collides with the opener header:
+
+:::: compare
+
+```carve
+{title="attr title"}
+::: note "opener title"
+Body.
+:::
+```
+
+```html
+<aside class="admonition note" title="attr title">
+  <p class="admonition-title">opener title</p>
+  <p>Body.</p>
+</aside>
+```
+
+::::
+
 A typeless generic div may carry a label too (a tab member with no semantic type); core still renders a plain `<div>`.
 
 :::: compare

--- a/tests/corpus/13-admonitions-5.crv
+++ b/tests/corpus/13-admonitions-5.crv
@@ -1,3 +1,4 @@
-::: [First]
-First panel.
+{title="attr title"}
+::: note "opener title"
+Body.
 :::

--- a/tests/corpus/13-admonitions-5.html
+++ b/tests/corpus/13-admonitions-5.html
@@ -1,4 +1,4 @@
-<div>
-  <p class="div-label">First</p>
-  <p>First panel.</p>
-</div>
+<aside class="admonition note" title="attr title">
+  <p class="admonition-title">opener title</p>
+  <p>Body.</p>
+</aside>

--- a/tests/corpus/13-admonitions-6.crv
+++ b/tests/corpus/13-admonitions-6.crv
@@ -1,3 +1,3 @@
-:::[First]
+::: [First]
 First panel.
 :::

--- a/tests/corpus/13-admonitions-7.crv
+++ b/tests/corpus/13-admonitions-7.crv
@@ -1,3 +1,3 @@
-::: warning
-Mind the gap.
+:::[First]
+First panel.
 :::

--- a/tests/corpus/13-admonitions-7.html
+++ b/tests/corpus/13-admonitions-7.html
@@ -1,3 +1,4 @@
-<aside class="admonition warning">
-  <p>Mind the gap.</p>
-</aside>
+<div>
+  <p class="div-label">First</p>
+  <p>First panel.</p>
+</div>

--- a/tests/corpus/13-admonitions-8.crv
+++ b/tests/corpus/13-admonitions-8.crv
@@ -1,6 +1,3 @@
-::: tip
-Quick steps:
-
-- read the docs
-- run the demo
+::: warning
+Mind the gap.
 :::

--- a/tests/corpus/13-admonitions-8.html
+++ b/tests/corpus/13-admonitions-8.html
@@ -1,7 +1,3 @@
-<aside class="admonition tip">
-  <p>Quick steps:</p>
-  <ul>
-    <li>read the docs</li>
-    <li>run the demo</li>
-  </ul>
+<aside class="admonition warning">
+  <p>Mind the gap.</p>
 </aside>

--- a/tests/corpus/13-admonitions-9.crv
+++ b/tests/corpus/13-admonitions-9.crv
@@ -1,0 +1,6 @@
+::: tip
+Quick steps:
+
+- read the docs
+- run the demo
+:::

--- a/tests/corpus/13-admonitions-9.html
+++ b/tests/corpus/13-admonitions-9.html
@@ -1,0 +1,7 @@
+<aside class="admonition tip">
+  <p>Quick steps:</p>
+  <ul>
+    <li>read the docs</li>
+    <li>run the demo</li>
+  </ul>
+</aside>

--- a/tests/spec/13-admonitions.test
+++ b/tests/spec/13-admonitions.test
@@ -45,6 +45,18 @@ Save early, save often.
 ```
 
 ```
+{title="attr title"}
+::: note "opener title"
+Body.
+:::
+.
+<aside class="admonition note" title="attr title">
+  <p class="admonition-title">opener title</p>
+  <p>Body.</p>
+</aside>
+```
+
+```
 ::: [First]
 First panel.
 :::


### PR DESCRIPTION
Corpus pin for the divergence found while working #252 (fixed php-side in markup-carve/carve-php#324).

`{title="..."}` on the attribute line above a container fence is an ordinary HTML `title` attribute on the wrapper; the visible `<p class="admonition-title">` comes only from the quoted opener header (PART 9 rule 12b), and the two channels never collide:

```carve
{title="attr title"}
::: note "opener title"
Body.
:::
```

```html
<aside class="admonition note" title="attr title">
  <p class="admonition-title">opener title</p>
  <p>Body.</p>
</aside>
```

carve-js and carve-rs already conform (verified byte-exact); carve-php promoted the attribute to the visible title and let it overwrite the opener header - fixed in carve-php#324, which should land before its next spec-submodule bump picks this pin up.

The new example slots into the admonitions section of docs/examples.md, so the later cases in `13-admonitions-*` renumber by one (corpus is generated from the docs).
