### PR TITLE
Docs: consume carve-grammars under its org scope

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import container from 'markdown-it-container'
-import { carveMarkdown } from 'carve-grammars/shiki'
+import { carveMarkdown } from '@markup-carve/carve-grammars/shiki'
 import carve from '@markup-carve/vite-plugin-carve'
 // @ts-expect-error - local ESM helper without TS resolution context
 import { carveExtensions } from './carve-extensions.js'

--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -274,7 +274,7 @@ function getHighlighter(): Promise<unknown> {
     highlighterPromise = (async () => {
       const { createHighlighter } = await import('shiki')
       // The repo's Carve TextMate grammar, so `language-carve` blocks highlight too.
-      const carveGrammar = (await import('carve-grammars/textmate/carve.tmLanguage.json')).default
+      const carveGrammar = (await import('@markup-carve/carve-grammars/textmate/carve.tmLanguage.json')).default
       return createHighlighter({
         themes: ['github-light', 'github-dark'],
         langs: [

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,6 @@
 import DefaultTheme from 'vitepress/theme'
 import type { Theme } from 'vitepress'
-import 'carve-grammars/shiki/carve.css'
+import '@markup-carve/carve-grammars/shiki/carve.css'
 import './custom.css'
 import 'katex/dist/katex.min.css'
 import Playground from './components/Playground.vue'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "mermaid": "^11.15.0"
       },
       "devDependencies": {
+        "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.35.0",
-        "carve-grammars": "github:markup-carve/carve-grammars",
         "markdown-it-container": "^4.0.0",
         "ohm-js": "^17.5.0",
         "vitepress": "^1.5.0"
@@ -969,6 +969,40 @@
       "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#b7b896069638f9eac2e60e1b5a67b61373b9304d",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@markup-carve/carve-grammars": {
+      "version": "0.1.2",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-grammars.git#83b1872991090b7f8e6840e51a4c4c75ce7e611d",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@shikijs/themes": "^2 || ^3",
+        "@tiptap/core": "^2",
+        "@tiptap/extension-underline": "^2",
+        "@tiptap/starter-kit": "^2",
+        "highlight.js": "^11",
+        "prismjs": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@shikijs/themes": {
+          "optional": true
+        },
+        "@tiptap/core": {
+          "optional": true
+        },
+        "@tiptap/extension-underline": {
+          "optional": true
+        },
+        "@tiptap/starter-kit": {
+          "optional": true
+        },
+        "highlight.js": {
+          "optional": true
+        },
+        "prismjs": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@markup-carve/vite-plugin-carve": {
       "version": "0.1.0",
@@ -2178,40 +2212,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/carve-grammars": {
-      "version": "0.1.1",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-grammars.git#d0fcd0d20742fc7f99992e96efe44181861359c8",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@shikijs/themes": "^2 || ^3",
-        "@tiptap/core": "^2",
-        "@tiptap/extension-underline": "^2",
-        "@tiptap/starter-kit": "^2",
-        "highlight.js": "^11",
-        "prismjs": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@shikijs/themes": {
-          "optional": true
-        },
-        "@tiptap/core": {
-          "optional": true
-        },
-        "@tiptap/extension-underline": {
-          "optional": true
-        },
-        "@tiptap/starter-kit": {
-          "optional": true
-        },
-        "highlight.js": {
-          "optional": true
-        },
-        "prismjs": {
-          "optional": true
-        }
       }
     },
     "node_modules/ccount": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.35.0",
-    "carve-grammars": "github:markup-carve/carve-grammars",
+    "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "markdown-it-container": "^4.0.0",
     "ohm-js": "^17.5.0",
     "vitepress": "^1.5.0"


### PR DESCRIPTION
Follow-up to markup-carve/carve-grammars#41, which renames the package to `@markup-carve/carve-grammars`. The docs site pins it as a `github:` dependency off `main`, so it breaks the moment that rename lands.

- Dependency key and the three import specifiers (shiki kit, shiki CSS, TextMate grammar in the playground) move to the scoped name.

Merge order: carve-grammars#41 first, then this. The lockfile is left for the merge commit to refresh, since `npm install` cannot resolve the scoped name until the rename is on the grammars `main`.