### PR TITLE
spec: refresh PART 12 §4's implementation status

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3376,6 +3376,37 @@ EOF = (* end of file *) ;
       spec surface for kind names. A document is
       `{"type":"document","children":[...]}`.
 
+      THE ROOT'S OWN FIELDS ARE FIXED -- NORMATIVE. Beyond `type` and
+      `children` the root carries `srcByteLength` always, and carries
+      `frontmatter` and `footnoteDefs` exactly when the document has them. It
+      carries nothing else.
+
+        {"type":"document","children":[...],"srcByteLength":42,
+         "frontmatter":{...},"footnoteDefs":{...}}
+
+      This was left open once and every engine answered differently: carve-js
+      emitted all five, carve-php emitted three and DROPPED a document's
+      frontmatter and footnote definitions on the way out, and carve-rb spelled
+      two of them `source_len` and `footnote_defs`. A consumer reading
+      `srcByteLength` got nothing from one engine, and a document round-tripped
+      through another came back without its frontmatter (carve#411).
+
+      Frontmatter and footnote definitions sit on the ROOT rather than in
+      `children` because neither is a position in the document's flow. A
+      footnote definition renders where the reference to it appears, not where
+      it was written, and frontmatter renders nowhere at all -- putting either
+      in `children` would give it a place in a sequence it does not occupy. The
+      open issue weighed moving footnote definitions into the tree on the
+      grounds that they are content rather than metadata, which is true and is
+      not the question: `children` is an ORDER, and content with no place in
+      that order does not belong in it.
+
+      `srcByteLength` counts BYTES of the source, and is the one field here
+      that is not codepoints (PART 12 §4) -- it answers "how much source was
+      this", not "where in it", so a byte count is the honest unit. It is named
+      here because it was never written down: three engines emitted it, or a
+      renaming of it, purely by copying the reference.
+
    3. FIELD NAMES ARE SPEC SURFACE, exactly as kind names are. The normative
       set per node type is the carve-js interface for that type. Notably:
         link       `href`, `children`, and `ref` when the author wrote a

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -130,7 +130,40 @@ function* walk(node, path = '$') {
   }
 }
 
+/**
+ * PART 12 section 2: the root carries `type`, `children` and `srcByteLength`,
+ * plus `frontmatter` and `footnoteDefs` when the document has them, and nothing
+ * else.
+ *
+ * Checked separately from the per-type shape comparison because the root is the
+ * one node with no other node of its type to be compared against - which is
+ * exactly why the engines diverged here unnoticed: carve-php dropped a
+ * document's frontmatter and footnote definitions on the way out, and carve-rb
+ * spelled two root fields `source_len` and `footnote_defs` (carve#411).
+ */
+const ROOT_REQUIRED = ['type', 'children', 'srcByteLength']
+const ROOT_OPTIONAL = ['frontmatter', 'footnoteDefs']
+
+function checkRoot(doc, source, findings) {
+  for (const key of ROOT_REQUIRED) {
+    if (!(key in doc)) findings.push(`root is missing "${key}" (PART 12 section 2)`)
+  }
+  // "Optional" means optional to the DOCUMENT, not to the engine. A source that
+  // opens with a frontmatter fence must come back with `frontmatter`, or the
+  // serializer has silently dropped content - which is the failure carve#411
+  // found in carve-php, and which a presence-only check cannot see.
+  if (/^---\r?\n/.test(source) && !('frontmatter' in doc)) {
+    findings.push('source has frontmatter but the root does not carry it (PART 12 section 2)')
+  }
+  for (const key of Object.keys(doc)) {
+    if (!ROOT_REQUIRED.includes(key) && !ROOT_OPTIONAL.includes(key)) {
+      findings.push(`root carries "${key}", which PART 12 section 2 does not describe`)
+    }
+  }
+}
+
 function checkDocument(doc, source, findings) {
+  checkRoot(doc, source, findings)
   // Offsets are codepoint indices (PART 12 §4), so the source has to be indexed
   // the same way to check them.
   const codepoints = [...source]


### PR DESCRIPTION
The paragraph said only carve-js records positions and carve-php has none. **carve-php now serializes conformantly** (markup-carve/carve-php#499) — it records positions behind a parse option and enables them whenever it serializes, which is exactly the arrangement the preceding paragraph permits.

The other two are now stated with what is actually missing rather than as a blanket "none", because the cases are not alike:

- **carve-js** records positions but not on every node. The eight types without one are all *reassembled* rather than sliced from the source — a caption built from a marker line plus continuations, a line block whose leading whitespace was expanded, a table cell scanned out of a row and re-joined, and the numbering nodes synthesized during resolution. They are **absent rather than wrong**, which is the half of the rule that matters. Tracked in markup-carve/carve-js#441.
- **carve-rs** has none at all, and why it is a bigger job than carve-php's is worth recording: several inline variants are tuple-shaped (`Text(String)`, `Code(String, Option<Attrs>)`), so there is nowhere to put a position without changing the variant itself. Tracked in markup-carve/carve-rs#333, which also carries the six trap classes carve-js hit — the part that does not look hard in advance.