### PR TITLE
spec: specify the canonical source writer (PART 11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The canonical source writer is now specified** (new PART 11). `carve fmt`
+  and the `carve` render target had no normative text at all, so their behavior
+  was defined only by three implementations happening to agree. PART 11 pins the
+  invariants (`parse(fmt(x)) == parse(x)` and idempotence), states the escaping
+  rule - a character is escaped if and only if omitting the escape would change
+  the re-parsed AST - and records why a static per-character table cannot
+  implement it: `[` is literal alone but an opener in `[a](b)`, `^` is literal
+  at column 0 but an opener in `^[note]`. The conformant strategy pins the
+  output while leaving the computation free: build the minimal form, re-parse
+  it, and fall back to escaping the whole line only when the re-parse differs.
+  A new `tests/corpus-roundtrip/` corpus pins Carve-source-in, Carve-source-out
+  pairs; the invariant assertions run today, the byte assertions are skipped
+  until an engine implements minimal escaping.
+
 - Smart typography now has a normative AST representation (PART 9 §8): a
   recognized substitution is a `smart_punctuation` inline node carrying both the
   resolved kind and the author's source run. Presentation renderers emit the

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -14,6 +14,7 @@ This is the canonical formal specification of Carve. It is **layered**, and each
 | PART 9 | Semantic constraints a context-free production cannot carry (emphasis resolution, paragraph interruption, table span walk, attribute floating, tabs) | Operational semantics: labeled rules over declared state |
 | PART 9R | Whole-document resolution (references, footnotes, crossrefs, numbering) | Two-pass rules over declared symbol tables |
 | PART 10 | HTML serialization | Tree-transform conventions |
+| PART 11 | Canonical source writer (`carve fmt`): round-trip invariants and the escaping rule | Invariants over `parse`/`fmt` + a decision procedure |
 
 ::: info Why layers instead of one grammar?
 Light markup languages are provably not context-free: fence-length matching is a counting constraint, indentation is 2D, and reference resolution needs a whole-document symbol table. No single EBNF can express Carve (or Djot, or CommonMark). What CAN be done - and what this file does - is state every rule in *some* exact formalism, so nothing normative rests on English prose.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sync-carve-lib": "node scripts/sync-carve-lib.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/corpus.test.mjs tests/optional-corpus.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/fixture-bytes.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/optional-corpus.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2806,4 +2806,95 @@ EOF = (* end of file *) ;
       when no URL template is configured; a configured template links to them. The footnote
       backlink glyph is `↩` (§16). Math wraps content in `\(…\)` /
       `\[…\]` inside `<span class="math inline|display">` (§18).
+
+   ============================================================================
+   PART 11: CANONICAL SOURCE WRITER (NORMATIVE)
+   ============================================================================
+
+   The canonical writer (`carve fmt`, the `carve` render target) serializes a
+   document back to Carve source. Nothing here specified it before, so its
+   behavior was defined only by three implementations happening to agree.
+
+   1. THE INVARIANTS. For any document x:
+
+        parse(fmt(x)) == parse(x)        -- meaning is preserved
+        fmt(fmt(x))   == fmt(x)          -- the writer is idempotent
+
+      The first is about the AST, not the bytes: `fmt` MAY normalize the
+      author's spelling (indentation, marker alignment, escape form) but MUST
+      NOT change what the document says. The second forbids growth -- a value
+      that gains an escape per pass violates it, which is how over-escaping is
+      usually first noticed.
+
+   2. THE ESCAPING RULE -- NORMATIVE. A character is escaped IF AND ONLY IF
+      omitting the escape would change the re-parsed AST.
+
+      Escaping MORE than that is a defect, not a safe default. It is how a
+      formatter turns `50% faster: yes (ok)` into `50\% faster\: yes \(ok\)`,
+      which re-parses identically -- so nothing there needed escaping.
+
+      Escaping LESS is a correctness bug: the document changes meaning.
+
+   3. WHY A STATIC CHARACTER TABLE CANNOT IMPLEMENT §2. Whether a character
+      is significant depends on the line, not on the character:
+
+        `[`  literal alone, an opener in `[a](b)`
+        `(`  literal in `[a] (b)`, an opener in `[a](b)`
+        `^`  literal at column 0 before a space, an opener in `^[note]`
+        `-`  literal mid-word, a list marker at column 0, an en dash doubled
+        `_`  literal alone, an opener only when a closer follows on the line
+
+      A writer that decides per character with no context must therefore
+      over-escape to stay correct, which is the defect §2 forbids.
+
+   4. THE CONFORMANT STRATEGY -- PINNED OUTPUT, FREE IMPLEMENTATION. An
+      implementation MAY compute §2 however it likes, but the OUTPUT is pinned
+      to this decision, taken per emitted line:
+
+      W1 Build the MINIMAL form: escape only the UNCONDITIONAL set (§5).
+      W2 Re-parse that line in its block context and compare the resulting
+         inline nodes with the nodes being written.
+      W3 If they match, emit the minimal form.
+      W4 Otherwise emit the CONSERVATIVE form: additionally escape every
+         CANDIDATE-set character (§5) on that line.
+
+      Two forms and one comparison, with the choice made by the parser rather
+      than by a table -- so the writer cannot drift from the grammar as the
+      grammar grows. W4 is deliberately whole-line rather than per-character:
+      it keeps the output a function of the line alone, so every
+      implementation lands on the same bytes.
+
+   5. THE TWO SETS.
+
+      UNCONDITIONAL -- always escaped in a text node, never re-derivable:
+        the backslash itself; the backtick (opens a code span in any
+        position); and `"` / `'`. A BARE quote re-derives as smart
+        punctuation (PART 9 §8), so a quote that reached the writer as TEXT
+        is one the author escaped, and it stays escaped. A quote carried by a
+        `smart_punctuation` node is NOT text: the writer emits that node's
+        source run BARE, which is what makes `fmt` reproduce the author's
+        spelling.
+
+      CANDIDATE -- escaped only when W2 fails on that line:
+        `* _ ~ / = ^ ,`      emphasis and the braced pair delimiters
+        `[ ] ( ) { } <`      links, images, spans, attributes, autolinks
+        `@ #`                mentions and tags (§7 boundary rules); `#` also
+                             opens a heading at column 0
+        `> + - . ) : | % !`  block openers at column 0, plus the inline forms
+                             `^[`, `%%` and `::`
+        `$`                  math
+
+      A character in neither set is never escaped.
+
+      The set must cover EVERY construct opener, or W4 has nothing to fall
+      back to and the document is unrecoverable: `\@user` would emit as
+      `@user`, W2 would correctly see a `mention` where the source had text,
+      and W4 could not fix it. When a new opener is added to the grammar, its
+      character belongs here.
+
+   6. WHAT IS NOT THE WRITER'S JOB. `fmt` does not re-wrap prose, reorder
+      attributes, or respell a construct to a synonym (`*` vs `-` bullets,
+      fence length, ordered-list dialect). Those are the author's choices and
+      the AST records them; changing one would satisfy §1 while still
+      surprising the author.
 *)

