### PR TITLE
spec: pin smart typography as unconditional, add an optional off switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Smart typography now has a normative AST representation (PART 9 §8): a
+  recognized substitution is a `smart_punctuation` inline node carrying both the
+  resolved kind and the author's source run. Presentation renderers emit the
+  glyph; the canonical Carve writer emits the source run, so `fmt` reproduces
+  the document instead of normalizing its punctuation. Writing the glyph
+  straight into the text buffer is no longer conformant. The eighteen kind names
+  are spec surface, a quote node also records its resolved (locale-dependent)
+  glyph, and a dash run partitions into one node per glyph so `----` round-trips
+  to four hyphens. For profiles the node is classified as `text`.
+
 - Smart typography is now specified as unconditional by default (PART 9 §8): a
   conformant implementation performs the substitution with no extension
   registered, and a locale/glyph extension selects which characters are emitted
   rather than whether the transform runs. Hosts may offer one document-global
-  `smartTypography` switch (default `true`) that suppresses the whole converted
-  set; per-target defaults are non-conformant. Escapes, `:name:` symbols and
-  heading ids are unaffected in either mode. Pinned by the optional corpus
-  feature `smart-typography-off`, and explained in
-  `docs/divergence-from-djot.md` section 12, which also records why Carve keeps
-  smart punctuation as plain text instead of Djot's `double_quoted` /
-  `smart_punctuation` AST nodes.
+  `smartTypography` switch (default `true`); with the node representation above
+  it is a rendering decision, so parsing is unchanged and the presentation
+  renderers emit each node's source run instead of its glyph. Per-target
+  defaults are non-conformant. Escapes, `:name:` symbols and heading ids are
+  unaffected in either mode. Pinned by the optional corpus feature
+  `smart-typography-off`, and explained in `docs/divergence-from-djot.md`
+  section 12, which also records why Carve uses one leaf node where Djot uses
+  two container types plus a leaf.
 
 ## [0.1.1] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Smart typography is now specified as unconditional by default (PART 9 §8): a
+  conformant implementation performs the substitution with no extension
+  registered, and a locale/glyph extension selects which characters are emitted
+  rather than whether the transform runs. Hosts may offer one document-global
+  `smartTypography` switch (default `true`) that suppresses the whole converted
+  set; per-target defaults are non-conformant. Escapes, `:name:` symbols and
+  heading ids are unaffected in either mode. Pinned by the optional corpus
+  feature `smart-typography-off`, and explained in
+  `docs/divergence-from-djot.md` section 12, which also records why Carve keeps
+  smart punctuation as plain text instead of Djot's `double_quoted` /
+  `smart_punctuation` AST nodes.
+
 ## [0.1.1] - 2026-07-27
 
 ### Fixed

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -394,6 +394,74 @@ Djot instead attaches at any indent, which means a block one space under the
 marker - visually left of the item's own text - still becomes a child. The
 `+` continuation marker (§3) still attaches a flush-left block regardless.
 
