### PR TITLE
spec: the AST records the authored bold-italic spelling

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3041,6 +3041,23 @@ EOF = (* end of file *) ;
       the AST records them; changing one would satisfy §1 while still
       surprising the author.
 
+      NESTED BOLD ITALIC joins that list, and needed the AST to catch up before
+      it could. `/*x*/` is a single production (`bold_italic`, PART 3) while
+      `*/x/*` is ordinary nesting, and BOTH yield the same `strong` wrapping
+      `emphasis`. So §1 held for either spelling and nothing pinned which one to
+      emit: carve-rs reproduced the author's, carve-js and carve-php normalized
+      to `*/x/*` (carve#375).
+
+      The AST therefore RECORDS the combined form -- a `strong` parsed from
+      `bold_italic` carries `boldItalic` (PART 12 §3) -- and the writer
+      reproduces it. Without that mark the rule could not be stated as an
+      author's choice at all, because there would be nothing to preserve.
+
+      `/*x*/` is also the spelling Carve teaches (docs/cheatsheet.md,
+      docs/migrate-from-markdown.md), so normalizing it away rewrote the
+      documented form into one documented nowhere. That is the concrete harm
+      behind the general rule.
+
    7. NO WHITESPACE-ONLY LINE -- NORMATIVE. `fmt` never emits a line whose only
       content is ASCII spaces or tabs. Such a line is emitted EMPTY.
 
@@ -3176,7 +3193,11 @@ EOF = (* end of file *) ;
         code       `value`
         text       `value`
         heading    `level`, `children`
-        list       `ordered`, `tight`, `start`, `items`
+        list       `ordered`, `tight`, `start`, `items`, and the AUTHOR-CHOICE
+                   fields `bulletChar` and `delim` (PART 11 §6) when the author's
+                   spelling is not the default
+        strong     `children`, and `boldItalic` when the author wrote the
+                   combined `/*…*/` form rather than nesting `*` around `/`
       An implementation MUST NOT invent a synonym, and MUST NOT expose an
       internal field the reference does not have. A consumer reading `href`
       must not have to know which engine produced the document.


### PR DESCRIPTION
Settles the nested-emphasis half of #375, the part left open by #381.

`/*x*/` is a single production (`bold_italic`, PART 3) while `*/x/*` is ordinary nesting, and **both** yield the same `strong` wrapping `emphasis`. So §1 held for either spelling and nothing pinned which one the writer should emit: carve-rs reproduced the author's, carve-js and carve-php normalized to `*/x/*`.

### Why §6 could not already cover it

§6 lists the respellings `fmt` must not perform - bullet characters, fence length, ordered-list dialect - and justifies each on the grounds that *"the AST records them"*. This one it did not record, which is precisely why the rule could not be stated for it.

So the AST records it: a `strong` parsed from `bold_italic` carries `boldItalic`, and the writer reproduces the authored form.

### The concrete harm

`/*x*/` is the spelling Carve **teaches** - `docs/cheatsheet.md`, `docs/index.md`, and `docs/migrate-from-markdown.md` as the replacement for Markdown's `***both***`. `*/x/*` is documented nowhere. Two engines were rewriting the documented form into an undocumented one.

### PART 12 also gains `bulletChar` and `delim`

Both were already in the reference interface but never written down here, which left a consumer needing source fidelity to discover them by reading an engine. Field names are spec surface by §3's own rule, so that was a gap in this document rather than in the engines.

### Considered and rejected

A separate `bold_italic` node type. It would need a `profiles.md` vocabulary entry and would let a profile deny the combined spelling while allowing the nested one - not a trust distinction, since the two are the same document.

Engine PRs follow in all three.
