### PR TITLE
docs: document the img SVG fence extension

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -170,6 +170,7 @@ export default defineConfig({
               ],
             },
             { text: 'Diagrams & Charts', link: '/diagrams' },
+            { text: 'SVG Images', link: '/svg-images' },
           ],
         },
         {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -85,6 +85,7 @@ export default defineConfig({
               { text: 'Cheat Sheet', link: '/cheatsheet' },
               { text: 'Examples', link: '/examples' },
               { text: 'Diagrams & Charts', link: '/diagrams' },
+              { text: 'SVG Images', link: '/svg-images' },
               { text: 'Formal Grammar', link: '/grammar' },
               { text: 'Blocks & Attributes', link: '/blocks-and-attributes' },
               { text: 'Validation', link: '/validation' },

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -51,6 +51,7 @@ PART 9 §19); Tier-2 / Tier-3 are off until enabled.
 | Mention/tag → URL templates, symbol map (e.g. emoji glyphs), locale smart-quote sets | <Badge type="info" text="standard" /> | off | — |
 | Mermaid / FencedRender, MathBlock, ListTable, Bibliography, Glossary, Index, HeadingNumbers, Details, Spoiler, Tabs, CodeGroup | <Badge type="warning" text="extension" /> | off | — |
 | TableOfContents, HeadingPermalinks / LevelShift, ExternalLinks, Wikilinks, SemanticSpan, ColorSwatch, Lowercase/AsciiHeadingIds | <Badge type="warning" text="extension" /> | off | — |
+| [ImgFence](/svg-images) (sanitized SVG `img` fence — sandboxed by default) | <Badge type="warning" text="extension" /> | off | — |
 
 A `:name[…]` / `::: name` whose word has no registered handler renders via the
 generic fallback (`<span>` / `<div class="name">`), so a document using an

--- a/docs/security.md
+++ b/docs/security.md
@@ -309,6 +309,13 @@ mode). For untrusted input, turn raw HTML off - the URL, attribute, and DoS
 defenses above are always on, but raw passthrough is the one switch you own.
 :::
 
+::: tip Prefer the `img` fence over raw `=html` for SVG
+To put SVG on the page without the raw-HTML passthrough, use the
+[`img` fence](/svg-images). It sanitizes the SVG and, by default, emits a
+browser-sandboxed `data:image/svg+xml` `<img>` - safe for untrusted input.
+Themeable inline `<svg>` is an opt-in the host enables only for trusted content.
+:::
+
 ::: tip Defense in depth still applies
 Carve's URL/CSS hardening is a **denylist** of known-dangerous constructs, not a
 full allowlist sanitizer. For genuinely hostile input that may carry arbitrary

--- a/docs/svg-images.md
+++ b/docs/svg-images.md
@@ -1,0 +1,103 @@
+# SVG Images (`img` fence)
+
+The `img` fence renders an **SVG image** from an SVG source block, sanitized,
+instead of showing the source verbatim. It is the safe alternative to the raw
+`` ```=html `` passthrough for putting SVG on the page.
+
+It is a <Badge type="warning" text="extension" /> (Tier-3): off by default, opt
+in per document.
+
+```` carve
+```img
+<svg viewBox="0 0 24 24"><path d="M4 12l6 6 10-12"/></svg>
+```
+````
+
+The fence word is `img` (alias `image`). `svg` and `xml` are deliberately **not**
+claimed, so you can still syntax-highlight SVG *source* with those words.
+
+## Two modes: sandbox by default
+
+Because a fence carries no inline attributes, the mode flag and any `{#id .class}`
+go on the **preceding** block-attribute line.
+
+### Sandbox (default)
+
+The sanitized SVG is encoded into a `data:image/svg+xml` URI on an `<img>`:
+
+```` carve
+```img
+<svg viewBox="0 0 24 24"><path d="M4 12l6 6 10-12"/></svg>
+```
+````
+
+renders as
+
+``` html
+<img src="data:image/svg+xml,%3Csvg%20xmlns%3D..." alt="">
+```
+
+The browser **sandboxes** an SVG loaded through `<img>`: no script runs, no
+external resource is fetched, and it cannot touch the surrounding page. This is
+the safe path for untrusted input. Set the alt text with `{alt="…"}`.
+
+### Inline (opt-in, host-gated)
+
+Inline mode emits a live `<svg>` in the DOM, so `currentColor`, CSS classes and
+dark-mode all apply — ideal for themeable icons:
+
+```` carve
+{inline}
+```img
+<svg viewBox="0 0 24 24"><path d="M4 12l6 6 10-12" fill="currentColor"/></svg>
+```
+````
+
+Inline is **only** available when the host enabled it:
+
+::: code-group
+``` ts [carve-js]
+import { imgFence } from '@markup-carve/carve'
+carveToHtml(src, { extensions: [imgFence({ allowInline: true })] })
+```
+``` php [carve-php]
+$converter->addExtension(new ImgFenceExtension(allowInline: true));
+```
+:::
+
+Without `allowInline`, a `{inline}` attribute is **ignored** and the fence stays
+sandboxed.
+
+> [!WARNING]
+> **Inline is a host capability, not an author one.** A fence body and its
+> attributes both come from the same author, so a bare `{inline}` must never let
+> that author break out of the sandbox. Only the host, by turning on
+> `allowInline`, opts in — and it should do so only for **trusted** content.
+
+## Security
+
+- **Sandbox mode is the strong boundary.** The browser isolates an
+  `<img>`-loaded SVG; this holds regardless of the sanitizer. Prefer it for
+  untrusted input.
+- **Inline mode relies on the built-in sanitizer** — a zero-dependency,
+  default-deny allowlist that drops `<script>`, event handlers,
+  `<foreignObject>`, `javascript:` and entity/escape-obfuscated schemes, external
+  and protocol-relative `url()` references, active CSS, and SMIL href
+  retargeting; forces a single well-formed `<svg>` root; and falls back to the
+  escaped source for anything it cannot make safe.
+- It is a string sanitizer, **not** a browser-grade parser, so parser-differential
+  and mutation-XSS cannot be fully ruled out. For untrusted input, stay in
+  sandbox mode, or post-process inline output with a browser-based sanitizer
+  (e.g. DOMPurify's SVG profile). See [Security](/security).
+
+Opt-in flags widen what inline mode keeps, each off by default: `allowStyle`
+(the `style` attribute, value-scrubbed — the `<style>` *element* is always
+dropped), `allowLinks` (`<a>` + external `href`), `allowAnimation` (SMIL), and
+`allowExternalImages` (`<image>` with an external raster `href`).
+
+## Fallback
+
+A body that is not a single, well-formed `<svg>` root degrades to an escaped code
+block — never blank, never raw. In sandbox mode the image is always a
+self-contained data URI, so it needs no network and works offline and in static
+renders.


### PR DESCRIPTION
Documents the `img` SVG fence extension (carve-js markup-carve/carve-js#366, carve-php markup-carve/carve-php#382).

Adds `docs/svg-images.md` covering:
- the `img` (alias `image`) fence and why `svg`/`xml` stay unclaimed,
- **sandbox by default** (a browser-sandboxed `data:image/svg+xml` `<img>`),
- **host-gated inline** (`allowInline` + an `{inline}` attribute) for themeable `<svg>`,
- the capability opt-ins (`allowStyle`, `allowLinks`, `allowAnimation`, `allowExternalImages`),
- the security boundary (sandbox is strong; inline uses the hand-rolled sanitizer and is trusted-content only).

Also wires it into the sidebar, lists ImgFence in the Tier-3 extensions table, and cross-references it from the raw-HTML section of the security page as the safe way to put SVG on the page.