+## 12. Smart punctuation is a text transform, not AST nodes
+
+**Djot:** smart punctuation is structural. The AST has `double_quoted` and
+`single_quoted` *container* nodes, plus a `smart_punctuation` node that retains
+the original source text. The HTML writer maps those to glyphs; the Djot writer
+emits the author's `"`, `--` and `...` back verbatim.
+
+**Carve:** the substitution is a plain text transform. A converted quote, dash
+or ellipsis is ordinary `text`; there is no node type for it, and
+[node-type profiles](/profiles) name none. The rules themselves are the same as
+Djot's: unconditional, per-character quote direction from the preceding
+character, `\"` for a literal.
+
+**Why.** The node types buy Djot exactly one thing - a writer that reproduces
+the author's spelling - and they charge every consumer for it. A filter, a
+profile allowlist, a renderer and every AST walker have to know three extra
+container types whose only content is punctuation, and a link label containing a
+quote becomes a nested container rather than a string. Carve keeps the AST
+vocabulary small enough to hold in your head, so punctuation stays text.
+
+The cost is real and worth naming: because the transform is not represented,
+`carve fmt` normalizes ASCII punctuation to its typographic form. Formatting
+`He said "hello"` writes back `He said “hello”`. That is a normalization, not a
+loss of meaning - the reformatted source renders byte-identically, and a second
+pass is stable - but it is the one place where Djot's model is better, and the
+gap is tracked rather than denied.
+
+### Turning it off
+
+The transform runs with no extension registered. A smart-quotes / locale
+extension picks *which* glyphs are emitted, not *whether* the substitution
+happens - removing it does not turn the transform off.
+
+Hosts may offer one document-global switch, `smartTypography` (default `true`),
+which suppresses the whole converted set - dashes, ellipsis, quotes, arrows,
+comparisons, `(c)` `(r)` `(tm)` `+-` - leaving the author's ASCII in place:
+
+::: code-group
+
+```js [carve-js]
+carveToHtml(source, { smartTypography: false })
+```
+
+```php [carve-php]
+$converter = CarveConverter::create(smartTypography: false);
+```
+
+```rust [carve-rs]
+let options = Options::default().with_smart_typography(false);
+```
+
+:::
+
+The switch is document-global on purpose. Defaulting it per target - on for
+HTML, off for Markdown and plain text - was considered and rejected: one source
+must carry the same text on every target, and a target-dependent default would
+let `to_html(x)` and `to_markdown(x)` disagree about what the document says.
+
+Turning it off is for **machine-facing** output: a corpus rendered to Markdown
+or plain text for a model to read, generated documentation that has to stay
+diff-stable, or anything re-parsed downstream, where a curly quote is a
+character the consumer did not ask for and cannot reverse. For output aimed at
+human readers - which is the default case - leave it on.
+
+The switch changes nothing else. Escapes still work (`\"` yields a straight
+quote either way), `:name:` symbols are untouched, and heading ids are
+byte-identical, because ids are computed from the ASCII source in both modes.
+
 ## What Carve adds on top (not breaks)
 
 These aren't divergences - Djot has no equivalent - but they're why Carve exists

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -3,7 +3,8 @@
 Carve starts from [Djot](https://djot.net) - John MacFarlane's predictable,
 backtracking-free reimagining of Markdown - and keeps almost all of it: the
 linear parse model, generic containers, arbitrary attributes, footnotes, math,
-and smart typography all carry over unchanged. Definition lists are one of the
+and smart typography all carry over - the last of those with the same rules but
+a smaller AST shape (see section 12 below). Definition lists are one of the
 deliberate breaks (see section 9 below).
 
 So why diverge at all? Because a handful of Djot's choices optimize for
@@ -394,32 +395,41 @@ Djot instead attaches at any indent, which means a block one space under the
 marker - visually left of the item's own text - still becomes a child. The
 `+` continuation marker (§3) still attaches a flush-left block regardless.
 
-## 12. Smart punctuation is a text transform, not AST nodes
+## 12. Smart punctuation is one leaf node, not three container types
 
-**Djot:** smart punctuation is structural. The AST has `double_quoted` and
-`single_quoted` *container* nodes, plus a `smart_punctuation` node that retains
-the original source text. The HTML writer maps those to glyphs; the Djot writer
-emits the author's `"`, `--` and `...` back verbatim.
+Both languages agree on the important half: a typographic substitution has to be
+*represented* in the AST, or the formatter cannot reproduce what the author
+typed. The substitution rules are also the same - unconditional, per-character
+quote direction from the preceding character, `\"` for a literal. The divergence
+is the shape of the representation.
 
-**Carve:** the substitution is a plain text transform. A converted quote, dash
-or ellipsis is ordinary `text`; there is no node type for it, and
-[node-type profiles](/profiles) name none. The rules themselves are the same as
-Djot's: unconditional, per-character quote direction from the preceding
-character, `\"` for a literal.
+**Djot:** three types. `double_quoted` and `single_quoted` are *containers* that
+wrap the quoted content, and `smart_punctuation` is a leaf retaining the source
+text for dashes and ellipses.
 
-**Why.** The node types buy Djot exactly one thing - a writer that reproduces
-the author's spelling - and they charge every consumer for it. A filter, a
-profile allowlist, a renderer and every AST walker have to know three extra
-container types whose only content is punctuation, and a link label containing a
-quote becomes a nested container rather than a string. Carve keeps the AST
-vocabulary small enough to hold in your head, so punctuation stays text.
+**Carve:** one type. `smart_punctuation` is always a leaf, carrying the resolved
+`kind` (`ellipsis`, `em_dash`, `left_double_quote`, …) and the author's source
+run (`...`, `--`, `"`). A quote node additionally carries its resolved glyph,
+because the glyph is locale-dependent and is decided during parsing. A dash run
+becomes one node per resolved glyph, each holding the hyphens it came from, so
+`----` round-trips to exactly four hyphens.
 
-The cost is real and worth naming: because the transform is not represented,
-`carve fmt` normalizes ASCII punctuation to its typographic form. Formatting
-`He said "hello"` writes back `He said “hello”`. That is a normalization, not a
-loss of meaning - the reformatted source renders byte-identically, and a second
-pass is stable - but it is the one place where Djot's model is better, and the
-gap is tracked rather than denied.
+Renderers split on which half they read: HTML, Markdown, plain text and ANSI
+emit the glyph; the canonical Carve writer emits the source run. That is what
+makes `carve fmt` non-destructive - formatting `He said "hello"` writes back
+`He said "hello"`, not the curly form.
+
+**Why one leaf instead of two containers.** A container type says the quotes
+have *scope*, and in Carve they do not. Quote direction is decided per character
+from what precedes it, so an unpaired quote is completely ordinary and `a"b` is
+just a right quote mid-word - there is no span to wrap. Making quotes containers
+would force every walker to handle a node whose children are the quoted prose,
+turn a link label containing a quote into a nested container rather than a
+string, and raise the question of what an unmatched opener contains. A leaf
+carrying both halves buys the same round-trip with none of that.
+
+For [profiles](/profiles) the node is classified as `text`: it is visible prose
+with no capability of its own, so it is not separately nameable.
 
 ### Turning it off
 
@@ -427,9 +437,13 @@ The transform runs with no extension registered. A smart-quotes / locale
 extension picks *which* glyphs are emitted, not *whether* the substitution
 happens - removing it does not turn the transform off.
 
-Hosts may offer one document-global switch, `smartTypography` (default `true`),
-which suppresses the whole converted set - dashes, ellipsis, quotes, arrows,
-comparisons, `(c)` `(r)` `(tm)` `+-` - leaving the author's ASCII in place:
+Hosts may offer one document-global switch, `smartTypography` (default `true`).
+With the node representation above, turning it off is a rendering decision
+rather than a parsing one: the nodes are still produced, and the presentation
+renderers emit each node's source run instead of its glyph, exactly as the
+canonical writer already does. The AST does not depend on the switch; the output
+is the author's ASCII across the whole converted set - dashes, ellipsis, quotes,
+arrows, comparisons, `(c)` `(r)` `(tm)` `+-`:
 
 ::: code-group
 
@@ -459,8 +473,11 @@ character the consumer did not ask for and cannot reverse. For output aimed at
 human readers - which is the default case - leave it on.
 
 The switch changes nothing else. Escapes still work (`\"` yields a straight
-quote either way), `:name:` symbols are untouched, and heading ids are
-byte-identical, because ids are computed from the ASCII source in both modes.
+quote either way) and `:name:` symbols are untouched. Heading ids are
+byte-identical in both modes: the id pass normalizes typographic output back to
+ASCII before slugging (section 1 above), so `# Don't repeat yourself` gives
+`Don-t-repeat-yourself` whether the heading
+renders with a curly apostrophe or a straight one.
 
 ## What Carve adds on top (not breaks)
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -46,6 +46,13 @@ An **`admonition`** is likewise its own type rather than a `div` carrying a
 class. A profile that wants to deny callouts while allowing generic
 containers has no way to express that if the kind lives in a class string.
 
