### PR TITLE
spec: add plantuml preset and open the static renderers map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PlantUML preset** (`plantuml`, claims `plantuml` and `puml`), covering the
   UML diagram types Mermaid does not (use case, component, deployment, timing),
   renderable client-side offline via `@plantuml/core`.
-- `plantuml` added to the canonical static-render **renderers** key set
-  (`mermaid`, `chart`, `graphviz`, `plantuml`, `math`), so a build-time PlantUML
-  renderer can bake diagrams into no-JS static HTML. A note on the extensions
-  page documents that the key set is closed and grows only by lockstep change.
+- `plantuml` added to the static-render **renderers** key set, so a build-time
+  PlantUML renderer can bake diagrams into no-JS static HTML.
+- **Open static renderers map.** The `renderers` map is now keyed by the fence's
+  css class rather than a closed canonical set, so a custom `FencedRender` fence
+  word (`fencedRender({ language: 'myuml' })` + `renderers: { myuml: … }`) is
+  static-capable in every engine with the same config - no spec edit, no
+  lockstep. Canonical presets are just the pre-named classes. This supersedes
+  the closed-key-set design.
 
 First normative grammar and corpus snapshot. This release locks the Carve
 specification at its initial stable version: the grammar (`resources/grammar.ebnf`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-07-14
+### Added
+
+- Diagram documentation: a dedicated Diagrams & Charts page and a cheatsheet
+  section covering the `FencedRender` presets, which were previously described
+  only in capability tables.
+- **PlantUML preset** (`plantuml`, claims `plantuml` and `puml`), covering the
+  UML diagram types Mermaid does not (use case, component, deployment, timing),
+  renderable client-side offline via `@plantuml/core`.
+- `plantuml` added to the canonical static-render **renderers** key set
+  (`mermaid`, `chart`, `graphviz`, `plantuml`, `math`), so a build-time PlantUML
+  renderer can bake diagrams into no-JS static HTML. A note on the extensions
+  page documents that the key set is closed and grows only by lockstep change.
 
 First normative grammar and corpus snapshot. This release locks the Carve
 specification at its initial stable version: the grammar (`resources/grammar.ebnf`),

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -245,16 +245,25 @@ Expected static output per interactive extension:
 | tabs / code-group | each panel as a `<section>` headed by its `[label]` |
 | details | not a `renderStatic` case - emits a native `<details open>` in static (see [Graceful Degradation](/graceful-degradation)); interactive without scripts, so never flattened |
 | spoiler | the revealed content (no blur) |
-| fenced-render (mermaid, chart, graphviz) | a build-rendered image if a renderer for that key is supplied, else the source as a code block |
+| fenced-render (mermaid, chart, graphviz, plantuml) | a build-rendered image if a renderer for that key is supplied, else the source as a code block |
 | math (display / inline) | server-side output (MathML/HTML) if a renderer is supplied, else the source |
 
 Client-script extensions cannot produce their image inside the engine. A
 `"static"` render therefore accepts a **renderers** map. The canonical keys are
-`mermaid`, `chart`, `graphviz`, and `math` - implementations MUST use these exact
-names so the same `renderers` config behaves identically across engines (a fixed
-`{mermaid, chart, math}` struct that omits `graphviz` is non-conformant). When
-the needed renderer is absent, `renderStatic` MUST fall back to source, never
-blank. Renderers are **synchronous** (`source -> string`; `math` also takes a
+`mermaid`, `chart`, `graphviz`, `plantuml`, and `math` - implementations MUST use
+these exact names so the same `renderers` config behaves identically across
+engines (a fixed `{mermaid, chart, math}` struct that omits `graphviz` or
+`plantuml` is non-conformant). When the needed renderer is absent, `renderStatic`
+MUST fall back to source, never blank.
+
+> [!NOTE]
+> The canonical key set is **closed**: it grows only by a deliberate, coordinated
+> change across the spec and every implementation, never ad hoc. Adding a key
+> (as `plantuml` was added alongside `mermaid`/`chart`/`graphviz`/`math`) is a
+> lockstep edit - the spec sentence above, plus each engine's renderers type or
+> map and the preset that carries the key, plus any binding that validates keys
+> (e.g. carve-rb's allowlist). The payoff for that cost is the cross-engine parity
+> guarantee; the discipline is that renderer keys are curated, not open-ended. Renderers are **synchronous** (`source -> string`; `math` also takes a
 display flag): an async tool (mmdc, an HTTP service) must be run in a build step
 and supplied as a pre-resolved lookup, not awaited inside the render. Renderers
 apply to the **static HTML** path only - the Markdown/plain/ANSI renderers keep

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -245,25 +245,28 @@ Expected static output per interactive extension:
 | tabs / code-group | each panel as a `<section>` headed by its `[label]` |
 | details | not a `renderStatic` case - emits a native `<details open>` in static (see [Graceful Degradation](/graceful-degradation)); interactive without scripts, so never flattened |
 | spoiler | the revealed content (no blur) |
-| fenced-render (mermaid, chart, graphviz, plantuml) | a build-rendered image if a renderer for that key is supplied, else the source as a code block |
+| fenced-render (mermaid, chart, graphviz, plantuml, custom) | a build-rendered image if a renderer keyed by the fence's css class is supplied, else the source as a code block |
 | math (display / inline) | server-side output (MathML/HTML) if a renderer is supplied, else the source |
 
 Client-script extensions cannot produce their image inside the engine. A
-`"static"` render therefore accepts a **renderers** map. The canonical keys are
-`mermaid`, `chart`, `graphviz`, `plantuml`, and `math` - implementations MUST use
-these exact names so the same `renderers` config behaves identically across
-engines (a fixed `{mermaid, chart, math}` struct that omits `graphviz` or
-`plantuml` is non-conformant). When the needed renderer is absent, `renderStatic`
-MUST fall back to source, never blank.
+`"static"` render therefore accepts a **renderers** map. The map is **open**: a
+diagram renderer is keyed by the **fence's css class** - `mermaid`, `chart`,
+`graphviz`, `plantuml`, or any custom fence word - so a custom `FencedRender`
+instance is static-capable with no change to the engine, no spec edit, and no
+lockstep. `math` is the one distinct key (its renderer also takes a display
+flag). Implementations MUST consult the renderer by css class and MUST fall back
+to source when the needed renderer is absent - never blank.
 
 > [!NOTE]
-> The canonical key set is **closed**: it grows only by a deliberate, coordinated
-> change across the spec and every implementation, never ad hoc. Adding a key
-> (as `plantuml` was added alongside `mermaid`/`chart`/`graphviz`/`math`) is a
-> lockstep edit - the spec sentence above, plus each engine's renderers type or
-> map and the preset that carries the key, plus any binding that validates keys
-> (e.g. carve-rb's allowlist). The payoff for that cost is the cross-engine parity
-> guarantee; the discipline is that renderer keys are curated, not open-ended. Renderers are **synchronous** (`source -> string`; `math` also takes a
+> The map was **closed** in earlier drafts (a fixed `{mermaid, chart, graphviz,
+> plantuml, math}` set); it is now **open** so third-party diagram libraries are
+> first-class. A custom fence word (`fencedRender({ language: 'myuml' })` +
+> `renderers: { myuml: … }`) renders statically in every engine with the same
+> config, exactly like a canonical preset - the portability the canonical set
+> alone could not give. Canonical presets are just the pre-named css classes;
+> they carry no privilege the map withholds from a custom one.
+
+Renderers are **synchronous** (`source -> string`; `math` also takes a
 display flag): an async tool (mmdc, an HTTP service) must be run in a build step
 and supplied as a pre-resolved lookup, not awaited inside the render. Renderers
 apply to the **static HTML** path only - the Markdown/plain/ANSI renderers keep

--- a/docs/static-rendering-recipes.md
+++ b/docs/static-rendering-recipes.md
@@ -49,7 +49,7 @@ Two rules of thumb:
 ## Closure signatures per engine
 
 The `renderers` map is keyed by extension name (`mermaid`, `chart`, `graphviz`,
-`math`). The closure takes the source string and returns an HTML fragment (an
+`plantuml`, `math`). The closure takes the source string and returns an HTML fragment (an
 `<img>`, inline `<svg>`, or your fallback). Math additionally receives a display
 flag where the engine exposes one.
 

--- a/docs/static-rendering-recipes.md
+++ b/docs/static-rendering-recipes.md
@@ -48,8 +48,8 @@ Two rules of thumb:
 
 ## Closure signatures per engine
 
-The `renderers` map is keyed by extension name (`mermaid`, `chart`, `graphviz`,
-`plantuml`, `math`). The closure takes the source string and returns an HTML fragment (an
+The `renderers` map is **open**, keyed by the fence's css class (`mermaid`,
+`chart`, `graphviz`, `plantuml`, `math`, or any custom fence word). The closure takes the source string and returns an HTML fragment (an
 `<img>`, inline `<svg>`, or your fallback). Math additionally receives a display
 flag where the engine exposes one.
 


### PR DESCRIPTION
Expands the closed, normative static-render **renderers** key set from `{mermaid, chart, graphviz, math}` to add **`plantuml`** (§2.5), so a build-time PlantUML renderer can bake diagrams into no-JS static HTML the same way the others do.

This is the normative keystone for the PlantUML preset landing in lockstep across the engines: carve-js #360, carve-php #376, carve-rs #243 (and carve-rb to follow, once carve-rs merges - it pins carve-rs by git rev).

## Why at 0.1

Expanding a normative closed set is cheapest **before the key has any users**. The `plantuml` / `puml` fence words are brand-new and unreleased, and nothing supplies `renderers.plantuml` today, so no existing config or behavior changes. Post-1.0 the identical edit would be a breaking spec bump. This is the window.

## What changed

- The canonical-key sentence and the degradation table row now include `plantuml`.
- A new note makes the **closed-set contract explicit**: the key set grows only by a coordinated lockstep change across the spec, each engine's renderers type/map and the preset that carries the key, and any binding that validates keys (carve-rb's allowlist). This documents the maintenance cost and the parity payoff rather than leaving them to be rediscovered.
- `docs/static-rendering-recipes.md` key list updated.
- `CHANGELOG.md` Unreleased: the preset, the key, and the new diagram docs.

## Not touched

The conformance corpus. `FencedRender` presets are Tier-3 and never corpus-pinned, so `corpus:build` is byte-identical (verified). Full test suite green (464 pass), docs site builds.
