### PR TITLE
docs: the AST carries node types a profile cannot deny

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -46,6 +46,16 @@ An **`admonition`** is likewise its own type rather than a `div` carrying a
 class. A profile that wants to deny callouts while allowing generic
 containers has no way to express that if the kind lives in a class string.
 
+### The AST has more node types than a profile can deny
+
+This page answers "what can a profile deny", which is a smaller set than "what
+appears in the tree". A serialized AST (PART 12) therefore carries type names
+this vocabulary does not list - `tag`, `abbreviation_def`, `smart_punctuation`,
+`literal_inline` and the `document` root - because denying them would mean
+nothing: they are either folded into another trust class or render nothing at
+all. A consumer reading an AST should expect them; a profile author should not
+look for them here.
+
 A **`tag`** node - the AST form of `#tag` - is deliberately **NOT** its own
 vocabulary entry: it is classified as **`mention`**, and all three
 implementations agree on that. `@user` and `#tag` are parsed by the same

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -54,11 +54,24 @@ function vocabulary() {
     for (const m of section[1].matchAll(/`([a-z_]+)`/g)) types.add(m[1])
   }
   // Types the vocabulary paragraphs do not list because they are not
-  // profile-deniable: the document root, and smart punctuation, which PART 9 §8
-  // folds into the `text` trust class.
+  // profile-deniable. profiles.md answers "what can a profile deny", which is a
+  // SMALLER set than "what appears in the AST" - so PART 12 §2's "the node-type
+  // identifier from profiles.md" reads tighter than the tree actually is.
+  //
+  //   document            the root, which no profile denies
+  //   smart_punctuation   PART 9 §8 folds it into the `text` trust class
+  //   literal_inline      likewise
+  //   tag                 profiles.md classifies `#tag` as `mention` on purpose,
+  //                       since `@user` and `#tag` are one trust class - but the
+  //                       AST keeps them distinct and every engine emits `tag`
+  //   abbreviation_def    the definition line renders nothing, so denying it
+  //                       would mean nothing; the inline `abbreviation` it feeds
+  //                       is what a profile controls
   types.add('document')
   types.add('smart_punctuation')
   types.add('literal_inline')
+  types.add('tag')
+  types.add('abbreviation_def')
   return types
 }
 


### PR DESCRIPTION
The conformance checker builds its vocabulary from `profiles.md` and reported `tag` and `abbreviation_def` as unknown node types. Neither is an engine bug.

`profiles.md` answers **"what can a profile deny"**, which is a smaller set than **"what appears in the tree"**:

| type | why it is not profile-deniable |
|---|---|
| `tag` | classified as `mention` on purpose - `@user` and `#tag` are one trust class - while the AST keeps them distinct |
| `abbreviation_def` | the definition line renders nothing, so denying it would mean nothing; the inline `abbreviation` it feeds is what a profile controls |
| `document`, `smart_punctuation`, `literal_inline` | already carried as checker exceptions for the same reason |

Both already had that status. What was missing is anywhere saying a **consumer** should expect them - so `profiles.md` now says so, and the checker's exception list explains each entry rather than listing three names.

### Worth a later pass, not changed here

PART 12 §2 says a node's type is *"the node-type identifier from profiles.md"*. That reads tighter than the tree actually is - five types would be non-conformant by definition. The wording is what needs revisiting, not the behavior, and I did not want to edit normative text on the way past.

### Findings after this

carve-js over the full 506 documents: 8 distinct, down from 13. What remains is line-block positions and the two definition-list spans (carve-js#441) - no vocabulary noise.