### PR TITLE
docs: reposition Carve as a shipped 0.1 specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,30 @@
 
 A lightweight markup language with visual mnemonics and human-centered design.
 
-> "The best markup is the one you don't have to think about."
+This repository is the normative definition of the language: the [formal
+grammar](resources/grammar.ebnf), the conformance corpus every implementation is
+tested against, and the design rationale behind each decision.
 
-## Philosophy
+## Status
 
-Carve builds on Markdown's basics and Djot's technical rigor while adding:
+**Carve 0.1 is specified and shipping.**
 
-- **Visual mnemonics** - Syntax resembles its output
-- **Human factors research** - Based on how non-technical users naturally mark up text
-- **Progressive disclosure** - Basic usage is trivial, power features exist when needed
-- **Extendable by design** - Core syntax stays small while standard and app-level extensions fit a defined contract
-- **Social conventions** - `@mentions` and `#tags` are recognized as first-class inline tokens
+| | |
+|---|---|
+| **Specification** | 0.1. Tier-1 core and Tier-2 standard extensions are normative and stable; Tier-3 app-level extensions ship but evolve. See [VERSIONING.md](VERSIONING.md). |
+| **Conformance** | 437 corpus examples pinning exact HTML output, plus 28 optional-corpus examples for host-dependent extensions. |
+| **Engines** | [carve-js](https://github.com/markup-carve/carve-js) (TypeScript, reference), [carve-php](https://github.com/markup-carve/carve-php), [carve-rs](https://github.com/markup-carve/carve-rs) - all three run the same corpus, with no open or intentional divergences ([tracker](MAINTAINING.md#known-cross-impl-divergences)). |
+| **Bindings** | Python, Ruby, Go, and WebAssembly, all over carve-rs. |
+| **Tooling** | Language server, tree-sitter grammar, formatter and linter (`carve fmt` / `carve lint`), converters from Markdown, HTML, Djot, and BBCode. |
+| **Editors** | VS Code, JetBrains, Sublime Text, Vim/Neovim, Emacs, Zed, Helix. |
+| **Integrations** | Laravel, Symfony, WordPress, Shopware, Hugo, Astro, Eleventy, Jekyll, and a Pandoc bridge to LaTeX, Typst, DOCX, and PDF. |
+
+Pre-1.0, a minor release may still change the grammar; the stability tiers and
+the release lockstep between the spec and the engines are defined in
+[VERSIONING.md](VERSIONING.md) and [MAINTAINING.md](MAINTAINING.md). The full
+project list is at <https://github.com/markup-carve#projects>.
+
+**File extension:** `.crv`
 
 ## Why Carve?
 
@@ -58,6 +71,26 @@ Extensions hook into this pipeline per target, so an extension can render rich
 HTML for the web while degrading cleanly to plain text elsewhere - one source,
 many endpoints. See the [Extensions Contract](https://markup-carve.github.io/carve/extensions)
 and the [Carve vs Markdown, Djot & MDX comparison](https://markup-carve.github.io/carve/comparison).
+
+## Get started
+
+Try it with nothing installed in the [Playground](https://markup-carve.github.io/carve/playground),
+or render Carve in your own project:
+
+```bash
+npm install @markup-carve/carve      # JavaScript / TypeScript
+composer require markup-carve/carve-php   # PHP
+cargo install carve-lang             # Rust, incl. the `carve` CLI
+```
+
+```ts
+import { carveToHtml } from '@markup-carve/carve'
+
+const html = carveToHtml('/italic/, *bold*, and _underline_')
+```
+
+Full instructions, including the Python, Ruby, Go, and WebAssembly bindings, are
+in [Get Started](https://markup-carve.github.io/carve/get-started).
 
 ## Demo
 
@@ -136,7 +169,11 @@ COMMENTS
 
 ## Design Principles
 
-Carve takes its rationale from Djot and Markdown, and extends both:
+Carve takes its parsing rationale from Djot and its authoring ergonomics from
+Markdown, and extends both. The additions are grounded in human-factors work on
+how non-technical writers actually mark up text - the reasoning is recorded in
+the [Case Study](https://markup-carve.github.io/carve/case-study/) and the
+[technical rationale](https://markup-carve.github.io/carve/technical-rationale).
 
 ### From Djot
 
@@ -342,15 +379,18 @@ Guidelines:
 - Unambiguous parsing rules
 - Built-in extension system
 
-## Status
+## Documentation
 
-Carve is a design exploration. The site renders at <https://markup-carve.github.io/carve/>.
+The full site renders at <https://markup-carve.github.io/carve/>: the
+[cheat sheet](https://markup-carve.github.io/carve/cheatsheet), the
+[extensions contract](https://markup-carve.github.io/carve/extensions), the
+[security model](https://markup-carve.github.io/carve/security), the
+[technical rationale](https://markup-carve.github.io/carve/technical-rationale),
+and [Build Your Own Implementation](https://markup-carve.github.io/carve/implementing-carve).
 
-**File extension:** `.crv`
-
-Maintaining the spec ↔ carve-* lockstep, and the list of known cross-implementation divergences, are documented in [`MAINTAINING.md`](MAINTAINING.md).
-
-For full overview see https://github.com/markup-carve#projects
+The [Case Study](https://markup-carve.github.io/carve/case-study/) records the
+original design research the language grew out of; it is history, not the
+normative spec.
 
 ## Influences
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,8 @@ npm run docs:build   # production build into docs/.vitepress/dist
 ## What lives here
 
 - `index.md`, `get-started.md`, `migrate-from-markdown.md`, `comparison.md`, … - the pages.
-- `case-study/`, `examples.md` - the normative narrative and example corpus source.
+- `grammar.md`, `extensions.md`, `examples.md` - the normative grammar, the extensions contract, and the example corpus source.
+- `case-study/` - the original design research, kept as a historical record.
 - `.vitepress/` - site config, theme, and the vendored `carve-lib` engine used by the live playground.
 
 > [!NOTE]

--- a/docs/case-study/implementation.md
+++ b/docs/case-study/implementation.md
@@ -53,7 +53,7 @@ Carve succeeds if:
 - Parsing is deterministic and fast
 - Migration from Markdown is trivial
 
-### 12.3 Next Steps
+### 12.3 Next Steps (as written at the time)
 
 1. Formalize EBNF grammar
 2. Build reference parser in TypeScript
@@ -62,11 +62,17 @@ Carve succeeds if:
 5. Editor integration (VS Code, Obsidian, etc.)
 6. Documentation and tutorials
 
+All six have since shipped: the [formal grammar](../grammar) is normative, three
+engines pass a shared [conformance corpus](https://github.com/markup-carve/carve/tree/main/tests/corpus),
+and Carve has editor support across seven editors plus a language server. See
+the [Ecosystem](../ecosystem) for the current state.
+
 ---
 
-*This case study captures Carve's original design exploration. Carve now has a
-normative grammar, a conformance corpus, and multiple implementations; real-world
-testing with diverse users continues to inform syntax decisions.*
+*This case study is a historical record of Carve's original design research.
+The normative definition of the language is the [formal grammar](../grammar) and
+the conformance corpus; real-world testing with diverse users continues to
+inform syntax decisions.*
 
 *Feedback and contributions welcome at <https://github.com/markup-carve>.*
 

--- a/docs/case-study/index.md
+++ b/docs/case-study/index.md
@@ -1,9 +1,18 @@
 ---
 title: Case Study
-description: A case study in post-Markdown markup design.
+description: The original design research behind Carve - historical, not normative.
 ---
 
 # Case Study
+
+::: info Historical document
+This case study records the design research Carve grew out of: the landscape it
+came from, the principles that guided it, and the reasoning behind each syntax
+decision. It is **not the normative specification** and is not kept in lockstep
+with the language. For what implementations must do, read the
+[formal grammar](../grammar), the [extensions contract](../extensions), and the
+[conformance corpus](https://github.com/markup-carve/carve/tree/main/tests/corpus).
+:::
 
 How Carve was designed: the landscape it grew out of, the principles that guided it, the syntax it ended up with, and the parsing / implementation considerations that fall out of those choices.
 
@@ -13,7 +22,7 @@ The full case study was split into themed chapters so each one stands on its own
 
 - [Background](./background) — the landscape of lightweight markup, what each existing format teaches us, and what observation of non-technical users reveals.
 - [Design](./design) — Carve's core principles, anti-patterns to avoid, and a reflection on why we don't just patch Markdown.
-- [Syntax Specification](./syntax) — the spec proper. Every construct, every delimiter, every rule.
+- [Syntax Walkthrough](./syntax) — every construct, every delimiter, every rule, as the design settled them. The normative version is the [formal grammar](../grammar).
 - [Parsing & AST](./parsing-ast) — block-then-inline parsing strategy and the shape of the AST it produces.
 - [Compatibility, Comparison & Open Questions](./compatibility) — migration paths from other formats, feature-by-feature comparison matrix, and what's still being debated.
 - [Implementation & Reflection](./implementation) — practical concerns for implementers, and what success looks like.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -86,7 +86,8 @@ The full ecosystem — editor integrations, framework plugins, and more — is l
 
 - **[Cheat Sheet](/cheatsheet)** — every construct, one scannable page.
 - **[Examples](/examples)** — Carve source next to the exact HTML it produces.
-- **[Case Study](/case-study/)** — the full design rationale and normative spec.
+- **[Formal Grammar](/grammar)** — the normative block and inline grammar.
+- **[Case Study](/case-study/)** — the design research the language grew out of (historical, not normative).
 
 ## 4. Core vs extensions
 

--- a/docs/implementing-carve.md
+++ b/docs/implementing-carve.md
@@ -17,9 +17,9 @@ repository. In rough order of usefulness when implementing:
   given input must match. It is the same corpus every reference parser runs
   against.
 - **[Formal Grammar](./grammar)** - the block and inline grammar.
-- **[Case Study](./case-study/)** - design rationale and the syntax
-  specification, including [Parsing & AST](./case-study/parsing-ast) and
-  [Implementation & Reflection](./case-study/implementation).
+- **[Case Study](./case-study/)** - the design rationale behind the rules
+  (historical, not normative), including [Parsing & AST](./case-study/parsing-ast)
+  and [Implementation & Reflection](./case-study/implementation).
 - **[Extensions Contract](./extensions)** - the normative contract for the
   `:type[content]{attrs}` extension syntax (optional - see tiers below).
 - **[Edge Cases](./edge-cases)** and **[Divergence from Djot](./divergence-from-djot)**

--- a/docs/index.md
+++ b/docs/index.md
@@ -177,7 +177,20 @@ block comment
 
 ## Status
 
-Carve is a design exploration. The specification lives in the [Case Study](./case-study/). Reference material covers the normative [extensions contract](./extensions), the [technical rationale](./technical-rationale), [parsing edge cases](./edge-cases), [native features](./native-features-analysis), and the [broader markup landscape](./markup-languages).
+**Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
+extensions are normative and stable; Tier-3 app-level extensions ship but evolve
+(see [Versioning](./versioning)). Conformance is pinned by 437 corpus examples
+with exact HTML output, and the three reference engines - carve-js (TypeScript),
+carve-php, and carve-rs - all run the same corpus with no open divergences.
+Pre-1.0, a minor release may still change the grammar.
+
+Reference material covers the normative [grammar](./grammar) and
+[extensions contract](./extensions), the [security model](./security), the
+[technical rationale](./technical-rationale), [parsing edge cases](./edge-cases),
+[native features](./native-features-analysis), and the
+[broader markup landscape](./markup-languages). The [Case Study](./case-study/)
+records the original design research the language grew out of; it is history,
+not the normative spec.
 
 Looking for a parser, editor plugin, or framework integration? See the [Ecosystem](./ecosystem). Want to write your own? Start with [Build Your Own Implementation](./implementing-carve).
 


### PR DESCRIPTION
The README and the docs home still described Carve as "a design exploration". That framing was accurate at the start and is now wrong: the project has a tagged 0.1 release, a normative grammar, 437 corpus examples pinning exact HTML output, three reference engines with no open or intentional divergences, four language bindings, seven editor integrations, and framework plugins across the ecosystem.

## What changed

**README**
- `Status` promoted from a two-line footnote at the bottom to a maturity table right under the intro: specification tier stability, conformance numbers, engines, bindings, tooling, editors, integrations.
- New `Get started` section with install commands for the three engines, before the demo links.
- `Philosophy` removed; its five bullets already existed, better stated, under `Design Principles`. The one idea not covered there (the human-factors grounding) moved into the `Design Principles` intro.
- The old bottom `Status` section became a `Documentation` section that points at the site, the grammar, the extensions contract, and the security model.
- Dropped the opening pull-quote, which read as blog voice rather than spec voice.

**docs/index.md**
- Same status statement, linked to the versioning policy and the tier definitions.

**Case study relabeled**
- `docs/case-study/index.md` gets an explicit "historical document" note and points at the grammar, the extensions contract, and the corpus as the normative sources. The "Syntax Specification" chapter entry is retitled "Syntax Walkthrough".
- `docs/case-study/implementation.md`: the section 12.3 "Next Steps" list is marked as written at the time, with a note that all six items have shipped.
- Three places that told readers the case study *is* the specification are corrected: `docs/get-started.md`, `docs/implementing-carve.md`, `docs/README.md`.

No syntax, grammar, or corpus changes; documentation only.
