### PR TITLE
spec: narrow PART 11 section 7 to whitespace-only lines

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3044,6 +3044,24 @@ EOF = (* end of file *) ;
    7. NO WHITESPACE-ONLY LINE -- NORMATIVE. `fmt` never emits a line whose only
       content is ASCII spaces or tabs. Such a line is emitted EMPTY.
 
+      EXCEPT where those spaces are VERBATIM CONTENT. Inside a code block or a
+      raw block the lines are data, and a line of three spaces renders as three
+      spaces:
+
+        ```           ->  <pre><code>a
+        a                 [three spaces]
+        [3 spaces]        b
+        b                 </code></pre>
+        ```
+
+      so emptying it would change the document. The rule there applies to the
+      STRUCTURAL INDENT only: a verbatim line sitting inside a list item carries
+      the item's content-column indent, and when the verbatim content on that
+      line is EMPTY the indent alone is what remains -- that is layout, and it is
+      omitted. When the verbatim content is itself whitespace, indent and content
+      are both reproduced, and the resulting line is whitespace-only by
+      necessity.
+
       The case this decides is a blank line INSIDE a list item, where the item's
       continuation is indented. Indenting the blank line to the content column
       keeps the block structure visible in the source, and carve-rs and

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3041,9 +3041,8 @@ EOF = (* end of file *) ;
       the AST records them; changing one would satisfy §1 while still
       surprising the author.
 
-   7. NO TRAILING WHITESPACE -- NORMATIVE. `fmt` never emits a line whose only
-      content is whitespace, and never leaves whitespace at the end of a line
-      that has content.
+   7. NO WHITESPACE-ONLY LINE -- NORMATIVE. `fmt` never emits a line whose only
+      content is ASCII spaces or tabs. Such a line is emitted EMPTY.
 
       The case this decides is a blank line INSIDE a list item, where the item's
       continuation is indented. Indenting the blank line to the content column
@@ -3057,6 +3056,24 @@ EOF = (* end of file *) ;
       diff on a file nobody edited. A formatter whose output cannot survive the
       tools it will be stored under is not idempotent in practice, whatever §1
       says about it in isolation.
+
+      WHAT THIS DOES NOT SAY, and said wrongly for one release of this text: it
+      does NOT extend to whitespace at the end of a line that HAS content. That
+      whitespace can be document content, and §1 outranks tidiness:
+
+        `a` + SPACE + newline + `b`   renders  `<p>a \nb</p>`
+        `a` + newline + `b`           renders  `<p>a\nb</p>`
+
+      The space survives into the output, so stripping it breaks
+      `to_html(fmt(x)) == to_html(x)`. carve-rs already limited its stripping to
+      lines that END a block for this reason (carve#359); a writer that strips
+      before a soft break corrupts the document. Where the PARSER discards
+      trailing whitespace the writer may too, and nowhere else.
+
+      A trailing NO-BREAK space is likewise content, not layout -- the author
+      wrote it and it renders as `&nbsp;` -- so an implementation whose
+      whitespace test treats U+00A0 as whitespace must exclude it here. Corpus
+      case 139 pins that.
 
    8. THE MARKDOWN TARGET'S ESCAPING -- NORMATIVE. The Markdown renderer is not
       the canonical writer and does not follow §2. It has a different


### PR DESCRIPTION
Corrects two things I got wrong in #381, and one measurement I got wrong while checking it.

### The second clause of §7 contradicted §1

As merged, §7 said `fmt` "never leaves whitespace at the end of a line that has content". That is false. Trailing whitespace on a content line can be document content, and it survives into the output:

```
`a` + SPACE + newline + `b`   renders  <p>a \nb</p>
`a` + newline + `b`           renders  <p>a\nb</p>
```

Byte-different, so stripping it breaks `to_html(fmt(x)) == to_html(x)`. carve-rs had already worked this out and limited its stripping to block-final lines (#359) - my clause would have required undoing that fix. §7 is now about whitespace-**only** lines, which is the case #375 actually raised.

### Verbatim content is exempt

A line of three spaces inside a code block is data:

```
```              ->   <pre><code>a
a                     [three spaces]
[three spaces]        b
b                     </code></pre>
```
```

carve-js round-trips that byte-exact today, so the rule as written would have demanded breaking a case all three engines get right. Inside a verbatim block the rule reaches only the **structural indent**: a fence inside a list item carries the item's content-column indent, and where the verbatim content on a line is empty, the indent alone is layout and is omitted. Corpus case 73 is exactly that shape.

### The NBSP carve-out

A trailing no-break space is content too. Rust's `trim_end` and JS `trim()` both treat U+00A0 as whitespace, so an implementation has to exclude it or corrupt corpus case 139. Not hypothetical - that same `trim()` behavior produced three phantom invariant failures in `compare-impls`, fixed in #379.

### Corrected scope

My first sweep reported carve-js as clean. That was wrong: the regex had been mangled through shell quoting and tested for a literal `$`, so it matched nothing. Re-measured properly over all 501 corpus inputs:

| engine | whitespace-only lines |
|---|---|
| carve-js | 1 |
| carve-rs | 1 (after the fix in flight; 6 before) |
| carve-php | 23, across 18 files |

carve-js was never at zero, so the empty-line decision in #381 does not have a fully-conformant engine backing it - it stands on the tooling-stability argument alone, which I think still holds.

Engine PRs follow for all three.