### PR TITLE
spec: pin admonition titles as inline content

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1689,6 +1689,25 @@ Body.
 
 ::::
 
+The title is ordinary inline content - emphasis, code, and the other inline forms work inside it (unlike a code-fence header, which targets an HTML attribute and stays literal):
+
+:::: compare
+
+```carve
+::: note "Install *now* via `npm`"
+Body.
+:::
+```
+
+```html
+<aside class="admonition note">
+  <p class="admonition-title">Install <strong>now</strong> via <code>npm</code></p>
+  <p>Body.</p>
+</aside>
+```
+
+::::
+
 A typeless generic div may carry a label too (a tab member with no semantic type); core still renders a plain `<div>`.
 
 :::: compare

--- a/tests/corpus/13-admonitions-10.crv
+++ b/tests/corpus/13-admonitions-10.crv
@@ -1,0 +1,6 @@
+::: tip
+Quick steps:
+
+- read the docs
+- run the demo
+:::

--- a/tests/corpus/13-admonitions-10.html
+++ b/tests/corpus/13-admonitions-10.html
@@ -1,0 +1,7 @@
+<aside class="admonition tip">
+  <p>Quick steps:</p>
+  <ul>
+    <li>read the docs</li>
+    <li>run the demo</li>
+  </ul>
+</aside>

--- a/tests/corpus/13-admonitions-6.crv
+++ b/tests/corpus/13-admonitions-6.crv
@@ -1,3 +1,3 @@
-::: [First]
-First panel.
+::: note "Install *now* via `npm`"
+Body.
 :::

--- a/tests/corpus/13-admonitions-6.html
+++ b/tests/corpus/13-admonitions-6.html
@@ -1,4 +1,4 @@
-<div>
-  <p class="div-label">First</p>
-  <p>First panel.</p>
-</div>
+<aside class="admonition note">
+  <p class="admonition-title">Install <strong>now</strong> via <code>npm</code></p>
+  <p>Body.</p>
+</aside>

--- a/tests/corpus/13-admonitions-7.crv
+++ b/tests/corpus/13-admonitions-7.crv
@@ -1,3 +1,3 @@
-:::[First]
+::: [First]
 First panel.
 :::

--- a/tests/corpus/13-admonitions-8.crv
+++ b/tests/corpus/13-admonitions-8.crv
@@ -1,3 +1,3 @@
-::: warning
-Mind the gap.
+:::[First]
+First panel.
 :::

--- a/tests/corpus/13-admonitions-8.html
+++ b/tests/corpus/13-admonitions-8.html
@@ -1,3 +1,4 @@
-<aside class="admonition warning">
-  <p>Mind the gap.</p>
-</aside>
+<div>
+  <p class="div-label">First</p>
+  <p>First panel.</p>
+</div>

--- a/tests/corpus/13-admonitions-9.crv
+++ b/tests/corpus/13-admonitions-9.crv
@@ -1,6 +1,3 @@
-::: tip
-Quick steps:
-
-- read the docs
-- run the demo
+::: warning
+Mind the gap.
 :::

--- a/tests/corpus/13-admonitions-9.html
+++ b/tests/corpus/13-admonitions-9.html
@@ -1,7 +1,3 @@
-<aside class="admonition tip">
-  <p>Quick steps:</p>
-  <ul>
-    <li>read the docs</li>
-    <li>run the demo</li>
-  </ul>
+<aside class="admonition warning">
+  <p>Mind the gap.</p>
 </aside>

--- a/tests/spec/13-admonitions.test
+++ b/tests/spec/13-admonitions.test
@@ -57,6 +57,17 @@ Body.
 ```
 
 ```
+::: note "Install *now* via `npm`"
+Body.
+:::
+.
+<aside class="admonition note">
+  <p class="admonition-title">Install <strong>now</strong> via <code>npm</code></p>
+  <p>Body.</p>
+</aside>
+```
+
+```
 ::: [First]
 First panel.
 :::


### PR DESCRIPTION
Corpus pin for markup-carve/carve-php#327 (cherry-picked off the merged #254, which the original branch was based on).

A quoted opener title is ordinary inline content - emphasis, code, and the other inline forms render inside the `admonition-title` paragraph - unlike a code-fence header, which targets an HTML attribute and stays literal. carve-js and carve-rs already conform; the existing corpus only covered plain-text titles, which is how the carve-php divergence (literal, escaped-only titles) went unnoticed. The php fix lands with markup-carve/carve-php#330.