### PR TITLE
spec: one answer for the root's fields, and say when a deny is invisible

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -158,6 +158,35 @@ an allowlist is a closed set.
 follows `disallowedAction` (`error` reports a violation; `to_text`/`strip`
 truncate/flatten).
 
+### Some types are deniable in the tree but invisible in rendered output
+
+`comment` and `frontmatter` render nothing. Denying either removes the node
+from the tree and reports a violation, but the rendered HTML is **byte-identical
+either way**:
+
+```
+carveToHtml("%% hidden\n\nBody.\n")                   -> "<p>Body.</p>"
+carveToHtml("%% hidden\n\nBody.\n", denyBlock:comment) -> "<p>Body.</p>"
+```
+
+This is not a no-op, and the distinction matters because the two look the same
+from the render path. Denying them changes:
+
+- **the serialized AST** - the node is gone from `children`, which is what a
+  consumer of `parse()` sees. A pipeline that hands untrusted documents to a
+  PDF renderer, an LSP, or a converter gets the tree, not the HTML.
+- **the violation report** - under `error`, a host learns the document carried
+  metadata or side commentary it did not ask for, and can refuse it.
+
+Frontmatter is the case where this is load-bearing rather than tidy. Carve's own
+renderers never emit it, but hosts routinely do - a title into a template, an
+author into a byline - which is why [Security](/security) PART 9 §25 requires a
+safe loader for it and escaping for any value later rendered. A profile that
+denies `frontmatter` keeps untrusted metadata out of that path entirely.
+
+A caller who denies one of these and diffs the HTML will see no change. Check
+the tree or the violations instead.
+
 ### A profile is not a substitute for disabling raw-HTML passthrough
 
 A profile restricts node **types**; it does **not** by itself turn off raw-HTML

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3376,46 +3376,14 @@ EOF = (* end of file *) ;
       spec surface for kind names. A document is
       `{"type":"document","children":[...]}`.
 
-      THE ROOT'S OWN FIELDS ARE FIXED -- NORMATIVE. Beyond `type` and
-      `children` the root carries `srcByteLength` always, and carries
-      `frontmatter` and `footnoteDefs` exactly when the document has them. It
-      carries nothing else.
+      The root's own fields are fixed by §7: `type`, `children` and
+      `srcByteLength`, and nothing else.
 
-        {"type":"document","children":[...],"srcByteLength":42,
-         "frontmatter":{"format":"yaml","content":"title: x"},
-         "footnoteDefs":{"r":[...]}}
-
-      `frontmatter` holds the RAW block and its format, not a parsed mapping.
-      Parsing YAML (or TOML, or JSON) is not this format's job, and a parsed map
-      cannot be serialized back to the bytes the author wrote -- key order,
-      comments and anchors are all gone. A consumer that wants the values runs
-      its own parser over `content`, which is the only form that keeps both
-      answers available.
+        {"type":"document","children":[...],"srcByteLength":42}
 
       `srcByteLength` counts BYTES of the source, and is the one field here that
       is not codepoints (PART 12 §4) -- it answers "how much source was this",
       not "where in it".
-
-      Frontmatter and footnote definitions sit on the ROOT rather than in
-      `children` because neither is a position in the document's flow. A
-      footnote definition renders where the REFERENCE to it appears, not where
-      it was written, and frontmatter renders nowhere at all. Putting either in
-      `children` gives it a place in a sequence it does not occupy: a consumer
-      walking `children` to render a document must then know to skip two of the
-      types it finds there.
-
-      This was left open once (carve#411) and the three engines answered
-      differently in three ways -- placement, spelling and CONTENT:
-
-        carve-js   root, `frontmatter` = {format, content}
-        carve-rb   root, `frontmatter` = the PARSED key/value mapping
-        carve-php  neither on the root; a `frontmatter` block and a `footnote`
-                   block inside `children`
-
-      The content disagreement is the one that matters most and the issue did
-      not record it: two engines publish a field of the same name holding
-      different data, so a consumer reading `frontmatter.content` gets a string
-      from one and `undefined` from the other. Placement at least fails loudly.
 
    3. FIELD NAMES ARE SPEC SURFACE, exactly as kind names are. The normative
       set per node type is the carve-js interface for that type. Notably:


### PR DESCRIPTION
Two changes to PART 12 §2 and `docs/profiles.md`. Text only - no grammar rule, no corpus, no new normative constraint.

## 1. §2 still carried the rule §7 replaced

§2 said:

> THE ROOT'S OWN FIELDS ARE FIXED -- NORMATIVE. Beyond `type` and `children` the root carries `srcByteLength` always, and carries `frontmatter` and `footnoteDefs` exactly when the document has them.

§7 says:

> THE DOCUMENT ROOT CARRIES EXACTLY THREE FIELDS -- NORMATIVE: `type`, `children`, `srcByteLength`. Nothing else.

Both normative, ~150 lines apart, plus three §2 paragraphs arguing the root case on the merits. §7 is newer and is the decided one; §2 is text markup-carve/carve#418 did not delete.

This is the same defect markup-carve/carve#421 removed from `profiles.md`, and it was not theoretical:

- `scripts/ast-conformance.mjs` had already moved on - it accepts the root form only as **"the pre-§7 root form"**, tolerated so an unmigrated engine is reported once rather than twice.
- The engines split two against two (carve-php and carve-rb in the tree, carve-js and carve-rs on the root) while the page endorsed both.

§2 now states the root's fields by reference to §7 and keeps only what §7 does not cover: what `srcByteLength` counts, and why it is the one field measured in bytes.

## 2. Some denials are invisible in rendered output

Not documented anywhere, and it looks exactly like the silent no-op the vocabulary exists to prevent:

```
carveToHtml("%% hidden\n\nBody.\n")                    -> "<p>Body.</p>"
carveToHtml("%% hidden\n\nBody.\n", denyBlock:comment)  -> "<p>Body.</p>"
```

Verified the same for `frontmatter` against carve-php: denying it leaves the HTML byte-identical.

Both types are in the Block vocabulary and both render nothing, so a caller who denies one and diffs the HTML sees no change and reasonably concludes it is broken. What denial actually changes is the **serialized tree** and the **violation report** - which is the entire product for a consumer calling `parse()` rather than `toHtml()`.

For `frontmatter` this is load-bearing rather than tidy. Carve's renderers never emit it, but hosts routinely do - a title into a template, an author into a byline - which is why Security PART 9 §25 already requires a safe loader for it and escaping for any value later rendered. Denying it keeps untrusted metadata out of that path.

Spec suite green: 599 pass, 0 fail.