### PR TITLE
Stop corpus fixtures losing their significant bytes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,43 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+; ---------------------------------------------------------------------------
+; Byte-exact test data. Several corpus pairs assert the handling of characters
+; an editor would otherwise "clean up": a trailing no-break space (U+00A0), a
+; trailing ASCII space, and zero-width / bidi control characters in the
+; Trojan-Source pairs. Those bytes ARE the assertion, so nothing may normalize
+; them. Two fixtures also deliberately end without a final newline.
+; ---------------------------------------------------------------------------
+
+[tests/corpus/**]
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[tests/corpus-optional/**]
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[tests/examples/**]
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[tests/spec/**]
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+; The corpus is GENERATED from the fenced blocks in these files, so trailing
+; whitespace and invisible characters inside them are load-bearing test input.
+[docs/examples/**]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Corpus fixtures and generated example output are BYTE-EXACT test data.
+# Marking them binary (-text) stops git from applying any content or
+# line-ending normalization on checkout/commit, which would silently destroy
+# the characters several pairs exist to assert: a trailing no-break space
+# (U+00A0), a trailing ASCII space, and the zero-width / bidi controls in the
+# Trojan-Source pairs. Diffs stay readable because the files are still UTF-8
+# text; only the normalization is disabled.
+tests/corpus/**        -text
+tests/corpus-optional/** -text
+tests/examples/**      -text
+tests/spec/**          -text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Protection for byte-exact corpus fixtures.** Several pairs assert the
+  handling of characters an editor or formatter would "clean up": a trailing
+  no-break space, a trailing ASCII space, and the zero-width / bidi controls in
+  the Trojan-Source pairs. An `.editorconfig` and `.gitattributes` now stop
+  those bytes being normalized away, and a `tests/fixture-bytes.test.mjs` guard
+  fails loudly if one goes missing. The guard is not redundant with the corpus
+  test: where the same invisible character appears raw on BOTH sides of a pair
+  (the Trojan-Source zero-width case), stripping it from both keeps them in
+  sync, so the corpus test stays green while no longer testing anything.
 - **Corpus coverage for trailing-whitespace boundaries.** The trailing-whitespace
   strip applies to the paragraph's SOURCE line, so it never touches spaces a
   construct produces while rendering: a paragraph whose entire content is an

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sync-carve-lib": "node scripts/sync-carve-lib.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/corpus.test.mjs tests/optional-corpus.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/optional-corpus.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/fixture-bytes.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },

--- a/tests/fixture-bytes.test.mjs
+++ b/tests/fixture-bytes.test.mjs
@@ -1,0 +1,108 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const corpusDir = resolve(__dirname, 'corpus')
+
+// Characters an editor, formatter or sanitizer would plausibly "clean up", but
+// which are the ASSERTION in the pairs below. Losing one silently weakens or
+// voids the test it belongs to, so their presence is pinned here.
+const WATCHED = new Map([
+  [0x00a0, 'NBSP'],
+  [0x200b, 'ZWSP'],
+  [0x200c, 'ZWNJ'],
+  [0x200d, 'ZWJ'],
+  [0x200e, 'LRM'],
+  [0x200f, 'RLM'],
+  [0x202a, 'LRE'],
+  [0x202b, 'RLE'],
+  [0x202c, 'PDF'],
+  [0x202d, 'LRO'],
+  [0x202e, 'RLO'],
+  [0x2066, 'LRI'],
+  [0x2067, 'RLI'],
+  [0x2068, 'FSI'],
+  [0x2069, 'PDI'],
+  [0xfeff, 'BOM'],
+])
+
+// The inventory. Each entry names the invisible characters (and trailing ASCII
+// whitespace) a fixture MUST still contain.
+//
+// `html` matters most where it is non-empty: when the same invisible character
+// appears raw in BOTH the input and the expected output, stripping it from the
+// pair keeps them in sync, so the corpus test still PASSES while no longer
+// testing anything. That is the only silent-decay shape, and today only the
+// Trojan-Source ZWSP pair has it. Everywhere else the expectation spells the
+// character differently (`&nbsp;`) or drops it, so loss shows up as a normal
+// corpus mismatch.
+const INVENTORY = [
+  { base: '102-paragraph-trailing-whitespace', crv: ['trailing-WS'], html: [] },
+  {
+    base: '117-trojan-source-heading-ids-are-nfc-normalized-and-strip-invisible-controls-3',
+    crv: ['RLO', 'ZWSP'],
+    html: ['ZWSP'], // silent-decay shape: raw in both sides
+  },
+  { base: '118-trojan-source-rendered-text-and-code-strip-bidi-override-controls', crv: ['RLO'], html: [] },
+  { base: '118-trojan-source-rendered-text-and-code-strip-bidi-override-controls-2', crv: ['RLO'], html: [] },
+  { base: '139-trailing-whitespace-boundaries-4', crv: ['NBSP'], html: [] },
+  { base: '16-reference-link-9', crv: ['trailing-WS'], html: [] },
+  { base: '29-non-breaking-space-3', crv: ['NBSP'], html: [] },
+]
+
+function scan(text) {
+  const found = new Set()
+  for (const ch of text) {
+    const name = WATCHED.get(ch.codePointAt(0))
+    if (name) found.add(name)
+  }
+  if (/[ \t]+$/m.test(text)) found.add('trailing-WS')
+  return found
+}
+
+function read(base, ext) {
+  return readFileSync(resolve(corpusDir, `${base}.${ext}`), 'utf8')
+}
+
+for (const { base, crv, html } of INVENTORY) {
+  test(`fixture keeps its significant bytes: ${base}`, () => {
+    const inCrv = scan(read(base, 'crv'))
+    for (const want of crv) {
+      assert.ok(
+        inCrv.has(want),
+        `${base}.crv lost ${want}. That character is the assertion, not incidental ` +
+          `whitespace - it was probably stripped by an editor or formatter. Restore it ` +
+          `(see .editorconfig / .gitattributes, which exist to prevent exactly this).`,
+      )
+    }
+    const inHtml = scan(read(base, 'html'))
+    for (const want of html) {
+      assert.ok(
+        inHtml.has(want),
+        `${base}.html lost ${want}. This pair carries the character raw on BOTH sides, ` +
+          `so losing it from both would keep the corpus test GREEN while testing nothing.`,
+      )
+    }
+  })
+}
+
+// Catches a fixture that gains invisible characters without being pinned here,
+// and a pinned fixture that loses them entirely (it would drop out of the scan).
+test('the inventory of fixtures carrying invisible characters is complete', () => {
+  const actual = []
+  for (const file of readdirSync(corpusDir).filter((f) => f.endsWith('.crv')).sort()) {
+    const base = file.slice(0, -4)
+    if (scan(readFileSync(resolve(corpusDir, file), 'utf8')).size > 0) actual.push(base)
+  }
+  const expected = INVENTORY.map((e) => e.base).sort()
+  assert.deepEqual(
+    actual.sort(),
+    expected,
+    'Corpus fixtures carrying invisible or whitespace-significant characters have changed. ' +
+      'If you ADDED such a fixture, add it to INVENTORY here so its bytes are pinned. ' +
+      'If one DISAPPEARED, its significant character was stripped - restore it.',
+  )
+})


### PR DESCRIPTION
Several corpus pairs assert the handling of characters an editor, formatter or sanitizer would plausibly strip: a trailing no-break space (U+00A0), a trailing ASCII space, and the zero-width / bidi controls in the Trojan-Source pairs. Those bytes are the assertion, and the repo had neither an `.editorconfig` nor a `.gitattributes` to protect them.

## Two layers

**Prevention** - `.editorconfig` and `.gitattributes` disable trailing-whitespace trimming, final-newline insertion and content normalization for `tests/corpus`, `tests/corpus-optional`, `tests/examples`, `tests/spec`, and `docs/examples` (from which the corpus is generated). Repo-wide defaults follow the sibling packages but use this repo's actual 2-space JS indent rather than importing carve-php's 4-space. Two `tests/examples` files deliberately end without a final newline, so that is disabled for fixtures rather than enforced against them.

**Detection** - `tests/fixture-bytes.test.mjs` pins an inventory of the seven fixtures carrying such characters and fails if one loses a watched byte, or gains one without being pinned.

## Why the guard is not redundant with the corpus test

Where the same invisible character appears raw on BOTH sides of a pair, stripping it from both keeps input and expectation in sync - so the corpus test still passes while testing nothing. Only the Trojan-Source zero-width pair has that shape today:

```
117-...-3.crv    # A<U+202E>B<U+200B>C
117-...-3.html   <h1>AB<U+200B>C</h1>     <- U+200B raw on both sides
```

Removing that U+200B from both files leaves the corpus suite at **440 pass / 0 fail** while the new guard fails. Everywhere else the expectation spells the character differently (`&nbsp;`) or drops it, so loss already surfaces as an ordinary mismatch - there the guard just makes the cause obvious instead of showing a confusing diff.

`core:check` 437/437 conformant, 0 defects; full suite 489 pass. No corpus fixture content changed.
