### PR TITLE
Run each optional corpus case on the target it pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   section 12, which also records why Carve uses one leaf node where Djot uses
   two container types plus a leaf.
 
+### Fixed
+
+- **`npm run compare:impls -- --corpus=optional` runs again.** The optional
+  corpus learned per-case targets (carve#360) but `scripts/compare-impls.mjs`
+  kept forcing every optional case to HTML and opening `NN-slug.html`, so the
+  run died with `ENOENT ... 30-symbol-map-markdown.html` at the first
+  Markdown-target case - the whole optional comparison, not just that case.
+
+  A case now runs on the target its manifest entry pins, paired with the
+  expected file for that target, and `--targets` filters which cases run instead
+  of overriding what they render (a filtered run reports `filtered_out=`). The
+  per-engine adapters take the target too, so the Markdown cases compare
+  Markdown; an adapter that is not wired for the target reports no adapter and
+  the case is skipped for that engine, the same visible skip an unsupported
+  feature already gets. A missing expected file is a hard error naming the file
+  and target, not a silent downgrade to an engines-agree check.
+
+  The pairing rule now lives in `scripts/lib/corpus-targets.mjs` and is shared
+  with `tests/optional-corpus.test.mjs`, with `tests/corpus-targets.test.mjs`
+  pinning it. Two runners holding private copies of the rule is what let one of
+  them fall a release behind the manifest.
+
+- **`cross_impl_diffs` counts every target.** It only counted HTML, so a
+  Markdown, plain-text, Carve or ANSI divergence printed its `DIFF [target]`
+  line while the headline figure - the one the docs snapshot pins and a reader
+  takes away - still said zero.
+
 ## [0.1.1] - 2026-07-27
 
 ### Fixed

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -120,13 +120,14 @@ The runner compares every render target, not just HTML: `--targets=all` (the
 default) covers `html`, `markdown`, `plain`, `carve` and `ansi`. Pass a
 comma-separated subset to narrow it.
 
-Only `html` has expected-output fixtures. The other four are compared
-**implementation against implementation**, because identical output across the
-three engines is the invariant that matters there, and committing four more
-expected files per corpus case would not add to it. The `Target agreement`
-block in the output reports per-target `compared` / `diffs` / `errors` counts,
-and each disagreement prints a `DIFF [target] slug` line naming the engines that
-ran.
+In the core corpus only `html` has expected-output fixtures. The other four are
+compared **implementation against implementation**, because identical output
+across the three engines is the invariant that matters there, and committing
+four more expected files per corpus case would not add to it. The `Target
+agreement` block in the output reports per-target `compared` / `diffs` /
+`errors` counts, and each disagreement prints a `DIFF [target] slug` line naming
+the engines that ran. `cross_impl_diffs` is the total across every target
+compared, not the HTML count.
 
 Comparison is trailing-newline-insensitive, matching the corpus runner and the
 profile parity battery: renderers legitimately differ on a final `\n`, so a
@@ -137,9 +138,19 @@ Running all five targets costs roughly five times a single-target run, since
 every case is a fresh process per engine per target. Use `--targets=html` for a
 quick check and `--limit=` while iterating.
 
-The optional corpus runs the `html` target only. Its per-feature adapters
-configure HTML conversion specifically, so a non-HTML target there would compare
-"feature configured" against "feature missing" and report a meaningless diff.
+The optional corpus works the other way round: a case pins its own target in
+[`manifest.json`](https://github.com/markup-carve/carve/blob/main/tests/corpus-optional/manifest.json)
+and carries the expected file for it (`html` unless the entry says otherwise -
+see [the corpus README](https://github.com/markup-carve/carve/blob/main/tests/corpus-optional/README.md)).
+Each case runs on the target it pins, so every optional target is scored against
+a fixture, and `--targets` filters which cases run rather than overriding what
+they render. A run that filters cases out reports `filtered_out=` so the pair
+count does not read as "all of these ran".
+
+A feature adapter that is not wired for the pinned target reports no adapter and
+the case is skipped for that engine, the same visible skip an unsupported
+feature gets. That is why the PHP adapters, which drive `CarveConverter::convert()`
+and so speak HTML, sit out the Markdown-target cases.
 
 ### Generated documents
 
@@ -201,10 +212,13 @@ extension_profile_note=this run compares default/no-opt-in output. Use --corpus=
 Optional raw output:
 
 > **Note:** the snapshot below is from 2026-06-19 (4 optional corpus pairs).
-> The optional corpus has since grown to 24 pairs (citations-numbered enrichment
+> The optional corpus has since grown to 31 pairs (citations-numbered enrichment
 > cases 13-24 for typed locators, integral marker, and suppress-author; code
-> callouts cases 10-12; trailing-comma case 24). Regenerate with
-> `npm run compare:impls -- --corpus=optional` to get current counts.
+> callouts cases 10-12; trailing-comma case 24; the Markdown-target cases 30-31).
+> The `Optional feature coverage` block also names each case's pinned target now
+> (`feature (target): engines`), and the summary line carries a `targets=` field.
+> Regenerate with `npm run compare:impls -- --corpus=optional` to get current
+> counts.
 
 ```text
 Implementation summary

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "sync-carve-lib": "node scripts/sync-carve-lib.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/corpus.test.mjs tests/optional-corpus.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { DEFAULT_TARGET, expectedFileFor, targetOf } from './lib/corpus-targets.mjs'
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)))
 const args = new Set(process.argv.slice(2))
@@ -24,11 +25,14 @@ if (!Object.hasOwn(corpusDirs, corpusName)) {
 }
 
 const corpusDir = join(root, corpusDirs[corpusName])
+const isOptional = corpusName === 'optional'
 
-// Render targets to compare. `html` is the only one with expected-output
-// fixtures; the rest are compared ENGINE-AGAINST-ENGINE, because byte-identical
-// output across implementations is the invariant that matters and committing
-// four more expected files per corpus case would not add to it.
+// Render targets to compare. In the core corpus `html` is the only one with
+// expected-output fixtures; the rest are compared ENGINE-AGAINST-ENGINE, because
+// byte-identical output across implementations is the invariant that matters and
+// committing four more expected files per corpus case would not add to it. In
+// the optional corpus each case pins its own target and carries the matching
+// expected file (tests/corpus-optional/README.md).
 const ALL_TARGETS = ['html', 'markdown', 'plain', 'carve', 'ansi']
 const targetsArg = process.argv.find((a) => a.startsWith('--targets='))
 const targetsRequest = targetsArg ? targetsArg.slice('--targets='.length) : 'all'
@@ -48,13 +52,15 @@ if (unknownTargets.length || targets.length === 0) {
   process.exit(2)
 }
 
-// The optional corpus is driven by per-feature adapters that are wired for HTML
-// only, so a non-HTML target there would compare "feature configured" against
-// "feature missing" and report a meaningless diff.
+// In the optional corpus the manifest pins a target per case, so the target set
+// is not a free choice: each case runs on the target it pins and `--targets`
+// narrows which of those cases run. Forcing every case to html instead - which
+// this script did until carve#360 grew Markdown-target cases - pairs a
+// Markdown case with a `.html` file that was never written.
 let targetNote = ''
-if (corpusName === 'optional' && targets.some((t) => t !== 'html')) {
-  targetNote = 'optional corpus runs the html target only; the feature adapters are html-specific'
-  targets = ['html']
+if (isOptional) {
+  targetNote =
+    'optional corpus renders each case on the target its manifest entry pins (html unless stated); --targets filters that set'
 }
 
 // Command suffix per target. An empty suffix is the default (HTML) render.
@@ -82,7 +88,9 @@ const impls = [
     cwd: process.env.CARVE_RS_DIR ?? resolve(root, '../carve-rs'),
     prepare: null,
     defaultCommand: (target = 'html') => ['cargo', 'run', '--quiet', '--', ...CLI_FLAGS[target]],
-    optionalCommand(feature) {
+    optionalCommand(feature, target = DEFAULT_TARGET) {
+      const flags = CLI_FLAGS[target]
+      if (!flags) return null
       if (feature === 'social-link-templates') {
         return [
           'cargo',
@@ -93,12 +101,14 @@ const impls = [
           '/users/{name}',
           '--tag-url',
           '/topics/{name}',
+          ...flags,
         ]
       }
       if (feature === 'symbol-map') {
         return [
           'cargo', 'run', '--quiet', '--',
           '--symbol', 'rocket=🚀', '--symbol', 'tada=🎉', '--symbol', '+1=👍', '--symbol', 'UPPER=⬆️',
+          ...flags,
         ]
       }
       return null
@@ -127,7 +137,9 @@ const impls = [
         process.stdout.write(${JS_ENTRY[target]}(source));
       `,
     ],
-    optionalCommand(feature) {
+    optionalCommand(feature, target = DEFAULT_TARGET) {
+      const entry = JS_ENTRY[target]
+      if (!entry) return null
       if (feature === 'social-link-templates') {
         return [
           'node',
@@ -135,9 +147,9 @@ const impls = [
           '-e',
           `
             import { readFileSync } from 'node:fs';
-            import { carveToHtml } from './dist/index.js';
+            import { ${entry} } from './dist/index.js';
             const source = readFileSync(process.argv[1], 'utf8');
-            process.stdout.write(carveToHtml(source, {
+            process.stdout.write(${entry}(source, {
               mentionUrl: '/users/{name}',
               tagUrl: '/topics/{name}',
             }));
@@ -151,9 +163,9 @@ const impls = [
           '-e',
           `
             import { readFileSync } from 'node:fs';
-            import { carveToHtml } from './dist/index.js';
+            import { ${entry} } from './dist/index.js';
             const source = readFileSync(process.argv[1], 'utf8');
-            process.stdout.write(carveToHtml(source, {
+            process.stdout.write(${entry}(source, {
               symbols: { rocket: '🚀', tada: '🎉', '+1': '👍', UPPER: '⬆️' },
             }));
           `,
@@ -175,7 +187,13 @@ const impls = [
     cwd: process.env.CARVE_PHP_DIR ?? resolve(root, '../carve-php'),
     prepare: null,
     defaultCommand: (target = 'html') => ['php', 'bin/carve', ...CLI_FLAGS[target]],
-    optionalCommand(feature) {
+    optionalCommand(feature, target = DEFAULT_TARGET) {
+      // These adapters drive CarveConverter::convert(), which is the HTML
+      // target. Rendering another target needs a different converter factory
+      // per case, so an unwired target reports "no adapter" - the same visible
+      // skip an unsupported feature gets - rather than comparing this engine's
+      // HTML against another engine's Markdown.
+      if (target !== 'html') return null
       if (feature === 'social-link-templates') {
         return [
           'php',
@@ -248,8 +266,8 @@ function run(cmd, cwd, extraArgs = [], timeout = 15000) {
   }
 }
 
-function commandFor(impl, pair, target = 'html') {
-  if (corpusName === 'optional') return impl.optionalCommand(pair.feature)
+function commandFor(impl, pair, target = DEFAULT_TARGET) {
+  if (isOptional) return impl.optionalCommand(pair.feature, target)
   return impl.defaultCommand(target)
 }
 
@@ -267,25 +285,68 @@ function available(impl) {
 }
 
 function loadPairs() {
-  if (corpusName !== 'optional') {
+  if (!isOptional) {
     return readdirSync(corpusDir)
       .filter((f) => f.endsWith('.crv'))
       .sort()
       .slice(0, limit)
-      .map((f) => ({ slug: basename(f, '.crv'), feature: 'core', file: join(corpusDir, f) }))
+      .map((f) => ({
+        slug: basename(f, '.crv'),
+        feature: 'core',
+        target: DEFAULT_TARGET,
+        file: join(corpusDir, f),
+      }))
   }
 
   const manifest = JSON.parse(readFileSync(join(corpusDir, 'manifest.json'), 'utf8'))
-  return manifest.cases
-    .slice(0, limit)
-    .map((entry) => ({
-      slug: basename(entry.slug),
+  return manifest.cases.slice(0, limit).map((entry) => {
+    const slug = basename(entry.slug)
+    const target = targetOf(entry)
+    // Surfaces a manifest typo here rather than as a confusing missing-file
+    // error further down.
+    expectedFileFor(slug, target)
+    return {
+      slug,
       feature: entry.feature,
-      file: join(corpusDir, `${basename(entry.slug)}.crv`),
-    }))
+      target,
+      file: join(corpusDir, `${slug}.crv`),
+    }
+  })
 }
 
 const pairs = loadPairs()
+
+// In the optional corpus a case runs on the one target its manifest entry pins,
+// and `--targets` filters which cases that leaves. In the core corpus every case
+// runs on every requested target.
+function targetsFor(pair) {
+  if (!isOptional) return targets
+  return targets.includes(pair.target) ? [pair.target] : []
+}
+
+const activeTargets = ALL_TARGETS.filter((target) =>
+  isOptional ? pairs.some((pair) => targetsFor(pair).includes(target)) : targets.includes(target),
+)
+
+/**
+ * The expected output for a pair on a target, or null when the pair has no
+ * fixture on it (every core-corpus target but html - those are compared
+ * engine-against-engine only).
+ *
+ * A fixture that should exist and does not is a hard error: continuing without
+ * it would quietly downgrade a scored case to an engines-agree check.
+ */
+function expectedFor(pair, target) {
+  if (!isOptional && target !== DEFAULT_TARGET) return null
+  const path = join(corpusDir, expectedFileFor(pair.slug, target))
+  if (!existsSync(path)) {
+    console.error(
+      `Missing expected output ${basename(path)} for ${pair.slug} (target ${target}).`,
+    )
+    process.exit(2)
+  }
+  return readFileSync(path, 'utf8').trim()
+}
 
 const active = []
 for (const impl of impls) {
@@ -304,13 +365,13 @@ const stats = Object.fromEntries(
 )
 let crossImplDiffs = 0
 const targetStats = Object.fromEntries(
-  targets.map((t) => [t, { compared: 0, diffs: 0, errors: 0 }]),
+  activeTargets.map((t) => [t, { compared: 0, diffs: 0, errors: 0 }]),
 )
 
 for (const pair of pairs) {
-  for (const target of targets) {
-    const expected =
-      target === 'html' ? readFileSync(join(corpusDir, `${pair.slug}.html`), 'utf8').trim() : null
+  const pairTargets = targetsFor(pair)
+  for (const target of pairTargets) {
+    const expected = expectedFor(pair, target)
     const outputs = []
     const ran = []
 
@@ -319,7 +380,7 @@ for (const pair of pairs) {
       if (!command) {
         // Skips are a per-pair property, not a per-target one; counting them
         // once per target would multiply the same gap by the target count.
-        if (target === targets[0]) stats[impl.name].skipped++
+        if (target === pairTargets[0]) stats[impl.name].skipped++
         continue
       }
       stats[impl.name].runnable++
@@ -332,7 +393,8 @@ for (const pair of pairs) {
         ran.push(impl.name)
         continue
       }
-      // Only the html target has an expected-output fixture to score against.
+      // Scored only where the case has an expected-output fixture: every
+      // optional case, and the html target of the core corpus.
       if (expected !== null) {
         if (result.stdout === expected) stats[impl.name].ok++
         else stats[impl.name].mismatch++
@@ -355,7 +417,10 @@ for (const pair of pairs) {
     const unique = new Set(outputs.map(([, out]) => out))
     if (unique.size > 1) {
       targetStats[target].diffs++
-      if (target === 'html') crossImplDiffs++
+      // Every target counts. Counting html alone let a Markdown or ANSI
+      // divergence print its DIFF line while the headline said zero, which is
+      // the number a reader takes away and the one the docs snapshot pins.
+      crossImplDiffs++
       console.log(`DIFF [${target}] ${pair.slug} (${pair.feature}): ${ran.join(', ')}`)
     }
   }
@@ -364,14 +429,22 @@ for (const pair of pairs) {
 console.log('\nImplementation summary')
 const profile = corpusName === 'optional' ? 'optional/opt-in' : 'default/no-opt-in'
 console.log(
-  `profile=${profile} corpus=${corpusName} corpus_pairs=${pairs.length} targets=${targets.join(',')}`,
+  `profile=${profile} corpus=${corpusName} corpus_pairs=${pairs.length} targets=${activeTargets.join(',')}`,
 )
 if (targetNote) console.log(`target_note=${targetNote}`)
+// A `--targets` subset can exclude a case's pinned target outright. Saying so
+// keeps corpus_pairs from reading as "all of these ran".
+const filteredOut = pairs.filter((pair) => targetsFor(pair).length === 0)
+if (filteredOut.length) {
+  console.log(
+    `filtered_out=${filteredOut.length} (pinned targets outside --targets: ${[...new Set(filteredOut.map((p) => p.target))].join(',')})`,
+  )
+}
 for (const impl of active) {
   const s = stats[impl.name]
   const avg = s.runnable ? (s.ms / s.runnable).toFixed(2) : '0.00'
-  // pass/mismatch score the html fixtures only, so they are reported against
-  // the pair count rather than the run count (which spans every target).
+  // pass/mismatch score the fixtures only, so they are reported against the
+  // pair count rather than the run count (which spans every target).
   console.log(
     `${impl.name}: pass=${s.ok}/${s.ok + s.mismatch} mismatch=${s.mismatch} error=${s.error} skipped=${s.skipped} runs=${s.runnable} avg_ms=${avg}`,
   )
@@ -379,23 +452,25 @@ for (const impl of active) {
 console.log(`cross_impl_diffs=${crossImplDiffs}`)
 
 console.log('\nTarget agreement (implementations compared against each other)')
-for (const target of targets) {
+for (const target of activeTargets) {
   const t = targetStats[target]
-  const fixtures = target === 'html' ? ' fixtures=yes' : ' fixtures=none'
+  const fixtures = isOptional || target === DEFAULT_TARGET ? ' fixtures=yes' : ' fixtures=none'
   console.log(`${target}: compared=${t.compared} diffs=${t.diffs} errors=${t.errors}${fixtures}`)
 }
 console.log(
-  'target_agreement_note=only html has expected-output fixtures; the other targets assert that the implementations agree with each other.',
+  isOptional
+    ? 'target_agreement_note=every optional case has an expected-output fixture on the target it pins; the counts here also assert that the implementations agree with each other.'
+    : 'target_agreement_note=only html has expected-output fixtures; the other targets assert that the implementations agree with each other.',
 )
 
-if (corpusName === 'optional') {
+if (isOptional) {
   console.log('\nOptional feature coverage')
   for (const pair of pairs) {
     const supported = active
-      .filter((impl) => commandFor(impl, pair))
+      .filter((impl) => commandFor(impl, pair, pair.target))
       .map((impl) => impl.name)
       .join(', ')
-    console.log(`${pair.feature}: ${supported || 'none'}`)
+    console.log(`${pair.feature} (${pair.target}): ${supported || 'none'}`)
   }
 }
 

--- a/scripts/lib/corpus-targets.mjs
+++ b/scripts/lib/corpus-targets.mjs
@@ -1,0 +1,54 @@
+/*
+ * The pairing rule for corpus cases that pin a render target.
+ *
+ * A case in the optional corpus may name a `target` in its manifest entry. The
+ * expected file's extension follows from that target, so a runner locates the
+ * expected output from the slug and the target alone
+ * (tests/corpus-optional/README.md).
+ *
+ * This lives in one place because it has to hold for every runner. It did not:
+ * carve#360 taught the vendored-reference runner about targets and left
+ * `scripts/compare-impls.mjs` pairing every optional case with a `.html` file,
+ * so `npm run compare:impls -- --corpus=optional` died on the first
+ * Markdown-target case with ENOENT.
+ */
+
+/*
+ * `carve` is deliberately absent. Carve-source expectations live in
+ * tests/corpus-roundtrip/, and giving them a second home here would mean two
+ * files named `NN-slug.crv` in one directory, one of them the input.
+ */
+export const TARGET_EXTENSIONS = {
+  html: 'html',
+  markdown: 'md',
+  plain: 'txt',
+  ansi: 'ansi',
+}
+
+export const DEFAULT_TARGET = 'html'
+
+export function targetNames() {
+  return Object.keys(TARGET_EXTENSIONS)
+}
+
+/** The target a manifest entry pins, defaulting to html. */
+export function targetOf(entry) {
+  return entry.target ?? DEFAULT_TARGET
+}
+
+/**
+ * The expected-output filename for a slug on a target.
+ *
+ * An unknown target is a manifest error, not an unsupported feature: returning
+ * a `.html` fallback would silently pair the case with the wrong file, which is
+ * exactly the failure this module exists to prevent.
+ */
+export function expectedFileFor(slug, target = DEFAULT_TARGET) {
+  const extension = TARGET_EXTENSIONS[target]
+  if (!extension) {
+    throw new Error(
+      `unknown target '${target}' for '${slug}' - expected one of ${targetNames().join(', ')}`,
+    )
+  }
+  return `${slug}.${extension}`
+}

--- a/tests/corpus-targets.test.mjs
+++ b/tests/corpus-targets.test.mjs
@@ -1,0 +1,88 @@
+/*
+ * The pairing rule that every corpus runner has to share.
+ *
+ * carve#360 let an optional case pin a target other than HTML. The vendored
+ * reference runner learned the rule; scripts/compare-impls.mjs did not, and
+ * kept opening `NN-slug.html` for every case - so
+ * `npm run compare:impls -- --corpus=optional` died on ENOENT at the first
+ * Markdown case. These tests pin the rule itself and pin that every case in the
+ * manifest actually has the file the rule names.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { basename, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  DEFAULT_TARGET,
+  TARGET_EXTENSIONS,
+  expectedFileFor,
+  targetNames,
+  targetOf,
+} from '../scripts/lib/corpus-targets.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const corpusDir = resolve(here, 'corpus-optional')
+const manifest = JSON.parse(readFileSync(resolve(corpusDir, 'manifest.json'), 'utf8'))
+
+test('a target maps to the extension the corpus README documents', () => {
+  assert.deepEqual(TARGET_EXTENSIONS, {
+    html: 'html',
+    markdown: 'md',
+    plain: 'txt',
+    ansi: 'ansi',
+  })
+})
+
+test('carve is not an expected-output target', () => {
+  // Carve-source expectations live in tests/corpus-roundtrip/. A second home
+  // would put two files named `NN-slug.crv` in one directory, one the input.
+  assert.equal(TARGET_EXTENSIONS.carve, undefined)
+  assert.throws(() => expectedFileFor('01-example', 'carve'), /unknown target 'carve'/)
+})
+
+test('an entry without a target pins html', () => {
+  assert.equal(targetOf({ slug: '01-example', feature: 'x' }), DEFAULT_TARGET)
+  assert.equal(expectedFileFor('01-example'), '01-example.html')
+})
+
+test('an entry naming a target pins that target', () => {
+  assert.equal(targetOf({ slug: '30-x', feature: 'x', target: 'markdown' }), 'markdown')
+  assert.equal(expectedFileFor('30-x', 'markdown'), '30-x.md')
+  assert.equal(expectedFileFor('30-x', 'plain'), '30-x.txt')
+  assert.equal(expectedFileFor('30-x', 'ansi'), '30-x.ansi')
+})
+
+test('an unknown target is an error, not a silent html fallback', () => {
+  // A fallback would pair the case with a file that was never written for it
+  // and report the resulting mismatch as an engine divergence.
+  assert.throws(() => expectedFileFor('30-x', 'pdf'), /unknown target 'pdf'/)
+  assert.throws(() => expectedFileFor('30-x', 'pdf'), new RegExp(targetNames().join(', ')))
+})
+
+test('every optional case has the input and expected file its target names', () => {
+  assert.ok(manifest.cases.length > 0, 'manifest has no cases')
+  for (const entry of manifest.cases) {
+    const slug = basename(entry.slug)
+    const expected = expectedFileFor(slug, targetOf(entry))
+    assert.ok(existsSync(resolve(corpusDir, `${slug}.crv`)), `missing ${slug}.crv`)
+    assert.ok(existsSync(resolve(corpusDir, expected)), `missing ${expected}`)
+  }
+})
+
+test('a non-html case does not also carry an html fixture', () => {
+  // Pinning this keeps the ENOENT crash from being "fixed" by adding the file
+  // the old code looked for: the target is the pairing rule, not a fallback
+  // chain, and two fixtures for one case would let the two runners disagree
+  // about which one is authoritative.
+  for (const entry of manifest.cases) {
+    const target = targetOf(entry)
+    if (target === DEFAULT_TARGET) continue
+    const slug = basename(entry.slug)
+    assert.ok(
+      !existsSync(resolve(corpusDir, `${slug}.html`)),
+      `${slug} pins target '${target}' but also has an html fixture`,
+    )
+  }
+})

--- a/tests/optional-corpus.test.mjs
+++ b/tests/optional-corpus.test.mjs
@@ -17,6 +17,7 @@ import assert from 'node:assert/strict'
 import { existsSync, readFileSync } from 'node:fs'
 import { basename, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { expectedFileFor, targetOf } from '../scripts/lib/corpus-targets.mjs'
 import {
   carveToAnsi,
   carveToHtml,
@@ -42,16 +43,15 @@ const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
 
 /*
  * The extension is part of the pairing rule, not a label: a runner locates the
- * expected file from the slug and the target alone. `carve` is deliberately
- * absent - Carve-source expectations live in ../corpus-roundtrip/, and giving
- * them a second home here would mean two files named `NN-slug.crv` in one
- * directory, one of them the input.
+ * expected file from the slug and the target alone. It is shared with
+ * scripts/compare-impls.mjs rather than restated, because a second copy is how
+ * that runner came to pair every optional case with a `.html` file.
  */
 const targets = {
-  html: { extension: 'html', render: carveToHtml },
-  markdown: { extension: 'md', render: carveToMarkdown },
-  plain: { extension: 'txt', render: carveToPlainText },
-  ansi: { extension: 'ansi', render: carveToAnsi },
+  html: { render: carveToHtml },
+  markdown: { render: carveToMarkdown },
+  plain: { render: carveToPlainText },
+  ansi: { render: carveToAnsi },
 }
 
 /*
@@ -86,20 +86,23 @@ const featureRunners = {
 
 for (const entry of manifest.cases) {
   const slug = basename(entry.slug)
-  const targetName = entry.target ?? 'html'
+  const targetName = targetOf(entry)
   const target = targets[targetName]
 
   // An unknown target is a manifest error, not an unsupported feature: silently
   // skipping it would read as "this implementation does not do that yet".
-  if (!target) {
+  let expectedFile
+  try {
+    expectedFile = expectedFileFor(slug, targetName)
+  } catch (error) {
     test(`${slug} (${entry.feature})`, () => {
-      assert.fail(`unknown target '${targetName}' - expected one of ${Object.keys(targets).join(', ')}`)
+      assert.fail(error.message)
     })
     continue
   }
 
   const crvPath = resolve(corpusDir, `${slug}.crv`)
-  const expectedPath = resolve(corpusDir, `${slug}.${target.extension}`)
+  const expectedPath = resolve(corpusDir, expectedFile)
   const runner = featureRunners[entry.feature]
 
   if (!runner) {
@@ -109,7 +112,7 @@ for (const entry of manifest.cases) {
 
   test(`${slug} (${entry.feature}, ${targetName})`, () => {
     assert.ok(existsSync(crvPath), `missing ${slug}.crv pair`)
-    assert.ok(existsSync(expectedPath), `missing ${slug}.${target.extension} pair`)
+    assert.ok(existsSync(expectedPath), `missing ${expectedFile} pair`)
     const source = readFileSync(crvPath, 'utf8')
     const expected = readFileSync(expectedPath, 'utf8')
     assert.equal(runner(source, target.render).trim(), expected.trim())


### PR DESCRIPTION
`npm run compare:impls -- --corpus=optional` has been dead since #365.

That PR let an optional case pin a `target` and pair with an expected file carrying the target's extension. `tests/optional-corpus.test.mjs` learned the rule; `scripts/compare-impls.mjs` did not - it forced every optional case back to `html` and opened `NN-slug.html`:

```text
Error: ENOENT: no such file or directory, open '.../tests/corpus-optional/30-symbol-map-markdown.html'
    at file:///.../scripts/compare-impls.mjs:313:27
```

That is the whole optional comparison, not just the Markdown cases - the read happens before any per-case skip.

## What changed

A case runs on the target its manifest entry pins and is scored against that target's expected file. `--targets` filters which cases run instead of overriding what they render, and a filtered run prints `filtered_out=` so `corpus_pairs=` is not read as "all of these ran".

The per-engine adapters take the target: the rust adapters append the target's CLI flag, the js adapters select the matching entry point. An adapter not wired for a target reports no adapter and the case is skipped for that engine - the same visible skip an unsupported feature already gets. That is what the php adapters do, since they drive `CarveConverter::convert()` and so speak HTML.

A missing expected file is now a hard error naming the file and the target, instead of a silent downgrade to an engines-agree check.

The pairing rule moves to `scripts/lib/corpus-targets.mjs`, shared with the reference runner and pinned by `tests/corpus-targets.test.mjs`. Two runners each holding a private copy of the rule is what let one fall a release behind the manifest. The new test also asserts every manifest case has the file its target names, and that a non-HTML case does not *also* carry an HTML fixture - so this cannot be "fixed" later by adding the file the old code happened to look for.

Second fix in the same file: `cross_impl_diffs` counted HTML only, so a Markdown, plain-text, Carve or ANSI divergence printed its `DIFF [target]` line while the headline figure - the one the docs snapshot pins - still said zero. It counts every compared target now.

## Result

```text
profile=optional/opt-in corpus=optional corpus_pairs=31 targets=html,markdown
rust: pass=3/3 mismatch=0 error=0 skipped=28 runs=3
js:   pass=3/3 mismatch=0 error=0 skipped=28 runs=3
php:  pass=3/3 mismatch=0 error=0 skipped=28 runs=3
cross_impl_diffs=0

html:     compared=2 diffs=0 errors=0 fixtures=yes
markdown: compared=1 diffs=0 errors=0 fixtures=yes
```

`symbol-map (markdown): rust, js` - both engines now render and are scored on the Markdown target, which is what #365 wanted asserted.

One observation worth a separate look, not touched here: a run over the first 40 core cases on `--targets=carve` reports `DIFF [carve] 01-emphasis (core): rust, js, php`. My three sibling checkouts were on feature branches rather than `main` at the time, so that needs re-running against `main` before it means anything.
