### PR TITLE
docs: complete the node-type vocabulary, and stop the conformance checker capping silently

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -46,6 +46,16 @@ An **`admonition`** is likewise its own type rather than a `div` carrying a
 class. A profile that wants to deny callouts while allowing generic
 containers has no way to express that if the kind lives in a class string.
 
+### The AST has more node types than a profile can deny
+
+This page answers "what can a profile deny", which is a smaller set than "what
+appears in the tree". A serialized AST (PART 12) therefore carries type names
+this vocabulary does not list - `tag`, `abbreviation_def`, `smart_punctuation`,
+`literal_inline` and the `document` root - because denying them would mean
+nothing: they are either folded into another trust class or render nothing at
+all. A consumer reading an AST should expect them; a profile author should not
+look for them here.
+
 A **`tag`** node - the AST form of `#tag` - is deliberately **NOT** its own
 vocabulary entry: it is classified as **`mention`**, and all three
 implementations agree on that. `@user` and `#tag` are parsed by the same

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -34,13 +34,20 @@ spelling.
 `soft_break`, `hard_break`, `raw_inline`, `escaped_text`, `footnote_ref`,
 `inline_footnote`, `heading_ref`, `citation_group`, `caption_number`,
 `span`, `superscript`, `subscript`, `highlight`, `insert`, `delete`,
-`substitution`, `symbol`, `math`, `abbreviation`.
+`substitution`, `critic_comment`, `symbol`, `math`, `abbreviation`.
 
 An **`autolink`** is its own type, not a `link`. The two differ in what the
 author wrote and in what a formatter must be able to reproduce: an autolink
 carries no label, shows its own target, and drops an added `mailto:` scheme
 when displayed. Folding it into `link` loses the authored form, so a
 round-trip could not restore it.
+
+A **`critic_comment`** is its own type rather than a `comment`, for the same
+reason `autolink` is not a `link`: the two are written differently and a
+formatter has to be able to reproduce which one the author used. It is also
+what makes editorial comments deniable on their own - a profile that accepts
+the other editorial marks but not side commentary has no way to say so if the
+type is shared with structural comments.
 
 An **`admonition`** is likewise its own type rather than a `div` carrying a
 class. A profile that wants to deny callouts while allowing generic

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -42,6 +42,26 @@ const jsDir = process.env.CARVE_JS_DIR ?? resolve(root, '../carve-js')
 const rbDir = process.env.CARVE_RB_DIR ?? resolve(root, '../carve-rb')
 const phpDir = process.env.CARVE_PHP_DIR ?? resolve(root, '../carve-php')
 
+/*
+ * How many distinct findings to PRINT. This bounds output only - every document
+ * is still checked and every finding still counted.
+ *
+ * It did not used to work that way. Each engine stopped collecting once it had
+ * accumulated a fixed number of findings (40 for the reference, 20 for the
+ * others), by passing a throwaway array to the checker for every later
+ * document. Those documents were parsed, walked, and their findings dropped on
+ * the floor - and since the summary line printed the capped total, a run that
+ * had stopped looking was indistinguishable from a clean one.
+ *
+ * That hid a real defect. carve-js emitted the node type `critic-comment`,
+ * hyphenated, which this file's own vocabulary gate is meant to reject - and it
+ * never fired, because the one corpus document exercising it sorts past where
+ * the reference hit its cap. The gate only started reporting once unrelated
+ * position fixes dropped the finding count below 40 and the document came back
+ * into view.
+ */
+const DISPLAY_LIMIT = 8
+
 const POS_KEYS = ['startLine', 'endLine', 'startColumn', 'endColumn', 'startOffset', 'endOffset']
 
 /** The node-type vocabulary, read from the spec rather than restated here. */
@@ -203,7 +223,7 @@ for (const { name, source } of samples) {
     jsFindings.push(`${name}: parse threw - ${error.message}`)
     continue
   }
-  checkDocument(doc, source, jsFindings.length < 40 ? jsFindings : [])
+  checkDocument(doc, source, jsFindings)
 
   // PART 12 §6: serialize then deserialize must equal the parse.
   const round = JSON.parse(JSON.stringify(doc))
@@ -234,7 +254,7 @@ if (existsSync(resolve(rbDir, 'lib/carve'))) {
       rbFindings.push(`${name}: could not serialize - ${String(error.message).split('\n')[0]}`)
       continue
     }
