### PR TITLE
Add a property check for the canonical writer

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -141,6 +141,29 @@ The optional corpus runs the `html` target only. Its per-feature adapters
 configure HTML conversion specifically, so a non-HTML target there would compare
 "feature configured" against "feature missing" and report a meaningless diff.
 
+### Generated documents
+
+`compare-impls` runs the committed corpus - documents somebody wrote.
+`npm run property:check` generates documents nobody wrote, from an alphabet of
+construct fragments, and asserts the two PART 11 invariants over them:
+
+```bash
+npm run property:check                      # invariants only, vendored engine
+npm run property:check -- --engines         # also compare the three writers
+npm run property:check -- --count=2000 --seed=7
+```
+
+It is deterministic by seed, so a failure is reproducible and one build's counts
+are comparable against another's - which is how it is used: run it against a
+branch and against the base, and compare, rather than reading the absolute
+number as a pass/fail.
+
+The reason it exists is that the corpus cannot reach some shapes. Generated
+input combines constructs at indentations a human would not type, and that is
+where the writer's normalization changes meaning. Its first run surfaced 48
+invariant failures (carve#359) and 41 cross-engine divergences (carve#352) that
+the corpus had not.
+
 By default the script expects sibling checkouts:
 
 - `../carve-rs`

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "docs:preview": "vitepress preview docs",
     "corpus:build": "node scripts/generate-corpus.mjs",
     "compare:impls": "node scripts/compare-impls.mjs",
+    "property:check": "node scripts/property-check.mjs",
     "core:check": "node scripts/formal-core-check.mjs",
     "sync-carve-lib": "node scripts/sync-carve-lib.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2875,7 +2875,7 @@ EOF = (* end of file *) ;
         source run BARE, which is what makes `fmt` reproduce the author's
         spelling.
 
-      CANDIDATE -- escaped only when W2 fails on that line:
+      CANDIDATE -- escaped only when W4 selects the conservative form:
         `* _ ~ / = ^ ,`      emphasis and the braced pair delimiters
         `[ ] ( ) { } <`      links, images, spans, attributes, autolinks
         `@ #`                mentions and tags (§7 boundary rules); `#` also
@@ -2888,7 +2888,7 @@ EOF = (* end of file *) ;
 
       The set must cover EVERY construct opener, or W4 has nothing to fall
       back to and the document is unrecoverable: `\@user` would emit as
-      `@user`, W2 would correctly see a `mention` where the source had text,
+      `@user`, W3 would correctly see a `mention` where the source had text,
       and W4 could not fix it. When a new opener is added to the grammar, its
       character belongs here.
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2875,7 +2875,7 @@ EOF = (* end of file *) ;
         source run BARE, which is what makes `fmt` reproduce the author's
         spelling.
 
-      CANDIDATE -- escaped only when W4 selects the conservative form:
+      CANDIDATE -- escaped only when W2 fails on that line:
         `* _ ~ / = ^ ,`      emphasis and the braced pair delimiters
         `[ ] ( ) { } <`      links, images, spans, attributes, autolinks
         `@ #`                mentions and tags (§7 boundary rules); `#` also
@@ -2888,7 +2888,7 @@ EOF = (* end of file *) ;
 
       The set must cover EVERY construct opener, or W4 has nothing to fall
       back to and the document is unrecoverable: `\@user` would emit as
-      `@user`, W3 would correctly see a `mention` where the source had text,
+      `@user`, W2 would correctly see a `mention` where the source had text,
       and W4 could not fix it. When a new opener is added to the grammar, its
       character belongs here.
 

--- a/scripts/property-check.mjs
+++ b/scripts/property-check.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/*
+ * Property check for the canonical writer (PART 11).
+ *
+ * The corpus pins documents somebody wrote. This generates documents nobody
+ * wrote, from an alphabet of construct fragments, and asserts the two PART 11
+ * invariants over them:
+ *
+ *   to_html(fmt(x)) == to_html(x)     meaning is preserved
+ *   fmt(fmt(x))     == fmt(x)         the writer is idempotent
+ *
+ * plus, when sibling engine checkouts are present, that the three canonical
+ * writers agree byte-for-byte.
+ *
+ * It exists because the corpus structurally cannot reach some shapes. Generated
+ * documents combine constructs at indentations a human would not type, and that
+ * is exactly where the writer's normalization changes meaning. The first run of
+ * this script found 48 invariant failures and 41 cross-engine divergences that
+ * a year of corpus testing had not.
+ *
+ * Deterministic: the seed is fixed, so a failure is reproducible and a run is
+ * comparable against another build. Pass --seed=N to explore elsewhere.
+ *
+ *   node scripts/property-check.mjs [--count=800] [--seed=12345] [--engines]
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { tmpdir } from 'node:os'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const root = resolve(here, '..')
+
+const arg = (name, fallback) => {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`))
+  return hit ? hit.slice(name.length + 3) : fallback
+}
+const count = Number(arg('count', 800))
+const compareEngines = process.argv.includes('--engines')
+
+let seed = Number(arg('seed', 12345))
+const rnd = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff
+const pick = (a) => a[Math.floor(rnd() * a.length)]
+
+// Construct fragments, deliberately including the escape forms and the
+// block openers, since the interesting failures come from their combinations
+// at unusual indentation rather than from any one of them alone.
+const ATOMS = [
+  'word', 'a', '  ', '\n', '\n\n', '"q"', "'s", '...', '--', '---', '->', '<-', '=>',
+  '(c)', '+-', '\\-\\-', '\\.', '\\"', '\\^', '\\#', '\\@', '[t](u)', '[t][r]', '`c`',
+  '*b*', '/i/', '_u_', '~s~', '=h=', '{.cls}', '^[fn]', '@user', '#tag', ':name:',
+  '- item', '# head', '> quote', '| a | b |', '::: note', ':::', '%% c', ':: term',
+  '1. x', 'a) y', '$m$', '!img', '![a](/u)', '^ cap', '\\ ', '10\\ kg', '{^x^}', '{,y,}',
+]
+
+function generate() {
+  const len = 1 + Math.floor(rnd() * 8)
+  return Array.from({ length: len }, () => pick(ATOMS)).join(rnd() < 0.4 ? ' ' : '\n') + '\n'
+}
+
+const lib = await import(resolve(root, 'docs/.vitepress/carve-lib/index.js'))
+
+const docs = Array.from({ length: count }, generate)
+const failures = { idempotence: [], meaning: [], threw: [] }
+
+for (const src of docs) {
+  try {
+    const once = lib.carveToCarve(src)
+    const twice = lib.carveToCarve(once)
+    if (once !== twice) failures.idempotence.push(src)
+    else if (lib.carveToHtml(once) !== lib.carveToHtml(src)) failures.meaning.push(src)
+  } catch (error) {
+    failures.threw.push([src, error.message])
+  }
+}
+
+console.log(`generated ${docs.length} documents (seed ${arg('seed', 12345)})`)
+console.log(`  idempotence failures : ${failures.idempotence.length}`)
+console.log(`  meaning changed      : ${failures.meaning.length}`)
+console.log(`  threw                : ${failures.threw.length}`)
+
+for (const [label, list] of [['IDEMPOTENCE', failures.idempotence], ['MEANING', failures.meaning]]) {
+  for (const src of list.slice(0, 3)) console.log(`  ${label} ${JSON.stringify(src)}`)
+}
+
+if (compareEngines) {
+  // Sibling checkouts, same convention as scripts/compare-impls.mjs.
+  const engines = [
+    ['rust', process.env.CARVE_RS_DIR ?? resolve(root, '../carve-rs'), (f) => execFileSync(resolve(root, '../carve-rs/target/release/carve'), ['--carve', f], { encoding: 'utf8' })],
+    ['js', process.env.CARVE_JS_DIR ?? resolve(root, '../carve-js'), (f) => execFileSync('node', [resolve(root, '../carve-js/dist/cli.js'), '--carve', f], { encoding: 'utf8' })],
+    ['php', process.env.CARVE_PHP_DIR ?? resolve(root, '../carve-php'), (f) => execFileSync('php', [resolve(root, '../carve-php/bin/carve'), '--carve', f], { encoding: 'utf8' })],
+  ]
+
+  const dir = resolve(tmpdir(), 'carve-property-check')
+  rmSync(dir, { recursive: true, force: true })
+  mkdirSync(dir, { recursive: true })
+
+  let diffs = 0
+  docs.forEach((src, i) => {
+    const file = resolve(dir, `g${String(i).padStart(4, '0')}.crv`)
+    writeFileSync(file, src)
+    const outputs = engines.map(([name, , run]) => {
+      try {
+        return [name, run(file)]
+      } catch {
+        return [name, 'ERROR']
+      }
+    })
+    if (new Set(outputs.map(([, out]) => out)).size > 1) diffs++
+  })
+  console.log(`  cross-engine --carve divergences: ${diffs}`)
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// Reporting only: these invariants do not hold across the board today
+// (markup-carve/carve#359), so failing the build here would just be noise. The
+// value is the count, compared against another build of the same engine.


### PR DESCRIPTION
Adds `npm run property:check`: a deterministic generator that produces documents nobody wrote and asserts the two PART 11 invariants over them.

## Why

Every check in this repo runs over the corpus - documents somebody chose to type. That leaves a whole class of input untested, and it is exactly the class where the canonical writer misbehaves: generated documents combine constructs at indentations a human would not produce, and that is where the writer's normalization changes meaning.

This is not hypothetical. The first run of this script found:

- **48 invariant failures** - `parse(fmt(x)) != parse(x)` on shapes like an indented `---` being renormalized to column 0, where it stops being a paragraph and becomes a thematic break. Recorded in #359.
- **41 cross-engine divergences** on the `--carve` target between carve-rs, carve-js and carve-php. Recorded in #352.

Both had been in shipped code for a long time. Neither is subtle. Nothing was generating input.

## What it does

```bash
npm run property:check                    # invariants, against the vendored engine
npm run property:check -- --engines       # also compare the three canonical writers
npm run property:check -- --count=2000 --seed=7
```

Asserts, over generated documents:

```
to_html(fmt(x)) == to_html(x)     meaning is preserved
fmt(fmt(x))     == fmt(x)         the writer is idempotent
```

## How it is meant to be used

**Compare two builds, do not read the absolute number.** The counts are known non-zero while #359 is open, so the signal is the delta: run it against a branch and against its base, and any new failure is a regression.

That is precisely how the PART 11 escaping work was validated in all three engines - each branch produced a failure set byte-identical to its own baseline build, which is what established that the change introduced nothing. Without this, "the suite passes" would have been the only evidence, and the suite does not cover this input class.

Deterministic by seed so a failure is reproducible and two runs are comparable.

## Deliberately reporting-only

It does not fail the build. Failing on counts that are known non-zero trains people to ignore the check. When #359 closes, gating on zero becomes reasonable and is a one-line change.
