### PR TITLE
test: cover unmapped types in the shared profile battery

### DIFF
--- a/tests/gen-profile-fixtures.php
+++ b/tests/gen-profile-fixtures.php
@@ -22,6 +22,9 @@ $cases = [
     'minimal-link-denied' => ['A [site](https://example.com) link.', fn () => Profile::minimal(), 'minimal'],
     'minimal-heading' => ["# H\n\nText.", fn () => Profile::minimal(), 'minimal'],
     'minimal-list' => ["- one\n- two\n", fn () => Profile::minimal(), 'minimal'],
+    'full-unmapped-type' => ["Body with a {~old~>new~} substitution and a :smile: symbol.\n", fn () => Profile::full(), 'full'],
+    'full-smart-typography' => ["A \"quoted\" phrase -- an en dash --- and an em dash.\n", fn () => Profile::full(), 'full'],
+    'comment-substitution-degraded' => ["Body with a {~old~>new~} substitution.\n", fn () => Profile::comment(), 'comment'],
 ];
 
 $out = [];

--- a/tests/profile-fixtures.json
+++ b/tests/profile-fixtures.json
@@ -53,5 +53,20 @@
         "carve": "- one\n- two\n",
         "profile": "minimal",
         "html": "<ul>\n  <li>one</li>\n  <li>two</li>\n</ul>\n"
+    },
+    "full-unmapped-type": {
+        "carve": "Body with a {~old~>new~} substitution and a :smile: symbol.\n",
+        "profile": "full",
+        "html": "<p>Body with a <del>old</del><ins>new</ins> substitution and a :smile: symbol.</p>\n"
+    },
+    "full-smart-typography": {
+        "carve": "A \"quoted\" phrase -- an en dash --- and an em dash.\n",
+        "profile": "full",
+        "html": "<p>A \u201cquoted\u201d phrase \u2013 an en dash \u2014 and an em dash.</p>\n"
+    },
+    "comment-substitution-degraded": {
+        "carve": "Body with a {~old~>new~} substitution.\n",
+        "profile": "comment",
+        "html": "<p>Body with a oldnew substitution.</p>\n"
     }
 }


### PR DESCRIPTION
`tests/profile-fixtures.json` is the shared cross-engine profile battery. It gained three cases covering the behavior markup-carve/carve#419 specifies and markup-carve/carve-php#503 implements, and was regenerated from the fixed carve-php.

| case | what it pins |
|---|---|
| `full-unmapped-type` | a full profile leaves a substitution and a symbol intact |
| `full-smart-typography` | curly quotes, en dash and em dash survive a full profile |
| `comment-substitution-degraded` | an allow-list profile degrades a denied substitution to `oldnew`, rather than deleting both wordings |

The middle case is the one that would previously have vanished: `smart_punctuation` is not in the profile vocabulary, so under the old resolution a full profile denied it.

**No pre-existing fixture changed.** The regeneration is a pure addition - 15 insertions, 0 deletions across the 11 existing cases. That is worth stating, because it is the blast-radius evidence for the carve-php change: the engine fix moved only the cases it was supposed to move.

## Note on the battery itself

This file's generator header says carve-js and carve-rs assert against it. Neither ever has - `grep -rln profile-fixtures` finds no reader in either engine outside their vendored copies of this repo. It was generated once and never read back, which is a large part of how all three engines drifted into the same profile defect without anyone noticing.

carve-php#503 adds the first real reader, holding carve-php to this file. The carve-js and carve-rs PRs that follow will add theirs.
