### PR TITLE
docs: state that a tag is classified as a mention

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -46,6 +46,25 @@ An **`admonition`** is likewise its own type rather than a `div` carrying a
 class. A profile that wants to deny callouts while allowing generic
 containers has no way to express that if the kind lives in a class string.
 
+A **`tag`** node - the AST form of `#tag` - is deliberately **NOT** its own
+vocabulary entry: it is classified as **`mention`**, and all three
+implementations agree on that. `@user` and `#tag` are parsed by the same
+boundary rules (PART 9 §7) and render through the same inert-span mechanism, so
+they are one trust class rather than two. Denying `mention` denies both:
+
+```js
+const p = Profile.minimal()
+p.denyInline(['mention'])
+applyProfile(parse('hi @user'), p).violations  // [{ nodeType: 'mention', ... }]
+applyProfile(parse('hi #tag'), p).violations   // [{ nodeType: 'mention', ... }]
+```
+
+The consequence is worth stating plainly, because it is a real limit: a host
+CANNOT allow mentions while denying tags. `tag` is not addressable, so naming it
+in `allowedInline` or `deniedInline` does nothing at all - silently, since an
+unrecognized identifier is not an error. A host that needs one without the other
+has to deny `mention` and reintroduce the wanted construct through an extension.
+
 A **`smart_punctuation`** node - the AST form of a typographic substitution,
 carrying the resolved kind and the author's source run (PART 9 §8) - is
 classified as **`text`**. It is ordinary visible prose with no capability of its

--- a/tests/node-vocabulary.test.mjs
+++ b/tests/node-vocabulary.test.mjs
@@ -53,6 +53,23 @@ test('no type is listed twice, or on both axes', () => {
   assert.deepEqual(duplicates, [], `duplicated type identifiers: ${duplicates.join(', ')}`)
 })
 
+test('tag stays folded into mention, and says so', () => {
+  // The parsers emit a distinct `tag` node, so its ABSENCE here has to be a
+  // stated decision rather than a missing word - that ambiguity is what
+  // carve#373 was. All three engines classify `#tag` as `mention`, and a host
+  // naming `tag` in a profile gets silence, so the fold is documented next to
+  // the vocabulary and pinned here.
+  assert.ok(
+    ![...block, ...inline].includes('tag'),
+    '`tag` is classified as `mention`; listing it would promise a denial that no engine honors',
+  )
+  assert.match(
+    profiles,
+    /A \*\*`tag`\*\* node[\s\S]{0,400}?classified as \*\*`mention`\*\*/,
+    'profiles.md must state that `tag` is classified as `mention`, or its absence reads as an oversight',
+  )
+})
+
 test('formatter-internal nodes stay out of the vocabulary', () => {
   // A profile naming these could break `fmt` while saying nothing about the
   // document's content, so the spec excludes them by name.


### PR DESCRIPTION
Closes #373.

The issue asked which of two things `tag` is: its own vocabulary entry, or folded into `mention`. It is already the second, in all three engines:

```
carve-js   case 'tag': return 'mention'
carve-rs   InlineNode::Tag(_) => Some("mention")
carve-php  no TAG node type at all; tags live under the mention feature
```

Measured rather than read off the source - with `mention` denied, both spellings report a `mention` violation:

```js
const p = Profile.minimal()
p.denyInline(['mention'])
applyProfile(parse('hi @user'), p).violations  // [{ nodeType: 'mention', ... }]
applyProfile(parse('hi #tag'), p).violations   // [{ nodeType: 'mention', ... }]
```

So this documents the fold rather than adding an entry. `@user` and `#tag` share the PART 9 §7 boundary rules and the same inert-span rendering, which makes them one trust class; splitting them would be a behavior change across three engines for a capability nobody has asked for.

### The limit is documented too

A host **cannot** allow mentions while denying tags, and naming `tag` in `allowedInline` / `deniedInline` does nothing *at all* rather than erroring, since an unrecognized identifier is not rejected. That is worth saying out loud - it was the part that made the missing word look like a bug. Anyone needing one without the other has to deny `mention` and reintroduce the wanted construct through an extension.

### What the test pins

Both halves: that `tag` stays out of the vocabulary, and that the reason is written next to the list. Absence alone cannot carry a decision - that is exactly what left this ambiguous long enough to become an issue.