+A **`smart_punctuation`** node - the AST form of a typographic substitution,
+carrying the resolved kind and the author's source run (PART 9 §8) - is
+classified as **`text`**. It is ordinary visible prose with no capability of its
+own: an em dash is not a different trust level from the words around it. Denying
+it would express nothing a `text` denial does not already express, so it is not
+separately nameable here.
+
 Types serving a formatter rather than a document are **not** in this
 vocabulary and cannot be named in a profile. An implementation may carry a
 node preserving literal source for round-trip formatting (carve-php calls it

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1810,10 +1810,13 @@ EOF = (* end of file *) ;
         carve-php, `Options::with_smart_typography(false)` in carve-rs).
         A host that omits the switch stays conformant. Where it IS offered
         and set to FALSE:
-        * every `smart_typography` production is suppressed -- dashes,
-          ellipsis, smart quotes, arrows, comparisons, and the typographic
-          symbols `(c)` `(r)` `(tm)` `+-` -- and each trigger character
-          survives as the ASCII the author typed;
+        * PARSING IS UNCHANGED. The nodes below are still produced, so the
+          AST does not depend on the switch. What changes is rendering: a
+          presentation renderer emits the node's SOURCE RUN instead of its
+          glyph, exactly as the canonical writer already does. Every trigger
+          character therefore survives as the ASCII the author typed --
+          dashes, ellipsis, quotes, arrows, comparisons, and the typographic
+          symbols `(c)` `(r)` `(tm)` `+-`;
         * the `:name:` symbol production is UNAFFECTED; it is not a
           `smart_typography` production, and its precedence over the
           typographic forms is unchanged;
