### PR TITLE
spec: the URL denylist covers every target that emits a resolvable URL

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2621,6 +2621,22 @@ EOF = (* end of file *) ;
         whitespace"). A `data:` exception for images, if offered, MUST be
         opt-in. An attribute-block `href`/`src` override (PART 4) MUST NOT
         reintroduce a rejected scheme.
+
+        THIS APPLIES TO EVERY TARGET THAT EMITS A RESOLVABLE URL, not only to
+        the HTML renderer. A Markdown target's link and image destinations are
+        resolved by whatever renders that Markdown, so a scheme blanked here
+        and passed through there is not blocked -- it is deferred by one step.
+        Measured before this was written down: all three engines blanked
+        `ms-msdt:` in HTML and emitted it verbatim in Markdown, because each
+        had mirrored the four-scheme core of the denylist into that target and
+        not the OS-handler class. One also failed to strip Unicode whitespace
+        in the Markdown probe, so `<U+202F>javascript:` survived there while
+        being blanked in its own HTML output (carve#352, corpus 119).
+
+        The rule was scoped to "an HTML renderer" because that is where the
+        sink was first identified; the scoping was not a decision that other
+        targets are safe. A target that emits no URL, such as plain text, has
+        nothing to blank and is unaffected.
       - ATTRIBUTE NAME/VALUE HARDENING. On EVERY rendered element -- including
         elements emitted by extensions -- an HTML renderer MUST drop
         attributes whose name begins with `on` (case-insensitive) and the


### PR DESCRIPTION
Security-relevant. Extends PART 9 §25.

The dangerous-scheme rule was scoped to *"an HTML renderer"*. But a Markdown target's link and image destinations are resolved by whatever renders that Markdown, so a scheme blanked in HTML and passed through in Markdown is not blocked - it is **deferred by one step**.

### Measured across all three engines

```
ms-msdt:/id PCWDiagnostic     html: href=""     markdown: emitted verbatim
<U+202F>javascript:alert(1)   html: href=""     markdown: emitted verbatim (carve-php only)
```

Each engine had mirrored the **four-scheme core** of the denylist into its Markdown target and not the OS protocol-handler class - so `ms-msdt` (Follina class), `search-ms`, `jar`, `vscode` and the rest survive a Carve → Markdown → HTML round trip in **every** implementation.

carve-php additionally probed with an ASCII-only whitespace strip there, so an obfuscated `<U+202F>javascript:` passed its Markdown target while being blanked by its own HTML renderer.

### Nothing was violating the spec, and that is the point

The rule named one renderer, so a partial mirror into another target was not a conformance failure, and no cross-engine check could report it - all three engines agreed with each other while all three were wrong. Corpus 119 pins the U+202F case for HTML and was silent about Markdown.

The original scoping recorded where the sink was first identified; it was not a finding that other targets are safe. A target that emits no URL - plain text - has nothing to blank and is unaffected.

Engine PRs follow in all three: apply the full denylist in the Markdown target, and fix the php probe to strip Unicode whitespace there as its HTML renderer already does.
