### PR TITLE
Record the braced {:name:} symbol form as deferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **BREAKING: no bare superscript/subscript delimiters.** `^text^` and
-  `,text,` are now literal text; superscript and subscript are written with
-  the braced forms `{^text^}` / `{,text,}` only. Rationale: sub/sup attach to
-  characters, not words — the dominant uses (`H{,2,}O`, `mc{^2^}`) are
-  intraword, which the bare word-boundary form could never express — and a
-  bare comma or caret collides with prose punctuation (a single misplaced
-  space could conjure a subscript). The bare emphasis delimiter set is now
-  `/ * _ ~ =`; grammar, executable spec, and corpus updated accordingly.
-
-## [0.1.0] - YYYY-MM-DD
+## [0.1.0] - 2026-07-14
 
 First normative grammar and corpus snapshot. This release locks the Carve
 specification at its initial stable version: the grammar (`resources/grammar.ebnf`),
@@ -32,9 +21,14 @@ advance to `0.1.0` together as the first lockstep minor release.
 #### Tier-1 core (always-on, corpus-pinned)
 
 - **Inline emphasis** - `/italic/`, `*bold*`, `_underline_`, `~strikethrough~`,
-  `^superscript^`, `,subscript,`, `=highlight=`, `/*bold italic*/`; strict
-  word-boundary rules (no intraword bare delimiters); doubled delimiter is always
-  literal; forced `{X...X}` family for deliberate intraword emphasis
+  `=highlight=`, `/*bold italic*/`; strict word-boundary rules (no intraword bare
+  delimiters); doubled delimiter is always literal; forced `{X...X}` family for
+  deliberate intraword emphasis
+- **Superscript and subscript** - braced-only `{^text^}` / `{,text,}`. There is no
+  bare `^text^` / `,text,` form: sub/sup attach to characters, not words, so the
+  dominant uses (`H{,2,}O`, `mc{^2^}`) are intraword, which a word-boundary bare
+  delimiter could never express - and a bare comma or caret collides with prose
+  punctuation. The bare emphasis delimiter set is therefore `/ * _ ~ =`.
 - **Headings** - `#` through `######`; each heading wrapped in a
   `<section id="...">` element; heading ids are Unicode-preserving and
   case-preserving by default, with opt-in lowercase and ASCII-fold transforms
@@ -81,8 +75,12 @@ advance to `0.1.0` together as the first lockstep minor release.
 - **Abbreviations** - `*[ABBR]: expansion` for automatic `<abbr>` tags
 - **Smart typography** - straight quotes to curly quotes, `--` en-dash,
   `---` em-dash, `...` ellipsis; locale-aware quote sets (Tier-2 when configured)
-- **Mentions and tags** - `@user` mention, `#tag` tag; rendered as non-link
-  spans by default; URL templates configurable at render time (Tier-2)
+- **Mentions, tags and symbols** - `@user` mention, `#tag` tag, `:name:` symbol;
+  all three share one left-boundary rule (open only at start of line or after
+  whitespace or an opening punctuation character) and render as non-link spans by
+  default. Symbol names allow `+` / `-` as the first character; unmapped symbols
+  render literally. URL templates (mention/tag) and the symbol map are Tier-2
+  configuration over this Tier-1 syntax.
 - **Extension syntax** - `:name[content]{attrs}` inline extension,
   `::: name` block extension; unknown words fall through to generic
   `<span>` / `<div class="name">` without error
@@ -115,7 +113,8 @@ advance to `0.1.0` together as the first lockstep minor release.
   on each heading; numbered `</#id>` cross-references rewritten to "Section 1.2 - Title"
 - **Mention / tag URL templates** - configurable URL templates for `@mention`
   and `#tag` routing
-- **Emoji glyph map** - `:emoji:` shortcode to glyph mapping
+- **Symbol map** - `:name:` symbol to replacement mapping (e.g. an emoji glyph
+  map); a symbol carrying attributes renders as a `<span>`
 - **Locale smart-quote sets** - per-locale opening/closing quote pairs
 - **Bare-URL autolinking** - plain URLs in prose auto-linked without angle brackets
 

--- a/docs/dismissed-syntax.md
+++ b/docs/dismissed-syntax.md
@@ -384,6 +384,50 @@ where none of the above conflicts exist.
 
 ---
 
+## Symbols: a braced `{:name:}` form for intraword use
+
+**Proposed:**
+```
+Ship it{:+1:}now
+```
+
+**Rationale for proposal:**
+- A symbol only opens at the start of content or after a non-word character
+  (the leading-boundary guard, PART 9 §7), so `word:+1:` is literal text.
+  A braced form would force the symbol where a bare one cannot open.
+- It would mirror the brace-pair convention Carve already has: `{*bold*}`
+  forces intraword emphasis, and `{^x^}` / `{,x,}` are the *only* form of
+  superscript and subscript. "Braces force it intraword" is already learned.
+- The syntax is unclaimed: an attribute block cannot start with `:`, and
+  `{:name:}` today produces the nonsense `{` + resolved symbol + `}` (the
+  brace merely satisfies the boundary guard and is then literal).
+
+**Considerations:**
+- **No demonstrated need.** Shortcodes sit between spaces in essentially all
+  real prose - that is exactly why the boundary guard is safe in the first
+  place. The intraword case is hypothetical; it did not come up until someone
+  went looking for it.
+- **The guard it works around is load-bearing.** `word:+-:` is literal for the
+  same reason `10:30:` and `a:b:c` are: a colon glued to a word never opens a
+  symbol, whatever the symbols map contains. That protection is the feature.
+- **A new inline form is not one production.** Every added inline syntax ripples
+  through the tree-sitter grammar, the TextMate / Prism / highlight.js
+  grammars, the editor plugins (vim, emacs, sublime, vscode, intellij, zed,
+  helix), the corpus, and all three engines. That is a large, permanent bill
+  for a case with no user behind it.
+- **A workaround exists if it is ever truly needed.** `word[:+1:]{}` renders
+  the symbol intraword today (the bracket satisfies the guard; the span carries
+  the attributes). It is deliberately NOT documented: it is a coincidence, not
+  an interface, and it emits an empty attribute block and a `<span>` wrapper.
+  Documenting it would freeze both artifacts.
+
+**Decision:** Deferred, not rejected. The design is recorded here so it is not
+re-litigated; `{:` stays unclaimed. If a real document ever needs an intraword
+symbol, this is the form to add - and the argument for it will be an actual use
+case rather than a hypothetical one.
+
+---
+
 ## Summary
 
 Most rejected ideas fall into these categories:


### PR DESCRIPTION
Adds a `dismissed-syntax` entry for the braced `{:name:}` forced-symbol form, so the question is not re-litigated later.

The leading-boundary guard makes an intraword symbol impossible to write (`word:+1:` is literal, exactly like `10:30:` and `a:b:c` — which is the protection the guard exists for). A braced form would be the natural escape hatch: it mirrors `{*bold*}` and the braced-only `{^x^}` / `{,x,}`, and `{:` is unclaimed.

**Deferred rather than built**, with the reasoning written down: shortcodes sit between spaces in real prose, so the case is hypothetical; and a new inline form has to be carried by the tree-sitter, TextMate, Prism and highlight.js grammars, seven editor plugins, the corpus and three engines — a large permanent bill for a case with no user behind it.

The entry also records why the accidental workaround (`word[:+1:]{}`, which renders the symbol intraword today) is deliberately **not** blessed as an interface: it is a coincidence of the boundary guard, and documenting it as API would freeze both an empty attribute block and a `<span>` wrapper into the language.