### PR TITLE
docs: reconcile the 0.1.1 changelog with the release range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   static-capable in every engine with the same config - no spec edit, no
   lockstep. Canonical presets are just the pre-named classes. This supersedes
   the closed-key-set design.
+- **SVG `img` fence** (Tier-3, off by default): a `` ```img `` block renders a
+  sanitized SVG, sandboxed by default (a `data:image/svg+xml` `<img>`), with an
+  opt-in inline mode for theming (#311).
 
 First normative grammar and corpus snapshot. This release locks the Carve
 specification at its initial stable version: the grammar (`resources/grammar.ebnf`),


### PR DESCRIPTION
The just-cut `## [0.1.1]` section logged the newest convergence batch but omitted the SVG `img` fence, which shipped in the release range (#311) and appears in the published GitHub release notes.

This adds the missing SVG `img` fence entry to the `### Added` section. No other release-note items were missing from the file. Post-release amend only; no code or version changes.