### PR TITLE
spec: pin the compact sub-list rule with a following sibling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Corpus pin for the compact sub-list rule with a following sibling**
+  (85-compact-list-blocks-2). §17 L2 keeps an item tight when a blank line
+  precedes its sub-block, and the existing pin used a block quote with no
+  sibling after it. The sub-list variant with a following item was unpinned, and
+  carve-rs got it wrong: the blank leaked past the sub-list and the sibling
+  marker read it as a blank between items, rendering the whole list loose
+  (carve-rs#286). Because the canonical writer emits exactly this shape for
+  ordinary nested lists, carve-rs was also breaking
+  `to_html(fmt(x)) == to_html(x)` on a plain two-level list.
+
 - Smart typography now has a normative AST representation (PART 9 §8): a
   recognized substitution is a `smart_punctuation` inline node carrying both the
   resolved kind and the author's source run. Presentation renderers emit the

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -1996,6 +1996,30 @@ A blank line is still required to start a block inside a list item, but it no lo
 
 :::
 
+A **sub-list** is one of those blocks, and the rule holds when a sibling item follows it: the blank belongs to the sub-list, not to the gap between items, so the whole list stays tight.
+
+::: compare
+
+```carve
+- fruit
+
+  - apples
+- vegetables
+```
+
+```html
+<ul>
+  <li>fruit
+    <ul>
+      <li>apples</li>
+    </ul>
+  </li>
+  <li>vegetables</li>
+</ul>
+```
+
+:::
+
 A genuine second prose paragraph still makes the list loose (and so does a blank line between items).
 
 ::: compare

--- a/tests/corpus/85-compact-list-blocks-2.crv
+++ b/tests/corpus/85-compact-list-blocks-2.crv
@@ -1,4 +1,4 @@
-- item
+- fruit
 
-  second para
-- next
+  - apples
+- vegetables

--- a/tests/corpus/85-compact-list-blocks-2.html
+++ b/tests/corpus/85-compact-list-blocks-2.html
@@ -1,6 +1,8 @@
 <ul>
-  <li><p>item</p>
-    <p>second para</p>
+  <li>fruit
+    <ul>
+      <li>apples</li>
+    </ul>
   </li>
-  <li><p>next</p></li>
+  <li>vegetables</li>
 </ul>

--- a/tests/corpus/85-compact-list-blocks-3.crv
+++ b/tests/corpus/85-compact-list-blocks-3.crv
@@ -1,0 +1,4 @@
+- item
+
+  second para
+- next

--- a/tests/corpus/85-compact-list-blocks-3.html
+++ b/tests/corpus/85-compact-list-blocks-3.html
@@ -1,0 +1,6 @@
+<ul>
+  <li><p>item</p>
+    <p>second para</p>
+  </li>
+  <li><p>next</p></li>
+</ul>

--- a/tests/spec/85-compact-list-blocks.test
+++ b/tests/spec/85-compact-list-blocks.test
@@ -15,6 +15,22 @@ Compact list blocks
 ```
 
 ```
+- fruit
+
+  - apples
+- vegetables
+.
+<ul>
+  <li>fruit
+    <ul>
+      <li>apples</li>
+    </ul>
+  </li>
+  <li>vegetables</li>
+</ul>
+```
+
+```
 - item
 
   second para


### PR DESCRIPTION
§17 L2 keeps a list item tight when a blank line precedes its sub-block. The existing example pins that with a block quote and no item after it:

```
- item

  > note
- next
```

The **sub-list** variant with a following sibling was never pinned, and it is the one that interacts. The blank sits before the sub-list, but an implementation can let it survive to the next marker, where it reads as a blank *between* items and loosens the whole list.

carve-rs did exactly that, and shipped it. The corpus could not catch it because dropping the sibling makes all three engines agree, so the failure needed both halves present.

## Why this one is worth a pin rather than a shrug

The canonical writer emits this exact shape for ordinary nested lists. So carve-rs was formatting a tight list into source it then parsed as loose - breaking `to_html(fmt(x)) == to_html(x)` on input as plain as a two-level bullet list. Not an exotic edge.

It surfaced through #351 (cross-engine comparison on non-HTML targets), not through the corpus. Fix in markup-carve/carve-rs#287; markup-carve/carve#353 proposes the round-trip mode that would have found it directly.

## The pin

```
- fruit

  - apples
- vegetables
```

```html
<ul>
  <li>fruit
    <ul>
      <li>apples</li>
    </ul>
  </li>
  <li>vegetables</li>
</ul>
```

Verified byte-identical in carve-js and carve-php today, and in carve-rs with #287 applied.

Regenerated with `npm run corpus:build`, which renumbers the existing second-paragraph case to `-3`. Spec suite: 551 pass, 0 fail.
