### PR TITLE
docs: carve-rs reads the stamp now, so the table moves

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -23,14 +23,14 @@ entries between that stamp and the target version.
 
 Tooling can read the marker back. `carve --stamp-check` exits non-zero for a
 document that predates the engine's spec version, so it works as a CI gate over a
-directory of stored documents, and the programmatic pair is `Stamp::read()` /
-`Stamp::needsReview()` in carve-php and `readStamp()` / `needsReview()` in
-carve-js. Both engines emit the same output for the same document, so either can
-check what the other wrote.
+directory of stored documents. All three engines implement it - `Stamp::read()` /
+`Stamp::needsReview()` in carve-php, `readStamp()` / `needsReview()` in carve-js,
+`read_stamp()` / `needs_review()` in carve-rs - behind the same two flags with the
+same output, so any of them can check what another wrote.
 
-Reading is not universal yet: carve-rs writes the marker but has no reader, and
-the Go, Ruby and Python bindings inherit that because they drive carve-rs. The
-[versioning page](docs/versioning.md) carries the per-implementation table.
+Reading is not universal yet: the Go, Ruby and Python bindings drive carve-rs but
+none of them surfaces the reader. The [versioning page](docs/versioning.md)
+carries the per-implementation table.
 
 ## Stability scope (0.1)
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -66,24 +66,29 @@ unstamped until `carve fmt --stamp` touches them.
 ### Which implementations can read it
 
 Writing the marker is universal; reading it back is not yet. The mechanical check
-above works in carve-php ([#473](https://github.com/markup-carve/carve-php/pull/473))
-and carve-js ([#436](https://github.com/markup-carve/carve-js/pull/436)), which
-expose the same two CLI flags and the same output, so either can check a document
-the other wrote.
+above works in carve-php ([#473](https://github.com/markup-carve/carve-php/pull/473)),
+carve-js ([#436](https://github.com/markup-carve/carve-js/pull/436)) and carve-rs
+([#329](https://github.com/markup-carve/carve-rs/pull/329)), which expose the same
+two CLI flags and the same output, so any of them can check a document another
+wrote.
 
 | implementation | writes | reads |
 |---|---|---|
 | carve-php | yes | yes - `Stamp::read` / `Stamp::needsReview`, `--stamp-info` / `--stamp-check` |
 | carve-js | yes | yes - `readStamp` / `needsReview`, same two flags |
-| carve-rs | yes (`--stamp`, `--stamp-block`) | not yet |
-| carve-go, carve-rb, carve-py | via the engine | not yet - they wrap carve-rs |
+| carve-rs | yes (`--stamp`, `--stamp-block`) | yes - `read_stamp` / `needs_review`, same two flags |
+| carve-go, carve-rb, carve-py | via the engine | not yet - the engine can, but none of them exposes it |
 
-carve-rs is the one that matters most for coverage: the Go, Ruby and Python
-bindings all drive it, so a reader there reaches four implementations at once.
+The three bindings drive carve-rs, so the capability is now one step away rather
+than absent: carve-go passes CLI flags to an embedded wasm engine and needs that
+artifact rebuilt past carve-rs#329 plus the flags surfaced on `Options`;
+carve-rb and carve-py link the crate and need `read_stamp` exposed through their
+bindings.
 
 The marker format is the contract, not any one API, so a document stamped by any
 engine is readable by any engine that has a reader. That was verified across
-carve-php and carve-js in both directions, in both the line and block forms, and
+carve-php, carve-js and carve-rs in all six directions, in both the line and
+block forms, and
 carve-js pins carve-php's exact bytes as test fixtures.
 
 ## Changelog


### PR DESCRIPTION
carve-rs#329 landed the reader that #391 had named as the highest-leverage gap, so the per-implementation table was stale within the hour.

All three engines now expose `--stamp-info` / `--stamp-check` with identical output, and the cross-engine claim is no longer two-way - verified in all six directions across carve-php, carve-js and carve-rs, in both the line and block marker forms.

| implementation | writes | reads |
|---|---|---|
| carve-php | yes | `Stamp::read` / `Stamp::needsReview` |
| carve-js | yes | `readStamp` / `needsReview` |
| carve-rs | yes | `read_stamp` / `needs_review` |
| carve-go, carve-rb, carve-py | via the engine | not yet |

The bindings are the remaining gap, and the page now says what each one actually needs rather than listing them as "not yet": carve-go passes CLI flags to an embedded wasm engine, so it needs that artifact rebuilt past carve-rs#329 plus the flags on `Options`; carve-rb and carve-py link the crate and need `read_stamp` exposed.

`VERSIONING.md` also ended up saying the same thing twice after the last update - one paragraph covering two engines and another adding the third. Now one.