-    if (rbFindings.length < 20) checkDocument(doc, source, rbFindings)
+    checkDocument(doc, source, rbFindings)
     for (const [type, keysets] of shapeOf(doc)) {
       const reference = referenceShape.get(type)
       if (!reference) continue
@@ -273,7 +293,7 @@ if (existsSync(resolve(phpDir, 'bin/carve'))) {
       phpFindings.push(`${name}: could not serialize - ${String(error.message).split('\n')[0]}`)
       continue
     }
-    if (phpFindings.length < 20) checkDocument(doc, source, phpFindings)
+    checkDocument(doc, source, phpFindings)
     for (const [type, keysets] of shapeOf(doc)) {
       const reference = referenceShape.get(type)
       if (!reference) continue
@@ -303,8 +323,15 @@ function report(label, findings) {
     counts.set(key, (counts.get(key) ?? 0) + 1)
   }
   console.log(`${label}: ${findings.length} findings, ${counts.size} distinct`)
-  for (const [key, n] of [...counts].sort((a, b) => b[1] - a[1]).slice(0, 8)) {
+  const ranked = [...counts].sort((a, b) => b[1] - a[1])
+  for (const [key, n] of ranked.slice(0, DISPLAY_LIMIT)) {
     console.log(`  ${String(n).padStart(4)}x ${key}`)
+  }
+  // Say so when the display is truncated. This used to end here, so a run with
+  // nine distinct findings looked exactly like a run with eight.
+  const hidden = ranked.length - DISPLAY_LIMIT
+  if (hidden > 0) {
+    console.log(`  ... and ${hidden} more distinct finding${hidden === 1 ? '' : 's'} not shown`)
   }
   console.log('')
 }

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -54,11 +54,24 @@ function vocabulary() {
     for (const m of section[1].matchAll(/`([a-z_]+)`/g)) types.add(m[1])
   }
   // Types the vocabulary paragraphs do not list because they are not
-  // profile-deniable: the document root, and smart punctuation, which PART 9 §8
-  // folds into the `text` trust class.
+  // profile-deniable. profiles.md answers "what can a profile deny", which is a
+  // SMALLER set than "what appears in the AST" - so PART 12 §2's "the node-type
+  // identifier from profiles.md" reads tighter than the tree actually is.
+  //
+  //   document            the root, which no profile denies
+  //   smart_punctuation   PART 9 §8 folds it into the `text` trust class
+  //   literal_inline      likewise
+  //   tag                 profiles.md classifies `#tag` as `mention` on purpose,
+  //                       since `@user` and `#tag` are one trust class - but the
+  //                       AST keeps them distinct and every engine emits `tag`
+  //   abbreviation_def    the definition line renders nothing, so denying it
+  //                       would mean nothing; the inline `abbreviation` it feeds
+  //                       is what a profile controls
   types.add('document')
   types.add('smart_punctuation')
   types.add('literal_inline')
+  types.add('tag')
+  types.add('abbreviation_def')
   return types
 }
 


### PR DESCRIPTION
Two findings, the second of which hid the first.

### The vocabulary was missing a type

`docs/profiles.md` listed `insert`, `delete` and `substitution` but not the
editorial-comment node type, so an implementation reading the spec had no way
to know what to call the fourth CriticMarkup node. carve-js called it
`critic-comment`, hyphenated - which the same document declares a defect two
paragraphs above the list.

It stays its own type rather than folding into `comment`, for the reason
`autolink` is not a `link`: the two are written differently and a formatter has
to reproduce which one the author used. Listing it is also what makes editorial
comments deniable on their own, which a profile cannot express while the type
is shared with structural comments.

carve-js takes the snake_case spelling in markup-carve/carve-js#454, with
markup-carve/carve-lsp#30 covering the one known consumer.

### The checker was capping silently

`scripts/ast-conformance.mjs` was meant to catch exactly this and did not. Each
engine stopped collecting once it had accumulated a fixed number of findings -
40 for the reference, 20 for the others - by passing a throwaway array to the
checker for every later document. Those documents were still parsed and walked,
and their findings dropped on the floor. Since the summary line printed the
capped total, a run that had stopped looking read the same as a thorough one.

The single corpus document exercising an editorial comment sorts past where the
reference hit its cap, so the hyphenated type went unreported for as long as
the reference carried 40 findings ahead of it. It only surfaced when unrelated
position fixes dropped the count and the document came back into view.

The caps are gone. Output is still bounded, but by the reporter, which now
states how many distinct findings it did not print rather than ending silently
at eight. The reference's headline moves from "40 findings, 40 distinct" to
"62 findings, 10 distinct" - the old number was the cap, not a measurement.

The gate was checked in both directions: with the type removed from the
vocabulary it reports `unknown node type "critic_comment"`, and with it present
it goes quiet.

Also carries an earlier commit documenting why the vocabulary paragraphs list
fewer types than the AST contains - `tag`, `abbreviation_def`,
`smart_punctuation`, `literal_inline` and the `document` root are not
profile-deniable, so the checker allowlists them.
