### PR TITLE
spec: specify the AST serialization format (PART 12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The AST serialization format is now specified** (new PART 12). A parsed
+  document is exchangeable: an implementation may serialize its AST to JSON, and
+  a consumer written against one engine must be able to read another's output.
+  Nothing specified this before, and the engines' internal field names already
+  differed for the same node - one calls a link's destination `href`, another
+  `destination` - so three incompatible dialects were the default outcome rather
+  than a risk.
+
+  The shape is carve-js's, because it is the reference implementation, its AST is
+  already plain data, and the one serializer in the wild (carve-rb, over
+  carve-rs's tree) independently arrived at the same field names. Field names are
+  spec surface exactly as node-type and smart-punctuation kind names are.
+
+  Positions are required. `pos` is what makes a serialized AST worth exchanging -
+  an editor, a language server or a tool grounding output back to source needs to
+  say where - and an optional field is one every consumer must handle the absence
+  of, which in practice means not using it. Only carve-js records positions
+  today: carve-php has none, and carve-rs has a parser-internal line map but no
+  columns or offsets, so both need position tracking before they can serialize
+  conformantly.
+
+### Added
+
 - **The optional corpus can pin a target other than HTML** (carve#360). A case's
   manifest entry may name a `target` - `markdown`, `plain` or `ansi` - and is
   paired with an expected file carrying that target's extension; an entry

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -15,6 +15,7 @@ This is the canonical formal specification of Carve. It is **layered**, and each
 | PART 9R | Whole-document resolution (references, footnotes, crossrefs, numbering) | Two-pass rules over declared symbol tables |
 | PART 10 | HTML serialization | Tree-transform conventions |
 | PART 11 | Canonical source writer (`carve fmt`): round-trip invariants and the escaping rule | Invariants over `parse`/`fmt` + a decision procedure |
+| PART 12 | AST serialization: the JSON shape a parsed document exchanges as | Reference-implementation field names + a round-trip invariant |
 
 ::: info Why layers instead of one grammar?
 Light markup languages are provably not context-free: fence-length matching is a counting constraint, indentation is 2D, and reference resolution needs a whole-document symbol table. No single EBNF can express Carve (or Djot, or CommonMark). What CAN be done - and what this file does - is state every rule in *some* exact formalism, so nothing normative rests on English prose.

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2969,4 +2969,73 @@ EOF = (* end of file *) ;
       fence length, ordered-list dialect). Those are the author's choices and
       the AST records them; changing one would satisfy §1 while still
       surprising the author.
+
+   ============================================================================
+   PART 12: AST SERIALIZATION (NORMATIVE)
+   ============================================================================
+
+   A parsed document is exchangeable: an implementation MAY serialize its AST
+   to JSON, and a consumer written against one implementation MUST be able to
+   read another's output. Nothing specified this before, and the engines'
+   INTERNAL field names already differ for the same node - one calls a link's
+   destination `href`, another `destination` - so three dialects were the
+   default outcome rather than a risk.
+
+   1. THE SHAPE IS carve-js's. It is the reference implementation, its AST is
+      already plain data, and the one serializer in the wild (carve-rb, over
+      carve-rs's tree) independently arrived at the same field names. An
+      implementation whose internals differ MAPS on the way out; it does not
+      export its internals.
+
+   2. EVERY NODE IS AN OBJECT with a `type` holding the node-type identifier
+      from profiles.md - the same snake_case strings PART 9 §8 already calls
+      spec surface for kind names. A document is
+      `{"type":"document","children":[...]}`.
+
+   3. FIELD NAMES ARE SPEC SURFACE, exactly as kind names are. The normative
+      set per node type is the carve-js interface for that type. Notably:
+        link       `href`, `children`, and `ref` when the author wrote a
+                   reference link
+        image      `src`, `alt`, `title`
+        code       `value`
+        text       `value`
+        heading    `level`, `children`
+        list       `ordered`, `tight`, `start`, `items`
+      An implementation MUST NOT invent a synonym, and MUST NOT expose an
+      internal field the reference does not have. A consumer reading `href`
+      must not have to know which engine produced the document.
+
+   4. POSITIONS ARE REQUIRED. Every node carries `pos`:
+
+        {"startLine":1,"endLine":1,"startColumn":2,"endColumn":5,
+         "startOffset":1,"endOffset":4}
+
+      Lines and columns are 1-based; offsets are 0-based byte offsets into the
+      source. `endColumn` and `endOffset` are exclusive.
+
+      This is the field that makes a serialized AST worth exchanging: an
+      editor, a language server or a tool grounding output back to source needs
+      to say WHERE, and a tree without positions can only be re-parsed rather
+      than navigated. Making it optional would mean every consumer has to
+      handle its absence, which in practice means not using it.
+
+      IMPLEMENTATION COST -- NOT A DESIGN CONCESSION, A SCHEDULING NOTE. Only
+      carve-js records positions today. carve-php has none on its nodes;
+      carve-rs has none either, though its parser already keeps a line map for
+      the source-line render option, so line granularity exists there and
+      columns and offsets do not. Both therefore need position tracking before
+      they can serialize conformantly. An implementation that cannot yet
+      produce positions MUST NOT emit `pos` with invented values, and MUST NOT
+      omit it silently: it does not yet serialize conformantly, and should say
+      so.
+
+   5. WHAT IS NOT IN THE SERIALIZED FORM. Formatter-internal nodes (PART 11,
+      and the `raw_text` case profiles.md excludes) are not part of the
+      document and are not serialized. Resolution results that a consumer can
+      recompute - footnote numbering, caption numbers - ARE serialized, because
+      recomputing them requires reimplementing PART 9R.
+
+   6. ROUND TRIP. `parse(x)` serialized and deserialized MUST equal `parse(x)`.
+      A serializer that loses a field is not a lossy convenience; it is a
+      consumer breaking silently one document later.
 *)


### PR DESCRIPTION
Closes #361.

## Why now

The engines' internal field names already differ for the same node - `href` in one, `destination` in another - and `pandoc-carve` already consumes an AST. Three incompatible dialects were the default outcome, not a risk.

The timing is specific: #355 requires carve-rb to bump its pinned carve-rs rev, and that bump is when a new node type (`smart_punctuation`) first enters a serialized surface. Speccing before that is cheap; speccing after means a breaking change in a published package.

## The shape is carve-js's

It is the reference implementation, its AST is already plain data, and - the part that makes this cheap - **the one serializer in the wild independently arrived at the same field names**. carve-rb serializes carve-rs's tree and already emits `href`, `src`, `alt`, matching carve-js exactly.

So this mostly ratifies what exists. An engine whose internals differ maps on the way out rather than exporting them.

Field names are spec surface for the same reason node-type identifiers and smart-punctuation kind names already are (PART 9 §8): a consumer reading `href` must not have to know which engine produced the document.

## Positions are required

`pos` carries 1-based lines and columns and 0-based byte offsets, with `endColumn` and `endOffset` exclusive.

This is the field that makes a serialized tree worth exchanging. An editor, a language server, or a tool grounding output back to source needs to say *where*; a tree without positions can only be re-parsed, not navigated. Optional would mean every consumer has to handle its absence, which in practice means not using it.

**The cost is real and the section states it rather than hiding it.** Only carve-js records positions today:

| Engine | positions |
|---|---|
| carve-js | full - lines, columns, offsets |
| carve-php | none on nodes |
| carve-rs | parser-internal line map for the source-line render option; no columns or offsets |

So carve-php and carve-rs both need position tracking before they can serialize conformantly. That is a scheduling consequence, not a reason to weaken the contract - but it does mean this spec lands ahead of its implementations, and the section says so explicitly: an engine that cannot yet produce positions must not invent values or omit the field silently.

I raised optional-`pos` as the cheaper route and was overruled on the merits; recording that here so the tradeoff is visible to review rather than buried in a thread.

## Also specified

- Formatter-internal nodes are not serialized; resolution results (footnote numbering, caption numbers) are, because recomputing them means reimplementing PART 9R
- `parse(x)` serialized then deserialized must equal `parse(x)` - a serializer that drops a field is a consumer breaking silently one document later

## Verification

Spec suite: 585 tests, 581 pass, 0 fail.