--- a/tests/corpus-roundtrip/01-prose-punctuation.crv
+++ b/tests/corpus-roundtrip/01-prose-punctuation.crv
@@ -1,0 +1,1 @@
+Carve is a "post-Markdown" language - it fixes it. 50% faster: yes (ok).

--- a/tests/corpus-roundtrip/01-prose-punctuation.expected.crv
+++ b/tests/corpus-roundtrip/01-prose-punctuation.expected.crv
@@ -1,0 +1,1 @@
+Carve is a "post-Markdown" language - it fixes it. 50% faster: yes (ok).

--- a/tests/corpus-roundtrip/02-unpaired-delimiters.crv
+++ b/tests/corpus-roundtrip/02-unpaired-delimiters.crv
@@ -1,0 +1,1 @@
+A path like /usr/local/bin and a range 10-20 and an email a@b.dev.

--- a/tests/corpus-roundtrip/02-unpaired-delimiters.expected.crv
+++ b/tests/corpus-roundtrip/02-unpaired-delimiters.expected.crv
@@ -1,0 +1,1 @@
+A path like /usr/local/bin and a range 10-20 and an email a@b.dev.

--- a/tests/corpus-roundtrip/03-nested-list.crv
+++ b/tests/corpus-roundtrip/03-nested-list.crv
@@ -1,0 +1,3 @@
+- fruit
+  - apples
+- vegetables

