### PR TITLE
spec: fix the document root's fields, and check them

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3376,6 +3376,37 @@ EOF = (* end of file *) ;
       spec surface for kind names. A document is
       `{"type":"document","children":[...]}`.
 
+      THE ROOT'S OWN FIELDS ARE FIXED -- NORMATIVE. Beyond `type` and
+      `children` the root carries `srcByteLength` always, and carries
+      `frontmatter` and `footnoteDefs` exactly when the document has them. It
+      carries nothing else.
+
+        {"type":"document","children":[...],"srcByteLength":42,
+         "frontmatter":{...},"footnoteDefs":{...}}
+
+      This was left open once and every engine answered differently: carve-js
+      emitted all five, carve-php emitted three and DROPPED a document's
+      frontmatter and footnote definitions on the way out, and carve-rb spelled
+      two of them `source_len` and `footnote_defs`. A consumer reading
+      `srcByteLength` got nothing from one engine, and a document round-tripped
+      through another came back without its frontmatter (carve#411).
+
+      Frontmatter and footnote definitions sit on the ROOT rather than in
+      `children` because neither is a position in the document's flow. A
+      footnote definition renders where the reference to it appears, not where
+      it was written, and frontmatter renders nowhere at all -- putting either
+      in `children` would give it a place in a sequence it does not occupy. The
+      open issue weighed moving footnote definitions into the tree on the
+      grounds that they are content rather than metadata, which is true and is
+      not the question: `children` is an ORDER, and content with no place in
+      that order does not belong in it.
+
+      `srcByteLength` counts BYTES of the source, and is the one field here
+      that is not codepoints (PART 12 §4) -- it answers "how much source was
+      this", not "where in it", so a byte count is the honest unit. It is named
+      here because it was never written down: three engines emitted it, or a
+      renaming of it, purely by copying the reference.
+
    3. FIELD NAMES ARE SPEC SURFACE, exactly as kind names are. The normative
       set per node type is the carve-js interface for that type. Notably:
         link       `href`, `children`, and `ref` when the author wrote a

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3382,30 +3382,40 @@ EOF = (* end of file *) ;
       carries nothing else.
 
         {"type":"document","children":[...],"srcByteLength":42,
-         "frontmatter":{...},"footnoteDefs":{...}}
+         "frontmatter":{"format":"yaml","content":"title: x"},
+         "footnoteDefs":{"r":[...]}}
 
