### PR TITLE
spec: amend PART 11 after implementing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   HTML. Nothing caught it because every existing check compares HTML, which is
   equal in all of those cases.
 
-### Changed
-
 - `scripts/compare-impls.mjs` now compares every render target, not just HTML.
   `--targets=all` (the new default) covers `html`, `markdown`, `plain`, `carve`
   and `ansi`; only `html` has expected-output fixtures, so the other four are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **PART 11 amended after implementing it.** Three corrections, each forced by
+  the parser rather than chosen:
+
+  The escaping decision is **document-scoped**, not per line. A line re-parsed
+  on its own has lost the document's link-reference and footnote definitions, so
+  a paragraph carrying `[text][ref]` comes back with an empty destination and
+  reports a difference escaping never caused. Any scope smaller than the
+  document has that defect.
+
+  The two renders are **compared with each other**, not the minimal render
+  against the document being written. Comparing against the source document
+  inherits the writer's existing round-trip gaps and flips the escaping decision
+  between passes, breaking idempotence for a reason unrelated to escaping.
+
+  The **caret is unconditional**. It opens nothing on its own, but its escape
+  carries information the AST records separately - a text node whose leading
+  caret came from an escape is marked, so an image followed by a caret line is
+  not promoted to a figure. Comparing that mark would escalate every document
+  whose text begins with a caret; ignoring it would silently turn the image case
+  into a figure.
+
+- **PART 11 §1 now records a known gap.** The first invariant,
+  `parse(fmt(x)) == parse(x)`, is not met by any engine today: a table with a
+  colspan, a doubled alignment marker, some list-item attribute forms and one
+  line-block shape re-parse to a different document while rendering identical
+  HTML. Nothing caught it because every existing check compares HTML, which is
+  equal in all of those cases.
+
+### Changed
+
 - `scripts/compare-impls.mjs` now compares every render target, not just HTML.
   `--targets=all` (the new default) covers `html`, `markdown`, `plain`, `carve`
   and `ansi`; only `html` has expected-output fixtures, so the other four are

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2915,7 +2915,7 @@ EOF = (* end of file *) ;
         BOTH forms keeps the two renders identical on that point, at the cost
         of one escape on a character that is rare in prose.
 
-      CANDIDATE -- escaped only when W2 fails on that line:
+      CANDIDATE -- escaped only when W4 selects the conservative form:
         `* _ ~ / = ,`        emphasis and the braced pair delimiters
         `[ ] ( ) { } <`      links, images, spans, attributes, autolinks
         `@ #`                mentions and tags (§7 boundary rules); `#` also
@@ -2929,7 +2929,7 @@ EOF = (* end of file *) ;
 
       The set must cover EVERY construct opener, or W4 has nothing to fall
       back to and the document is unrecoverable: `\@user` would emit as
-      `@user`, W2 would correctly see a `mention` where the source had text,
+      `@user`, W3 would correctly see a `mention` where the source had text,
       and W4 could not fix it. When a new opener is added to the grammar, its
       character belongs here.
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2826,6 +2826,15 @@ EOF = (* end of file *) ;
       that gains an escape per pass violates it, which is how over-escaping is
       usually first noticed.
 
+      KNOWN GAP -- the first invariant is NOT met by every implementation
+      today. A table carrying a colspan, a doubled alignment marker, some
+      list-item attribute forms and one line-block shape re-parse to a
+      DIFFERENT document while rendering identical HTML, in every engine.
+      Nothing caught it because every existing check compares rendered HTML,
+      which is equal in all of those cases. It is stated here rather than left
+      implied: an implementation that satisfies §2 can still fail §1, and §4's
+      comparison is built to be unaffected by that.
+
    2. THE ESCAPING RULE -- NORMATIVE. A character is escaped IF AND ONLY IF
       omitting the escape would change the re-parsed AST.
 
@@ -2849,20 +2858,41 @@ EOF = (* end of file *) ;
 
    4. THE CONFORMANT STRATEGY -- PINNED OUTPUT, FREE IMPLEMENTATION. An
       implementation MAY compute §2 however it likes, but the OUTPUT is pinned
-      to this decision, taken per emitted line:
+      to this decision, taken over the WHOLE DOCUMENT:
 
