### PR TITLE
docs: fix raw-block syntax, corpus count, and surface the column-0 rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ tested against, and the design rationale behind each decision.
 | | |
 |---|---|
 | **Specification** | 0.1. Tier-1 core and Tier-2 standard extensions are normative and stable; Tier-3 app-level extensions ship but evolve. See [VERSIONING.md](VERSIONING.md). |
-| **Conformance** | 437 corpus examples pinning exact HTML output, plus 28 optional-corpus examples for host-dependent extensions. |
+| **Conformance** | 492 corpus examples pinning exact HTML output, plus 28 optional-corpus examples for host-dependent extensions. |
 | **Engines** | [carve-js](https://github.com/markup-carve/carve-js) (TypeScript, reference), [carve-php](https://github.com/markup-carve/carve-php), [carve-rs](https://github.com/markup-carve/carve-rs) - all three run the same corpus, with no open or intentional divergences ([tracker](MAINTAINING.md#known-cross-impl-divergences)). |
 | **Bindings** | Python, Ruby, Go, and WebAssembly, all over carve-rs. |
 | **Tooling** | Language server, tree-sitter grammar, formatter and linter (`carve fmt` / `carve lint`), converters from Markdown, HTML, Djot, and BBCode. |
@@ -302,7 +302,7 @@ the [Case Study](https://markup-carve.github.io/carve/case-study/) and the
 | Inline spans | n/a | `[text]{.c}` (→ `<span>`) | `[text]{.c}` (→ `<span>`) |
 | Editorial markup | n/a | `{+ +}` `{- -}` `{= =}` | `{+ +}` `{- -}` `{~ ~> ~}` `{= =}` `{# #}` |
 | Comments | `<!-- … -->` (HTML) | `{% … %}` | `%%` line / `text %% trailing` / `%%%` block |
-| Raw / passthrough | inline / block HTML | inline `` `…`{=html} `` + ` ```=html ` block | inline `` `…`{=html} `` + ` ```raw html ` block |
+| Raw / passthrough | inline / block HTML | inline `` `…`{=html} `` + ` ```=html ` block | inline `` `…`{=html} `` + ` ```=html ` block |
 | Includes | n/a | n/a | `{{ path/to/file }}` |
 | Abbreviations | n/a (PHP-Markdown ext: `*[ABBR]: ...`) | n/a | `*[ABBR]: ...` |
 | Attributes | n/a | `{.class}` | `{.class}` |

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -123,7 +123,7 @@ An inline element lives inside a line of text.
 
 - Emphasis `/…/`, strong `*…*`, underline `_…_`
 - Strikethrough `~…~`, highlight `=…=`, subscript `{,…,}`, superscript `{^…^}`
-- Inline code - `` `…` ``
+- Inline code - `` `…` ``, inline literal - `` !`…` `` (verbatim text, no code styling)
 - Link `[…](…)`, reference link `[…][…]`, image `![…](…)`
 - Span `[…]{…}`, autolink `<…>`, footnote reference `[^…]`
 - Math, `:symbol:`, `@mention`, `#tag`

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -108,6 +108,11 @@ two
 :::
 ````
 
+> Block markers must start at column 0 (or, inside a list, at the item's content
+> column). A marker indented past that - an indented `#`, `>`, `-`, `` ``` ``, or
+> `:::` - is literal paragraph text, not a block. Markdown tolerates 0-3 spaces
+> of leading indent here; Carve does not.
+
 ## Tables
 
 ```carve

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -61,7 +61,7 @@ differs by processor. The narrative below details each tier.
 - Tier 1: corpus categories 01–88 (admonitions, footnotes, cross-references,
   list-item attributes, `::: |` verse, `<…>` autolinks, the
   `:name[…]` / `::: name` extension syntax). Recognized `:::` type words
-  (the eight admonitions + `line-block`) are catalogued in [`examples/extensions.md`](/examples/extensions). Smart
+  (the eight admonitions + `line-block`) are cataloged in [`examples/extensions.md`](/examples/extensions). Smart
   typography and `@mention` / `#tag` / `:symbol:` parsing are also default-on and
   corpus-pinned, but per grammar PART 9 §19 a processor MAY disable them.
 - Tier 2: configuration over Tier-1 syntax — mention/tag→URL, symbol map (e.g. emoji glyphs),

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 437 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 492 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus with no open divergences.
 Pre-1.0, a minor release may still change the grammar.

--- a/docs/migrate-from-markdown.md
+++ b/docs/migrate-from-markdown.md
@@ -265,4 +265,5 @@ When moving a document from Markdown to Carve:
 - [ ] Convert GFM table delimiter rows to `|=` header cells
 - [ ] Replace `~~strike~~` with `~strike~` (single tilde)
 - [ ] Move any heading `{#id}` onto the line above the heading (trailing is literal)
+- [ ] Check the indentation of top-level block markers: a leading-indented `#`, `>`, `-`, `` ``` ``, or `:::` is literal paragraph text in Carve, not a block. Markdown tolerates 0-3 spaces of indent; Carve requires a block marker at column 0 (or, inside a list, at the item's content column)
 - [ ] Decide on raw HTML: bare `<tags>` become literal text, so replace them with Carve constructs (or use the explicit `{=html}` passthrough for trusted content; disable it with `allowRawHtml: false` for untrusted input)


### PR DESCRIPTION
Pre-release documentation corrections from a docs deep-dive:

- **README comparison table** showed the Carve raw block as `` ```raw html ``; the canonical form is `` ```=html `` (the `` ```raw html `` form renders as an escaped code block). Corrected the Carve cell.
- **Corpus example count** 437 to 492 in `README.md` and `docs/index.md`.
- **Strict column-0 rule on the front door.** The rule (a leading-indented block marker is literal, not a block) was already documented in the deep reference pages, but not on the two pages a Markdown author reads first. Added a note to the cheatsheet Blocks section and a checklist item to migrate-from-markdown (Markdown tolerates 0-3 spaces of indent; Carve does not).
- **Inline literal** `` !`…` `` now listed in the blocks-and-attributes inline elements.
- American English: "catalogued" to "cataloged".

Docs-only.