### PR TITLE
spec: captions are multi-line (paragraph continuation model)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -141,6 +141,16 @@ two
 A `^` caption after a fenced code block makes a numbered *listing*; after a
 standalone `$$`-math block, a numbered *equation*.
 
+A caption spans multiple lines like a paragraph — following lines fold in until
+a blank line or a block that would interrupt a paragraph (a list marker folds
+in, it does not end the caption):
+
+```carve
+![Photo](img.jpg)
+^ A long caption that
+continues on the next line.
+```
+
 ## Attributes & metadata
 
 ```carve

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -550,7 +550,24 @@ cell_content = inline_content ;
    the exception is not expressible context-free. *)
 
 (* --- Captions --- *)
-caption = '^', space, inline_content, newline ;
+caption = '^', space, inline_content, newline, {caption_continuation_line} ;
+caption_continuation_line = inline_content, newline ;  (* a PLAIN line only *)
+(* MULTI-LINE CAPTIONS -- NORMATIVE. A caption is multi-line inline CONTENT, so
+   its text spills onto following lines exactly like a PARAGRAPH (§10), NOT like
+   a heading. It ends the same way an open paragraph does:
+     1. a blank line ends the caption;
+     2. a line that INTERRUPTS a paragraph -- a heading, blockquote, table,
+        fenced code, `:::` div, thematic break, or `%%%` comment -- ends the
+        caption and starts that block;
+     3. a LIST MARKER does NOT end the caption: like a paragraph, a caption
+        folds a `- ` / `1.` line in as literal text (djot -- a list needs a
+        blank line to interrupt). `^ cap` + `- x` yields the caption `cap\n- x`;
+     4. a further `^ ` line does NOT continue the caption (there is no repeated
+        marker); it ends the caption and, having no captionable block to attach
+        to, is ordinary paragraph text.
+   Continuation lines join with a newline, so `^ cap` + `more` yields the
+   caption text `cap\nmore`. The caption id (`#` placeholder) and cross-reference
+   targeting use the full folded text. *)
 caption_slot = [blank_line], caption ;
 (* FORMAL adjacency (PART 9 §4, now structural): a caption attaches to the
    immediately preceding captionable block, with AT MOST ONE blank line


### PR DESCRIPTION
A caption is multi-line inline **content**, so its text spills onto following lines exactly like a **paragraph** (§10) - not a single line, and not like a heading.

It ends the way an open paragraph does:
- a blank line ends it;
- a paragraph-interrupting block (heading, blockquote, table, fenced code, `:::` div, thematic break, `%%%` comment) ends it and starts that block;
- a **list marker FOLDS in** (like a paragraph - djot, a list needs a blank line to interrupt): `^ cap` + `- x` -> caption `cap\n- x`;
- a further `^ ` line ends it.

Continuation lines join with a newline. Updates the `caption` grammar production + the cheatsheet.

carve-php already implemented this; carve-js (markup-carve/carve-js#…) and carve-rs (markup-carve/carve-rs#…) are updated to match. Verified byte-identical 3-way across image / code / blockquote / table / reference-image targets, all continuation shapes, in HTML + markdown/plain/ansi.