### PR TITLE
compare-impls: compare every render target, not just HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `scripts/compare-impls.mjs` now compares every render target, not just HTML.
+  `--targets=all` (the new default) covers `html`, `markdown`, `plain`, `carve`
+  and `ansi`; only `html` has expected-output fixtures, so the other four are
+  compared implementation-against-implementation (trailing-newline-insensitively,
+  as elsewhere in the project). Identical output across the three engines was an
+  invariant that four of five targets had nothing checking it.
+
 ### Added
 
 - Smart typography now has a normative AST representation (PART 9 §8): a

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -111,7 +111,35 @@ available in each implementation today.
 npm run compare:impls
 npm run compare:impls -- --corpus=optional
 npm run compare:impls -- --limit=20 --bench
+npm run compare:impls -- --targets=html          # fast path, HTML only
 ```
+
+### Targets
+
+The runner compares every render target, not just HTML: `--targets=all` (the
+default) covers `html`, `markdown`, `plain`, `carve` and `ansi`. Pass a
+comma-separated subset to narrow it.
+
+Only `html` has expected-output fixtures. The other four are compared
+**implementation against implementation**, because identical output across the
+three engines is the invariant that matters there, and committing four more
+expected files per corpus case would not add to it. The `Target agreement`
+block in the output reports per-target `compared` / `diffs` / `errors` counts,
+and each disagreement prints a `DIFF [target] slug` line naming the engines that
+ran.
+
+Comparison is trailing-newline-insensitive, matching the corpus runner and the
+profile parity battery: renderers legitimately differ on a final `\n`, so a
+byte-strict comparison would flag that known difference on every case and bury
+the real divergences.
+
+Running all five targets costs roughly five times a single-target run, since
+every case is a fresh process per engine per target. Use `--targets=html` for a
+quick check and `--limit=` while iterating.
+
+The optional corpus runs the `html` target only. Its per-feature adapters
+configure HTML conversion specifically, so a non-HTML target there would compare
+"feature configured" against "feature missing" and report a meaningless diff.
 
 By default the script expects sibling checkouts:
 

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -25,12 +25,63 @@ if (!Object.hasOwn(corpusDirs, corpusName)) {
 
 const corpusDir = join(root, corpusDirs[corpusName])
 
+// Render targets to compare. `html` is the only one with expected-output
+// fixtures; the rest are compared ENGINE-AGAINST-ENGINE, because byte-identical
+// output across implementations is the invariant that matters and committing
+// four more expected files per corpus case would not add to it.
+const ALL_TARGETS = ['html', 'markdown', 'plain', 'carve', 'ansi']
+const targetsArg = process.argv.find((a) => a.startsWith('--targets='))
+const targetsRequest = targetsArg ? targetsArg.slice('--targets='.length) : 'all'
+let targets =
+  targetsRequest === 'all'
+    ? [...ALL_TARGETS]
+    : targetsRequest
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean)
+
+const unknownTargets = targets.filter((t) => !ALL_TARGETS.includes(t))
+if (unknownTargets.length || targets.length === 0) {
+  console.error(
+    `Unknown target(s) "${unknownTargets.join(', ')}". Use --targets=all or a comma-separated subset of ${ALL_TARGETS.join(', ')}.`,
+  )
+  process.exit(2)
+}
+
+// The optional corpus is driven by per-feature adapters that are wired for HTML
+// only, so a non-HTML target there would compare "feature configured" against
+// "feature missing" and report a meaningless diff.
+let targetNote = ''
+if (corpusName === 'optional' && targets.some((t) => t !== 'html')) {
+  targetNote = 'optional corpus runs the html target only; the feature adapters are html-specific'
+  targets = ['html']
+}
+
+// Command suffix per target. An empty suffix is the default (HTML) render.
+const CLI_FLAGS = {
+  html: [],
+  markdown: ['--markdown'],
+  plain: ['--plain'],
+  carve: ['--carve'],
+  ansi: ['--ansi'],
+}
+
+// carve-js is driven through its API rather than its CLI, matching how the
+// html path already worked.
+const JS_ENTRY = {
+  html: 'carveToHtml',
+  markdown: 'carveToMarkdown',
+  plain: 'carveToPlainText',
+  carve: 'carveToCarve',
+  ansi: 'carveToAnsi',
+}
+
 const impls = [
   {
     name: 'rust',
     cwd: process.env.CARVE_RS_DIR ?? resolve(root, '../carve-rs'),
     prepare: null,
-    defaultCommand: () => ['cargo', 'run', '--quiet', '--'],
+    defaultCommand: (target = 'html') => ['cargo', 'run', '--quiet', '--', ...CLI_FLAGS[target]],
     optionalCommand(feature) {
       if (feature === 'social-link-templates') {
         return [
@@ -65,15 +116,15 @@ const impls = [
     name: 'js',
     cwd: process.env.CARVE_JS_DIR ?? resolve(root, '../carve-js'),
     prepare: ['npm', 'run', 'build'],
-    defaultCommand: () => [
+    defaultCommand: (target = 'html') => [
       'node',
       '--input-type=module',
       '-e',
       `
         import { readFileSync } from 'node:fs';
