### PR TITLE
spec: pin static diagram wrapper to a uniform <div> (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Static diagram output now uses a uniform wrapper across engines: a supplied
+  renderer's output is wrapped in a `<div class="{cssClass}">` carrying the
+  fence's merged attributes. Previously carve-js emitted `<pre>`, carve-php a
+  `<div>`, and carve-rs bare output that dropped the css class (carve#302).
+
 ### Added
 
 - Diagram documentation: a dedicated Diagrams & Charts page and a cheatsheet

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -257,6 +257,21 @@ lockstep. `math` is the one distinct key (its renderer also takes a display
 flag). Implementations MUST consult the renderer by css class and MUST fall back
 to source when the needed renderer is absent - never blank.
 
+A supplied diagram renderer's output MUST be wrapped in a single
+`<div>` carrying the fence's **merged attributes** - the css class ahead of any
+author `{#id .class data-*}` - so the wrapper is uniform across engines and the
+class survives for styling:
+
+```html
+<div class="mermaid"><!-- renderer output (svg / img) --></div>
+```
+
+The wrapper is a `<div>`, not the interactive hydration tag (`<pre>` for text
+mode, `<div>` for json), because the rendered output is an image, not source
+text. The source-fallback form (no renderer) stays a `<pre><code>` block.
+(Attribute ordering within the tag follows the engine's element serialization,
+PART 10.)
+
 > [!NOTE]
 > The map was **closed** in earlier drafts (a fixed `{mermaid, chart, graphviz,
 > plantuml, math}` set); it is now **open** so third-party diagram libraries are


### PR DESCRIPTION
Fixes the wrapper-shape half of markup-carve/carve#302.

A supplied static diagram renderer's output was wrapped three different ways: carve-js `<pre class>`, carve-php `<div class>`, carve-rs **bare** (dropping the css class and author attributes entirely). This unifies them to a single `<div>` carrying the fence's merged attributes (css class ahead of any author `{#id .class data-*}`), so the same config yields the same wrapper across engines and the class survives for styling.

- The wrapper is a `<div>`, not the interactive hydration tag (`<pre>` text / `<div>` json), because the rendered output is an image, not source text.
- The source-fallback path (no renderer supplied) is unchanged - still `<pre><code class="language-…">`.

carve-php already emitted `<div class + attrs>` and is the shape reference; it needs no change.

## Verified

The same `{#fig1 .wide}` + mermaid renderer config now yields `<div … class="mermaid wide" …>` in all three engines (carve-js and carve-rs byte-identical).

## Out of scope (separate follow-up)

A finer divergence remains: **attribute order**. carve-js/carve-rs emit `id` before `class`; carve-php's extension layer (fenced-render, spoiler, colorswatch, …) emits `class` before `id`, diverging from php's own core renderer. That is broader than diagrams and predates this change - tracked separately, not fixed here.
