### PR TITLE
spec: the document root carries exactly three fields

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -25,9 +25,9 @@ spelling.
 
 **Block:** `paragraph`, `heading`, `code_block`, `block_quote`, `list`,
 `list_item`, `table`, `table_row`, `table_cell`, `thematic_break`, `div`,
-`admonition`, `raw_block`, `footnote`, `definition_list`, `definition_term`,
-`definition_description`, `section`, `line_block`, `comment`, `figure`,
-`caption`.
+`admonition`, `raw_block`, `footnote`, `frontmatter`, `definition_list`,
+`definition_term`, `definition_description`, `section`, `line_block`,
+`comment`, `figure`, `caption`.
 
 **Inline:** `text`, `emphasis`, `strong`, `underline`, `strike`,
 `inline_extension`, `mention`, `code`, `link`, `autolink`, `image`,

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3524,4 +3524,53 @@ EOF = (* end of file *) ;
    6. ROUND TRIP. `parse(x)` serialized and deserialized MUST equal `parse(x)`.
       A serializer that loses a field is not a lossy convenience; it is a
       consumer breaking silently one document later.
+
+   7. THE DOCUMENT ROOT CARRIES EXACTLY THREE FIELDS -- NORMATIVE:
+      `type`, `children`, `srcByteLength`. Nothing else. An implementation MUST
+      NOT hang document-level data off the root; content goes in the tree,
+      where every other piece of content already lives.
+
+      Two things had drifted there. carve-js carried `frontmatter` and
+      `footnoteDefs`; carve-rb (over carve-rs) carried `frontmatter`. carve-php
+      carried neither, because it already put both in the tree (carve#411).
+
+      WHY THE TREE AND NOT THE ROOT. §4 requires every node except the root to
+      carry `pos`, on the grounds that a tree without positions can only be
+      re-parsed rather than navigated. A root FIELD cannot carry `pos`.
+      Frontmatter and a footnote definition are source constructs occupying
+      real bytes: an editor jumps to them, a formatter reproduces them, a
+      language server renames a label. Putting them on the root would make them
+      the only content in the document that cannot be navigated to. That
+      applies to frontmatter exactly as much as to a footnote body, which is
+      why the two do NOT split along a metadata/content line.
+
+      FRONTMATTER IS A BLOCK NODE, `type: "frontmatter"`, carrying:
+        format   the info word on the opening fence (`frontmatter_format` in
+                 PART 2), or `"yaml"` when the fence carries none
+        content  the text between the fences, VERBATIM
+      It is the FIRST child when present, since that is where it is written.
+
+      CONTENT IS RAW, NOT PARSED -- NORMATIVE. `content` is the source text.
+      An implementation MUST NOT emit parsed key/value pairs in its place:
+      parsing YAML or TOML is not the markup parser's job, the raw text plus
+      `format` lets any consumer do it, and a parsed map cannot represent a
+      document whose frontmatter is malformed. carve-rs holds a parsed map
+      internally; that is an internal choice, and §1 already requires mapping
+      on the way out rather than exporting internals.
+
+      A FOOTNOTE DEFINITION IS A BLOCK NODE, `type: "footnote"`, carrying:
+        label     the label as written, without the `[^` and `]:`
+        children  the definition body, parsed as blocks
+      `label`, not `id`: PART 9 §16 calls it a label throughout, and `id`
+      collides with the attribute of that name.
+
+      A DEFINITION IS A CHILD OF THE DOCUMENT even when it was authored inside
+      a container. PART 9 §16 already makes a definition document-level
+      metadata that is collected out of its blockquote or list item, leaving
+      that container empty; the serialized tree follows the same rule rather
+      than inventing a second one. Its `pos` still records where it was
+      WRITTEN, so nothing about navigation is lost by the move.
+
+      Definitions appear in DOCUMENT ORDER by source position. Numbering is a
+      resolution result and stays on the reference (§5).
 *)


### PR DESCRIPTION
Settles #411 with option 2, for both fields.

## The rule

The document root is exactly `type`, `children`, `srcByteLength`. Frontmatter and footnote definitions are block nodes in the tree.

- **`frontmatter`** carries `format` (the info word on the opening fence, `"yaml"` when absent) and `content` (the text between the fences, **verbatim**). First child when present.
- **`footnote`** carries `label` (as written, without `[^` and `]:`) and `children`. It is a child of the **document** even when authored inside a container, matching PART 9 section 16, which already collects a definition out of its blockquote or list item. Its `pos` still records where it was written.

`frontmatter` also joins the block vocabulary in `docs/profiles.md`.

## Why not the split the issue leaned toward

The issue proposed extending the root for frontmatter (metadata) and using the tree for footnotes (content), and called the inconsistency the real distinction. One thing overrides it:

**Section 4 requires every node except the root to carry `pos`, because a tree without positions "can only be re-parsed rather than navigated" - and a root field cannot carry one.** Frontmatter and a footnote body are both source constructs occupying real bytes. An editor jumps to them, a formatter reproduces them, a language server renames a label. Hanging either off the root makes it the only content in the document you cannot navigate to. That applies to frontmatter exactly as much as to a footnote body.

Two premises in the issue also turned out to be wrong, which I verified by running the engines rather than reading the table (see the comment on #411): carve-js carries `frontmatter` at the root too, so "there is no counterpart to map it onto" does not hold; and option 2 is not hypothetical - carve-php already ships it for both, which is why its root was already minimal.

## Raw, not parsed

`content` is source text, normatively. Parsing YAML or TOML is not the markup parser's job, the raw text plus `format` lets any consumer do it, and a parsed map cannot represent malformed frontmatter. carve-rs holds a parsed map internally; section 1 already requires mapping on the way out rather than exporting internals.

## `label`, not `id`

PART 9 section 16 calls it a label throughout, and `id` collides with the attribute of that name. carve-php currently emits `id` and will need the rename.

## What each engine owes after this

| engine | change |
|---|---|
| carve-js | serialize both as children; internals may keep `footnoteDefs` for endnote rendering |
| carve-php | add the missing `format` to its frontmatter node; rename `id` to `label` |
| carve-rb | move `frontmatter` off the root into the tree |
| carve-rs | no serializer yet; the mapping is now defined for when it gains one |

## Verification

`npm test` 599 pass / 0 fail, executable-spec gate 504/504 conformant with 0 refused and 0 defects, node-vocabulary test green with the new type.
