### PR TITLE
Pin quote flanking after an escaped character

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -5499,13 +5499,13 @@ implementation that loses the literal at that point silently flips the direction
 
 A \{ before a quote still opens it: \{"open"
 
-Unescaped for contrast: {"open"} and *'q'*
+Unescaped for contrast: {"open"}
 ```
 
 ```html
 <p>{“quoted”} and &lt;”q”&gt; and *’q’*</p>
 <p>A { before a quote still opens it: {“open”</p>
-<p>Unescaped for contrast: {“open”} and <strong>‘q’</strong></p>
+<p>Unescaped for contrast: {“open”}</p>
 ```
 
 :::

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -5480,3 +5480,32 @@ are each wrapped.
 ```
 
 :::
+
+## Quote flanking after an escaped character
+
+A backslash-escaped character still flanks as the character it is, so a quote
+that follows it decides direction from the literal. `\{` is an opening bracket
+and opens the quote; `\<` and `\*` are not, so the quote closes - the same
+decision the unescaped character produces. Escaping changes what the character
+*is*, not what it flanks like.
+
+Worth pinning because the escape is consumed before the quote is resolved, so an
+implementation that loses the literal at that point silently flips the direction.
+
+::: compare
+
+```carve
+\{"quoted"\} and \<"q"\> and \*'q'\*
+
+A \{ before a quote still opens it: \{"open"
+
+Unescaped for contrast: {"open"} and *'q'*
+```
+
+```html
+<p>{“quoted”} and &lt;”q”&gt; and *’q’*</p>
+<p>A { before a quote still opens it: {“open”</p>
+<p>Unescaped for contrast: {“open”} and <strong>‘q’</strong></p>
+```
+
+:::

--- a/tests/corpus/163-quote-flanking-after-an-escaped-character.crv
+++ b/tests/corpus/163-quote-flanking-after-an-escaped-character.crv
@@ -2,4 +2,4 @@
 
 A \{ before a quote still opens it: \{"open"
 
-Unescaped for contrast: {"open"} and *'q'*
+Unescaped for contrast: {"open"}

--- a/tests/corpus/163-quote-flanking-after-an-escaped-character.crv
+++ b/tests/corpus/163-quote-flanking-after-an-escaped-character.crv
@@ -1,0 +1,5 @@
+\{"quoted"\} and \<"q"\> and \*'q'\*
+
+A \{ before a quote still opens it: \{"open"
+
+Unescaped for contrast: {"open"} and *'q'*

--- a/tests/corpus/163-quote-flanking-after-an-escaped-character.html
+++ b/tests/corpus/163-quote-flanking-after-an-escaped-character.html
@@ -1,0 +1,3 @@
+<p>{“quoted”} and &lt;”q”&gt; and *’q’*</p>
+<p>A { before a quote still opens it: {“open”</p>
+<p>Unescaped for contrast: {“open”} and <strong>‘q’</strong></p>

--- a/tests/corpus/163-quote-flanking-after-an-escaped-character.html
+++ b/tests/corpus/163-quote-flanking-after-an-escaped-character.html
@@ -1,3 +1,3 @@
 <p>{“quoted”} and &lt;”q”&gt; and *’q’*</p>
 <p>A { before a quote still opens it: {“open”</p>
-<p>Unescaped for contrast: {“open”} and <strong>‘q’</strong></p>
+<p>Unescaped for contrast: {“open”}</p>

--- a/tests/spec/163-quote-flanking-after-an-escaped-character.test
+++ b/tests/spec/163-quote-flanking-after-an-escaped-character.test
@@ -1,0 +1,13 @@
+Quote flanking after an escaped character
+
+```
+\{"quoted"\} and \<"q"\> and \*'q'\*
+
+A \{ before a quote still opens it: \{"open"
+
+Unescaped for contrast: {"open"} and *'q'*
+.
+<p>{“quoted”} and &lt;”q”&gt; and *’q’*</p>
+<p>A { before a quote still opens it: {“open”</p>
+<p>Unescaped for contrast: {“open”} and <strong>‘q’</strong></p>
+```

--- a/tests/spec/163-quote-flanking-after-an-escaped-character.test
+++ b/tests/spec/163-quote-flanking-after-an-escaped-character.test
@@ -5,9 +5,9 @@ Quote flanking after an escaped character
 
 A \{ before a quote still opens it: \{"open"
 
-Unescaped for contrast: {"open"} and *'q'*
+Unescaped for contrast: {"open"}
 .
 <p>{“quoted”} and &lt;”q”&gt; and *’q’*</p>
 <p>A { before a quote still opens it: {“open”</p>
-<p>Unescaped for contrast: {“open”} and <strong>‘q’</strong></p>
+<p>Unescaped for contrast: {“open”}</p>
 ```


### PR DESCRIPTION
A backslash-escaped character still flanks as the character it is, so a quote that follows it decides direction from the literal:

```
\{"quoted"\}   ->   {“quoted”}      \{ is an opening bracket, so the quote opens
\<"q"\>        ->   &lt;”q”&gt;     \< is not, so the quote closes
\*'q'\*        ->   *’q’*           same
```

That is the same decision the unescaped character produces. Escaping changes what the character *is*, not what it flanks like.

## Why it needs pinning

Nothing covered this. The existing escape-coverage case escapes every punctuation character in one run - including the quotes - so no flanking decision after an escaped character ever occurs in the corpus.

The gap was not theoretical. carve-php and carve-js disagreed on `\{'q'\}`:

```
carve-js   \{'q'\}  ->  <p>{‘q’}</p>
carve-php  \{'q'\}  ->  <p>{’q’}</p>
```

The corpus could not see it because the escape is consumed before the quote is resolved, so an implementation that loses the literal at that point silently flips the direction. It stayed invisible for as long as the formatter froze quotes as glyphs; it only surfaced once a formatter change made them re-derive on a round trip (markup-carve/carve-php#411, which fixes the php side).

Expected output is carve-js, the reference implementation. carve-php matches it byte-for-byte after that PR.

## Note on placement

The example is appended at the end of `edge-cases.md` rather than next to the other escape material, so the generated corpus keeps its existing numbering. Inserting it mid-file renumbered ~90 cases.
