### PR TITLE
docs: say which implementations provide the lint rules

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -118,6 +118,23 @@ document targets, versus what last processed it - and the rule is about intent.
 See [versioning](./versioning) for what a version difference means for a stored
 document.
 
+### Which implementations provide these rules
+
+The table above is carve-js. The other engines do not currently match it, and
+`carve lint` is not the same command everywhere:
+
+| implementation | `carve lint` | covers |
+|---|---|---|
+| carve-js | yes | the rules above, plus the Djot/Markdown migration checks |
+| carve-php | yes | Markdown-habit checks only (`markdown-strong-asterisks`, `markdown-strong-underscores`, `markdown-strikethrough`, `heading-lazy-continuation`); none of the semantic rules above |
+| carve-rs | no | the binary has no `lint` command |
+
+Rule ids do not currently line up either: carve-php and carve-js both flag
+`**bold**` and `~~strike~~`, under different names. So a CI filter or an editor
+suppression keyed on a rule id is engine-specific today. Tracked in
+[carve#268](https://github.com/markup-carve/carve/issues/268), which is where the
+question of whether a rule id is contract belongs.
+
 The CLI also reports Djot/Markdown delimiter collisions from the migration
 checker — mis-rendering constructs by default, plus the Djot semantic shifts
 under `--from-djot` — so `carve lint` is the broadest single validation


### PR DESCRIPTION
The rule table is carve-js's. The page said so about the **command** ("use the `carve lint` command from the TypeScript implementation") while the table itself read as if it described Carve tooling generally.

It does not, and the gap is not theoretical - measured by running one document through all three engines:

```
$ carve lint doc.crv          # doc contains </#missing>
carve-js   3:5 broken-crossref — ...              exit 1
carve-php  (no output)                            exit 0
carve-rs   carve: multiple input files specified    # no lint command
```

carve-php ships a `carve lint` command that reports **none** of these rules, which is worse than not having one: the name promises something the output does not deliver.

Rule ids do not line up either. Both engines flag `**bold**` and `~~strike~~` - agreeing on the finding, disagreeing on every identifier:

| carve-php | carve-js |
|---|---|
| `markdown-strong-asterisks` | `markdown-strong-double-star` |
| `markdown-strikethrough` | `markdown-strikethrough-double-tilde` |

The intersection of the two vocabularies is empty, so a CI filter or editor suppression keyed on a rule id is engine-specific today.

Whether a rule id is *contract* is the open question in #268 and stays there - this only stops the page from implying an answer it does not have. Full measurement is on that issue.