@@ -1832,13 +1835,36 @@ EOF = (* end of file *) ;
           `to_html(x)` and `to_markdown(x)` disagree about what the
           document says.
         Pinned in tests/corpus-optional (feature `smart-typography-off`).
-      - THE LAYER IS UNOBSERVABLE. An implementation MAY apply the
-        substitution at inline-parse time (carve-js, carve-php) or inside
-        each renderer (carve-rs); both are conformant, because the rendered
-        output is identical in every target. Render time is RECOMMENDED but
-        not required: it keeps the author's ASCII in the AST, which is what
-        a canonical writer needs to reproduce the source spelling. See
-        divergence-from-djot.md section 12.
+      - AST REPRESENTATION -- NORMATIVE. A recognized substitution is its
+        own inline node, `smart_punctuation`, carrying BOTH halves: the
+        resolved KIND and the author's SOURCE RUN. A presentation renderer
+        (HTML, Markdown, plain text, ANSI) emits the glyph for the kind; the
+        canonical Carve writer emits the source run, so `fmt` reproduces the
+        document instead of normalizing its punctuation. Writing the glyph
+        straight into the text buffer is NOT conformant: it discards the
+        spelling, after which `...` cannot be told from a literal U+2026 and
+        the writer has nothing to reproduce.
+        * KIND NAMES ARE SPEC SURFACE -- an implementation inventing its own
+          spelling breaks every AST consumer. The fourteen table-resolved
+          kinds are `ellipsis`, `em_dash`, `en_dash`, `left_right_arrow`,
+          `rightwards_arrow`, `leftwards_arrow`, `rightwards_double_arrow`,
+          `less_than_or_equal`, `greater_than_or_equal`, `not_equal`,
+          `plus_minus`, `copyright`, `registered`, `trademark`. The four
+          quote kinds are `left_double_quote`, `right_double_quote`,
+          `left_single_quote`, `right_single_quote`.
+        * A QUOTE NODE ALSO CARRIES ITS RESOLVED GLYPH. Quote characters are
+          locale-dependent (a German or Swiss set), and the choice is made
+          during parsing, so the node records the character rather than
+          leaving it to the kind table. Every other kind resolves through the
+          table above, which is why the quote kinds are absent from it.
+        * A DASH RUN PARTITIONS INTO ONE NODE PER RESOLVED GLYPH, each
+          carrying the hyphens it came from, so `----` (two en dashes)
+          round-trips to exactly four hyphens.
+        * FOR PROFILES the node folds into the `text` trust class. It is
+          ordinary visible prose, not a distinct capability, so it is not
+          separately nameable in a profile (profiles.md).
+        See divergence-from-djot.md section 12 for how this compares to
+        Djot's container-node model.
 
    9. EMPHASIS SPAN RESOLUTION -- FORMAL GUARDS + DELIMITER-STACK
       OPERATIONAL SEMANTICS (governs the *_content productions in PART 3;

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1795,6 +1795,50 @@ EOF = (* end of file *) ;
         fractions (recorded in dismissed-syntax.md). Converted set:
         dashes, ellipsis, smart quotes, arrows, comparisons, `+-`, and
         symbols (`(c)`,`(r)`,`(tm)`).
+      - UNCONDITIONAL BY DEFAULT -- NORMATIVE. The substitution belongs to
+        the default inline layer, not to an opt-in feature: a conformant
+        implementation performs it with NO extension registered. A locale
+        or glyph extension (a German / Swiss quote set, say) selects WHICH
+        characters are emitted; it does NOT decide WHETHER the substitution
+        runs, and removing such an extension does not disable the
+        transform. Stated explicitly because the existence of a
+        smart-quotes extension otherwise reads as "the transform is that
+        extension" -- it is not (carve#338).
+      - OPTIONAL OFF SWITCH -- NORMATIVE WHERE OFFERED. A host MAY expose
+        one document-global switch, `smartTypography`, defaulting to TRUE
+        (idiomatic spellings: `smartTypography: false` in carve-js and
+        carve-php, `Options::with_smart_typography(false)` in carve-rs).
+        A host that omits the switch stays conformant. Where it IS offered
+        and set to FALSE:
+        * every `smart_typography` production is suppressed -- dashes,
+          ellipsis, smart quotes, arrows, comparisons, and the typographic
+          symbols `(c)` `(r)` `(tm)` `+-` -- and each trigger character
+          survives as the ASCII the author typed;
+        * the `:name:` symbol production is UNAFFECTED; it is not a
+          `smart_typography` production, and its precedence over the
+          typographic forms is unchanged;
+        * escape handling is UNAFFECTED: `\"`, `\-`, `\.` still consume the
+          backslash and yield the bare character (PART 7). Turning the
+          switch off changes which UNESCAPED characters convert, nothing
+          about escapes;
+        * heading ids are BYTE-IDENTICAL either way. Ids are computed from
+          the ASCII source (the reverse pass in HEADING IDENTIFIERS above),
+          so with the switch off that pass has nothing to reverse -- it is
+          a no-op, not a different result;
+        * the switch is DOCUMENT-GLOBAL and applies to EVERY target.
+          PER-TARGET DEFAULTS ARE NON-CONFORMANT (on for HTML, off for
+          Markdown / plain / ANSI): one source must carry the same text on
+          every target, and a target-dependent default would let
+          `to_html(x)` and `to_markdown(x)` disagree about what the
+          document says.
+        Pinned in tests/corpus-optional (feature `smart-typography-off`).
+      - THE LAYER IS UNOBSERVABLE. An implementation MAY apply the
+        substitution at inline-parse time (carve-js, carve-php) or inside
+        each renderer (carve-rs); both are conformant, because the rendered
+        output is identical in every target. Render time is RECOMMENDED but
+        not required: it keeps the author's ASCII in the AST, which is what
+        a canonical writer needs to reproduce the source spelling. See
+        divergence-from-djot.md section 12.
 
    9. EMPHASIS SPAN RESOLUTION -- FORMAL GUARDS + DELIMITER-STACK
       OPERATIONAL SEMANTICS (governs the *_content productions in PART 3;

--- a/tests/corpus-optional/29-smart-typography-off.crv
+++ b/tests/corpus-optional/29-smart-typography-off.crv
@@ -1,0 +1,9 @@
+He said "hello" and it's fine... a--b, c---d.
+
+Arrows -> <- <-> => and comparisons != <= >= and (c) (r) (tm) +- stay as typed.
+
+Escapes still consume the backslash: \" and \-\-.
+
+Code spans never convert either way: `a--b "q" (c)`.
+
+# Don't repeat yourself

--- a/tests/corpus-optional/29-smart-typography-off.html
+++ b/tests/corpus-optional/29-smart-typography-off.html
@@ -1,0 +1,7 @@
+<p>He said "hello" and it's fine... a--b, c---d.</p>
+<p>Arrows -&gt; &lt;- &lt;-&gt; =&gt; and comparisons != &lt;= &gt;= and (c) (r) (tm) +- stay as typed.</p>
+<p>Escapes still consume the backslash: " and --.</p>
+<p>Code spans never convert either way: <code>a--b "q" (c)</code>.</p>
+<section id="Don-t-repeat-yourself">
+  <h1>Don't repeat yourself</h1>
+</section>

--- a/tests/corpus-optional/README.md
+++ b/tests/corpus-optional/README.md
@@ -24,6 +24,8 @@ Examples:
 - `symbol-map` → `:name:` symbol map (e.g. shortcode-to-glyph for emoji)
 - `smart-quotes-locale-de` → locale-aware quote extension/config
 - `bare-url-autolink` → bare-URL autolink extension/config
+- `smart-typography-off` → the optional document-global `smartTypography: false`
+  switch (PART 9 §8); implementations that do not offer the switch skip the case
 
 The filenames are stable (`NN-slug.crv` / `NN-slug.html`) so runners can pair
 them by basename after filtering through the manifest.

--- a/tests/corpus-optional/manifest.json
+++ b/tests/corpus-optional/manifest.json
@@ -140,6 +140,11 @@
       "slug": "28-tabs-panel-title",
       "feature": "tabs",
       "description": "A tab's quoted title is content: it stays inside the panel as the admonition-title line while the [label] becomes the tab button."
+    },
+    {
+      "slug": "29-smart-typography-off",
+      "feature": "smart-typography-off",
+      "description": "With the optional document-global smartTypography switch set to false, the whole converted set stays as authored ASCII; escapes, code spans and heading ids are unchanged (carve#338)."
     }
   ]
 }


