### PR TITLE
spec: an unmapped node type resolves like any other

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -95,6 +95,11 @@ node preserving literal source for round-trip formatting (carve-php calls it
 `raw_text`); denying it would break `fmt` while expressing nothing about the
 document's content.
 
+A **`frontmatter`** block - the AST form of a document's leading metadata
+fence - is likewise not in this vocabulary. It renders nothing, so denying it
+would express nothing; an implementation that parses frontmatter allows the
+node unconditionally.
+
 The inline literal of PART 9 §27 (`` !`…` ``) is classified as **`code`** for
 profiles — it is a code span with the `<code>` wrapper dropped, sharing code's
 verbatim capture, escaping, and trailing-attribute surface, so it is allowed
@@ -128,8 +133,20 @@ For a node of type `T`, in its axis (inline or block):
    `T` is in it.
 3. Else → **allowed**.
 
-A type that is neither a known block nor inline type is **denied**. `document`
-is always allowed. Deny always beats allow; an allowlist is a closed set.
+These three steps are exhaustive. A node whose type is **not** in the
+vocabulary above resolves through them unchanged: it cannot appear in a deny
+list, so step 1 never matches; step 2 excludes it whenever an allow list is
+set; and step 3 allows it otherwise. An implementation MUST NOT add a fourth
+step denying unrecognized types.
+
+The consequence is the point: a profile that denies nothing and sets no allow
+list is **lossless**, for every document, including documents using node types
+the implementation's vocabulary predates. A vocabulary gap makes a type
+un-nameable, never invisible. An allow list still excludes unknown types, so a
+restrictive profile loses no safety.
+
+`document` is always allowed and cannot be denied. Deny always beats allow;
+an allowlist is a closed set.
 
 ### Actions on a disallowed node
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3493,14 +3493,27 @@ EOF = (* end of file *) ;
       The contract a consumer relies on is unchanged: JSON it is handed carries
       positions. How the producer arranged that is the producer's business.
 
-      IMPLEMENTATION STATUS. Only carve-js records positions today. carve-php
-      has none on its nodes; carve-rs has none either, though its parser keeps a
-      line map for the source-line render option, so line granularity exists
-      there and columns and offsets do not. Both therefore need position
-      tracking before they can serialize conformantly. An implementation that
-      cannot yet produce positions MUST NOT emit `pos` with invented values, and
-      MUST NOT omit it silently: it does not yet serialize conformantly, and
-      should say so.
+      IMPLEMENTATION STATUS. carve-php serializes conformantly: it records
+      positions behind a parse option and enables them whenever it serializes,
+      which is the arrangement the paragraph above permits.
+
+      carve-js records positions but not on every node. The types that come out
+      without one are all REASSEMBLED rather than sliced from the source -- the
+      hard break a line block synthesizes from a soft one, and table rows and
+      cells put back together from several lines. They are absent rather than
+      wrong, which is the half of the rule below that matters, and they are
+      tracked in carve-js#441.
+
+      carve-rs has none at all: 47 node structs with no position field, and
+      several of its inline variants are tuple-shaped, so there is nowhere to
+      put one without changing the variant itself. Its parser does keep a line
+      map for the source-line render option, so line granularity exists there
+      and columns and offsets do not. Tracked in carve-rs#333, which also
+      records the six trap classes carve-js hit, in the order they bit.
+
+      An implementation that cannot yet produce positions MUST NOT emit `pos`
+      with invented values, and MUST NOT omit it silently: it does not yet
+      serialize conformantly, and should say so.
 
    5. WHAT IS NOT IN THE SERIALIZED FORM. Formatter-internal nodes (PART 11,
       and the `raw_text` case profiles.md excludes) are not part of the


### PR DESCRIPTION
`docs/profiles.md` gave two answers for a node type outside the profile vocabulary.

The `### Resolution (normative)` section lists three steps - deny list, then allow list, then allowed. One paragraph below them sat a sentence saying the opposite:

> A type that is neither a known block nor inline type is **denied**.

All three engines implement the second one. That is why `Profile::full()` can delete content: a construct whose type the vocabulary does not list renders as nothing rather than being allowed. In carve-php a `{~old~>new~}` substitution lost both the old wording and the new one; carve-rs currently drops `symbol`, `heading_ref` and `caption_number`, all three of which are *in* the normative vocabulary.

This removes the denying sentence and states that the three steps are exhaustive: an unmapped type cannot appear in a deny list, an allow list excludes it, and otherwise it is allowed.

**This is a normative behavior change, not a clarification.** The engines were not contradicting the spec - they were following it. Calling it a clarification would misrepresent what merging this does.

The consequence is the point: a profile that denies nothing becomes lossless for every document, including documents using node types an implementation's vocabulary predates. A vocabulary gap makes a type un-nameable, never invisible. An allow list still excludes unknown types by construction, so a restrictive profile loses no safety.

Also adds a sentence for `frontmatter`, which had none: it renders nothing, so an implementation that parses it allows the node unconditionally.

Engine PRs implementing this follow. markup-carve/carve-php#503 is the first.