### PR TITLE
docs: explain target-routed raw passthrough and the pandoc boundary

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -37,7 +37,7 @@ implementation — except rows marked **✦**, which are opt-in extensions
 | `\*literal\*` | escape | backslash + any ASCII punctuation |
 | `--` `---` `...` `->` `(c)` | – — … → © | smart typography |
 | `\` at end of line | hard break | `\ ` (backslash-space) = no-break space |
-| `` `<br>`{=html} `` | raw inline | emitted only for that output format |
+| `` `<br>`{=html} `` | raw inline | target-routed; Carve renderers emit only `=html`, others feed external writers ([why](/divergence-from-djot#_10-raw-passthrough-is-target-routed-and-the-pandoc-boundary)) |
 
 Bare delimiters work only at word boundaries; force one intraword with the brace form, e.g. `H{,2,}O`, `mc{^2^}`.
 

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -306,6 +306,63 @@ Carve treats the double-colon as a term and reserves three colons for a
 div/admonition. The loose body itself is *not* traded away: form A is djot's
 indentation-scoped body, and `+` (form B) is added on top.
 
+## 10. Raw passthrough is target-routed (and the pandoc boundary)
+
+**Djot and Carve share the raw-passthrough syntax:** `` `content`{=format} `` inline
+and a ```` ```=format ```` block emit `content` verbatim, but **only** to the renderer
+whose output target is `format`. Every other renderer drops the span. This is the
+same `RawInline`/`RawBlock` model pandoc-flavored Markdown has used for years
+(`` `\alpha`{=latex} ``), and Djot inherits it to feed **pandoc** - which is where
+`{=latex}`, `{=typst}`, `{=docx}`, etc. actually render, since the Djot reference
+library itself writes only HTML.
+
+**Where Carve differs: it has no pandoc-style multi-writer.** Carve ships HTML,
+Markdown, ANSI, and plain-text renderers, and **only the HTML renderer owns a
+format** (`html`). So today every non-`html` raw span is inert in Carve's own
+renderers - it survives in the AST (`raw-inline` / `raw-block` node, tagged with
+its `format`) for a custom AST consumer or a future native writer, but no built-in
+renderer emits it.
+
+| raw span | Carve HTML | Carve MD / ANSI / plain |
+|----------|-----------|-------------------------|
+| `` `x`{=html} `` | emitted verbatim | escaped to text (MD) / dropped |
+| `` `x`{=latex} ``, `` `x`{=typst} ``, `` `x`{=markdown} `` | dropped | dropped |
+
+**The raw construct itself is pandoc-compatible.** Pandoc's Djot reader parses
+Carve's `` `x`{=format} `` byte-identically and routes it correctly per writer:
+
+| pandoc: djot → | survives | drops |
+|----------------|----------|-------|
+| `html` | `{=html}` | latex, typst, markdown |
+| `latex` | `{=latex}` | html, typst, markdown |
+| `typst` | `{=typst}` | html, latex, markdown |
+
+::: warning Do not pipe a whole Carve document through pandoc
+Only the raw-passthrough construct is byte-shared. A full Carve document is **not**
+valid Djot: pandoc's Djot reader reads `/italic/` as literal text and remaps
+`_underline_` to `<em>` (Djot emphasis). Carve's visual-mnemonic emphasis
+(section 4) is the break. Use pandoc for the raw spans' sake only if you first
+convert the surrounding document, not by feeding Carve source to `-f djot`.
+:::
+
+**Why document this.** A `` `x`{=latex} `` that silently renders nothing in Carve
+looks like a bug. It is not - it is a hatch for an external writer that Carve does
+not yet bundle. The one live, escape-free target in Carve is `html`.
+
+**Closing the gap: pandoc-carve.** The
+[pandoc-carve](https://github.com/markup-carve/pandoc-carve) bridge converts the
+Carve AST to Pandoc's JSON AST, so one Carve document reaches every pandoc
+writer - LaTeX, Typst, DOCX, PDF, and beyond - with the emphasis mapping done
+correctly and raw spans target-routed by pandoc itself:
+
+```bash
+pandoc-carve doc.crv -t latex -o doc.tex
+pandoc-carve doc.crv -t typst -o doc.typ
+```
+
+With the bridge in play, `{=latex}` and friends are no longer inert: they are
+authored for the pandoc writer that will eventually consume the document.
+
 ## What Carve adds on top (not breaks)
 
 These aren't divergences - Djot has no equivalent - but they're why Carve exists

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -75,6 +75,7 @@ Render Carve documents to formats beyond HTML.
 |---|---|---|
 | [carve-pdf](https://github.com/markup-carve/carve-pdf) | PDF | Render `.crv` documents to clean, paginated PDFs. |
 | [carve-hexapdf](https://github.com/markup-carve/carve-hexapdf) | PDF | Carve to PDF via the pure-Ruby HexaPDF engine (over carve-lang / carve-rb). |
+| [pandoc-carve](https://github.com/markup-carve/pandoc-carve) | LaTeX, Typst, DOCX, PDF, ... | Carve AST to Pandoc JSON bridge; reaches every pandoc writer and makes `{=latex}`-style raw spans fire. |
 
 ## Extensions
 


### PR DESCRIPTION
## What

- New section 10 in `divergence-from-djot.md`: how `{=FORMAT}` raw passthrough actually works - target-routed raw content, emitted only by the renderer whose output target matches, dropped everywhere else - and where Carve differs from the Djot/pandoc ecosystem (Carve bundles no multi-format writer, so only `html` is live today; other formats are AST-only hatches).
- Documents the verified pandoc boundary: pandoc's Djot reader routes Carve's raw spans byte-identically (`latex`/`typst`/`html` tables included), but a whole Carve document is NOT valid Djot (`/italic/` reads as literal, `_underline_` remaps to em) - with an explicit warning box.
- Links the new [pandoc-carve](https://github.com/markup-carve/pandoc-carve) bridge as the gap-closer that makes `{=latex}`-style spans actually fire, and adds it to the ecosystem page.
- Cheatsheet raw-inline row now points at the new section.

## Why

A ``` `x`{=latex} ``` span silently rendering nothing looks like a bug; no doc explained the routing model, what is inert in Carve's own renderers, or that piping Carve source through `pandoc -f djot` silently mangles emphasis. Came out of the {=literal} discussion in issue 280.