### PR DESCRIPTION
Closes #338.

Two things, one of which corrects the other.

## 1. The transform is unconditional by default, and gets an opt-out

`SmartQuotesExtension` looks like the thing that controls smart quotes. It is not - the substitution runs with no extension registered, and the extension only picks which glyphs come out per locale. The spec never said that either way. It does now (PART 9 section 8).

Hosts may offer one document-global `smartTypography` switch (default `true`); omitting it stays conformant. Where offered and set to `false`, parsing is unchanged and the presentation renderers emit each node's source run instead of its glyph, so the output is the author's ASCII across the whole converted set. `:name:` symbols are untouched, escapes still consume the backslash, and heading ids stay byte-identical because the id pass normalizes typographic output back to ASCII either way.

The switch applies to **every target**. Per-target defaults (on for HTML, off for Markdown and plain text) are explicitly non-conformant: one source has to carry the same text everywhere, and a target-dependent default would let `to_html(x)` and `to_markdown(x)` disagree about the document.

This exists for machine-facing output - a corpus rendered for a model to read, generated documentation that has to stay diff-stable, anything re-parsed downstream. The reported case produced 2,791 curly quotes from a source with 136. For human-facing HTML, the default is right and stays.

## 2. The AST representation is now normative

The first commit on this branch asserted that Carve keeps smart punctuation as plain text and that Djot's node model had been considered and rejected. Both were written against engine checkouts that were a few hours stale. carve-js#396 and carve-php#411 had already shipped the node model. The second commit rewrites that.

