### PR TITLE
ci: make draft bump PRs say what failed and where to fix it

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -42,14 +42,17 @@ jobs:
             submodule: spec
             lang: node
             test: npm ci && npx vitest run test/corpus.test.ts
+            allowlist: the `IMPLEMENTED` set in `test/corpus.test.ts`
           - repo: markup-carve/carve-php
             submodule: tests/spec
             lang: php
             test: composer install --prefer-dist --no-progress && vendor/bin/phpunit --group corpus
+            allowlist: the `IMPLEMENTED` const in `tests/CarveCorpusTest.php` (its `isImplemented()` strips a trailing `-<n>`, so one base entry covers every sub-pair)
           - repo: markup-carve/carve-rs
             submodule: tests/spec
             lang: rust
             test: cargo test --test corpus
+            allowlist: the `IMPLEMENTED` slice in `tests/corpus.rs`
     steps:
       # Toolchain to run the impl's corpus conformance (mirrors each repo's
       # own CI), so the bump can decide draft-vs-ready.
@@ -74,6 +77,7 @@ jobs:
           REPO: ${{ matrix.repo }}
           SUB: ${{ matrix.submodule }}
           TEST_CMD: ${{ matrix.test }}
+          ALLOWLIST: ${{ matrix.allowlist }}
           # Optional: set the CODEX_API_KEY secret to let codex attempt the
           # implementation when a bump fails conformance. Dormant if unset.
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
@@ -103,15 +107,62 @@ jobs:
           fi
 
           # Does the impl conform to the bumped corpus? A failure -> draft PR.
-          # Wrapped in `if` so a non-zero exit doesn't trip `set -e`.
+          # Wrapped in `if` so a non-zero exit doesn't trip `set -e`. The output
+          # is tee'd so it still shows in the Actions log AND can be mined for
+          # what actually failed, which goes into the PR body.
+          CONF_LOG="$(mktemp)"
           draft=""
           note="Conforms to the bumped corpus — ready to merge."
-          if bash -c "$TEST_CMD"; then
+          detail=""
+          if bash -c "$TEST_CMD" 2>&1 | tee "$CONF_LOG"; then
             echo "$REPO conforms to carve $short -> ready PR"
           else
             echo "$REPO does NOT conform to carve $short -> draft PR (needs impl)"
             draft="--draft"
-            note="Does NOT yet conform — opened as a draft (implement, then mark ready)."
+            note="Does NOT yet conform — opened as a DRAFT on purpose (implement, then mark ready)."
+
+            # Say WHAT failed and WHERE to fix it, so the draft is actionable
+            # without re-running conformance locally. The three impls word the
+            # failure differently (carve-js "missing from IMPLEMENTED", carve-php
+            # "not implemented (add to IMPLEMENTED...)", carve-rs "not in
+            # IMPLEMENTED"), so pull slugs from any line mentioning the
+            # allowlist, then drop the `-<n>` sub-pair suffix exactly as each
+            # impl's own matcher does (carve-php reports per-pair, js/rs report
+            # base categories).
+            cats="$(grep -iE 'IMPLEMENTED' "$CONF_LOG" 2>/dev/null \
+              | grep -oE '[0-9]{2,}-[a-z0-9]+(-[a-z0-9]+)*' \
+              | sed -E 's/-[0-9]+$//' | sort -u || true)"
+            # A rendering difference is a DIFFERENT failure: the category may
+            # already be allowlisted and the engine simply disagrees with the
+            # corpus. Distinguish it so nobody "fixes" it by allowlisting.
+            mismatch="$(grep -ciE 'did not match|corpus mismatch' "$CONF_LOG" 2>/dev/null || true)"
+
+            # Append one markdown line to the PR body. Built line-by-line
+            # rather than with a heredoc: a heredoc body would have to start at
+            # column 0, which falls outside this `run: |` block scalar and
+            # breaks the workflow YAML.
+            add() { detail="$detail$1"$'\n'; }
+
+            if [ -n "$cats" ]; then
+              add ""
+              add "**New corpus categories not in this repo's allowlist:**"
+              add ""
+              while IFS= read -r c; do add "- \`$c\`"; done <<< "$cats"
+              add ""
+              add "To land this:"
+              add ""
+              add "1. Add the categories above to $ALLOWLIST."
+              add "2. Verify each pair renders **byte-exact** against its corpus \`.html\`. Do not merely allowlist: an entry asserts this engine implements the category, so a silent mismatch here is a real engine/spec divergence."
+              add "3. \`gh pr ready <N> --repo $REPO\`, then merge."
+            fi
+
+            if [ "${mismatch:-0}" != "0" ]; then
+              add ""
+              add "**Rendering mismatches were also reported.** That is a behavior difference, not a missing allowlist entry: the engine and the corpus disagree. Fix the engine (or adjudicate the spec) — allowlisting would only hide it. Expected-vs-actual output is in the workflow run log."
+            fi
+
+            add ""
+            add "_This PR is a draft deliberately._ Note that \`gh pr view\` reports \`mergeable=MERGEABLE\` and \`mergeStateStatus=CLEAN\` while hiding \`isDraft=true\`, so \`gh pr merge\` fails opaquely until it is marked ready."
 
             # Optional auto-attempt: if CODEX_API_KEY is set, let codex try the
             # implementation against the bumped corpus. Its output is unreviewed
