### PR TITLE
spec: pin a widened fence for every verbatim form

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -5610,3 +5610,38 @@ after
 ```
 
 :::
+
+## Widened verbatim fences
+
+A verbatim run widens so its content can hold a shorter backtick run: the span
+ends at a run of EXACTLY the opening width, and any shorter run inside is
+content. That applies uniformly to the whole verbatim family - inline code, the
+inline literal, and both math forms - because each is the same backtick run with
+a different sigil in front.
+
+Worth pinning because a highlighter or engine that only handles the one- and
+two-backtick widths closes at the first shorter run inside a wider fence and
+leaks the rest of the span as prose, which is exactly what happened in the
+highlight.js grammar (markup-carve/carve-grammars#52). No other corpus case uses
+a fence wider than two backticks for these constructs.
+
+::: compare
+
+```carve
+A ```span with `` inside``` stays one code span.
+
+A !```literal with `` inside``` stays prose.
+
+Then $```a `` b``` ends the run.
+
+$$```x `` y```
+```
+
+```html
+<p>A <code>span with `` inside</code> stays one code span.</p>
+<p>A literal with `` inside stays prose.</p>
+<p>Then <span class="math inline">\(a `` b\)</span> ends the run.</p>
+<p><span class="math display">\[x `` y\]</span></p>
+```
+
+:::

--- a/tests/corpus/166-widened-verbatim-fences.crv
+++ b/tests/corpus/166-widened-verbatim-fences.crv
@@ -1,0 +1,7 @@
+A ```span with `` inside``` stays one code span.
+
+A !```literal with `` inside``` stays prose.
+
+Then $```a `` b``` ends the run.
+
+$$```x `` y```

--- a/tests/corpus/166-widened-verbatim-fences.html
+++ b/tests/corpus/166-widened-verbatim-fences.html
@@ -1,0 +1,4 @@
+<p>A <code>span with `` inside</code> stays one code span.</p>
+<p>A literal with `` inside stays prose.</p>
+<p>Then <span class="math inline">\(a `` b\)</span> ends the run.</p>
+<p><span class="math display">\[x `` y\]</span></p>

--- a/tests/spec/166-widened-verbatim-fences.test
+++ b/tests/spec/166-widened-verbatim-fences.test
@@ -1,0 +1,16 @@
+Widened verbatim fences
+
+````
+A ```span with `` inside``` stays one code span.
+
+A !```literal with `` inside``` stays prose.
+
+Then $```a `` b``` ends the run.
+
+$$```x `` y```
+.
+<p>A <code>span with `` inside</code> stays one code span.</p>
+<p>A literal with `` inside stays prose.</p>
+<p>Then <span class="math inline">\(a `` b\)</span> ends the run.</p>
+<p><span class="math display">\[x `` y\]</span></p>
+````


### PR DESCRIPTION
Closes the corpus gap that markup-carve/carve-grammars#52 identified: no corpus case used a verbatim fence wider than **two** backticks, for any of the four forms.

## Why the gap mattered

A verbatim run widens so its content can hold a shorter backtick run - the span ends at a run of **exactly** the opening width, and any shorter run inside is content. That is uniform across the family, since inline code, the inline literal and both math forms are the same backtick run behind different sigils.

With nothing wider than two backticks pinned, an implementation handling only the one- and two-backtick widths passed every fixture while closing at the first shorter run inside a wider fence and leaking the rest of the span as prose. That is precisely what the highlight.js grammar did - and its snapshots could not catch it, because none of them exercised the width. Twelve snapshots there had been happily pinning truncated closing fences.

## What is added

One example covering all four forms:

```carve
A ```span with `` inside``` stays one code span.

A !```literal with `` inside``` stays prose.

Then $```a `` b``` ends the run.

$$```x `` y```
```

Appended at the end of `docs/examples/edge-cases.md` rather than inserted, so no existing case is renumbered - it lands as `166-widened-verbatim-fences`.

## Verification

- `npm test`: 599 pass, 0 fail
- `npm run core:check`: 504/504 executable-spec conformant, 0 refused, 0 defects - so the new case is inside the executable subset and did not need a refusal-allowlist entry
- `npm run engine:report`: the pinned carve-js build reproduces all 504 pairs including this one

Both oracles were checked against each other on these four inputs before the fixture was written, rather than hand-authoring the expected HTML.
