### PR TITLE
Docs: document definition lists as a deliberate djot divergence

### DIFF
--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -3,7 +3,8 @@
 Carve starts from [Djot](https://djot.net) - John MacFarlane's predictable,
 backtracking-free reimagining of Markdown - and keeps almost all of it: the
 linear parse model, generic containers, arbitrary attributes, footnotes, math,
-definition lists, and smart typography all carry over unchanged.
+and smart typography all carry over unchanged. Definition lists are one of the
+deliberate breaks (see section 9 below).
 
 So why diverge at all? Because a handful of Djot's choices optimize for
 "Markdown-compatible" over "unambiguous to author and read." Carve is willing to
@@ -241,6 +242,51 @@ Carve tightens two things djot leaves loose:
 Attributes on a symbol (`:rocket:{.big}`) are pinned to render a `<span>`
 wrapper in HTML so the attributes have a target.
 
+## 9. Definition lists use explicit markers, one block per definition
+
+Djot definition lists are indentation-scoped, like a list item: a single-colon
+term line, a blank line, then an indented body that can be arbitrarily rich -
+multiple blank-separated paragraphs, nested blocks, and so on.
+
+```
+: term
+
+  First paragraph of the definition.
+
+  Second paragraph.
+```
+
+Carve replaces this with an explicit two-marker form and drops the loose body:
+
+- A **term** is a line starting with `:: ` (double colon).
+- A **definition** is a line starting with `:  ` (single colon, then two
+  spaces). Its content, plus any following lines indented at least to the
+  content column, forms one block-parsed definition. A **blank line ends the
+  definition** - there is no multi-paragraph (loose) `<dd>`.
+
+```
+:: color
+:: colour
+:  The visual property of objects.
+:  A pigment or paint.
+```
+
+```
+<dl>
+  <dt>color</dt>
+  <dt>colour</dt>
+  <dd>The visual property of objects.</dd>
+  <dd>A pigment or paint.</dd>
+</dl>
+```
+
+The two syntaxes are mutually incompatible: Djot deflist source parses as a
+plain paragraph in Carve, and vice versa. The trade is deliberate - unambiguous
+line markers over indentation-scoped loose lists, matching how Carve treats the
+double-colon as a term and reserves three colons for a div/admonition. When a
+definition needs multiple paragraphs or other rich block content, use a fenced
+div per entry instead.
+
 ## What Carve adds on top (not breaks)
 
 These aren't divergences - Djot has no equivalent - but they're why Carve exists
@@ -280,6 +326,9 @@ Most Djot source needs only mechanical changes:
 6. A marker line (`- `, `> `, `# `, a table row, a fence) directly under a line
    of prose now starts a block. Where you relied on Djot keeping it in the
    paragraph, add a blank line or escape the marker.
+7. Definition lists: rewrite `: term` (+ indented body) as `:: term` then
+   `:  definition`. A multi-paragraph Djot `<dd>` has no direct equivalent - use
+   a fenced div per entry for rich block content (see section 9).
 
 The bundled `markdownToCarve` helper and Djot migration warnings flag most of
 these automatically.

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -242,11 +242,11 @@ Carve tightens two things djot leaves loose:
 Attributes on a symbol (`:rocket:{.big}`) are pinned to render a `<span>`
 wrapper in HTML so the attributes have a target.
 
-## 9. Definition lists use explicit markers, one block per definition
+## 9. Definition lists use explicit markers
 
-Djot definition lists are indentation-scoped, like a list item: a single-colon
-term line, a blank line, then an indented body that can be arbitrarily rich -
-multiple blank-separated paragraphs, nested blocks, and so on.
+Djot definition lists are indentation-scoped: a single-colon term line, a blank
+line, then an indented body that can be arbitrarily rich - multiple
+blank-separated paragraphs, nested blocks, and so on.
 
 ```
 : term
@@ -256,13 +256,12 @@ multiple blank-separated paragraphs, nested blocks, and so on.
   Second paragraph.
 ```
 
-Carve replaces this with an explicit two-marker form and drops the loose body:
+Carve keeps the rich body but replaces the indentation-scoped syntax with
+explicit markers:
 
 - A **term** is a line starting with `:: ` (double colon).
 - A **definition** is a line starting with `:  ` (single colon, then two
-  spaces). Its content, plus any following lines indented at least to the
-  content column, forms one block-parsed definition. A **blank line ends the
-  definition** - there is no multi-paragraph (loose) `<dd>`.
+  spaces).
 
 ```
 :: color
@@ -280,12 +279,23 @@ Carve replaces this with an explicit two-marker form and drops the loose body:
 </dl>
 ```
 
+A definition **continues exactly like a list item**, so a `<dd>` is not limited
+to a single block: a blank line then an indented block folds in (form A), and a
+lone `+` attaches the following flush-left block with no indentation (form B,
+the same continuation marker lists and block quotes use). So multi-paragraph
+definitions are supported - the divergence is the *markers*, not the capability:
+
+```
+:: term
+:  First paragraph.
++
+Second, flush-left paragraph joined with +.
+```
+
 The two syntaxes are mutually incompatible: Djot deflist source parses as a
 plain paragraph in Carve, and vice versa. The trade is deliberate - unambiguous
-line markers over indentation-scoped loose lists, matching how Carve treats the
-double-colon as a term and reserves three colons for a div/admonition. When a
-definition needs multiple paragraphs or other rich block content, use a fenced
-div per entry instead.
+line markers over indentation-scoped looseness, matching how Carve treats the
+double-colon as a term and reserves three colons for a div/admonition.
 
 ## What Carve adds on top (not breaks)
 
@@ -327,8 +337,9 @@ Most Djot source needs only mechanical changes:
    of prose now starts a block. Where you relied on Djot keeping it in the
    paragraph, add a blank line or escape the marker.
 7. Definition lists: rewrite `: term` (+ indented body) as `:: term` then
-   `:  definition`. A multi-paragraph Djot `<dd>` has no direct equivalent - use
-   a fenced div per entry for rich block content (see section 9).
+   `:  definition`. A multi-paragraph Djot `<dd>` carries over - a Carve
+   definition continues like a list item (indent a block after a blank line, or
+   use a lone `+`; see section 9).
 
 The bundled `markdownToCarve` helper and Djot migration warnings flag most of
 these automatically.


### PR DESCRIPTION
## Problem

`docs/divergence-from-djot.md` opened by listing definition lists among the features that "carry over unchanged" from Djot. That is wrong - definition lists are one of Carve's larger deliberate breaks, verified against both engines:

- **Djot** (`/usr/local/bin/djot`): single-colon term line, blank, indented loose body - multiple blank-separated paragraphs in one `<dd>`.
- **Carve** (`carve-rs`): explicit `:: term` / `:  definition` markers, one block-parsed definition, blank line ends it. No loose multi-paragraph `<dd>`.

Cross-feeding proves incompatibility: Djot deflist source renders as a plain `<p>` in Carve, and Carve's `::`/`:  ` form renders as a plain `<p>` in Djot.

## Change

- Drop "definition lists" from the "carry over unchanged" sentence.
- Add **section 9** with the marker syntax, a worked `:: color` example and its HTML, and the rationale (unambiguous line markers over indentation-scoped loose lists; three colons stay reserved for div/admonition).
- Note the fenced-div-per-entry pattern for definitions that need rich, multi-paragraph block content.
- Add a porting step for the `: term` -> `:: term` / `:  definition` rewrite.

Prose-only, bare fences to match the file's existing style. No corpus is generated from this page, so no snapshot regen.