-        import { carveToHtml } from './dist/index.js';
+        import { ${JS_ENTRY[target]} } from './dist/index.js';
         const source = readFileSync(process.argv[1], 'utf8');
-        process.stdout.write(carveToHtml(source));
+        process.stdout.write(${JS_ENTRY[target]}(source));
       `,
     ],
     optionalCommand(feature) {
@@ -123,7 +174,7 @@ const impls = [
     name: 'php',
     cwd: process.env.CARVE_PHP_DIR ?? resolve(root, '../carve-php'),
     prepare: null,
-    defaultCommand: () => ['php', 'bin/carve'],
+    defaultCommand: (target = 'html') => ['php', 'bin/carve', ...CLI_FLAGS[target]],
     optionalCommand(feature) {
       if (feature === 'social-link-templates') {
         return [
@@ -197,9 +248,9 @@ function run(cmd, cwd, extraArgs = [], timeout = 15000) {
   }
 }
 
-function commandFor(impl, pair) {
+function commandFor(impl, pair, target = 'html') {
   if (corpusName === 'optional') return impl.optionalCommand(pair.feature)
-  return impl.defaultCommand()
+  return impl.defaultCommand(target)
 }
 
 function available(impl) {
@@ -252,51 +303,90 @@ const stats = Object.fromEntries(
   active.map((i) => [i.name, { ok: 0, mismatch: 0, error: 0, skipped: 0, ms: 0, runnable: 0 }]),
 )
 let crossImplDiffs = 0
+const targetStats = Object.fromEntries(
+  targets.map((t) => [t, { compared: 0, diffs: 0, errors: 0 }]),
+)
 
 for (const pair of pairs) {
-  const expected = readFileSync(join(corpusDir, `${pair.slug}.html`), 'utf8').trim()
-  const outputs = []
-  const ran = []
+  for (const target of targets) {
+    const expected =
+      target === 'html' ? readFileSync(join(corpusDir, `${pair.slug}.html`), 'utf8').trim() : null
+    const outputs = []
+    const ran = []
 
-  for (const impl of active) {
-    const command = commandFor(impl, pair)
-    if (!command) {
-      stats[impl.name].skipped++
-      continue
-    }
-    stats[impl.name].runnable++
-    const result = run(command, impl.cwd, [pair.file])
-    stats[impl.name].ms += result.elapsedMs
-    if (!result.ok) {
-      stats[impl.name].error++
-      outputs.push([impl.name, `ERROR:${result.stderr || result.error || result.status}`])
+    for (const impl of active) {
+      const command = commandFor(impl, pair, target)
+      if (!command) {
+        // Skips are a per-pair property, not a per-target one; counting them
+        // once per target would multiply the same gap by the target count.
+        if (target === targets[0]) stats[impl.name].skipped++
+        continue
+      }
+      stats[impl.name].runnable++
+      const result = run(command, impl.cwd, [pair.file])
+      stats[impl.name].ms += result.elapsedMs
+      if (!result.ok) {
+        stats[impl.name].error++
+        targetStats[target].errors++
+        outputs.push([impl.name, `ERROR:${result.stderr || result.error || result.status}`])
+        ran.push(impl.name)
+        continue
+      }
+      // Only the html target has an expected-output fixture to score against.
+      if (expected !== null) {
+        if (result.stdout === expected) stats[impl.name].ok++
+        else stats[impl.name].mismatch++
+      }
+      outputs.push([impl.name, result.stdout])
       ran.push(impl.name)
-      continue
     }
-    if (result.stdout === expected) stats[impl.name].ok++
-    else stats[impl.name].mismatch++
-    outputs.push([impl.name, result.stdout])
-    ran.push(impl.name)
-  }
 
-  const unique = new Set(outputs.map(([, out]) => out))
-  if (unique.size > 1) {
-    crossImplDiffs++
-    console.log(`DIFF ${pair.slug} (${pair.feature}): ${ran.join(', ')}`)
+    if (outputs.length < 2) continue
+    targetStats[target].compared++
+
+    // `run()` trims, so agreement here means "identical apart from leading and
+    // trailing whitespace". That is deliberate and matches the rest of the
+    // project: the corpus runner trims too, and the profile parity battery
+    // compares trailing-newline-insensitively on the stated grounds that
+    // renderers differ on a final `\n` (docs/profiles.md). Comparing untrimmed
+    // would report that known, accepted difference on every case and bury the
+    // real divergences.
+
+    const unique = new Set(outputs.map(([, out]) => out))
+    if (unique.size > 1) {
+      targetStats[target].diffs++
+      if (target === 'html') crossImplDiffs++
+      console.log(`DIFF [${target}] ${pair.slug} (${pair.feature}): ${ran.join(', ')}`)
+    }
   }
 }
 
 console.log('\nImplementation summary')
 const profile = corpusName === 'optional' ? 'optional/opt-in' : 'default/no-opt-in'
-console.log(`profile=${profile} corpus=${corpusName} corpus_pairs=${pairs.length}`)
+console.log(
+  `profile=${profile} corpus=${corpusName} corpus_pairs=${pairs.length} targets=${targets.join(',')}`,
+)
+if (targetNote) console.log(`target_note=${targetNote}`)
 for (const impl of active) {
   const s = stats[impl.name]
   const avg = s.runnable ? (s.ms / s.runnable).toFixed(2) : '0.00'
+  // pass/mismatch score the html fixtures only, so they are reported against
+  // the pair count rather than the run count (which spans every target).
   console.log(
-    `${impl.name}: pass=${s.ok}/${s.runnable} mismatch=${s.mismatch} error=${s.error} skipped=${s.skipped} avg_ms=${avg}`,
+    `${impl.name}: pass=${s.ok}/${s.ok + s.mismatch} mismatch=${s.mismatch} error=${s.error} skipped=${s.skipped} runs=${s.runnable} avg_ms=${avg}`,
   )
 }
 console.log(`cross_impl_diffs=${crossImplDiffs}`)
+
+console.log('\nTarget agreement (implementations compared against each other)')
+for (const target of targets) {
+  const t = targetStats[target]
+  const fixtures = target === 'html' ? ' fixtures=yes' : ' fixtures=none'
+  console.log(`${target}: compared=${t.compared} diffs=${t.diffs} errors=${t.errors}${fixtures}`)
+}
+console.log(
+  'target_agreement_note=only html has expected-output fixtures; the other targets assert that the implementations agree with each other.',
+)
 
 if (corpusName === 'optional') {
   console.log('\nOptional feature coverage')


### PR DESCRIPTION
Closes #349.

`compare-impls.mjs` rendered each corpus case to HTML in all three engines and diffed against the `.html` fixture. That was the entire differential safety net, covering one of five targets.

## The change

`--targets` defaults to all of `html`, `markdown`, `plain`, `carve`, `ansi`, and takes a comma-separated subset. `--targets=html` restores the previous scope and runtime.

Only `html` has expected-output fixtures. The other four are compared implementation-against-implementation, because engine agreement is the property that matters there and four more expected files per corpus case would not add to it. A new `Target agreement` block reports per-target counts, and each disagreement prints `DIFF [target] slug` naming the engines that ran.

Comparison stays trailing-newline-insensitive, matching `tests/corpus.test.mjs` and the profile parity battery, which documents the same choice because renderers legitimately differ on a final newline. Byte-strict comparison would flag that on every case and bury the real findings.

The optional corpus runs `html` only, with the reason printed: its per-feature adapters configure HTML conversion specifically, so a non-HTML target there would compare "feature configured" against "feature missing".

## Baseline on the current main

Full sweep, 497 corpus cases, three engines:

| Target | Compared | Diffs | Fixtures |
|---|---|---|---|
| html | 497 | **0** | yes |
| markdown | 497 | 35 | none |
| plain | 497 | 8 | none |
| carve | 497 | 40 | none |
| ansi | 497 | 15 | none |

HTML remains clean, which is the good news: the invariant that *was* checked held. The other 98 divergences were all invisible until now.

Which engine is the outlier, per target:

| Target | php odd | js odd | rs odd |
|---|---|---|---|
| markdown | 30 | 1 | 4 |
| plain | 7 | 0 | 1 |
| carve | 20 | 20 | 0 |
| ansi | 11 | 0 | 4 |

Note the `carve` column: it is a js-versus-php split, with carve-rs agreeing with whichever. That was not the shape I expected going in.

Samples, one per target:

```
# markdown - php escapes punctuation the others leave bare (#350)
source : \/literal\/ and \*not bold\*
js, rs : /literal/ and \*not bold\*
php    : \/literal\/ and \*not bold\*

