### PR TITLE
spec: PART 12 §4 counts codepoints, and the checker can now tell

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3262,8 +3262,29 @@ EOF = (* end of file *) ;
         {"startLine":1,"endLine":1,"startColumn":2,"endColumn":5,
          "startOffset":1,"endOffset":4}
 
-      Lines and columns are 1-based; offsets are 0-based byte offsets into the
-      source. `endColumn` and `endOffset` are exclusive.
+      Lines are 1-based. Columns are 1-based and offsets 0-based, both counted
+      in UNICODE CODEPOINTS. `endColumn` and `endOffset` are exclusive.
+
+      The unit is stated because there is no convention to inherit: every
+      implementation otherwise reports whatever its own strings are indexed by,
+      and the differences are invisible on ASCII. Measured on `\u{1F600} *b*`,
+      where the delimiter sits at codepoint 2, UTF-16 unit 3 and byte 5:
+      djot.js and commonmark.js report 3, carve-js reported 3, and a byte-indexed
+      engine would report 5 -- three implementations, three answers, all
+      believing they were right.
+
+      Codepoints rather than bytes or UTF-16 code units because a codepoint index
+      always lands on a CHARACTER BOUNDARY. A byte offset can point inside a
+      UTF-8 sequence and a UTF-16 offset inside a surrogate pair; either lets a
+      consumer slice a document into invalid text. This also follows djot's
+      reference implementation, which builds a byte-to-charpos table specifically
+      so it can report characters from a byte-indexed language -- the format's
+      author paid that conversion deliberately rather than exporting the host's
+      unit.
+
+      Every implementation therefore converts, and each pays it once per document
+      rather than per position: the mapping is a single pass, and it is the
+      identity for any document without an astral character.
 
       The document root is exempt because it spans the whole source by
       definition, so a span on it carries no information a consumer does not

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -71,6 +71,9 @@ function* walk(node, path = '$') {
 }
 
 function checkDocument(doc, source, findings) {
+  // Offsets are codepoint indices (PART 12 §4), so the source has to be indexed
+  // the same way to check them.
+  const codepoints = [...source]
   for (const [node, path] of walk(doc)) {
     if (!KNOWN_TYPES.has(node.type)) {
       findings.push(`unknown node type "${node.type}" at ${path}`)
@@ -91,8 +94,22 @@ function checkDocument(doc, source, findings) {
       if (pos.endOffset < pos.startOffset) {
         findings.push(`pos.endOffset < startOffset on "${node.type}" at ${path}`)
       }
-      if (pos.endOffset > source.length) {
+      if (pos.endOffset > codepoints.length) {
         findings.push(`pos.endOffset past end of source on "${node.type}" at ${path}`)
+      }
+      // THE UNIT, checked rather than assumed. PART 12 §4 counts codepoints, and
+      // codepoints, UTF-16 units and bytes all agree on ASCII - so nothing here
+      // distinguished them until this compared a span against the text it
+      // claims to cover. A text node is the only node whose exact source text is
+      // known from the AST alone.
+      if (node.type === 'text' && typeof node.value === 'string') {
+        const slice = codepoints.slice(pos.startOffset, pos.endOffset).join('')
+        if (slice !== node.value) {
+          findings.push(
+            `pos does not cover the text it belongs to on "${node.type}" at ${path}: ` +
+              `offsets give ${JSON.stringify(slice)}, node says ${JSON.stringify(node.value)}`,
+          )
+        }
       }
     }
     if (pos.startLine < 1 || pos.startColumn < 1) {
@@ -113,11 +130,30 @@ function shapeOf(doc) {
 }
 
 const corpusDir = resolve(root, 'tests/corpus')
-const samples = readdirSync(corpusDir)
-  .filter((f) => f.endsWith('.crv'))
-  .sort()
-  .slice(0, limit)
-  .map((f) => ({ name: f, source: readFileSync(resolve(corpusDir, f), 'utf8') }))
+
+/**
+ * Synthetic samples carrying ASTRAL characters, because no corpus case does.
+ *
+ * Codepoints, UTF-16 code units and bytes agree on ASCII, and codepoints and
+ * UTF-16 agree across the whole Basic Multilingual Plane - so a document needs a
+ * SURROGATE PAIR before the position unit PART 12 §4 pins is observable at all.
+ * Without these the unit check above would pass for an engine reporting UTF-16,
+ * which is exactly the kind of check that cannot fail.
+ */
+const ASTRAL_SAMPLES = [
+  { name: '<astral: emphasis after an emoji>', source: '\u{1F600} plain *bold* tail\n' },
+  { name: '<astral: inside a blockquote>', source: '# H\n\n> \u{1F600} quoted *b*\n' },
+  { name: '<astral: across two lines>', source: '\u{1F600} one\n\u{1F600}\u{1F600} two\n' },
+]
+
+const samples = [
+  ...ASTRAL_SAMPLES,
+  ...readdirSync(corpusDir)
+    .filter((f) => f.endsWith('.crv'))
+    .sort()
+    .slice(0, limit)
+    .map((f) => ({ name: f, source: readFileSync(resolve(corpusDir, f), 'utf8') })),
+]
 
 console.log(`PART 12 conformance over ${samples.length} corpus documents\n`)
 


### PR DESCRIPTION
Closes #394.

§4 said *"offsets are 0-based byte offsets into the source"* and left the unit for **columns** unstated entirely. Both are now codepoints, and stated.

### Bytes came from an assumption, which I then checked

I had measured djot.js and commonmark.js - both JavaScript, both UTF-16 - and assumed byte-indexed implementations report bytes. **djot.lua does the opposite:**

```lua
-- sourcepos_map[bytepos] = "line:column:charpos"
return string.format("%d:%d:%d", sourceposmap.line[bytepos],
        sourceposmap.col[bytepos], sourceposmap.charpos[bytepos])
```

A language whose strings *are* bytes, and the format's author built a conversion table to emit **characters**. cmark's byte-ish columns are an acknowledged ASCII-only approximation by its own comment - not a decision, and not evidence.

Codepoints also have a property neither alternative does: **the index always lands on a character boundary.** A byte offset can point inside a UTF-8 sequence, a UTF-16 offset inside a surrogate pair; both let a consumer slice a document into invalid text.

### The check that makes it enforceable

`ast-conformance.mjs` now slices the source by codepoints with a text node's reported offsets and compares against the node's own value. Nothing before this compared a span to the text it claims to cover, so an engine could report any unit and pass.

**And it needs input it can fail on.** Codepoints, UTF-16 and bytes agree on ASCII; codepoints and UTF-16 agree across the whole BMP. The unit is only observable on a surrogate pair - and **no corpus case has one**. Three synthetic astral samples now run alongside the corpus.

Verified it fails rather than assuming: with carve-js's conversion neutered, the checker reports

```
pos does not cover the text it belongs to on "text":
  offsets give "😀 plain *", node says "😀 plain "
```

and eight more. With it restored, carve-js reports **conformant**.

Engine side is carve-js#447.