### PR TITLE
docs: the carve-version-unsupported rule, and the authored version key

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -92,6 +92,31 @@ the command-line and editor behavior stay aligned.
 | `raw-block-syntax` | a legacy `` ```raw FORMAT `` fence; Carve raw blocks use `` ```=FORMAT `` |
 | `block-marker-as-text` | a line that opens like a block (`:::`, `{#`, `{.`) but parsed as plain text |
 | `fence-delimiter-indentation` | an indented fenced-code delimiter (`` ``` `` / `~~~`); a Carve fence is column-exact and must sit at its container's content column (column 0 at the top level), so an indented run does not open a code block |
+| `carve-version-unsupported` | a document declaring a Carve spec version the processor does not implement, so constructs added after that version render as something else without any error |
+
+### Declaring a target version
+
+`carve-version-unsupported` is the one rule that reads a declaration rather than
+inspecting a construct. A document may state which Carve version it targets in
+frontmatter:
+
+```
+---
+carve-version: 0.1
+---
+```
+
+The key is optional, and its absence is never a diagnostic. Frontmatter is raw
+uninterpreted text to a Carve processor, so a linter reads this key without
+implying that the declared frontmatter format is parsed.
+
+A document with no frontmatter key falls back to the trailing `%% carve-version:`
+provenance marker that `carve fmt --stamp` writes, so a stamped document is
+covered without the author writing anything. When both are present the
+frontmatter declaration wins: the two answer different questions - what the
+document targets, versus what last processed it - and the rule is about intent.
+See [versioning](./versioning) for what a version difference means for a stored
+document.
 
 The CLI also reports Djot/Markdown delimiter collisions from the migration
 checker — mis-rendering constructs by default, plus the Djot semantic shifts

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -40,6 +40,25 @@ When upgrading a document across spec versions, you only need to act on
 **`[behavior]`** entries between the document's stamped `carve-version` and the
 target version.
 
+### Declaring a target version
+
+The marker above is written by tooling. An author who wants to state which
+version a document targets does it in frontmatter:
+
+```
+---
+carve-version: 0.1
+---
+```
+
+The key is optional. `carve lint` reads it and reports
+[`carve-version-unsupported`](./validation#declaring-a-target-version) when a
+document targets a version the processor does not implement, which is otherwise a
+silent degradation: the constructs the author relied on parse as something else
+and nothing says so. The two fields do not compete - the frontmatter key is the
+author's intent, the trailing marker is what last processed the file - and a
+document carrying only the marker is still checked.
+
 ### Checking documents mechanically
 
 The marker is machine-readable, so this does not have to be done by eye. In


### PR DESCRIPTION
The spec-side half of #268. carve-js implements the rule in carve-js#443.

`docs/validation.md` gains the rule in the table, plus a short section on the one thing that makes it unlike every other rule: it reads a **declaration** rather than inspecting a construct.

`docs/versioning.md` gains the authored `carve-version:` frontmatter key next to the provenance marker, since #268 asked for both to be documented together.

Two points the table alone would not carry:

- **Frontmatter stays raw.** It is uninterpreted text to a Carve processor, so a linter reads `carve-version:` out of it without implying the declared frontmatter format is parsed. Nothing about the format changes.
- **The key and the marker do not compete.** One is the author's intent, the other is what last processed the file. A document carrying only the marker is still checked, and the frontmatter declaration wins when both exist.

carve-rs and carve-php still need the rule for the lockstep #268 asks for.