### PR TITLE
feat(compare-impls): add a --roundtrip mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`compare-impls --roundtrip`** (carve#353). Formats each corpus case, then
+  feeds that output back in as a fresh input, so every case covers two inputs
+  instead of one - and the second is a document nobody wrote. The formatter
+  emits shapes an author rarely types (normalized indentation, inserted blank
+  lines, escape runs), which is exactly where the engines are least likely to
+  have been compared.
+
+  It also asserts the two PART 11 §1 invariants per engine while the outputs are
+  in hand: `to_html(fmt(x)) == to_html(x)` and `fmt(fmt(x)) == fmt(x)`. Those are
+  per-engine properties, reported separately from cross-engine agreement - all
+  three engines can agree and still be wrong together.
+
 ### Fixed
 
 - **The executable spec's quote open/close decision matches the engines**

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -152,6 +152,44 @@ the case is skipped for that engine, the same visible skip an unsupported
 feature gets. That is why the PHP adapters, which drive `CarveConverter::convert()`
 and so speak HTML, sit out the Markdown-target cases.
 
+### Round-trip inputs
+
+`--roundtrip` formats each corpus case, then feeds that output back in as a
+fresh input:
+
+```bash
+node scripts/compare-impls.mjs --roundtrip
+```
+
+Every case then covers two inputs instead of one, and the second is a document
+nobody wrote. That matters because the formatter emits shapes an author rarely
+types by hand - normalized indentation, inserted blank lines, escape runs - so
+its output is exactly where the engines are least likely to have been compared.
+The case that prompted it (carve#353) was a nested list whose formatted form the
+engines then parsed differently, tight in one and loose in another: an
+HTML-level parser divergence the corpus structurally could not see, because the
+input only exists after formatting.
+
+Three numbers come out of it:
+
+```text
+roundtrip_compared=499 roundtrip_diffs=0 semantic_failures=0 idempotence_failures=0
+```
+
+`roundtrip_diffs` is a cross-engine disagreement on the HTML of formatted
+source, and belongs with the target-agreement block. The other two are each
+engine failing its own stated invariant (PART 11 §1) and are reported apart from
+it:
+
+- `semantic_failures` - `to_html(fmt(x)) != to_html(x)`, the formatter changing
+  what the document renders as.
+- `idempotence_failures` - `fmt(fmt(x)) != fmt(x)`, a second pass that is not a
+  no-op.
+
+A per-engine failure is not a divergence: all three engines can agree and still
+be wrong together, which is why the counts are separate rather than folded into
+`cross_impl_diffs`.
+
 ### Generated documents
 
 `compare-impls` runs the committed corpus - documents somebody wrote.

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -9,6 +9,11 @@ import { DEFAULT_TARGET, expectedFileFor, targetOf } from './lib/corpus-targets.
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)))
 const args = new Set(process.argv.slice(2))
 const bench = args.has('--bench')
+// Round-trip mode: format each case, then treat that output as a fresh input.
+// The formatter emits shapes an author would rarely type - normalized
+// indentation, inserted blank lines, escape runs - so its output is exactly
+// where the engines are least likely to have been compared (carve#353).
+const roundtrip = args.has('--roundtrip')
 const limitArg = process.argv.find((a) => a.startsWith('--limit='))
 const limit = limitArg ? Number(limitArg.slice('--limit='.length)) : Infinity
 const corpusArg = process.argv.find((a) => a.startsWith('--corpus='))
@@ -426,6 +431,64 @@ for (const pair of pairs) {
   }
 }
 
