### PR TITLE
docs: note inline-literal for literal paths without code styling

### DIFF
--- a/docs/edge-cases.md
+++ b/docs/edge-cases.md
@@ -59,10 +59,18 @@ Use /italic/ for emphasis.
 | `/italic/` | *italic* | Valid emphasis |
 | `/etc/nginx/` | *etc/nginx* | Also valid (inner `/` is content) |
 | `` `/etc/nginx/` `` | `/etc/nginx/` | Code span - recommended for paths |
+| `` !`/etc/nginx/` `` | /etc/nginx/ | Inline literal - literal text, no code styling |
 | `the/path/here` | the/path/here | No whitespace before opener |
 | `/ spaced /` | / spaced / | Whitespace after opener - invalid |
 
 **Best practice:** Paths, URLs, and file references should use backticks - they're technical/code content.
+
+If you want the path to read as ordinary prose rather than monospace code, use
+the inline literal `` !`…` `` prefix instead (PART 9 §27): it suppresses *all*
+markup inside the span - so `_`, `/`, `*` stay literal - but emits plain text
+with no `<code>` wrapper. So `` !`/etc/nginx_foo/` `` renders the bare string
+`/etc/nginx_foo/` with no emphasis and no code styling, whereas the backtick
+form `` `/etc/nginx_foo/` `` renders it as a `<code>` span.
 
 ---
 


### PR DESCRIPTION
Section 1 (Italic vs File Paths) of the edge-cases analysis recommended backtick code spans for paths. This adds the inline-literal `!` prefix as the alternative for when a path should read as ordinary prose rather than monospace code: it suppresses all inner markup (so the underscore, slash, asterisk stay literal) yet emits plain text with no `<code>` wrapper.

Adds one table row and a short contrasting note. Docs-only, non-normative page.