### PR TITLE
Docs: list carve-skill in the ecosystem and satellites

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -65,7 +65,7 @@ it targets in its own README.
 
 Current satellites: carve-emacs, carve.vim, carve-sublime, carve-wysiwyg,
 carve-components, python-carve, intellij-carve, vscode-carve, lsp-carve,
-vite-plugin-carve.
+vite-plugin-carve, carve-skill.
 
 ## Version map
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -63,6 +63,14 @@ Carve embedded in another tool or framework.
 | [carve-grammars](https://github.com/markup-carve/carve-grammars) | Tiptap | Editor kit and Carve serializer. |
 | [vite-plugin-carve](https://github.com/markup-carve/vite-plugin-carve) | Vite | Import `.crv` documents as rendered HTML. *Early.* |
 
+## AI / agent tooling
+
+Skills and context packs that teach AI coding agents to author Carve.
+
+| Project | Target | Status |
+|---|---|---|
+| [carve-skill](https://github.com/markup-carve/carve-skill) | Claude Code / agents | Authoring skill - a syntax card, the Markdown/Djot trap list, and a `carve lint` validation loop so agents write valid `.crv` the first time. |
+
 ## Resources
 
 | Project | Description |


### PR DESCRIPTION
Lists the new [carve-skill](https://github.com/markup-carve/carve-skill) agent-authoring skill (issue #269):

- New **AI / agent tooling** section in `docs/ecosystem.md`.
- Added to the satellites list in `VERSIONING.md`.