### PR TITLE
fix: stop the conformance checker sampling the satellites into a pass

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -38,6 +38,26 @@ const root = resolve(here, '..')
 const limitArg = process.argv.find((a) => a.startsWith('--limit='))
 const limit = limitArg ? Number(limitArg.slice('--limit='.length)) : Infinity
 
+/*
+ * The satellite engines serialize through a SUBPROCESS PER DOCUMENT, so they
+ * cost about a tenth of a second each where the reference costs nothing.
+ *
+ * That is why they used to run over only the first twelve samples - and why
+ * this script reported "carve-php: conformant" while carve-php had eight nodes
+ * with no position. All eight sit in documents 41, 56, 63, 96 and 104; the
+ * first twelve documents alphabetically contain none of them. The cap was not
+ * a sampling decision, it was a check that could not fail, and it printed a
+ * clean bill of health for an engine the full corpus finds non-conformant.
+ *
+ * They now run over everything by default (about 45 seconds each). A smaller
+ * cap stays available for a quick local pass, and the report NAMES the count it
+ * ran over, so a partial run can never again read as a complete one.
+ */
+const satelliteLimitArg = process.argv.find((a) => a.startsWith('--satellite-limit='))
+const satelliteLimit = satelliteLimitArg
+  ? Number(satelliteLimitArg.slice('--satellite-limit='.length))
+  : Infinity
+
 const jsDir = process.env.CARVE_JS_DIR ?? resolve(root, '../carve-js')
 const rbDir = process.env.CARVE_RB_DIR ?? resolve(root, '../carve-rb')
 const phpDir = process.env.CARVE_PHP_DIR ?? resolve(root, '../carve-php')
@@ -204,6 +224,8 @@ const samples = [
     .map((f) => ({ name: f, source: readFileSync(resolve(corpusDir, f), 'utf8') })),
 ]
 
+const satelliteSamples = samples.slice(0, satelliteLimit)
+
 console.log(`PART 12 conformance over ${samples.length} corpus documents\n`)
 
 // ---- reference: carve-js ---------------------------------------------------
@@ -241,7 +263,7 @@ report('carve-js (reference)', jsFindings)
 // ---- carve-rb: serializes carve-rs's tree ----------------------------------
 if (existsSync(resolve(rbDir, 'lib/carve'))) {
   const rbFindings = []
-  for (const { name, source } of samples.slice(0, 12)) {
+  for (const { name, source } of satelliteSamples) {
     let doc
     try {
       const out = execFileSync(
@@ -265,7 +287,7 @@ if (existsSync(resolve(rbDir, 'lib/carve'))) {
       }
     }
   }
-  report('carve-rb (over carve-rs)', rbFindings)
+  report(`carve-rb (over carve-rs, ${satelliteSamples.length} documents)`, rbFindings)
 } else {
   console.log('carve-rb: checkout not found, not checked\n')
 }
@@ -279,7 +301,7 @@ if (existsSync(resolve(rbDir, 'lib/carve'))) {
 // already in use.
 if (existsSync(resolve(phpDir, 'bin/carve'))) {
   const phpFindings = []
-  for (const { name, source } of samples.slice(0, 12)) {
+  for (const { name, source } of satelliteSamples) {
     let doc
     try {
       const out = execFileSync('php', ['bin/carve', '--json'], {
@@ -304,7 +326,7 @@ if (existsSync(resolve(phpDir, 'bin/carve'))) {
       }
     }
   }
-  report('carve-php (over bin/carve --json)', phpFindings)
+  report(`carve-php (over bin/carve --json, ${satelliteSamples.length} documents)`, phpFindings)
 } else if (existsSync(phpDir)) {
   console.log('carve-php: checkout found but bin/carve is missing, not checked\n')
 } else {


### PR DESCRIPTION
`scripts/ast-conformance.mjs` checked the reference over every corpus document and the two subprocess-serializing engines over `samples.slice(0, 12)`, because a process per document is slow.

Twelve was not a sample. It was a check that could not fail.

## What it was hiding

carve-php has nodes with no position in documents 41, 56, 63, 96 and 104. The first twelve documents alphabetically contain none of them, so the script printed:

```
carve-php (over bin/carve --json): conformant
```

for an engine the full corpus finds non-conformant in **263 places**. The engine that verifies a span against the source before emitting it - the most careful of the three, the only one with zero wrong spans - was the one the cap flattered into a pass.

## What the full run actually says

```
carve-js (reference):                         62 findings, 10 distinct
carve-rb (over carve-rs, 507 documents):    4008 findings, 65 distinct
carve-php (over bin/carve --json, 507 docs): 263 findings, 42 distinct
```

None of this is new behavior in any engine. It was simply never reported. carve-php's 263 are 34 missing positions plus shape divergences the twelve-document window never reached (`list` carrying `bulletChar`, `mention` carrying `cssClass`, and so on - field names are spec surface under PART 12 section 3).

## The change

Both satellites run over everything by default. Cost is about four minutes for a full three-engine run, which is what an on-demand conformance script can afford. `--satellite-limit=N` keeps a quick local pass available.

The report now names the document count it ran over:

```
carve-php (over bin/carve --json, 507 documents): ...
```

That is the part that makes a bounded run safe to keep. A partial run that says how far it got is a sample; one that stays silent is a false negative wearing a pass.

## Why this keeps happening

This is the same defect this repo has now hit several times: a check whose scope or short-circuit makes it structurally unable to report the thing it exists to report. The previous instance was in this same file - each engine stopped collecting after a fixed number of findings, so fixing forty findings could make a non-conformant document disappear from the output entirely. The fix then was to bound PRINTING rather than checking; the fix now is to bound with the count stated. Worth treating "what would make this check pass when it should fail" as a required question when adding one.