--- a/tests/corpus-roundtrip/03-nested-list.expected.crv
+++ b/tests/corpus-roundtrip/03-nested-list.expected.crv
@@ -1,0 +1,3 @@
+- fruit
+    - apples
+- vegetables

--- a/tests/corpus-roundtrip/04-literal-punctuation.crv
+++ b/tests/corpus-roundtrip/04-literal-punctuation.crv
@@ -1,0 +1,1 @@
+Literal \-\- and \.\.\. and \" must stay escaped.

--- a/tests/corpus-roundtrip/04-literal-punctuation.expected.crv
+++ b/tests/corpus-roundtrip/04-literal-punctuation.expected.crv
@@ -1,0 +1,1 @@
+Literal \-\- and \.\.\. and \" must stay escaped\.

--- a/tests/corpus-roundtrip/05-real-constructs.crv
+++ b/tests/corpus-roundtrip/05-real-constructs.crv
@@ -1,0 +1,1 @@
+See [docs](https://example.com) and `code` and *bold*.

--- a/tests/corpus-roundtrip/05-real-constructs.expected.crv
+++ b/tests/corpus-roundtrip/05-real-constructs.expected.crv
@@ -1,0 +1,1 @@
+See [docs](https://example.com) and `code` and *bold*.

--- a/tests/corpus-roundtrip/06-column-zero-literals.crv
+++ b/tests/corpus-roundtrip/06-column-zero-literals.crv
@@ -1,0 +1,5 @@
+\# not a heading
+
+\- not a list
+
+\> not a quote

--- a/tests/corpus-roundtrip/06-column-zero-literals.expected.crv
+++ b/tests/corpus-roundtrip/06-column-zero-literals.expected.crv
@@ -1,0 +1,5 @@
+\# not a heading
+
+\- not a list
+
+\> not a quote

--- a/tests/corpus-roundtrip/07-mention-and-tag-literals.crv
+++ b/tests/corpus-roundtrip/07-mention-and-tag-literals.crv
@@ -1,0 +1,1 @@
+Ping \@user and \#tag literally, plus a real @who and #topic.

--- a/tests/corpus-roundtrip/07-mention-and-tag-literals.expected.crv
+++ b/tests/corpus-roundtrip/07-mention-and-tag-literals.expected.crv
@@ -1,0 +1,1 @@
+Ping \@user and \#tag literally, plus a real @who and #topic\.

--- a/tests/corpus-roundtrip/README.md
+++ b/tests/corpus-roundtrip/README.md
@@ -1,0 +1,47 @@
+# Canonical-writer round-trip corpus
+
+Pairs of `NN-slug.crv` (input) and `NN-slug.expected.crv` (the output the
+canonical writer must produce), pinning [PART 11](../../resources/grammar.ebnf)
+of the grammar.
+
+Unlike `../corpus/`, which pins rendered HTML, these pin **Carve source in,
+Carve source out**. That covers behavior the HTML corpus structurally cannot:
+the writer's escaping decisions, and whether formatting a document preserves it.
+
+## What each case pins
+
+- **The minimal-escape form** where it re-parses identically (PART 11 §2). This
+  is the interesting half: `50% faster: yes (ok)` must come back unchanged, not
+  as `50\% faster\: yes \(ok\)`.
+- **The conservative whole-line form** where the minimal form would change
+  meaning (PART 11 §4 W4). `04-literal-punctuation` and
+  `06-column-zero-literals` are those cases - their escapes are load-bearing,
+  and a writer that drops them corrupts the document.
+
+`04` also shows the cost the whole-line fallback accepts: the trailing `.` in
+that line does not need escaping on its own, but the line falls back as a unit,
+so it is escaped along with the rest. That keeps the output a function of the
+line, which is what lets three engines agree byte-for-byte.
+
+`07` covers the case that proves the candidate set has to be complete: a line
+carrying both literal `\@user` / `\#tag` text and a real `@who` mention. If `@`
+were missing from the set, W4 would have nothing to escape with and the literal
+would silently become a mention.
+
+## Why the byte assertions are skipped
+
+`../roundtrip.test.mjs` asserts the PART 11 §1 invariants against the vendored
+reference today - those hold, and they guard the class of bug that shipped in
+carve-rs as a nested list being reformatted from tight to loose.
+
+The byte comparisons are skipped until an engine implements minimal escaping.
+Asserting them against the current over-escaping writer would either fail the
+suite or, if the fixtures were generated from that writer, pin the defect as
+the expected output.
+
+## Regenerating
+
+Do **not** regenerate expected files from an implementation's current output -
+that is how a defect becomes a fixture. Derive them from PART 11: build the
+minimal form, check it re-parses to the same AST, and fall back to the
+conservative form only when it does not.

--- a/tests/normativity.test.mjs
+++ b/tests/normativity.test.mjs
@@ -22,9 +22,14 @@ const repo = resolve(here, '..')
 const grammarPath = resolve(repo, 'resources/grammar.ebnf')
 const grammar = readFileSync(grammarPath, 'utf8')
 
-// PART 9 is the last PART; collect its section numbers from the
-// "   N. TITLE" headings that follow the PART 9 banner.
-const part9 = grammar.slice(grammar.indexOf('PART 9: SEMANTIC CONSTRAINTS'))
+// Collect PART 9's section numbers from the "   N. TITLE" headings between its
+// banner and the next PART banner. Bounding the slice matters: PART 10 and
+// PART 11 have their own numbered items, and letting those leak in would make a
+// dangling "PART 9 §N" reference resolve against a section that lives
+// somewhere else entirely.
+const part9Start = grammar.indexOf('PART 9: SEMANTIC CONSTRAINTS')
+const part10Start = grammar.indexOf('PART 10: HTML SERIALIZATION', part9Start)
+const part9 = grammar.slice(part9Start, part10Start === -1 ? undefined : part10Start)
 const part9Sections = new Set(
   [...part9.matchAll(/^ {3}(\d+)\. {1,3}[A-Z]/gm)].map((m) => Number(m[1])),
 )

--- a/tests/roundtrip.test.mjs
+++ b/tests/roundtrip.test.mjs
@@ -1,0 +1,85 @@
+/*
+ * Canonical-writer round-trip corpus (PART 11).
+ *
+ * Each case is a `.crv` input paired with a `.expected.crv` holding the output
+ * PART 11 requires: the minimal-escape form where it re-parses identically, the
+ * conservative whole-line form where it does not.
+ *
+ * Two things are asserted separately, on purpose:
+ *
+ *   - The INVARIANTS (PART 11 §1) run against the vendored reference now.
+ *     They hold today and guard against a writer that changes meaning - the
+ *     class of bug that shipped in carve-rs as a nested list being reformatted
+ *     from tight to loose (carve-rs#286).
+ *
+ *   - The BYTES (PART 11 §2, §4) are skipped until an engine implements
+ *     minimal escaping. The vendored carve-lib over-escapes, so asserting them
+ *     now would either fail or, worse, pin the defect as expected output.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync } from 'node:fs'
+import { basename, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { carveToCarve, parse } from '../docs/.vitepress/carve-lib/index.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const dir = resolve(here, 'corpus-roundtrip')
+
+const cases = readdirSync(dir)
+  .filter((f) => f.endsWith('.crv') && !f.endsWith('.expected.crv'))
+  .sort()
+  .map((f) => ({
+    slug: basename(f, '.crv'),
+    source: readFileSync(resolve(dir, f), 'utf8'),
+    expected: readFileSync(resolve(dir, `${basename(f, '.crv')}.expected.crv`), 'utf8'),
+  }))
+
+test('the round-trip corpus is non-empty', () => {
+  assert.ok(cases.length >= 6, `found ${cases.length} cases`)
+})
+
+// `pos` records source offsets, which legitimately move when the writer
+// renormalizes indentation, so it is not part of "same document".
+function withoutPositions(node) {
+  if (Array.isArray(node)) return node.map(withoutPositions)
+  if (node && typeof node === 'object') {
+    const out = {}
+    for (const [k, v] of Object.entries(node)) {
+      if (k === 'pos' || k === 'srcByteLength') continue
+      out[k] = withoutPositions(v)
+    }
+    return out
+  }
+  return node
+}
+
+for (const { slug, source, expected } of cases) {
+  test(`${slug}: parse(fmt(x)) == parse(x)`, () => {
+    assert.deepEqual(
+      withoutPositions(parse(carveToCarve(source))),
+      withoutPositions(parse(source)),
+      'the formatter changed what the document says',
+    )
+  })
+
+  test(`${slug}: fmt is idempotent`, () => {
+    const once = carveToCarve(source)
+    assert.equal(carveToCarve(once), once, 'a second pass changed the output')
+  })
+
+  test(`${slug}: the expected output re-parses to the same document`, () => {
+    // Guards the fixtures themselves: an expected file that does not round-trip
+    // would pin a writer that corrupts documents.
+    assert.deepEqual(
+      withoutPositions(parse(expected)),
+      withoutPositions(parse(source)),
+      'the expected output is not a faithful serialization of the input',
+    )
+  })
+
+  test.skip(`${slug}: fmt(x) == expected bytes (needs PART 11 minimal escaping)`, () => {
+    assert.equal(carveToCarve(source), expected)
+  })
+}


### PR DESCRIPTION
Addresses the spec half of #344. Engine work follows separately - this PR changes no output.

## The problem, restated precisely

`carve fmt` and the `carve` render target had **no normative text at all**. The only mention of `fmt` in the grammar was the `--stamp` line. Behavior was defined by three implementations happening to agree, and what they agreed on was over-escaping:

```
$ carve --carve bare.crv
Carve is a "post\-Markdown" language \- it fixes it\. 50\% faster\: yes \(ok\).
```

Every backslash there is unnecessary - the bare text re-parses to identical HTML.

## PART 11

**The invariants.** `parse(fmt(x)) == parse(x)` and `fmt(fmt(x)) == fmt(x)`. The first is about the AST, not the bytes: `fmt` may renormalize spelling but must not change what the document says. The second forbids growth, which is how over-escaping usually gets noticed.

**The escaping rule.** A character is escaped if and only if omitting the escape would change the re-parsed AST. Escaping more is a defect, not a safe default; escaping less is corruption.

**Why a static table cannot implement it.** I probed this rather than assuming. Significance is a property of the line, not the character:

| Character | Literal | Significant |
|---|---|---|
| `[` | alone | in `[a](b)` |
| `(` | in `[a] (b)` | in `[a](b)` |
| `^` | at column 0 before a space | in `^[note]` |
| `-` | mid-word | at column 0, or doubled |
| `_` | alone | only when a closer follows on the line |

A writer deciding per character with no context has to over-escape to stay correct - which is exactly the defect the rule forbids. That is why the current escapers look the way they do; they are not careless, they are context-blind.

**The strategy.** Output is pinned, computation is free:

1. Build the minimal form - escape only the unconditional set.
2. Re-parse that line in its block context, compare the inline nodes.
3. Match → emit minimal.
4. Otherwise → escape every candidate-set character on the line.

The parser decides, not a table, so the writer cannot drift as the grammar grows. The fallback is whole-line rather than per-character deliberately: it keeps output a function of the line alone, which is what lets three engines land on the same bytes.

## Round-trip corpus

`tests/corpus-roundtrip/` pins Carve source in, Carve source out - covering what the HTML corpus structurally cannot.

Split deliberately:

- **Invariant assertions run today** against the vendored reference and pass. They guard the class of bug that shipped in carve-rs as a nested list reformatted from tight to loose (markup-carve/carve-rs#286).
- **Byte assertions are skipped** until an engine implements minimal escaping. Generating them from the current writer would pin the defect as expected output, which is worse than no fixture.

Expected outputs were derived from the rule and then verified to re-parse to the same AST, not lifted from any implementation's output.

Cases 04, 06 and 07 are the ones where escapes are load-bearing and the conservative form is correct. 04 also shows the cost the whole-line fallback accepts: its trailing `.` needs no escape on its own but goes along with the line.

## One thing codex caught

The first draft omitted `@` from the candidate set. That is a real hole, not a nit: `\@user` would emit bare, re-parse as a mention, and W4 would have nothing to escape with - the document becomes unrecoverable. Both social markers are in the set now, `07-mention-and-tag-literals` covers it, and the requirement that the set cover *every* opener is stated so the next one added to the grammar comes with its character.

## Also

`tests/normativity.test.mjs` bounded its PART 9 slice at the PART 10 banner. It claimed PART 9 was the last part, so later parts' numbered items leaked into the set that a dangling `PART 9 §N` reference resolves against - which this PR would have made worse by adding PART 11.

Spec suite: 572 pass, 0 fail, 10 skipped.
