### PR TITLE
fix: measure carve-js's serialized form, not its parse tree

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -277,10 +277,28 @@ const lib = await import(resolve(jsDir, 'dist/index.js'))
 
 const jsFindings = []
 const referenceShape = new Map()
+
+/**
+ * carve-js's SERIALIZED form, not its parse tree.
+ *
+ * PART 12 governs what an implementation exchanges, and §1 explicitly lets an
+ * engine keep different internals and map on the way out. carve-js does exactly
+ * that: `parse()` keeps `frontmatter` and `footnoteDefs` on the root, and
+ * `toAstJson` moves them into the tree as the block nodes §7 requires.
+ *
+ * This script read the parse tree, so it measured carve-js's INTERNALS against
+ * the serialized output of the other two - and then used those internals as the
+ * reference shape everything else was compared to. carve-js looked
+ * non-conformant on §7 while being the only engine with the mapping already
+ * written, and carve-php was reported as diverging from a shape no engine
+ * publishes (carve-js#480).
+ */
+const serialize = (doc) => (typeof lib.toAstJson === 'function' ? lib.toAstJson(doc) : doc)
+
 for (const { name, source } of samples) {
   let doc
   try {
-    doc = lib.parse(source)
+    doc = serialize(lib.parse(source))
   } catch (error) {
     jsFindings.push(`${name}: parse threw - ${error.message}`)
     continue


### PR DESCRIPTION
The script read `lib.parse(source)` for carve-js and the **serialized** output of the other two - `bin/carve --json` for carve-php, `Carve.parse` for carve-rb. Then it used carve-js's parse tree as the reference shape everything else was compared against.

PART 12 governs what an implementation **exchanges**, and §1 explicitly lets an engine keep different internals and map on the way out. carve-js does exactly that:

```js
parse(src)        // root: type, children, srcByteLength, frontmatter, footnoteDefs
toAstJson(parse)  // root: type, children, srcByteLength
                  // children: ['frontmatter', 'paragraph', 'footnote']
```

So the script reported carve-js as violating §7 while it was **the only engine with the mapping already written**, and reported carve-php as diverging from a shape no engine publishes. I filed markup-carve/carve-js#480 against that reading before checking what `toAstJson` produced; it is corrected there.

## It makes the reference look worse, correctly

```
carve-js: 4 findings -> 22
    14x missing pos on "footnote"
     3x missing pos on "frontmatter"
      (the 4 that were already there)
```

Those 18 are real. The frontmatter and footnote nodes `toAstJson` synthesizes carry no `pos`, because the root fields they come from never had one - which is the same fact §7's rationale rests on ("a root FIELD cannot carry `pos`"), showing up as a measurement instead of an argument.

carve-php stays at 14 and carve-rb at 410, so those findings were not artifacts of the wrong reference.

## Guard

`serialize()` falls back to the parse tree when `toAstJson` is absent, so an older carve-js checkout still measures rather than crashing.