### PR TITLE
spec: frontmatter is in the vocabulary or it is not

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -95,11 +95,6 @@ node preserving literal source for round-trip formatting (carve-php calls it
 `raw_text`); denying it would break `fmt` while expressing nothing about the
 document's content.
 
-A **`frontmatter`** block - the AST form of a document's leading metadata
-fence - is likewise not in this vocabulary. It renders nothing, so denying it
-would express nothing; an implementation that parses frontmatter allows the
-node unconditionally.
-
 The inline literal of PART 9 §27 (`` !`…` ``) is classified as **`code`** for
 profiles — it is a code span with the `<code>` wrapper dropped, sharing code's
 verbatim capture, escaping, and trailing-attribute surface, so it is allowed


### PR DESCRIPTION
`docs/profiles.md` currently answers "is `frontmatter` in the profile vocabulary" both ways.

The Block list says yes:

```
`admonition`, `raw_block`, `footnote`, `frontmatter`, `definition_list`,
```

A paragraph two sections later says no:

> A **`frontmatter`** block … is likewise not in this vocabulary. It renders nothing, so denying it would express nothing; an implementation that parses frontmatter allows the node unconditionally.

Both are normative. A reader gets whichever they reach first.

This is the same shape as the defect #419 just removed - two statements on one page giving opposite answers - and it arrived because #418 added the type to the list while #419 was open, so neither PR saw the other.

**The listing wins.** #418 settled that frontmatter is a block node in the tree rather than a root field, so a profile walking `children` genuinely encounters it and can name it. markup-carve/carve-php#503 already implements that reading: `NodeType::FRONTMATTER` is registered, denying it is honoured, and denial *strips* the node rather than degrading it to text - the content is document metadata and must never reach the rendered body.

Verified against carve-php main:

```
denyBlock(['frontmatter'])  ->  <p>Body text.</p>
leaks metadata?  no
placeholder?     no
```

So denying it changes no rendered output. It only means a host that names the type gets an answer instead of silence, which is the whole point of the vocabulary being normative.

Timing matters here: the carve-js and carve-rs PRs implementing #419 are written against this page.
