### PR TITLE
fix: two critical dependencies (@markup-carve/carve-... in...

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "@markup-carve/carve": "github:markup-carve/carve-js#30aa1d8ce5143b71da21282eb51ad6f9c5d2b3a3",
-    "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
-    "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
+    "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#5a491cc843757b96273242ca596c67866b5d7d17",
+    "@markup-carve/vite-plugin-carve": "github:markup-carve/vite-plugin-carve#0cdfd0833bc79b0e224ad81424114b42ba135258",
     "@mermaid-lint/cli": "^0.35.0",
     "markdown-it-container": "^4.0.0",
     "ohm-js": "^17.5.0",


### PR DESCRIPTION
## Summary
Fix high severity security issue in `scripts/bump-carve-pin.mjs`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `scripts/bump-carve-pin.mjs:1` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: Two critical dependencies (@markup-carve/carve-grammars and @markup-carve/vite-plugin-carve) are referenced as Git URLs without specific commit SHA pinning. This means they resolve to the HEAD of their default branches at install time, creating a supply chain vulnerability.

## Evidence

**Exploitation scenario**: If an attacker compromises the upstream GitHub repositories, they can push malicious code to the default branch.

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `package.json`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project builds successfully with this change applied.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