-      W1 Build the MINIMAL form: escape only the UNCONDITIONAL set (§5).
-      W2 Re-parse that line in its block context and compare the resulting
-         inline nodes with the nodes being written.
-      W3 If they match, emit the minimal form.
-      W4 Otherwise emit the CONSERVATIVE form: additionally escape every
-         CANDIDATE-set character (§5) on that line.
+      W1 Render the document twice: the MINIMAL form, escaping only the
+         UNCONDITIONAL set (§5), and the CONSERVATIVE form, additionally
+         escaping every CANDIDATE-set character (§5).
+      W2 If the two are byte-identical, emit either.
+      W3 Otherwise parse BOTH and compare the resulting documents, ignoring
+         source positions and key order.
+      W4 Equal -> emit the minimal form. Different -> emit the conservative
+         form.
 
       Two forms and one comparison, with the choice made by the parser rather
       than by a table -- so the writer cannot drift from the grammar as the
-      grammar grows. W4 is deliberately whole-line rather than per-character:
-      it keeps the output a function of the line alone, so every
-      implementation lands on the same bytes.
+      grammar grows.
+
+      WHY DOCUMENT SCOPE. An earlier draft of this section decided per line.
+      That cannot be implemented: a line re-parsed on its own has lost the
+      document's link-reference and footnote definitions, so a paragraph
+      carrying `[text][ref]` comes back with an empty destination and reports a
+      difference escaping never caused. Any scope smaller than the document has
+      the same defect. The cost is bluntness -- one genuinely-escaped character
+      anywhere makes the whole document conservative -- which is still strictly
+      better than escaping everything unconditionally, and finer granularity
+      would cost a full parse per block.
+
+      WHY THE TWO RENDERS ARE COMPARED WITH EACH OTHER, and not the minimal
+      render with the document being written. The writer is not required to be
+      AST-faithful for every construct, and in practice is not: a table with a
+      colspan, a doubled alignment marker, some list-item attribute forms and
+      one line-block shape all re-parse to a DIFFERENT document while rendering
+      identical HTML. Comparing against the source document would inherit those
+      defects, flip the escaping decision between passes and break §1's
+      idempotence for a reason that has nothing to do with escaping. Comparing
+      the two renders isolates the only question this decision asks: does
+      dropping the candidate escapes change anything?
 
    5. THE TWO SETS.
 
@@ -2875,13 +2905,24 @@ EOF = (* end of file *) ;
         source run BARE, which is what makes `fmt` reproduce the author's
         spelling.
 
+        The CARET is also unconditional, for a different reason: it opens
+        nothing on its own, but its escape carries information the AST records
+        separately. A text node whose LEADING caret came from an escape is
+        marked as such, so an image followed by a caret line stays a paragraph
+        instead of being promoted to a figure. Comparing that mark in W3 would
+        escalate every document whose text begins with a caret; ignoring it
+        would silently turn the image case into a figure. Escaping the caret in
+        BOTH forms keeps the two renders identical on that point, at the cost
+        of one escape on a character that is rare in prose.
+
       CANDIDATE -- escaped only when W2 fails on that line:
-        `* _ ~ / = ^ ,`      emphasis and the braced pair delimiters
+        `* _ ~ / = ,`        emphasis and the braced pair delimiters
         `[ ] ( ) { } <`      links, images, spans, attributes, autolinks
         `@ #`                mentions and tags (§7 boundary rules); `#` also
                              opens a heading at column 0
         `> + - . ) : | % !`  block openers at column 0, plus the inline forms
-                             `^[`, `%%` and `::`
+                             `%%` and `::` (the inline-footnote `^[` is covered
+                             by the unconditional caret above)
         `$`                  math
 
       A character in neither set is never escaped.

--- a/tests/corpus-roundtrip/README.md
+++ b/tests/corpus-roundtrip/README.md
@@ -13,20 +13,22 @@ the writer's escaping decisions, and whether formatting a document preserves it.
 - **The minimal-escape form** where it re-parses identically (PART 11 §2). This
   is the interesting half: `50% faster: yes (ok)` must come back unchanged, not
   as `50\% faster\: yes \(ok\)`.
