### PR TITLE
docs: which implementations can read the stamp, and which cannot

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -21,12 +21,16 @@ document migration. A document records the spec version it was last processed
 under via `carve fmt --stamp`, so upgrading means reviewing the `[behavior]`
 entries between that stamp and the target version.
 
-Tooling can read the marker back: `Stamp::read()` and `Stamp::needsReview()` in
-carve-php, plus `carve --stamp-check`, which exits non-zero for a document that
-predates the engine's spec version - usable as a CI gate over a directory of
-stored documents ([carve-php#473](https://github.com/markup-carve/carve-php/pull/473)).
-carve-js writes the marker but has no reader yet, so the mechanical check is
-carve-php only today.
+Tooling can read the marker back. `carve --stamp-check` exits non-zero for a
+document that predates the engine's spec version, so it works as a CI gate over a
+directory of stored documents, and the programmatic pair is `Stamp::read()` /
+`Stamp::needsReview()` in carve-php and `readStamp()` / `needsReview()` in
+carve-js. Both engines emit the same output for the same document, so either can
+check what the other wrote.
+
+Reading is not universal yet: carve-rs writes the marker but has no reader, and
+the Go, Ruby and Python bindings inherit that because they drive carve-rs. The
+[versioning page](docs/versioning.md) carries the per-implementation table.
 
 ## Stability scope (0.1)
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -63,10 +63,28 @@ An **unstamped** document counts as needing review: its provenance is unknown,
 and assuming it is current is the unsafe direction. Hand-written documents are
 unstamped until `carve fmt --stamp` touches them.
 
-The reader shipped in
-[carve-php#473](https://github.com/markup-carve/carve-php/pull/473). carve-js
-writes the marker today but has no reader yet, so the mechanical check is
-carve-php only.
+### Which implementations can read it
+
+Writing the marker is universal; reading it back is not yet. The mechanical check
+above works in carve-php ([#473](https://github.com/markup-carve/carve-php/pull/473))
+and carve-js ([#436](https://github.com/markup-carve/carve-js/pull/436)), which
+expose the same two CLI flags and the same output, so either can check a document
+the other wrote.
+
+| implementation | writes | reads |
+|---|---|---|
+| carve-php | yes | yes - `Stamp::read` / `Stamp::needsReview`, `--stamp-info` / `--stamp-check` |
+| carve-js | yes | yes - `readStamp` / `needsReview`, same two flags |
+| carve-rs | yes (`--stamp`, `--stamp-block`) | not yet |
+| carve-go, carve-rb, carve-py | via the engine | not yet - they wrap carve-rs |
+
+carve-rs is the one that matters most for coverage: the Go, Ruby and Python
+bindings all drive it, so a reader there reaches four implementations at once.
+
+The marker format is the contract, not any one API, so a document stamped by any
+engine is readable by any engine that has a reader. That was verified across
+carve-php and carve-js in both directions, in both the line and block forms, and
+carve-js pins carve-php's exact bytes as test fixtures.
 
 ## Changelog
 


### PR DESCRIPTION
Both pages said carve-js writes the marker but cannot read it. carve-js#436 landed a reader, so that was stale in one direction - and incomplete in the other, because naming carve-php as the only reader left out that carve-rs has none either, and that carve-go / carve-rb / carve-py inherit the gap because they drive carve-rs.

Checked, not assumed:

| implementation | writes | reads |
|---|---|---|
| carve-php | yes | `Stamp::read` / `Stamp::needsReview`, `--stamp-info` / `--stamp-check` |
| carve-js | yes | `readStamp` / `needsReview`, same two flags, same output |
| carve-rs | `--stamp`, `--stamp-block` | no reader |
| carve-go, carve-rb, carve-py | via the engine | none - no stamp surface at all |

carve-rs is named as the highest-leverage gap: the Go, Ruby and Python bindings all drive it, so one reader there reaches four implementations.

The pages also now state the thing that makes the marker worth having - the format is the contract, not any one API, so a document stamped by one engine is readable by any engine that has a reader. That was verified across carve-php and carve-js in both directions and in both marker forms, and carve-js pins carve-php's exact bytes as fixtures.