### PR TITLE
spec: position tracking may be opt-in, serialization may not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **PART 12 §4: position tracking may be opt-in, serialization may not.** An
+  implementation may gate position tracking behind a parse option and must
+  enable it when asked to serialize. What is forbidden is a serialized document
+  without positions, not a parse without them.
+
+  The cost is what forced this. Recording a span for every node is not free -
+  carve-rs builds its line map only when the source-line render option asks for
+  it, precisely so an ordinary parse does not pay - and serialization is an
+  operation most callers never perform. Charging every parse in the fastest
+  engine for a feature used by exporters and language servers is the wrong
+  trade, and a spec demanding it would be quietly ignored or quietly
+  unimplemented.
+
+  The contract a consumer relies on is unchanged: JSON it is handed carries
+  positions.
+
 ### Added
 
 - **`compare-impls --roundtrip`** (carve#353). Formats each corpus case, then

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3436,15 +3436,30 @@ EOF = (* end of file *) ;
       than navigated. Making it optional would mean every consumer has to
       handle its absence, which in practice means not using it.
 
-      IMPLEMENTATION COST -- NOT A DESIGN CONCESSION, A SCHEDULING NOTE. Only
-      carve-js records positions today. carve-php has none on its nodes;
-      carve-rs has none either, though its parser already keeps a line map for
-      the source-line render option, so line granularity exists there and
-      columns and offsets do not. Both therefore need position tracking before
-      they can serialize conformantly. An implementation that cannot yet
-      produce positions MUST NOT emit `pos` with invented values, and MUST NOT
-      omit it silently: it does not yet serialize conformantly, and should say
-      so.
+      POSITION TRACKING MAY BE OPT-IN, SERIALIZATION MAY NOT. An implementation
+      MAY gate position tracking behind a parse option, and MUST enable it when
+      asked to serialize. What is forbidden is a serialized document without
+      positions, not a parse without them.
+
+      This is a concession to where the cost falls. Recording a span for every
+      node is not free -- carve-rs builds its line map only when the
+      source-line render option asks for it, precisely so an ordinary parse does
+      not pay -- and serialization is an operation most callers never perform.
+      Charging every parse in the fastest engine for a feature used by
+      exporters, editors and language servers would be the wrong trade, and a
+      spec that demanded it would be quietly ignored or quietly unimplemented.
+
+      The contract a consumer relies on is unchanged: JSON it is handed carries
+      positions. How the producer arranged that is the producer's business.
+
+      IMPLEMENTATION STATUS. Only carve-js records positions today. carve-php
+      has none on its nodes; carve-rs has none either, though its parser keeps a
+      line map for the source-line render option, so line granularity exists
+      there and columns and offsets do not. Both therefore need position
+      tracking before they can serialize conformantly. An implementation that
+      cannot yet produce positions MUST NOT emit `pos` with invented values, and
+      MUST NOT omit it silently: it does not yet serialize conformantly, and
+      should say so.
 
    5. WHAT IS NOT IN THE SERIALIZED FORM. Formatter-internal nodes (PART 11,
       and the `raw_text` case profiles.md excludes) are not part of the


### PR DESCRIPTION
PART 12 required a position on every node, which reads as a requirement on **parsing**. It cannot be, and implementing it in carve-rs is what surfaced why.

## The problem

carve-rs builds its line map **only when `options.source_lines` asks for it** - `parse_mapped_source` early-returns down a path with no line tracking at all otherwise. That gate is deliberate: it exists so an ordinary parse does not pay for a feature it does not use.

Satisfying "every node carries `pos`" unconditionally therefore means building a line map on every parse, in the engine that carries this project's perf regression tests and DoS-audit history, to serve an operation - serialization - that most callers never invoke.

## The amendment

> An implementation MAY gate position tracking behind a parse option, and MUST enable it when asked to serialize. What is forbidden is a serialized document without positions, not a parse without them.

**The consumer contract is unchanged**: JSON it is handed carries positions. How the producer arranged that is the producer's business.

This is narrower than the "optional `pos`" I argued for when §4 was first written and was overruled on. That would have let a serialized document arrive without positions, so every consumer would have to handle their absence - which in practice means not using them. This does not: serialized output still always has them.

## What this unblocks

The carve-rs work is otherwise done and green - `Pos` type, `col_map` on `MappedSource` (Option-typed, so an unknown strip width yields *no* position rather than a wrong one), strip widths accumulating through nested containers, `pos` fields on `Heading` and `Paragraph`. 1350 tests pass, clippy and fmt clean, no output change.

It was blocked purely on this decision, since populating `pos` means choosing whether the parser tracks unconditionally.

## Cost measured, not predicted

Adding the field broke **7 construction sites across two test files** in carve-rs alone. Extension authors constructing nodes literally will hit the same. Acceptable on 0.1.x, but worth knowing it is real rather than theoretical.

Spec suite: 602 tests, 598 pass, 0 fail.
