### PR TITLE
spec: name the third type a denial does not show

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -184,7 +184,20 @@ author into a byline - which is why [Security](/security) PART 9 §25 requires a
 safe loader for it and escaping for any value later rendered. A profile that
 denies `frontmatter` keeps untrusted metadata out of that path entirely.
 
-A caller who denies one of these and diffs the HTML will see no change. Check
+**`escaped_text` reaches the same place by a different route.** It is not that
+it renders nothing - it renders the character. It is that `to_text` degrades it
+to that same character, so a denial and an allowance produce identical output:
+
+```
+carveToHtml("a \\* b")                          -> "<p>a * b</p>"
+carveToHtml("a \\* b", denyInline:escaped_text) -> "<p>a * b</p>"   + a violation
+```
+
+What a host learns by denying it is that the document used escapes at all -
+authoring intent the rendered character does not carry. The escape is syntax;
+the character is content.
+
+A caller who denies any of these and diffs the HTML will see no change. Check
 the tree or the violations instead.
 
 ### A profile is not a substitute for disabling raw-HTML passthrough


### PR DESCRIPTION
The "Some types are deniable in the tree but invisible in rendered output" section names `comment` and `frontmatter`. That was the complete list when markup-carve/carve#425 added it. It is not any more: markup-carve/carve-js#474 made carve-js honour `escaped_text`, so denying it now reports violations and changes the tree while leaving the HTML byte-identical - which is exactly what that section describes.

Verified against both engines on `a \* b and \_c\_ d`:

```
plain :     <p>a * b and _c_ d</p>
denied:     <p>a * b and _c_ d</p>
violations: 3  (escaped_text x3)
```

A section that reads as an exhaustive list of two sends the next person to diff the HTML, see no change, and conclude the denial is broken - the exact confusion it exists to prevent.

## Why it is stated separately rather than folded in

`comment` and `frontmatter` are invisible because they **render nothing**, so removing them cannot change the output. `escaped_text` renders the character; it is invisible because `to_text` degrades it to that **same character**, so the degradation is indistinguishable from the original.

Same consequence for a caller, different mechanism. Folding it into "these render nothing" would have been wrong, and would have left a reader unable to predict which other types behave this way.

The closing line now covers all three.
