### PR TITLE
docs: connect the release policy to the document-compatibility contract

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -8,6 +8,26 @@ All Carve repositories use [Semantic Versioning](https://semver.org/) (`MAJOR.MI
 introduce breaking changes to grammar, output, or the extension API. Patch
 releases fix bugs without changing behavior.
 
+## Stored documents
+
+This file is about **repository and release** versioning. The companion question -
+what a spec change means for `.crv` files that already exist - is answered by the
+[versioning and changelog page](docs/versioning.md), which is the source of truth
+for "did the language change in a way that affects my documents?".
+
+The short version: every changelog entry is tagged `[behavior]`,
+`[clarification]` or `[addition]`, and only `[behavior]` entries can require
+document migration. A document records the spec version it was last processed
+under via `carve fmt --stamp`, so upgrading means reviewing the `[behavior]`
+entries between that stamp and the target version.
+
+Tooling can read the marker back: `Stamp::read()` and `Stamp::needsReview()` in
+carve-php, plus `carve --stamp-check`, which exits non-zero for a document that
+predates the engine's spec version - usable as a CI gate over a directory of
+stored documents. (Landing in
+[carve-php#473](https://github.com/markup-carve/carve-php/pull/473); carve-js
+still writes the marker without a reader.)
+
 ## Stability scope (0.1)
 
 What the 0.1 release guarantees, by tier (the line is drawn at the

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -24,9 +24,9 @@ entries between that stamp and the target version.
 Tooling can read the marker back: `Stamp::read()` and `Stamp::needsReview()` in
 carve-php, plus `carve --stamp-check`, which exits non-zero for a document that
 predates the engine's spec version - usable as a CI gate over a directory of
-stored documents. (Landing in
-[carve-php#473](https://github.com/markup-carve/carve-php/pull/473); carve-js
-still writes the marker without a reader.)
+stored documents ([carve-php#473](https://github.com/markup-carve/carve-php/pull/473)).
+carve-js writes the marker but has no reader yet, so the mechanical check is
+carve-php only today.
 
 ## Stability scope (0.1)
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -40,6 +40,33 @@ When upgrading a document across spec versions, you only need to act on
 **`[behavior]`** entries between the document's stamped `carve-version` and the
 target version.
 
+### Checking documents mechanically
+
+The marker is machine-readable, so this does not have to be done by eye. In
+carve-php:
+
+```php
+use MarkupCarve\Carve\Stamp;
+
+Stamp::read($source);        // ['version' => '0.1', 'generatedBy' => 'carve-php 0.1.0'] or null
+Stamp::needsReview($source); // true when the document predates the engine's spec version
+```
+
+and from the CLI, for a repository of stored documents:
+
+```bash
+carve --stamp-info doc.crv    # report the version and the writer
+carve --stamp-check doc.crv   # exit 1 when the document predates this spec version
+```
+
+An **unstamped** document counts as needing review: its provenance is unknown,
+and assuming it is current is the unsafe direction. Hand-written documents are
+unstamped until `carve fmt --stamp` touches them.
+
+The reader is landing in
+[carve-php#473](https://github.com/markup-carve/carve-php/pull/473). carve-js
+writes the marker today but has no reader yet.
+
 ## Changelog
 
 ### 0.1

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -63,9 +63,10 @@ An **unstamped** document counts as needing review: its provenance is unknown,
 and assuming it is current is the unsafe direction. Hand-written documents are
 unstamped until `carve fmt --stamp` touches them.
 
-The reader is landing in
+The reader shipped in
 [carve-php#473](https://github.com/markup-carve/carve-php/pull/473). carve-js
-writes the marker today but has no reader yet.
+writes the marker today but has no reader yet, so the mechanical check is
+carve-php only.
 
 ## Changelog
 


### PR DESCRIPTION
P0.2 from #386, and the discovery was that the policy already exists - it is just hard to find from where people look.

## The problem

Two documents, neither pointing at the other:

- `VERSIONING.md` - repository and release versioning: semver, tier stability scope, core lockstep, satellites.
- `docs/versioning.md` - the document-compatibility contract: change categories (`[behavior]`, `[clarification]`, `[addition]`), what each means for existing files, and the upgrade procedure via the provenance marker.

Evaluating Carve for an application that would store `.crv` content, I read `VERSIONING.md`, concluded there was no statement about what happens to documents already written, and wrote that up as a gap. The contract was in the other file the whole time. That is a discoverability bug in exactly the place where being wrong is expensive - it is the same failure mode as the safe-mode confusion behind markup-carve/carve-php#464.

## Changes

- `VERSIONING.md` gains a **Stored documents** section: points at the companion page as the source of truth, summarizes the procedure in three sentences (only `[behavior]` entries can require migration; the stamp records where a document stands; review the entries between stamp and target).
- `docs/versioning.md` gains **Checking documents mechanically**: the marker is machine-readable, so the procedure should not have to be done by eye. Shows `Stamp::read()` / `Stamp::needsReview()` and the `--stamp-info` / `--stamp-check` CLI modes, and states that an unstamped document counts as needing review because unknown provenance is the unsafe direction.

Both note honestly that the reader is still landing (markup-carve/carve-php#473) and that carve-js writes the marker without a reader today.

No policy is changed here - only stated where people will find it.