@@ -139,11 +190,21 @@ jobs:
           # Stage the submodule bump plus any files codex changed.
           git add -A
           git commit -m "chore: bump spec corpus submodule to carve $short${draft:+ (+ impl attempt)}"
+          # HAZARD: this recreates the branch from the downstream repo's main
+          # (the clone is --depth 1 of main and never fetches the existing
+          # automation/bump-spec), so the force-push DISCARDS any commits a
+          # human added to an open bump PR -- including the allowlist entry the
+          # draft PR body asks for, or a `main` merged in to pick up a fix the
+          # branch predated. That happens whenever another corpus change lands
+          # on carve main while a draft bump PR is still open. If that bites,
+          # guard it: refuse to force-push when the remote branch carries
+          # commits this workflow did not author, or bump on a per-SHA branch.
           git push -f origin automation/bump-spec
 
-          body="$(printf '%s\n\n%s' \
+          body="$(printf '%s\n\n%s\n%s' \
             "Automated bump of the \`$SUB\` submodule to carve main (\`$short\`)." \
-            "$note The downstream repo's own CI re-validates conformance on this PR.")"
+            "$note The downstream repo's own CI re-validates conformance on this PR." \
+            "$detail")"
 
           existing="$(gh pr list --repo "$REPO" --head automation/bump-spec --state open --json number --jq '.[0].number // empty')"
           if [ -z "$existing" ]; then


### PR DESCRIPTION
The bump-downstream workflow already runs each implementation's corpus conformance before opening the PR, and opens a **draft** when it fails - meaning "implement me, not ready to merge". That design is right and is unchanged here.

What was missing was in the PR body: it never said **which** corpus category failed or **where** that repo's allowlist lives, so each draft cost a local re-run to rediscover. This happened three times in a day.

## What changed

The conformance output is now `tee`'d - still visible in full in the Actions log - and mined for the failing category slugs. The three implementations word the failure differently:

```
carve-js   Corpus categories missing from IMPLEMENTED (...): 139-trailing-whitespace-boundaries
carve-php  Corpus category not implemented (add to IMPLEMENTED, or KNOWN_GAPS to defer): 139-trailing-whitespace-boundaries-2
carve-rs   corpus categories not in IMPLEMENTED (add them, then implement/verify): ["139-trailing-whitespace-boundaries"]
```

so slugs are pulled from any line mentioning the allowlist, then the `-<n>` sub-pair suffix is dropped exactly as each implementation's own matcher does (carve-php reports per-pair; js and rs report base categories). A new `allowlist` matrix field carries the per-repo path.

A **rendering mismatch** is surfaced as a separate failure class, so a behavior difference is not mistakenly "fixed" by allowlisting it.

The body also states that the draft state is deliberate, and that `gh pr view` reports `mergeable=MERGEABLE` / `mergeStateStatus=CLEAN` while hiding `isDraft=true` - which is why `gh pr merge` fails opaquely on these.

## What deliberately did not change

Draft-vs-ready logic, the dormant codex gating, and auto-merge are untouched. The allowlist entry is still added by a human: it asserts "this engine implements this category", and automating it would make it a rubber stamp. That human step is what recently caught a bump branch predating a fix it needed.

## Rendered output

For a carve-rs bump missing two categories:

```
Automated bump of the `tests/spec` submodule to carve main (`7370f6a`).

Does NOT yet conform - opened as a DRAFT on purpose (implement, then mark ready). The
downstream repo's own CI re-validates conformance on this PR.

**New corpus categories not in this repo's allowlist:**

- `138-all-space-verbatim-content`
- `139-trailing-whitespace-boundaries`

To land this:

1. Add the categories above to the `IMPLEMENTED` slice in `tests/corpus.rs`.
2. Verify each pair renders **byte-exact** against its corpus `.html`. Do not merely
   allowlist: an entry asserts this engine implements the category, so a silent
   mismatch here is a real engine/spec divergence.
3. `gh pr ready <N> --repo markup-carve/carve-rs`, then merge.

_This PR is a draft deliberately._ Note that `gh pr view` reports `mergeable=MERGEABLE`
and `mergeStateStatus=CLEAN` while hiding `isDraft=true`, so `gh pr merge` fails
opaquely until it is marked ready.
```

## Also noted, not changed

A comment now documents a pre-existing hazard at the force-push: the clone is `--depth 1` of main and never fetches the existing `automation/bump-spec`, so `checkout -B` plus `push -f` discards any commits a human added to an open bump PR - including the allowlist entry this very body asks for. It triggers whenever another corpus change lands on main while a draft bump PR is open. Left as a comment rather than a behavior change, with two suggested guards.

No CHANGELOG entry: the file carries no CI-only entries, matching the project's convention of omitting non-functional changes.