A recognized substitution is its own inline node, `smart_punctuation`, carrying the resolved kind **and** the author's source run. Presentation renderers emit the glyph; the canonical writer emits the source run, which is what makes `fmt` reproduce the document instead of normalizing it. Writing the glyph straight into the text buffer is no longer conformant.

Also pinned, because two engines already agree on all of it and a third has to match:

- the eighteen kind names, as spec surface - an engine inventing its own spelling breaks every AST consumer, which is the same failure the node-vocabulary test was written for;
- a quote node records its resolved glyph, since quote characters are locale-dependent and chosen during parsing;
- a dash run partitions into one node per resolved glyph, each carrying the hyphens it came from, so `----` round-trips to four hyphens;
- the node is classified as `text` for profiles - visible prose with no capability of its own.

`docs/divergence-from-djot.md` section 12 is rewritten around what actually diverges, which is shape rather than principle: both languages represent the substitution, Djot with two container types plus a leaf, Carve with one leaf. Containers imply the quotes have scope, and in Carve they do not - direction is decided per character from what precedes it, so an unpaired quote is ordinary and there is no span to wrap.

## Corpus

`29-smart-typography-off` pins the off mode: the full converted set, escapes, a code span and a heading id. It skips until an engine offers the switch, exactly as `smart-quotes-locale-de` and `bare-url-autolink` already do. Wiring a runner is not possible yet - no engine has the option - and the corpus-optional contract is that unsupported features stay visible as skips rather than silent gaps.

## Related

- #345 - carve-rs still uses the text-substitution model, so the three engines currently disagree on `--carve` output. HTML is unaffected (496/496, `cross_impl_diffs=0`).
- #344 - the canonical writer over-escapes, independent of all of this.
- #350 - carve-php escapes smart-typography triggers on the Markdown target where the other two do not.
- #349 - none of those last two would be caught by CI today; `compare-impls.mjs` only compares HTML.