### PR TITLE
Docs: list the missing satellites and stop duplicating the list

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -63,9 +63,11 @@ the core but version on their own cadence. They are not required to match core
 version numbers at any level. Each satellite should document which core version
 it targets in its own README.
 
-Current satellites: carve-emacs, carve.vim, carve-sublime, carve-wysiwyg,
-carve-components, python-carve, intellij-carve, vscode-carve, lsp-carve,
-vite-plugin-carve, carve-skill.
+The authoritative list of satellites is [the ecosystem page](docs/ecosystem.md),
+which is grouped by role (parsers, bindings, editor support, framework
+integrations, AI tooling). It is deliberately not duplicated here: the copy that
+used to live in this file drifted and ended up naming repositories that do not
+exist.
 
 ## Version map
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -41,6 +41,7 @@ Syntax highlighting, structural editing, and diagnostics inside editors.
 | [emacs-carve](https://github.com/markup-carve/emacs-carve) | Emacs | Major mode for `.crv` files. |
 | [vim-carve](https://github.com/markup-carve/vim-carve) | Vim / Neovim | Syntax highlighting + tree-sitter grammar. |
 | [sublime-carve](https://github.com/markup-carve/sublime-carve) | Sublime Text | Syntax package for `.crv` files. |
+| [sublime-carve-lsp](https://github.com/markup-carve/sublime-carve-lsp) | Sublime Text | LSP helper package - diagnostics, hover and symbols via the Carve language server. |
 | [helix-carve](https://github.com/markup-carve/helix-carve) | Helix | Editor support for Carve. |
 | [intellij-carve](https://github.com/markup-carve/intellij-carve) | JetBrains IDEs | Highlighting, live preview, and export for IntelliJ, PhpStorm, etc. |
 | [zed-carve](https://github.com/markup-carve/zed-carve) | Zed | Editor support. |
@@ -84,6 +85,7 @@ Opt-in extensions that add non-core syntax.
 | Project | Target | Notes |
 |---|---|---|
 | [carve-php-media-embed](https://github.com/markup-carve/carve-php-media-embed) | carve-php | Embeds audio/video from 30+ providers via dereuromark/media-embed. |
+| [carve-php-chat](https://github.com/markup-carve/carve-php-chat) | carve-php | Renders Carve to chat-platform markup (WhatsApp, Slack, Telegram, Discord) via data-driven flavor definitions. |
 
 ## Benchmarks
 


### PR DESCRIPTION
Found by an org-wide audit driven off `gh repo list` rather than a remembered list of repos.

**Two repositories existed but appeared in no ecosystem doc:**

- `sublime-carve-lsp` - LSP helper package for Sublime Text (tagged, CI green, submission pending in the LSP channel)
- `carve-php-chat` - renders Carve to chat-platform markup (WhatsApp, Slack, Telegram, Discord)

**The satellite list in `VERSIONING.md` was wrong**, so it is replaced by a pointer to `docs/ecosystem.md`. It named `carve-emacs`, `carve.vim`, `carve-sublime`, `python-carve` and `lsp-carve`, none of which are real repository names (the real ones are `emacs-carve`, `vim-carve`, `sublime-carve`, `carve-py`, `carve-lsp`), and it listed 11 of roughly 35 satellites. A second hand-maintained list is exactly the thing that drifts unnoticed, so this keeps one source of truth.