### PR TITLE
spec: the Markdown target spells a hard break with a backslash

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3120,6 +3120,32 @@ EOF = (* end of file *) ;
       in the AST, not licence to skip the rule -- `escaped_text` is in the
       inline vocabulary (docs/profiles.md).
 
+   9. THE MARKDOWN TARGET'S HARD BREAK -- NORMATIVE. A `hard_break` is emitted
+      as a BACKSLASH before the newline, never as two trailing spaces.
+
+      Both spellings mean the same thing to a CommonMark reader:
+
+        `a` SPACE SPACE newline `b`   ->  <p>a<br />b</p>
+        `a` BACKSLASH newline `b`     ->  <p>a<br />b</p>
+
+      The difference is what survives handling. Trailing whitespace is removed by
+      editors that strip it on save, by `git apply --whitespace=fix`, and by CI
+      whitespace checks -- and removing ONE of the two spaces is enough:
+
+        `a` SPACE newline `b`         ->  <p>a b</p>
+
+      so the break does not degrade, it VANISHES, silently, in a file nobody
+      edited. The backslash form cannot be damaged that way, and it is the only
+      hard-break spelling this target emits that ordinary tooling will not touch.
+
+      The cost is pre-CommonMark processors, which show a literal backslash
+      instead of a break. That is a visible artifact in a rare consumer, against
+      silent data loss in a common one.
+
+      This is a property of the MARKDOWN target only. The canonical writer spells
+      a hard break the way the Carve grammar does (`hard_break`, PART 3), and
+      §7's no-whitespace-only-line rule already covers the writer's side.
+
    ============================================================================
    PART 12: AST SERIALIZATION (NORMATIVE)
    ============================================================================


### PR DESCRIPTION
Adds PART 11 §9, normative.

All three engines emit two trailing spaces for a Markdown hard break. Both spellings mean the same thing to a CommonMark reader - measured against commonmark.js, not assumed:

```
`a` SPACE SPACE newline `b`   ->  <p>a<br />b</p>
`a` BACKSLASH newline `b`     ->  <p>a<br />b</p>
```

The difference is what survives handling. Trailing whitespace is removed by editors that strip on save, by `git apply --whitespace=fix`, and by CI whitespace checks - and removing **one** of the two spaces is enough:

```
`a` SPACE newline `b`         ->  <p>a b</p>
```

So the break does not degrade, it **vanishes**, silently, in a file nobody edited.

### It bites our own output

A line block (`::: |`) converts to hard breaks - that is corpus `41-line-blocks` - so every line block we emit as Markdown carried the fragile spelling.

### Cost

Pre-CommonMark processors show a literal backslash instead of a break. A visible artifact in a rare consumer, against silent data loss in a common one.

### Why a new section

It is not an escaping rule, so folding it into §8 would misfile it. It is normative so the three engines stay converged - this was a case where all three agreed *and* all three were fragile, which no cross-engine comparison could have surfaced.

Engine PRs follow in carve-js, carve-rs and carve-php.
