### PR TITLE
Undo a fixture re-pin, and stop compare-impls corrupting its own input

### DIFF
--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -265,6 +265,11 @@ function run(cmd, cwd, extraArgs = [], timeout = 15000) {
     ok: result.status === 0,
     status: result.status,
     stdout: (result.stdout ?? '').trim(),
+    // Untrimmed, for anything that feeds output back in as input. `trim()`
+    // removes Unicode whitespace, U+00A0 among it, so a document ending in a
+    // no-break space loses it on the way through -- see the write in the
+    // roundtrip pass.
+    rawStdout: result.stdout ?? '',
     stderr: (result.stderr ?? '').trim(),
     elapsedMs,
     error: result.error?.message,
@@ -453,9 +458,12 @@ if (roundtrip) {
         if (!formatted.ok) continue
 
         // fmt(x) written back out as a real file, so each engine re-reads it
-        // exactly as it would any other input.
+        // exactly as it would any other input. This has to be the UNTRIMMED
+        // output: trimming would strip a trailing no-break space, and the
+        // reparse would then differ for a reason the engine had no part in.
         const once = join(tmp, `${impl.name}-once.crv`)
-        writeFileSync(once, formatted.stdout.endsWith('\n') ? formatted.stdout : `${formatted.stdout}\n`)
+        const raw = formatted.rawStdout
+        writeFileSync(once, raw.endsWith('\n') ? raw : `${raw}\n`)
 
         const htmlOfFormatted = run(htmlCmd, impl.cwd, [once])
         const htmlOfSource = run(htmlCmd, impl.cwd, [pair.file])
@@ -468,7 +476,7 @@ if (roundtrip) {
           semanticFailures++
           console.log(`INVARIANT to_html(fmt(x)) != to_html(x) [${impl.name}] ${pair.slug}`)
         }
-        if (formattedTwice.ok && formattedTwice.stdout !== formatted.stdout) {
+        if (formattedTwice.ok && formattedTwice.rawStdout !== formatted.rawStdout) {
           idempotenceFailures++
           console.log(`INVARIANT fmt(fmt(x)) != fmt(x) [${impl.name}] ${pair.slug}`)
         }

--- a/tests/corpus-roundtrip/04-literal-punctuation.expected.crv
+++ b/tests/corpus-roundtrip/04-literal-punctuation.expected.crv
@@ -1,1 +1,1 @@
-Literal \-\- and \.\.\. and \" must stay escaped.
+Literal \-\- and \.\.\. and \" must stay escaped\.

--- a/tests/corpus-roundtrip/07-mention-and-tag-literals.expected.crv
+++ b/tests/corpus-roundtrip/07-mention-and-tag-literals.expected.crv
@@ -1,1 +1,1 @@
-Ping \@user and \#tag literally, plus a real @who and #topic.
+Ping \@user and \#tag literally, plus a real @who and #topic\.

--- a/tests/corpus-roundtrip/08-trailing-no-break-space.crv
+++ b/tests/corpus-roundtrip/08-trailing-no-break-space.crv
@@ -1,0 +1,2 @@
+A trailing no-break space 
+and one mid-line: kept.

--- a/tests/corpus-roundtrip/08-trailing-no-break-space.expected.crv
+++ b/tests/corpus-roundtrip/08-trailing-no-break-space.expected.crv
@@ -1,0 +1,2 @@
+A trailing no-break space 
+and one mid-line: kept.

--- a/tests/corpus-roundtrip/README.md
+++ b/tests/corpus-roundtrip/README.md
@@ -33,13 +33,24 @@ silently become a mention.
 ## What the byte assertions are worth
 
 `../roundtrip.test.mjs` asserts the PART 11 §1 invariants and the expected bytes
-against the vendored reference.
+against the vendored reference. The §1 comparisons run MODULO ESCAPING, as §1
+requires: an escape both retypes a text node and splits the run it sat in, so a
+raw AST comparison would report a difference for every escape the writer emitted
+- the one thing these fixtures exist to pin.
+
+Two byte assertions are reported as PENDING rather than passing: `04` and `07`
+are the conservative-form cases, and the engines currently emit a MIXED form,
+escaping a candidate only where leaving it bare would change the parse. That is
+the §2-versus-§4 tension in carve#374. The fixtures keep the form PART 11 pins
+and the assertion stays visible; re-pinning them to the engines' output would
+settle an open spec question by accident, which is exactly what "Regenerating"
+below warns against.
 
 The byte comparisons were skipped while no engine implemented minimal escaping -
 asserting them against an over-escaping writer would either fail the suite or,
 if the fixtures had been generated from that writer, pin the defect as the
 expected output. carve-js#397 implements PART 11 §4, so they now run, and the
-vendored build reproduces all seven fixtures exactly.
+vendored build reproduces the fixtures exactly, the two noted below aside.
 
 That is worth something only because of where the fixtures came from: they were
 derived from PART 11 by hand before any engine implemented it, so agreement

--- a/tests/roundtrip.test.mjs
+++ b/tests/roundtrip.test.mjs
@@ -13,8 +13,8 @@
  *
  *   - The BYTES (PART 11 §2, §4) pin the escaping decision itself. They were
  *     skipped while no engine implemented minimal escaping; the vendored
- *     carve-lib does now (carve-js#397), and it reproduces all seven fixtures
- *     exactly. The fixtures were derived from PART 11 rather than from any
+ *     carve-lib does now (carve-js#397), and it reproduces them exactly apart
+ *     from the two conservative-form cases noted below. The fixtures were derived from PART 11 rather than from any
  *     writer's output, so this is a check of the engine against the spec, not
  *     of the engine against itself.
  */
@@ -42,6 +42,38 @@ test('the round-trip corpus is non-empty', () => {
   assert.ok(cases.length >= 6, `found ${cases.length} cases`)
 })
 
+/**
+ * Collapse adjacent text and escaped-text runs into one text node.
+ *
+ * PART 11 §1 states the invariant's equality as being MODULO ESCAPING, and this
+ * is what that means in practice. Escaping a character both retypes the node and
+ * SPLITS the run it sat in - `escaped.` is one text node, `escaped\.` is a text
+ * node plus an escaped-text node - so a raw AST comparison reports a difference
+ * for every escape the writer emitted, which is the one thing these fixtures are
+ * pinning. Both engines' W3 comparison normalizes the same way.
+ */
+function mergeTextRuns(node) {
+  if (Array.isArray(node)) {
+    const merged = []
+    for (const child of node.map(mergeTextRuns)) {
+      const isText = child && (child.type === 'text' || child.type === 'escaped_text')
+      const previous = merged[merged.length - 1]
+      if (isText && previous && previous.type === 'text') {
+        previous.value = `${previous.value}${child.value}`
+        continue
+      }
+      merged.push(isText ? { ...child, type: 'text' } : child)
+    }
+    return merged
+  }
+  if (node && typeof node === 'object') {
+    const out = {}
+    for (const [k, v] of Object.entries(node)) out[k] = mergeTextRuns(v)
+    return out
+  }
+  return node
+}
+
 // `pos` records source offsets, which legitimately move when the writer
 // renormalizes indentation, so it is not part of "same document".
 function withoutPositions(node) {
@@ -57,11 +89,30 @@ function withoutPositions(node) {
   return node
 }
 
+/*
+ * Cases whose expected form is the CONSERVATIVE one (PART 11 §4 W4), where the
+ * engines currently emit a MIXED form instead: they escape a candidate only
+ * where leaving it bare would change the parse, so `\-\-` and `\.\.\.` are
+ * escaped but a sentence-final `.` is not.
+ *
+ * That is the tension carve#374 is open on - §2 says do not over-escape, §4
+ * pins whole-document conservative - and it is not this file's call to settle.
+ * The assertion stays and is reported as pending, rather than being re-pinned
+ * to whatever the engines happen to emit: derive these from PART 11, never from
+ * an implementation (see the README next to the fixtures).
+ */
+const CONSERVATIVE_PENDING = new Set([
+  '04-literal-punctuation',
+  '07-mention-and-tag-literals',
+])
+
 for (const { slug, source, expected } of cases) {
+  const comparable = (src) => mergeTextRuns(withoutPositions(parse(src)))
+
   test(`${slug}: parse(fmt(x)) == parse(x)`, () => {
     assert.deepEqual(
-      withoutPositions(parse(carveToCarve(source))),
-      withoutPositions(parse(source)),
+      comparable(carveToCarve(source)),
+      comparable(source),
       'the formatter changed what the document says',
     )
   })
@@ -75,13 +126,16 @@ for (const { slug, source, expected } of cases) {
     // Guards the fixtures themselves: an expected file that does not round-trip
     // would pin a writer that corrupts documents.
     assert.deepEqual(
-      withoutPositions(parse(expected)),
-      withoutPositions(parse(source)),
+      comparable(expected),
+      comparable(source),
       'the expected output is not a faithful serialization of the input',
     )
   })
 
-  test(`${slug}: fmt(x) == expected bytes (PART 11 §2, §4)`, () => {
+  const pending = CONSERVATIVE_PENDING.has(slug)
+    ? { todo: 'engines emit the mixed form; pending the carve#374 decision' }
+    : {}
+  test(`${slug}: fmt(x) == expected bytes (PART 11 §2, §4)`, pending, () => {
     assert.equal(carveToCarve(source), expected)
   })
 }


### PR DESCRIPTION
Two corrections to measurement, one of them mine from #378.

### The fixture re-pin was wrong

#378 changed `04-literal-punctuation` and `07-mention-and-tag-literals` to drop a trailing escape, on the reading that the writer had improved and the fixtures were stale:

```
was     ... must stay escaped\.
became  ... must stay escaped.
```

That reading was wrong. A period is in the CANDIDATE set, and W4 pins the CONSERVATIVE form for any document whose minimal form re-parses differently - which this one's does, since bare `--` and `...` re-derive as smart punctuation. The conservative form escapes every candidate, trailing period included. So the original bytes are what PART 11 requires, and the engines emit a MIXED form that §4 does not describe: they escape a candidate only where leaving it bare would change the parse.

That gap is #374, open and undecided. Re-pinning the fixtures to the engines' output settled it silently in favor of whatever happened to be implemented - the exact failure the README beside those fixtures warns about. The bytes are restored, and the two byte assertions are reported as **pending** with a pointer to #374, so the question stays visible instead of looking answered.

### Why the re-pin looked justified

The fixture guard - "the expected output re-parses to the same document" - genuinely failed on the restored bytes. But that failure was the test's, not the fixtures': it compared raw ASTs. An escape both retypes a text node and *splits* the run it sat in, so `escaped\.` differs from `escaped.` by construction once `escaped_text` exists as a node type. §1 states this comparison as being **modulo escaping**, and both engines' own W3 comparison normalizes exactly that way. The test now does too, and the guard passes on the conservative bytes - which is the evidence that they are a faithful serialization.

### compare-impls corrupted its own input

The roundtrip pass writes `fmt(x)` to a file and re-renders it. It wrote the *trimmed* stdout, and JS `trim()` removes Unicode whitespace, U+00A0 among it. A document ending in a no-break space lost it on the way through, so the pass reported this for all three engines:

```
INVARIANT to_html(fmt(x)) != to_html(x) [rust] 139-trailing-whitespace-boundaries-4
INVARIANT to_html(fmt(x)) != to_html(x) [js]   139-trailing-whitespace-boundaries-4
INVARIANT to_html(fmt(x)) != to_html(x) [php]  139-trailing-whitespace-boundaries-4
```

None of them had done anything wrong - each reproduces that document byte-for-byte. Three identical failures across independent engines is what made it worth checking by hand.

`run()` now also returns untrimmed output, and the write-back and idempotence comparison use it. A fixture is added for the shape that was being corrupted, so the engine side is pinned by the suite and not only by this script.

The sweep is now 0 semantic failures, 0 idempotence failures, 0 roundtrip diffs across all three engines, which closes out what #369 was tracking.
