### PR TITLE
test(ast): check carve-php's serializer instead of excusing it

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -21,12 +21,16 @@ document migration. A document records the spec version it was last processed
 under via `carve fmt --stamp`, so upgrading means reviewing the `[behavior]`
 entries between that stamp and the target version.
 
-Tooling can read the marker back: `Stamp::read()` and `Stamp::needsReview()` in
-carve-php, plus `carve --stamp-check`, which exits non-zero for a document that
-predates the engine's spec version - usable as a CI gate over a directory of
-stored documents ([carve-php#473](https://github.com/markup-carve/carve-php/pull/473)).
-carve-js writes the marker but has no reader yet, so the mechanical check is
-carve-php only today.
+Tooling can read the marker back. `carve --stamp-check` exits non-zero for a
+document that predates the engine's spec version, so it works as a CI gate over a
+directory of stored documents, and the programmatic pair is `Stamp::read()` /
+`Stamp::needsReview()` in carve-php and `readStamp()` / `needsReview()` in
+carve-js. Both engines emit the same output for the same document, so either can
+check what the other wrote.
+
+Reading is not universal yet: carve-rs writes the marker but has no reader, and
+the Go, Ruby and Python bindings inherit that because they drive carve-rs. The
+[versioning page](docs/versioning.md) carries the per-implementation table.
 
 ## Stability scope (0.1)
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -63,10 +63,28 @@ An **unstamped** document counts as needing review: its provenance is unknown,
 and assuming it is current is the unsafe direction. Hand-written documents are
 unstamped until `carve fmt --stamp` touches them.
 
-The reader shipped in
-[carve-php#473](https://github.com/markup-carve/carve-php/pull/473). carve-js
-writes the marker today but has no reader yet, so the mechanical check is
-carve-php only.
+### Which implementations can read it
+
+Writing the marker is universal; reading it back is not yet. The mechanical check
+above works in carve-php ([#473](https://github.com/markup-carve/carve-php/pull/473))
+and carve-js ([#436](https://github.com/markup-carve/carve-js/pull/436)), which
+expose the same two CLI flags and the same output, so either can check a document
+the other wrote.
+
+| implementation | writes | reads |
+|---|---|---|
+| carve-php | yes | yes - `Stamp::read` / `Stamp::needsReview`, `--stamp-info` / `--stamp-check` |
+| carve-js | yes | yes - `readStamp` / `needsReview`, same two flags |
+| carve-rs | yes (`--stamp`, `--stamp-block`) | not yet |
+| carve-go, carve-rb, carve-py | via the engine | not yet - they wrap carve-rs |
+
+carve-rs is the one that matters most for coverage: the Go, Ruby and Python
+bindings all drive it, so a reader there reaches four implementations at once.
+
+The marker format is the contract, not any one API, so a document stamped by any
+engine is readable by any engine that has a reader. That was verified across
+carve-php and carve-js in both directions, in both the line and block forms, and
+carve-js pins carve-php's exact bytes as test fixtures.
 
 ## Changelog
 

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -17,8 +17,7 @@
  * Sibling checkouts, same convention as compare-impls.mjs:
  *   ../carve-js   (reference, required)
  *   ../carve-rb   (serializes carve-rs's tree through the Ruby binding)
- *   carve-php has no serializer yet and is reported as unsupported, not skipped
- *   silently.
+ *   carve-php  (serializes through `bin/carve --json`)
  */
 
 import { execFileSync } from 'node:child_process'
@@ -186,9 +185,45 @@ if (existsSync(resolve(rbDir, 'lib/carve'))) {
   console.log('carve-rb: checkout not found, not checked\n')
 }
 
-// ---- carve-php: no serializer ----------------------------------------------
-if (existsSync(phpDir)) {
-  console.log('carve-php: NO SERIALIZER - cannot be checked for conformance yet (PART 12 §4)\n')
+// ---- carve-php: serializes through bin/carve --json -------------------------
+//
+// This branch used to print "NO SERIALIZER - cannot be checked", which stopped
+// being true when carve-php shipped AstCodec and `--json`. A checker that
+// excuses an implementation it could actually check is worse than no checker:
+// it reports conformance work as pending while a non-conformant serializer is
+// already in use.
+if (existsSync(resolve(phpDir, 'bin/carve'))) {
+  const phpFindings = []
+  for (const { name, source } of samples.slice(0, 12)) {
+    let doc
+    try {
+      const out = execFileSync('php', ['bin/carve', '--json'], {
+        cwd: phpDir,
+        input: source,
+        encoding: 'utf8',
+        env: { ...process.env },
+      })
+      doc = JSON.parse(out)
+    } catch (error) {
+      phpFindings.push(`${name}: could not serialize - ${String(error.message).split('\n')[0]}`)
+      continue
+    }
+    if (phpFindings.length < 20) checkDocument(doc, source, phpFindings)
+    for (const [type, keysets] of shapeOf(doc)) {
+      const reference = referenceShape.get(type)
+      if (!reference) continue
+      for (const keys of keysets) {
+        if (!reference.has(keys)) {
+          phpFindings.push(`${name}: "${type}" fields [${keys}] not in the reference shape`)
+        }
+      }
+    }
+  }
+  report('carve-php (over bin/carve --json)', phpFindings)
+} else if (existsSync(phpDir)) {
+  console.log('carve-php: checkout found but bin/carve is missing, not checked\n')
+} else {
+  console.log('carve-php: checkout not found, not checked\n')
 }
 
 function report(label, findings) {


### PR DESCRIPTION
Part of markup-carve/carve#386 P0.1, and a dead check in the meantime.

`scripts/ast-conformance.mjs` printed:

```
carve-php: NO SERIALIZER - cannot be checked for conformance yet (PART 12 §4)
```

That stopped being true when carve-php shipped `AstCodec` and `bin/carve --json`. So the checker was reporting conformance work as *pending* while a non-conformant serializer was already in use - the worst of both outcomes, since catching exactly this is the script's only job.

Wired to `php bin/carve --json` on stdin, the same way carve-rb is driven through its binding, it reports **48 findings over 12 documents, 8 distinct**:

```
17x missing pos on "text"
12x "document" fields [ast,children,sourceLength,type] not in the reference shape
12x "text" fields [content,type] not in the reference shape
 3x missing pos on "paragraph"
 1x missing pos on "strong" / "underline" / "emphasis"
 1x "escaped_text" fields [content,type] not in the reference shape
```

Which is precisely the divergence PART 12 was written to describe: field names are spec surface, and the reference calls a text node's payload `value`, not `content`. Positions are the other half, and PART 12 §4 already anticipated carve-php having none on its nodes.

### What this does not change

The script still exits 0 on findings and is still not wired into CI, so no build outcome changes.

Whether it *should* gate is a decision I'm not making here. Turning it red today blocks on 48 carve-php findings, 45 carve-rb findings, and **2 in carve-js itself** - a missing `pos` on `emphasis`, and an `unknown node type "tag"` the checker doesn't know about. The reference implementation not being clean is its own finding.