# ansi - doubled reset on nested emphasis
js, php : ^[[1m^[[3mbold italic^[[0m^[[0m
rs      : ^[[1m^[[3mbold italic^[[0m

# plain - php drops the stanza separator in a line block
rs, js : "Stanza one,\nstill one.\n\nStanza two."
php    : "Stanza one,\nstill one.\nStanza two."

# carve - rs and php insert a blank line before a nested list, js does not
```

Triage of the 98 is deliberately not in this PR; each target needs its own call about which output is canonical. Follow-up issues are being filed with this data.

## One finding worth reading before merge

Chasing the `carve` sample above turned up something the runner does not yet catch directly. carve-rs and carve-php emit **byte-identical** canonical output for `05-lists-4`, and then parse it differently:

```
$ carve --carve tests/corpus/05-lists-4.crv   # rs and php agree byte-for-byte
- fruit

    - apples
    - oranges
- vegetables

$ carve-rs  <that output>   ->  <li><p>fruit</p>     (loose)
$ carve-php <that output>   ->  <li>fruit           (tight)
```

That is an HTML-level parser divergence, the exact thing the corpus exists to catch. It slipped through because the input is *generated* - a blank line between an item's text and its nested list at that indent is not in the corpus, so nothing compares the engines on it.

It also means carve-rs breaks `to_html(fmt(x)) == to_html(x)` on that case, while carve-js and carve-php hold it.

The obvious follow-up is a round-trip mode here: format, re-render, compare across engines. Cheap to add on top of this, and it turns generated output into corpus coverage. Filing separately rather than growing this PR.
