### PR TITLE
profiles: complete the node-type vocabulary and fix its spelling rule

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -19,17 +19,38 @@ parity is verified by those fixtures, not the corpus.
 A profile's allow/deny lists use these exact type strings. They are stable
 identifiers, independent of a renderer's output tag.
 
+Type identifiers are **`snake_case`**, always. A hyphenated or camelCased
+identifier is a defect in the implementation that emits it, not an alternate
+spelling.
+
 **Block:** `paragraph`, `heading`, `code_block`, `block_quote`, `list`,
 `list_item`, `table`, `table_row`, `table_cell`, `thematic_break`, `div`,
-`raw_block`, `footnote`, `definition_list`, `definition_term`,
+`admonition`, `raw_block`, `footnote`, `definition_list`, `definition_term`,
 `definition_description`, `section`, `line_block`, `comment`, `figure`,
 `caption`.
 
 **Inline:** `text`, `emphasis`, `strong`, `underline`, `strike`,
-`inline_extension`, `mention`, `code`, `link`, `image`, `soft_break`,
-`hard_break`, `raw_inline`, `escaped_text`, `footnote_ref`, `inline_footnote`,
-`span`, `superscript`, `subscript`, `highlight`, `insert`, `delete`, `symbol`,
-`math`, `abbreviation`.
+`inline_extension`, `mention`, `code`, `link`, `autolink`, `image`,
+`soft_break`, `hard_break`, `raw_inline`, `escaped_text`, `footnote_ref`,
+`inline_footnote`, `heading_ref`, `citation_group`, `caption_number`,
+`span`, `superscript`, `subscript`, `highlight`, `insert`, `delete`,
+`substitution`, `symbol`, `math`, `abbreviation`.
+
+An **`autolink`** is its own type, not a `link`. The two differ in what the
+author wrote and in what a formatter must be able to reproduce: an autolink
+carries no label, shows its own target, and drops an added `mailto:` scheme
+when displayed. Folding it into `link` loses the authored form, so a
+round-trip could not restore it.
+
+An **`admonition`** is likewise its own type rather than a `div` carrying a
+class. A profile that wants to deny callouts while allowing generic
+containers has no way to express that if the kind lives in a class string.
+
+Types serving a formatter rather than a document are **not** in this
+vocabulary and cannot be named in a profile. An implementation may carry a
+node preserving literal source for round-trip formatting (carve-php calls it
+`raw_text`); denying it would break `fmt` while expressing nothing about the
+document's content.
 
 The inline literal of PART 9 §27 (`` !`…` ``) is classified as **`code`** for
 profiles — it is a code span with the `<code>` wrapper dropped, sharing code's

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sync-carve-lib": "node scripts/sync-carve-lib.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/corpus.test.mjs tests/optional-corpus.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/optional-corpus.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },

