### PR TITLE
Let the optional corpus pin a target other than HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The optional corpus can pin a target other than HTML** (carve#360). A case's
+  manifest entry may name a `target` - `markdown`, `plain` or `ansi` - and is
+  paired with an expected file carrying that target's extension; an entry
+  without one keeps its `NN-slug.html` pair, so all 29 existing cases are
+  unchanged and a runner that predates targets needs no change.
+
+  This closes a gap wider than the feature that prompted it: **no corpus,
+  mandatory or optional, pinned any target but HTML.** 498 mandatory and 29
+  optional cases, all HTML, which is how carve-php and carve-js came to disagree
+  about escaping intraword underscores with nothing failing.
+
+- **First two Markdown-target cases.** `30-symbol-map-markdown` pins that a
+  symbol keeps its `:name:` source spelling on the Markdown target while the map
+  resolves for HTML. All three engines already agree on that byte-for-byte and
+  nothing asserted it. Smart punctuation in the same case still resolves to its
+  glyph, which is the contrast the case is built around.
+  `31-markdown-typography-source` pins the new optional feature below.
+
 ### Changed
+
+- **PART 9 §8 admits source output on the Markdown target as a named optional
+  feature** (`markdown-typography-source`, carve#360). Read strictly, §8 made
+  the glyph the only conformant Markdown output, so an implementation offering
+  the setting was non-conformant. The glyph stays the default on every target;
+  the feature is per-render-call, Markdown only, and changes no default, which
+  leaves the `smartTypography` switch's ban on per-target defaults intact. The
+  other presentation targets MUST NOT offer it - Markdown is re-parseable
+  source, which is what makes the canonical writer's round-trip argument apply
+  to it, and what does not apply to a terminal presentation.
 
 - **The PART 11 byte assertions now run.** `tests/roundtrip.test.mjs` skipped
   seven byte comparisons while no engine implemented minimal escaping; the

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -327,6 +327,12 @@ Implementations MUST agree here or cross-implementation anchors drift.
 - Conformance: Tier-1 = existing corpus (mandatory); Tier-2 =
   `tests/corpus-optional` + `manifest.json`, run per enabled feature; Tier-3 =
   never in any corpus.
+- A Tier-2 case pins the HTML target unless its manifest entry names another
+  `target` (`markdown`, `plain`, `ansi`), in which case the expected file
+  carries that target's extension. See
+  [`tests/corpus-optional/README.md`](https://github.com/markup-carve/carve/blob/main/tests/corpus-optional/README.md).
+  Carve-source expectations are not a target here; they live in
+  `tests/corpus-roundtrip`.
 
 ## 4. Citations (Tier-2)
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1844,6 +1844,37 @@ EOF = (* end of file *) ;
         straight into the text buffer is NOT conformant: it discards the
         spelling, after which `...` cannot be told from a literal U+2026 and
         the writer has nothing to reproduce.
+        * SOURCE OUTPUT ON THE MARKDOWN TARGET -- OPTIONAL, NORMATIVE WHERE
+          OFFERED. The glyph above is the DEFAULT on every presentation
+          target and stays so. An implementation MAY additionally offer, as
+          the named optional feature `markdown-typography-source`, a
+          Markdown-renderer setting that emits the SOURCE RUN instead. An
+          implementation that omits it stays conformant. Where it IS
+          offered:
+          - IT IS NOT A DEFAULT AND NOT DOCUMENT-GLOBAL. It is asked for per
+            render call, on the Markdown target only. The `smartTypography`
+            switch above is untouched, and so is its rule that per-target
+            DEFAULTS are non-conformant: nothing here changes what any
+            target emits unless a caller asks;
+          - PARSING IS UNCHANGED, exactly as for the off switch. The same
+            nodes are produced and the AST does not depend on the setting;
+          - THE OTHER PRESENTATION TARGETS MUST NOT OFFER IT. Markdown is
+            re-parseable source, which is what makes the canonical writer's
+            argument apply to it: the source run survives a re-parse as the
+            same node, while the glyph cannot be told from a literal one.
+            HTML, plain text and ANSI are terminal presentations, where the
+            glyph is the only sensible output and a source run would just be
+            worse typography;
+          - IT REVERSES ONLY WHAT THE RENDERER SUBSTITUTED. A quote the
+            author typed as a typographic character is not a
+            `smart_punctuation` node and is emitted unchanged either way.
+          Rationale: Markdown is the target generated for machines to read,
+          and the glyph breaks exact-match search against the source - a
+          quote substituted around a code-ish value (`= 'verification-link-
+          sent'`) can no longer be found by searching for what the author
+          wrote, and the reader cannot undo it because the glyph is all that
+          survives. Pinned in tests/corpus-optional (feature
+          `markdown-typography-source`, target `markdown`).
         * KIND NAMES ARE SPEC SURFACE -- an implementation inventing its own
           spelling breaks every AST consumer. The fourteen table-resolved
           kinds are `ellipsis`, `em_dash`, `en_dash`, `left_right_arrow`,

--- a/tests/corpus-optional/30-symbol-map-markdown.crv
+++ b/tests/corpus-optional/30-symbol-map-markdown.crv
@@ -1,0 +1,6 @@
+# Release :tada:
+
+Ship it :rocket: -- the pipeline is green.
+
+A `:rocket:` inside a code span stays literal, and :unmapped: keeps its
+source spelling because the map has no entry for it.

--- a/tests/corpus-optional/30-symbol-map-markdown.md
+++ b/tests/corpus-optional/30-symbol-map-markdown.md
@@ -1,0 +1,6 @@
+# Release :tada:
+
+Ship it :rocket: – the pipeline is green.
+
+A `:rocket:` inside a code span stays literal, and :unmapped: keeps its
+source spelling because the map has no entry for it.

--- a/tests/corpus-optional/31-markdown-typography-source.crv
+++ b/tests/corpus-optional/31-markdown-typography-source.crv
@@ -1,0 +1,4 @@
+The API returns "statusFilter" and the flag 'verification-link-sent'.
+
+Use 1--3 for a range, an aside -- like this one -- for a break, and ... to
+trail off. *Strong stays strong* on the Markdown target.

--- a/tests/corpus-optional/31-markdown-typography-source.md
+++ b/tests/corpus-optional/31-markdown-typography-source.md
@@ -1,0 +1,4 @@
+The API returns "statusFilter" and the flag 'verification-link-sent'.
+
+Use 1--3 for a range, an aside -- like this one -- for a break, and ... to
+trail off. **Strong stays strong** on the Markdown target.

--- a/tests/corpus-optional/README.md
+++ b/tests/corpus-optional/README.md
@@ -1,6 +1,6 @@
 # Carve optional Tier-2 corpus
 
-This directory contains **optional** `(input.crv, expected.html)` pairs for
+This directory contains **optional** `(input.crv, expected output)` pairs for
 Tier-2 features from the Carve extensions contract.
 
 Unlike the mandatory Tier-1 corpus in [`../corpus/`](../corpus/), these cases
@@ -26,6 +26,35 @@ Examples:
 - `bare-url-autolink` → bare-URL autolink extension/config
 - `smart-typography-off` → the optional document-global `smartTypography: false`
   switch (PART 9 §8); implementations that do not offer the switch skip the case
+- `markdown-typography-source` → the optional Markdown-renderer setting that
+  emits a smart-punctuation node's source run instead of its glyph (PART 9 §8)
 
-The filenames are stable (`NN-slug.crv` / `NN-slug.html`) so runners can pair
+The filenames are stable (`NN-slug.crv` / `NN-slug.<ext>`) so runners can pair
 them by basename after filtering through the manifest.
+
+## Targets
+
+A case may name a `target` in its manifest entry. It defaults to `html`, which
+is what every case pinned before [carve#360](https://github.com/markup-carve/carve/issues/360),
+so an entry without one keeps its `NN-slug.html` pair and needs no runner
+change. The expected file's extension follows the target:
+
+| `target` | expected file | rendered with |
+|---|---|---|
+| `html` (default) | `NN-slug.html` | the HTML target |
+| `markdown` | `NN-slug.md` | the Markdown target |
+| `plain` | `NN-slug.txt` | the plain-text target |
+| `ansi` | `NN-slug.ansi` | the ANSI target |
+
+There is deliberately no `carve` target here: Carve-source expectations live in
+[`../corpus-roundtrip/`](../corpus-roundtrip/), and a second home would put two
+files named `NN-slug.crv` in this directory, one of them the input.
+
+Why this exists: until #360 **no corpus pinned any target but HTML**, so two
+engines could render the same document to different Markdown and nothing
+failed. That is not hypothetical - it is how carve-php and carve-js came to
+disagree about escaping intraword underscores.
+
+A runner that predates targets is unaffected. It reads a feature id it does not
+recognize and skips the case, which is the same thing it already does for any
+feature it has not implemented.

--- a/tests/corpus-optional/manifest.json
+++ b/tests/corpus-optional/manifest.json
@@ -74,7 +74,7 @@
     {
       "slug": "15-citations-locator-labels",
       "feature": "citations-numbered",
-      "description": "Multiple locator labels (chap., \u00a7) parse to their canonical citeproc names."
+      "description": "Multiple locator labels (chap., §) parse to their canonical citeproc names."
     },
     {
       "slug": "16-citations-locator-default-page",
@@ -145,6 +145,18 @@
       "slug": "29-smart-typography-off",
       "feature": "smart-typography-off",
       "description": "With the optional document-global smartTypography switch set to false, the whole converted set stays as authored ASCII; escapes, code spans and heading ids are unchanged (carve#338)."
+    },
+    {
+      "slug": "30-symbol-map-markdown",
+      "feature": "symbol-map",
+      "target": "markdown",
+      "description": "On the Markdown target a symbol keeps its :name: source spelling: the map resolves for HTML only, so the output re-parses to the same symbol node. Smart punctuation in the same case still resolves to its glyph (PART 9 section 8), which is the contrast."
+    },
+    {
+      "slug": "31-markdown-typography-source",
+      "feature": "markdown-typography-source",
+      "target": "markdown",
+      "description": "With the optional Markdown-renderer setting that emits the author source run instead of the glyph, quotes, dashes and the ellipsis stay as the ASCII that was typed (PART 9 section 8; carve#360)."
     }
   ]
 }

--- a/tests/optional-corpus.test.mjs
+++ b/tests/optional-corpus.test.mjs
@@ -5,6 +5,11 @@
  * manifest.json. The reference implementation runs only the features it
  * actually supports; unsupported Tier-2 features stay visible as skipped tests
  * instead of being silently ignored.
+ *
+ * A case may also name a `target`. It defaults to `html`, which is what every
+ * case pinned before carve#360; a case naming another target is paired with an
+ * expected file carrying that target's extension and is rendered through that
+ * target's entry point.
  */
 
 import { test } from 'node:test'
@@ -13,7 +18,10 @@ import { existsSync, readFileSync } from 'node:fs'
 import { basename, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
+  carveToAnsi,
   carveToHtml,
+  carveToMarkdown,
+  carveToPlainText,
   citations,
   codeCallouts,
   details,
@@ -32,14 +40,33 @@ if (!existsSync(manifestPath)) {
 
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
 
+/*
+ * The extension is part of the pairing rule, not a label: a runner locates the
+ * expected file from the slug and the target alone. `carve` is deliberately
+ * absent - Carve-source expectations live in ../corpus-roundtrip/, and giving
+ * them a second home here would mean two files named `NN-slug.crv` in one
+ * directory, one of them the input.
+ */
+const targets = {
+  html: { extension: 'html', render: carveToHtml },
+  markdown: { extension: 'md', render: carveToMarkdown },
+  plain: { extension: 'txt', render: carveToPlainText },
+  ansi: { extension: 'ansi', render: carveToAnsi },
+}
+
+/*
+ * A feature runner supplies the configuration its feature needs and renders
+ * through whichever target the case named, so one entry serves a feature that
+ * is pinned on more than one target.
+ */
 const featureRunners = {
-  'social-link-templates': (source) =>
-    carveToHtml(source, {
+  'social-link-templates': (source, render) =>
+    render(source, {
       mentionUrl: '/users/{name}',
       tagUrl: '/topics/{name}',
     }),
-  'symbol-map': (source) =>
-    carveToHtml(source, {
+  'symbol-map': (source, render) =>
+    render(source, {
       symbols: {
         rocket: '🚀',
         tada: '🎉',
@@ -47,32 +74,44 @@ const featureRunners = {
         UPPER: '⬆️',
       },
     }),
-  'citations-numbered': (source) => carveToHtml(source, { extensions: [citations()] }),
-  'citations-author-date': (source) =>
-    carveToHtml(source, { extensions: [citations({ mode: 'author-date' })] }),
-  'code-callouts': (source) => carveToHtml(source, { extensions: [codeCallouts()] }),
-  details: (source) => carveToHtml(source, { extensions: [details()] }),
-  'list-table': (source) => carveToHtml(source, { extensions: [listTable()] }),
-  spoiler: (source) => carveToHtml(source, { extensions: [spoiler()] }),
-  tabs: (source) => carveToHtml(source, { extensions: [tabs()] }),
+  'citations-numbered': (source, render) => render(source, { extensions: [citations()] }),
+  'citations-author-date': (source, render) =>
+    render(source, { extensions: [citations({ mode: 'author-date' })] }),
+  'code-callouts': (source, render) => render(source, { extensions: [codeCallouts()] }),
+  details: (source, render) => render(source, { extensions: [details()] }),
+  'list-table': (source, render) => render(source, { extensions: [listTable()] }),
+  spoiler: (source, render) => render(source, { extensions: [spoiler()] }),
+  tabs: (source, render) => render(source, { extensions: [tabs()] }),
 }
 
 for (const entry of manifest.cases) {
   const slug = basename(entry.slug)
-  const crvPath = resolve(corpusDir, `${slug}.crv`)
-  const htmlPath = resolve(corpusDir, `${slug}.html`)
-  const render = featureRunners[entry.feature]
+  const targetName = entry.target ?? 'html'
+  const target = targets[targetName]
 
-  if (!render) {
+  // An unknown target is a manifest error, not an unsupported feature: silently
+  // skipping it would read as "this implementation does not do that yet".
+  if (!target) {
+    test(`${slug} (${entry.feature})`, () => {
+      assert.fail(`unknown target '${targetName}' - expected one of ${Object.keys(targets).join(', ')}`)
+    })
+    continue
+  }
+
+  const crvPath = resolve(corpusDir, `${slug}.crv`)
+  const expectedPath = resolve(corpusDir, `${slug}.${target.extension}`)
+  const runner = featureRunners[entry.feature]
+
+  if (!runner) {
     test.skip(`${slug} (${entry.feature})`, () => {})
     continue
   }
 
-  test(`${slug} (${entry.feature})`, () => {
+  test(`${slug} (${entry.feature}, ${targetName})`, () => {
     assert.ok(existsSync(crvPath), `missing ${slug}.crv pair`)
-    assert.ok(existsSync(htmlPath), `missing ${slug}.html pair`)
+    assert.ok(existsSync(expectedPath), `missing ${slug}.${target.extension} pair`)
     const source = readFileSync(crvPath, 'utf8')
-    const expected = readFileSync(htmlPath, 'utf8')
-    assert.equal(render(source).trim(), expected.trim())
+    const expected = readFileSync(expectedPath, 'utf8')
+    assert.equal(runner(source, target.render).trim(), expected.trim())
   })
 }


### PR DESCRIPTION
Closes #360.

Takes the first of the two options in that issue: extend the corpus format rather than declare the Markdown target implementation-configurable and leave it unpinned. The second is coherent and needs no machinery, but it is the status quo that already produced one silent divergence.

## The gap this closes is wider than the feature

**No corpus, mandatory or optional, pinned any target but HTML.** 498 mandatory and 29 optional cases, all `(input.crv, expected.html)`. Markdown, plain-text and ANSI parity across three engines rested entirely on each engine's own tests - which is exactly how carve-php and carve-js came to disagree about escaping intraword underscores with nothing failing.

## The format change

A case's manifest entry may name a `target`; the expected file's extension follows it.

| `target` | expected file |
|---|---|
| `html` (default, absent) | `NN-slug.html` |
| `markdown` | `NN-slug.md` |
| `plain` | `NN-slug.txt` |
| `ansi` | `NN-slug.ansi` |

All 29 existing entries are unchanged. No `carve` target: Carve-source expectations live in `tests/corpus-roundtrip`, and a second home would put two files named `NN-slug.crv` in one directory, one of them the input.

An unknown target name fails the case loudly rather than skipping - a skip would read as "this implementation does not do that yet".

## Two Markdown cases

**`30-symbol-map-markdown`** is the one worth reviewing. It pins that a symbol keeps its `:name:` source spelling on the Markdown target while the map resolves for HTML:

```
carveToHtml     :rocket:  ->  🚀
carveToMarkdown :rocket:  ->  :rocket:
```

I checked all three engines and they already agree byte-for-byte (`format!(":{}:", symbol.name)` in carve-rs, the same in the carve-php and carve-js Markdown renderers). Nothing asserted it. It is defensible on the same grounds as the canonical writer - the source spelling re-parses to the same node, a glyph cannot be told from a literal one - but **it is new normative surface**, so flagging it rather than burying it: this PR pins behavior that was previously unspecified.

Smart punctuation in the same case still resolves to its glyph, so the case carries the contrast rather than just the rule.

**`31-markdown-typography-source`** pins the feature. The vendored reference does not offer it, so it is a visible skip. Expected output derived from §8 by hand, then confirmed against markup-carve/carve-php#416.

## The §8 amendment

Read strictly, §8 made the glyph the only conformant Markdown output. The amendment makes it the default and admits `markdown-typography-source` as a named optional feature, with four constraints:

- not a default and not document-global - per render call, so the existing ban on per-target *defaults* is untouched;
- parsing unchanged, as for the off switch;
- the other presentation targets MUST NOT offer it;
- it reverses only what the renderer substituted.

The reason Markdown and not the rest: it is re-parseable source, which is what makes the canonical writer's round-trip argument apply. HTML, plain and ANSI are terminal presentations where a source run is just worse typography.

## Downstream: runners must filter by target

Any case reusing a feature id a runner already implements will pair it with a missing `.html`. I verified this against the real runners rather than assuming:

| engine | behavior on case 30 today |
|---|---|
| carve-js | **fails** - `expect(existsSync(htmlPath)).toBe(true)` |
| carve-php | silently dropped - `continue` when the pair is missing |
| carve-rs | no optional-corpus runner exists |

So the submodule bump needs the carve-js and carve-php runner updates first. I can open both as small follow-ups. Case 31 alone would have been safe in every engine (unknown feature id = skip), but designing around that would mean minting a fake feature id per target, which corrupts the taxonomy to protect a runner one line short.

Spec suite: 585 tests, 581 pass, 4 skipped, 0 fail (was 583/580/3 - the new markdown case runs, the feature case skips).