-- **The conservative whole-line form** where the minimal form would change
-  meaning (PART 11 §4 W4). `04-literal-punctuation` and
-  `06-column-zero-literals` are those cases - their escapes are load-bearing,
-  and a writer that drops them corrupts the document.
+- **The conservative form** where the minimal form would change meaning
+  (PART 11 §4 W4). `04-literal-punctuation`, `06-column-zero-literals` and
+  `07-mention-and-tag-literals` are those cases - their escapes are
+  load-bearing, and a writer that drops them corrupts the document.
 
-`04` also shows the cost the whole-line fallback accepts: the trailing `.` in
-that line does not need escaping on its own, but the line falls back as a unit,
-so it is escaped along with the rest. That keeps the output a function of the
-line, which is what lets three engines agree byte-for-byte.
+`04` shows the cost the fallback accepts: the trailing `.` needs no escape on
+its own, but the decision is document-scoped, so it is escaped along with the
+rest. That bluntness is deliberate - see PART 11 §4, "why document scope". A
+finer rule cannot be implemented, because anything smaller than a document
+loses the link-reference and footnote definitions and reports differences that
+escaping never caused.
 
-`07` covers the case that proves the candidate set has to be complete: a line
-carrying both literal `\@user` / `\#tag` text and a real `@who` mention. If `@`
-were missing from the set, W4 would have nothing to escape with and the literal
-would silently become a mention.
+`07` proves the candidate set has to be complete: a document carrying both
+literal `\@user` / `\#tag` text and a real `@who` mention. If `@` were missing
+from the set, W4 would have nothing to escape with and the literal would
+silently become a mention.
 
 ## Why the byte assertions are skipped
 


### PR DESCRIPTION
Amends PART 11 after implementing it in carve-js (markup-carve/carve-js#… , same branch). Three corrections, each forced by the parser rather than chosen - I got each one wrong first and the implementation pushed back.

## 1. The decision is document-scoped, not per line

The merged text said "re-parse that line in its block context". That cannot be implemented. A line re-parsed on its own has lost the document's link-reference and footnote definitions, so a paragraph carrying `[text][ref]` comes back with an empty destination:

```
with the definition present : link href="/url"
in isolation                : link href=""
```

That is a difference escaping never caused, and it would escalate the document for nothing. Any scope smaller than the document has the same defect.

The cost is bluntness, and the amendment says so: one genuinely-escaped character anywhere makes the whole document conservative. Still strictly better than today (which escapes everything, always), and finer granularity would cost a full parse per block.

## 2. The two renders are compared with each other

The merged text compared the minimal render against the nodes being written. That breaks idempotence, for a reason that has nothing to do with escaping: **the writer is not AST-faithful for every construct today.**

Verified on the corpus - each of these re-parses to a different document while rendering identical HTML:

| Case | AST round-trip | HTML |
|---|---|---|
| `52-table-alignment-with-colspan` | BROKEN | ok |
| `53-table-doubled-alignment-marker` | BROKEN | ok |
| `88-list-item-attributes-5` | BROKEN | ok |
| `41-line-blocks-2` | BROKEN | ok |

Comparing against the source document inherits those defects: pass 1 sees a difference and goes conservative, pass 2 (whose input is already the re-parsed shape) verifies and goes minimal, so `fmt(fmt(x)) != fmt(x)`. Comparing the two renders isolates the only question the decision asks - does dropping the candidate escapes change anything?

## 3. The caret is unconditional

It opens nothing on its own, but its escape carries information the AST records separately: a text node whose **leading** caret came from an escape is marked, so an image followed by a caret line stays a paragraph instead of being promoted to a figure.

That mark cannot be compared (it would escalate every document whose text begins with a caret) and cannot be ignored (that silently turns the image case into a figure). Escaping the caret in both forms keeps the two renders identical on that point, for one escape on a character that is rare in prose.

## Also: §1 now records the known gap

The first invariant, `parse(fmt(x)) == parse(x)`, is **not met by any engine today** - see the table above. Nothing caught it because every existing check compares rendered HTML, which is equal in all four cases. Stating it beats leaving it implied, and §4's comparison is deliberately built not to care.

That gap is a real defect and wants its own issue; it is not fixed here.

## Verification

Spec suite: 583 tests, 573 pass, 0 fail, 10 skipped.

The round-trip corpus fixtures were regenerated from the amended rule using the new carve-js build and came out **byte-identical** to the ones committed in #356, which were hand-derived from the original rule. That is a useful cross-check: the amendments change how the decision is computed and justified, not what it produces on those cases.