+let roundtripDiffs = 0
+let semanticFailures = 0
+let idempotenceFailures = 0
+let roundtripCompared = 0
+
+if (roundtrip) {
+  // Each engine formats the case, then re-renders its own output. The formatted
+  // source is a fresh input the corpus never contained, so this doubles the
+  // inputs every case covers.
+  const tmp = mkdtempSync(join(tmpdir(), 'carve-roundtrip-'))
+  try {
+    for (const pair of pairs) {
+      const rendered = []
+      for (const impl of active) {
+        const carveCmd = commandFor(impl, pair, 'carve')
+        const htmlCmd = commandFor(impl, pair, 'html')
+        if (!carveCmd || !htmlCmd) continue
+
+        const formatted = run(carveCmd, impl.cwd, [pair.file])
+        if (!formatted.ok) continue
+
+        // fmt(x) written back out as a real file, so each engine re-reads it
+        // exactly as it would any other input.
+        const once = join(tmp, `${impl.name}-once.crv`)
+        writeFileSync(once, formatted.stdout.endsWith('\n') ? formatted.stdout : `${formatted.stdout}\n`)
+
+        const htmlOfFormatted = run(htmlCmd, impl.cwd, [once])
+        const htmlOfSource = run(htmlCmd, impl.cwd, [pair.file])
+        const formattedTwice = run(carveCmd, impl.cwd, [once])
+
+        // Per-engine properties, reported apart from cross-engine agreement:
+        // these are the formatter's own stated invariants (PART 11 section 1),
+        // not a disagreement between engines.
+        if (htmlOfFormatted.ok && htmlOfSource.ok && htmlOfFormatted.stdout !== htmlOfSource.stdout) {
+          semanticFailures++
+          console.log(`INVARIANT to_html(fmt(x)) != to_html(x) [${impl.name}] ${pair.slug}`)
+        }
+        if (formattedTwice.ok && formattedTwice.stdout !== formatted.stdout) {
+          idempotenceFailures++
+          console.log(`INVARIANT fmt(fmt(x)) != fmt(x) [${impl.name}] ${pair.slug}`)
+        }
+        if (htmlOfFormatted.ok) rendered.push([impl.name, htmlOfFormatted.stdout])
+      }
+
+      if (rendered.length < 2) continue
+      roundtripCompared++
+      if (new Set(rendered.map(([, out]) => out)).size > 1) {
+        roundtripDiffs++
+        console.log(
+          `ROUNDTRIP DIFF ${pair.slug} (${pair.feature}): ${rendered.map(([name]) => name).join(', ')}`,
+        )
+      }
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
 console.log('\nImplementation summary')
 const profile = corpusName === 'optional' ? 'optional/opt-in' : 'default/no-opt-in'
 console.log(
@@ -450,6 +513,14 @@ for (const impl of active) {
   )
 }
 console.log(`cross_impl_diffs=${crossImplDiffs}`)
+if (roundtrip) {
+  // Reported apart from the target-agreement block above: the first line is a
+  // cross-engine disagreement, the other two are each engine failing its own
+  // stated invariant.
+  console.log(
+    `roundtrip_compared=${roundtripCompared} roundtrip_diffs=${roundtripDiffs} semantic_failures=${semanticFailures} idempotence_failures=${idempotenceFailures}`,
+  )
+}
 
 console.log('\nTarget agreement (implementations compared against each other)')
 for (const target of activeTargets) {


### PR DESCRIPTION
Closes #353.

Formats each corpus case, writes that output back out as a real file, and re-renders it in every engine. Each case then covers two inputs instead of one - and the second is a document nobody wrote.

That is where the gap was. The corpus is documents somebody typed; the formatter emits shapes an author rarely types by hand - normalized indentation, inserted blank lines, escape runs - so its output is exactly where the engines are least likely to have been compared.

It also asserts the two PART 11 §1 invariants per engine while the outputs are in hand.

## It found a real one on its first clean run

`carve-rs` breaks **both** invariants on `103-marker-line-nested-lists-2`, and the engines then disagree on the HTML:

```
source            fmt (carve-rs)
- - A             - - A
                      ⎵⎵⎵⎵          <- whitespace-only line
    second            second
  - B             ⎵⎵                <- whitespace-only line
                    - B
```

Those lines are blank as far as the parser is concerned, so the list splits in two and `B` flips from loose to tight:

```html
before fmt                after fmt
<li><p>B</p></li>         </ul><ul><li>B</li>
```

`carve fmt` changing what a document renders as - the exact class #353 was filed to catch, and the same shape as the `05-lists-4` case that prompted it. Filed as markup-carve/carve-rs#299. carve-js and carve-php hold both invariants on it.

## Numbers

```text
corpus_pairs=100 targets=html,markdown,plain,carve,ansi
cross_impl_diffs=14
roundtrip_compared=100 roundtrip_diffs=1 semantic_failures=1 idempotence_failures=1
```

**This is a 100-case slice, not the full 499.** A full sweep spawns roughly 27 subprocesses per case across three engines and takes over an hour here; the slice is what I can stand behind having watched it complete. The mode is not wired into CI by this PR - that is a separate decision about where an hour-long job belongs.

One caveat learned the hard way: my first full run pointed at the sibling checkouts, which were sitting on a feature branch rather than `main`, so its findings described someone's work-in-progress. The numbers above come from three worktrees pinned at each engine's `main`. If you run this, check what the engine checkouts are on - `CARVE_RS_DIR` and friends override them.

## Reporting

`roundtrip_diffs` is a cross-engine disagreement and belongs with target agreement. The other two are each engine failing its **own** stated invariant, so they are counted and printed separately - all three engines can agree with each other and still be wrong together, and folding them in would hide exactly that.

Docs: a new "Round-trip inputs" section in `docs/implementation-comparison.md`.