### PR TITLE
spec: carve-rs places blocks now, and carve-rb publishes them

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3504,12 +3504,19 @@ EOF = (* end of file *) ;
       wrong, which is the half of the rule below that matters, and they are
       tracked in carve-js#441.
 
-      carve-rs has none at all: 47 node structs with no position field, and
-      several of its inline variants are tuple-shaped, so there is nowhere to
-      put one without changing the variant itself. Its parser does keep a line
-      map for the source-line render option, so line granularity exists there
-      and columns and offsets do not. Tracked in carve-rs#333, which also
+      carve-rs records positions on BLOCK nodes and none on inline ones. Over
+      the corpus that places 869 block nodes and leaves 54, and the ones left
+      are refusals rather than gaps: line-block content is reassembled around
+      an indentation sentinel, so it is not a slice of the source and cannot
+      honestly be placed. Its inline variants are tuple-shaped, so there is
+      nowhere to put a position without changing the variant itself, which is
+      why the inline half has not started. Tracked in carve-rs#333, which also
       records the six trap classes carve-js hit, in the order they bit.
+
+      carve-rb serializes carve-rs's tree, so it publishes exactly what that
+      engine records - the block positions and not the inline ones. It is the
+      route by which the conformance checker reaches carve-rs at all, since
+      carve-rs has no JSON serializer of its own.
 
       An implementation that cannot yet produce positions MUST NOT emit `pos`
       with invented values, and MUST NOT omit it silently: it does not yet


### PR DESCRIPTION
PART 12 section 4's implementation status still said carve-rs had "none at all: 47 node structs with no position field". Block positions landed in markup-carve/carve-rs#350, so that paragraph described a state that no longer exists.

## What it says now

**carve-rs**: block positions, no inline ones. Over the corpus that is **869 placed, 54 left** - and the 54 are refusals rather than gaps. Line-block content is reassembled around an indentation sentinel, so it is not a slice of the source and cannot be placed honestly; section 4 wants it absent. The tuple-shaped inline variants remain the reason the inline half has not started.

**carve-rb**: added, because the note left it out entirely. It is the only route by which `scripts/ast-conformance.mjs` reaches carve-rs, which has no JSON serializer of its own, so what the checker measures is whatever the Ruby binding publishes. It now publishes positions (markup-carve/carve-rb#24), which took it from 3413 findings to 2535 over the 507-document corpus.

Text only. No grammar rule, no corpus, no normative clause changes.