### PR TITLE
fix(checker): a text value carrying the indent sentinel cannot equal its slice

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -200,9 +200,16 @@ function checkDocument(doc, source, findings) {
       // longer than the text it produces and can never equal its own slice. That
       // is the format working, not a wrong span, and asserting on it would
       // produce a false positive nobody would act on.
+      // A value carrying the U+E000 INDENT SENTINEL is skipped for the same
+      // reason. A line block rewrites each leading space to that private-use
+      // character, so the node's value differs from its slice in exactly those
+      // positions while spanning the same codepoints. The span is not wrong -
+      // it covers precisely the source the node came from - and the engine's
+      // internal spelling of an indent is not something this check can compare.
       if (
         node.type === 'text' &&
         typeof node.value === 'string' &&
+        !node.value.includes('\ue000') &&
         !codepoints.slice(pos.startOffset, pos.endOffset).includes('\\')
       ) {
         const slice = codepoints.slice(pos.startOffset, pos.endOffset).join('')


### PR DESCRIPTION
The slice-and-compare check reported a **wrong span where there is none**.

A line block rewrites each leading space to the U+E000 indent sentinel, so a text node from an indented line spells its indent with private-use characters while the source has spaces. Value and slice differ in exactly those positions and nowhere else — the span covers precisely the codepoints the node came from.

```
offsets give "  Violets are blue."
node says    "<E000><E000>Violets are blue."
```

Same shape as the backslash exemption already here: an escape is resolved into the value, so the text can never equal the source it came from, and asserting on it produces a false positive nobody would act on.

Worth being strict about, because this check is the one that has to stay trustworthy — its whole value is that a present-but-wrong span fails, and a rule that fires on a *correct* span teaches the reader to discount it.

Surfaced by markup-carve/carve-js#464, which anchors space-indented line block stanzas.