-      This was left open once and every engine answered differently: carve-js
-      emitted all five, carve-php emitted three and DROPPED a document's
-      frontmatter and footnote definitions on the way out, and carve-rb spelled
-      two of them `source_len` and `footnote_defs`. A consumer reading
-      `srcByteLength` got nothing from one engine, and a document round-tripped
-      through another came back without its frontmatter (carve#411).
+      `frontmatter` holds the RAW block and its format, not a parsed mapping.
+      Parsing YAML (or TOML, or JSON) is not this format's job, and a parsed map
+      cannot be serialized back to the bytes the author wrote -- key order,
+      comments and anchors are all gone. A consumer that wants the values runs
+      its own parser over `content`, which is the only form that keeps both
+      answers available.
+
+      `srcByteLength` counts BYTES of the source, and is the one field here that
+      is not codepoints (PART 12 §4) -- it answers "how much source was this",
+      not "where in it".
 
       Frontmatter and footnote definitions sit on the ROOT rather than in
       `children` because neither is a position in the document's flow. A
-      footnote definition renders where the reference to it appears, not where
-      it was written, and frontmatter renders nowhere at all -- putting either
-      in `children` would give it a place in a sequence it does not occupy. The
-      open issue weighed moving footnote definitions into the tree on the
-      grounds that they are content rather than metadata, which is true and is
-      not the question: `children` is an ORDER, and content with no place in
-      that order does not belong in it.
+      footnote definition renders where the REFERENCE to it appears, not where
+      it was written, and frontmatter renders nowhere at all. Putting either in
+      `children` gives it a place in a sequence it does not occupy: a consumer
+      walking `children` to render a document must then know to skip two of the
+      types it finds there.
 
-      `srcByteLength` counts BYTES of the source, and is the one field here
-      that is not codepoints (PART 12 §4) -- it answers "how much source was
-      this", not "where in it", so a byte count is the honest unit. It is named
-      here because it was never written down: three engines emitted it, or a
-      renaming of it, purely by copying the reference.
+      This was left open once (carve#411) and the three engines answered
+      differently in three ways -- placement, spelling and CONTENT:
+
+        carve-js   root, `frontmatter` = {format, content}
+        carve-rb   root, `frontmatter` = the PARSED key/value mapping
+        carve-php  neither on the root; a `frontmatter` block and a `footnote`
+                   block inside `children`
+
+      The content disagreement is the one that matters most and the issue did
+      not record it: two engines publish a field of the same name holding
+      different data, so a consumer reading `frontmatter.content` gets a string
+      from one and `undefined` from the other. Placement at least fails loudly.
 
    3. FIELD NAMES ARE SPEC SURFACE, exactly as kind names are. The normative
       set per node type is the carve-js interface for that type. Notably:

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -130,7 +130,40 @@ function* walk(node, path = '$') {
   }
 }
 
+/**
+ * PART 12 section 2: the root carries `type`, `children` and `srcByteLength`,
+ * plus `frontmatter` and `footnoteDefs` when the document has them, and nothing
+ * else.
+ *
+ * Checked separately from the per-type shape comparison because the root is the
+ * one node with no other node of its type to compare against - which is exactly
+ * why the engines diverged here unnoticed: carve-php dropped a document's
+ * frontmatter and footnote definitions on the way out, and carve-rb spelled two
+ * root fields `source_len` and `footnote_defs` (carve#411).
+ */
+const ROOT_REQUIRED = ['type', 'children', 'srcByteLength']
+const ROOT_OPTIONAL = ['frontmatter', 'footnoteDefs']
+
+function checkRoot(doc, source, findings) {
+  for (const key of ROOT_REQUIRED) {
+    if (!(key in doc)) findings.push(`root is missing "${key}" (PART 12 section 2)`)
+  }
+  // "Optional" means optional to the DOCUMENT, not to the engine. A source that
+  // opens with a frontmatter fence must come back with `frontmatter`, or the
+  // serializer has silently dropped content - the failure carve#411 found in
+  // carve-php, and one a presence-only check cannot see.
+  if (/^---\r?\n/.test(source) && !('frontmatter' in doc)) {
+    findings.push('source has frontmatter but the root does not carry it (PART 12 section 2)')
+  }
+  for (const key of Object.keys(doc)) {
+    if (!ROOT_REQUIRED.includes(key) && !ROOT_OPTIONAL.includes(key)) {
+      findings.push(`root carries "${key}", which PART 12 section 2 does not describe`)
+    }
+  }
+}
+
 function checkDocument(doc, source, findings) {
+  checkRoot(doc, source, findings)
   // Offsets are codepoint indices (PART 12 §4), so the source has to be indexed
   // the same way to check them.
   const codepoints = [...source]


### PR DESCRIPTION
Closes markup-carve/carve#411.

PART 12 described a document as `{"type":"document","children":[...]}` and stopped there. The three engines then answered the rest differently - in three separate ways:

| engine | frontmatter | footnote definitions |
|---|---|---|
| carve-js (reference) | root, `{format:"yaml", content:"title: x"}` | root `footnoteDefs` |
| carve-rb | root, `{title:"x"}` - the **parsed** mapping | root `footnoteDefs` |
| carve-php | a `frontmatter` block inside `children` | a `footnote` block inside `children` |

`srcByteLength` had never been written down anywhere. Three engines emit it purely by copying the reference.

## The disagreement the issue did not record

#411 framed this as placement. The worse problem is **content**: carve-js and carve-rb publish a field of the same name holding different data. A consumer reading `frontmatter.content` gets a string from one engine and `undefined` from the other, with nothing raising an error. Placement at least fails loudly.

So this section says what the field HOLDS, not only that it exists: the raw block and its format. Parsing YAML is not this format's job, and a parsed map cannot be serialized back to the bytes the author wrote - key order, comments and anchors are gone. A consumer that wants values runs its own parser over `content`, which is the only form that keeps both answers available.

## The decision

Root carries `type`, `children`, `srcByteLength` always; `frontmatter` and `footnoteDefs` exactly when the document has them; nothing else.

Both stay on the root rather than in `children` because neither is a position in the document's flow: a footnote definition renders where its *reference* appears, not where it was written, and frontmatter renders nowhere. Putting either in `children` gives it a place in a sequence it does not occupy - a consumer walking `children` to render must then know to skip two of the types it finds.

## Two premises in #411 were out of date, and two of my own were wrong

- #411 records that carve-js "does not expose frontmatter in the AST at all". It does, on the root - which is what makes ratifying the reference an answer rather than a compromise.
- My first draft of this PR said carve-php DROPS frontmatter and footnote definitions. It does not; it models both as blocks in `children`. I had looked at its root and not its tree.
- It also said carve-rb spells them `source_len` and `footnote_defs`. That was a stale branch in a shared checkout; `main` already uses the reference names.

Corrected in the second commit rather than force-pushed, so the record of what was actually measured stays visible.

## The check a presence test cannot make

A missing optional field is legal when the document has none - so "the root may carry `frontmatter`" is unfalsifiable against an engine that never emits it. The checker also asserts: a source opening with a frontmatter fence must come back with `frontmatter`.

**Optional means optional to the DOCUMENT, not to the engine.**

## Engine follow-ups

- carve-rb emitted both fields for every document, empty object included - "this document has frontmatter, and it is empty" is a different claim from "it has none". Fixed in markup-carve/carve-rb#21.
- carve-rb also needs to publish the raw block rather than the parsed mapping; not in #21.
- carve-php needs to move both from `children` to the root.

Neither is a data-loss bug, so both can land after this.