--- a/tests/node-vocabulary.test.mjs
+++ b/tests/node-vocabulary.test.mjs
@@ -1,0 +1,83 @@
+/*
+ * Node-type vocabulary checks.
+ *
+ * docs/profiles.md is the single place the normative vocabulary is written
+ * down, and implementations copy those strings verbatim. A typo or an
+ * inconsistent spelling there propagates into every implementation and is only
+ * caught when two of them disagree at runtime - which is how carve-php ended up
+ * emitting `citation-group` while spelling every other type with underscores.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const profiles = readFileSync(resolve(here, '../docs/profiles.md'), 'utf8')
+
+/** Pulls the backticked identifiers out of one labelled vocabulary paragraph. */
+function vocabulary(label) {
+  const section = profiles.match(
+    new RegExp(`\\*\\*${label}:\\*\\*([\\s\\S]*?)\\n\\n`),
+  )
+  assert.ok(section, `no ${label} vocabulary paragraph in docs/profiles.md`)
+
+  // Deliberately permissive: a malformed identifier must be captured so the
+  // snake_case assertion can fail on it, rather than skipped and passing.
+  return [...section[1].matchAll(/`([A-Za-z0-9_-]+)`/g)].map((m) => m[1])
+}
+
+const block = vocabulary('Block')
+const inline = vocabulary('Inline')
+
+test('the vocabulary paragraphs are found and non-trivial', () => {
+  assert.ok(block.length > 15, `block vocabulary looks truncated: ${block.length}`)
+  assert.ok(inline.length > 20, `inline vocabulary looks truncated: ${inline.length}`)
+})
+
+test('every type identifier is snake_case', () => {
+  for (const type of [...block, ...inline]) {
+    assert.match(
+      type,
+      /^[a-z][a-z0-9]*(_[a-z0-9]+)*$/,
+      `"${type}" is not snake_case; the spec states there is no alternate spelling`,
+    )
+  }
+})
+
+test('no type is listed twice, or on both axes', () => {
+  const all = [...block, ...inline]
+  const duplicates = all.filter((type, i) => all.indexOf(type) !== i)
+  assert.deepEqual(duplicates, [], `duplicated type identifiers: ${duplicates.join(', ')}`)
+})
+
+test('formatter-internal nodes stay out of the vocabulary', () => {
+  // A profile naming these could break `fmt` while saying nothing about the
+  // document's content, so the spec excludes them by name.
+  for (const internal of ['raw_text']) {
+    assert.ok(
+      ![...block, ...inline].includes(internal),
+      `"${internal}" is formatter-internal and must not be profile-addressable`,
+    )
+  }
+})
+
+test('types the implementations emit are all covered', () => {
+  // Regression guard for the specific gaps that let nodes degrade unchecked in
+  // every chat target at once before anyone noticed.
+  for (const type of [
+    'autolink',
+    'admonition',
+    'heading_ref',
+    'citation_group',
+    'caption_number',
+    'substitution',
+  ]) {
+    assert.ok(
+      [...block, ...inline].includes(type),
+      `"${type}" is emitted by an implementation but absent from the vocabulary`,
+    )
+  }
+})


### PR DESCRIPTION
The normative node-type vocabulary was missing six types the implementations actually emit, so nothing anchored their names and no profile could address them.

This surfaced while adding chat-platform flavor tables (#309): those tables are keyed by this vocabulary, so a type absent from it degrades in **every** chat target at once with no gate noticing. That is exactly how `citation_group` went unmapped and silently dropped every citation in carve-php-chat.

## Added

`admonition` (block), plus `autolink`, `heading_ref`, `citation_group`, `caption_number` and `substitution` (inline).

## Two are deliberately their own type

**`autolink` is not a `link`.** It carries no label, shows its own target, and drops an added `mailto:` scheme when displayed. Folding it into `link` loses the authored form, so a round-trip could not restore it. carve-js already models it separately and is right to; carve-php should follow.

**`admonition` is not a `div` with a class.** A profile that wants to deny callouts while allowing generic containers cannot express that when the kind lives in a class string. Again carve-js has the better shape here.

## Spelling

Identifiers are now stated to be `snake_case`, with no alternate spelling. That makes carve-php's hyphenated `citation-group` a defect to fix rather than a variant to accommodate - it is the only one of its 52 node types spelled that way.

## Exclusion

Nodes serving a formatter rather than a document are excluded **by name**. carve-php's `raw_text` preserves literal source for round-trip formatting; a profile denying it would break `fmt` while expressing nothing about the document's content.

## Enforcement

The vocabulary is prose in a single file that implementations copy verbatim, so a typo there propagates everywhere and only shows up when two implementations disagree at runtime. `tests/node-vocabulary.test.mjs` now parses it and asserts snake_case, no duplicates across axes, formatter-internal types absent, and the six added types present.

Its extractor is deliberately permissive about what it captures: an earlier version matched only `[a-z_]+`, which silently skipped a malformed identifier and meant the snake_case assertion could never fail. Verified by hyphenating a type and confirming it fails.

## Follow-ups this implies

- carve-php: rename `citation-group` to `citation_group`; gain `autolink` and `admonition` node types.
- carve-js: converge its AST type strings on this vocabulary (`italic` to `emphasis`, `code-block` to `code_block`, and so on); keep `autolink` and `admonition` as-is, since this PR adopts its shape.
- #309 hardcodes the vocabulary in the flavor-table validator; it should derive from this list once both land.