### PR TITLE
fix: repair the differential harness php namespace and symbol map

### DIFF
--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -47,7 +47,7 @@ const impls = [
       if (feature === 'symbol-map') {
         return [
           'cargo', 'run', '--quiet', '--',
-          '--symbol', 'rocket=🚀', '--symbol', 'tada=🎉', '--symbol', 'UPPER=⬆️',
+          '--symbol', 'rocket=🚀', '--symbol', 'tada=🎉', '--symbol', '+1=👍', '--symbol', 'UPPER=⬆️',
         ]
       }
       return null
@@ -103,7 +103,7 @@ const impls = [
             import { carveToHtml } from './dist/index.js';
             const source = readFileSync(process.argv[1], 'utf8');
             process.stdout.write(carveToHtml(source, {
-              symbols: { rocket: '🚀', tada: '🎉', UPPER: '⬆️' },
+              symbols: { rocket: '🚀', tada: '🎉', '+1': '👍', UPPER: '⬆️' },
             }));
           `,
         ]
@@ -131,8 +131,8 @@ const impls = [
           '-r',
           `
             require 'vendor/autoload.php';
-            $converter = new Carve\\CarveConverter();
-            $converter->addExtension(new Carve\\Extension\\MentionsExtension(
+            $converter = new MarkupCarve\\Carve\\CarveConverter();
+            $converter->addExtension(new MarkupCarve\\Carve\\Extension\\MentionsExtension(
               mentionUrl: '/users/{name}',
               tagUrl: '/topics/{name}',
             ));
@@ -146,8 +146,8 @@ const impls = [
           '-r',
           `
             require 'vendor/autoload.php';
-            $converter = new Carve\\CarveConverter();
-            $converter->addExtension(new Carve\\Extension\\SmartQuotesExtension(locale: 'de'));
+            $converter = new MarkupCarve\\Carve\\CarveConverter();
+            $converter->addExtension(new MarkupCarve\\Carve\\Extension\\SmartQuotesExtension(locale: 'de'));
             echo $converter->convert(file_get_contents($argv[1]));
           `,
         ]
@@ -158,8 +158,8 @@ const impls = [
           '-r',
           `
             require 'vendor/autoload.php';
-            $converter = new Carve\\CarveConverter();
-            $converter->addExtension(new Carve\\Extension\\AutolinkExtension());
+            $converter = new MarkupCarve\\Carve\\CarveConverter();
+            $converter->addExtension(new MarkupCarve\\Carve\\Extension\\AutolinkExtension());
             echo $converter->convert(file_get_contents($argv[1]));
           `,
         ]


### PR DESCRIPTION
## What

Repairs two independent defects in the cross-impl differential harness
(`scripts/compare-impls.mjs`) that made `--corpus=optional` report false results.

### 1. Wrong php namespace

The php optional commands constructed `Carve\CarveConverter` and
`Carve\Extension\*`, but carve-php's PSR-4 root is `MarkupCarve\Carve\`. Every
php optional case threw `Class "Carve\CarveConverter" not found` and was tallied
as `error=3`, silently hiding all php Tier-2 (extension) coverage from the
differential. The core corpus path is unaffected because it invokes
`php bin/carve`.

### 2. Stale symbol-map option set

The `symbol-map` feature passed only `rocket`/`tada`/`UPPER`, while the canonical
`tests/optional-corpus.test.mjs` also maps the `+1` shortcode to a thumbs-up.
Under the harness the shortcode stayed literal, so `02-symbol-map` was scored as
a mismatch and produced a bogus `cross_impl_diffs=1`.

## Result

Before: `php error=3`, `cross_impl_diffs=1`, symbol-map mismatch.
After: `rust 2/2`, `js 2/2`, `php 3/3`, `cross_impl_diffs=0` — matching the
canonical `node --test tests/optional-corpus.test.mjs` run.

No language/behavior change; dev tooling only.
