### PR TITLE
checker: let the display cap be raised, because it hid every wrong span

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -107,7 +107,7 @@ const phpDir = process.env.CARVE_PHP_DIR ?? resolve(root, '../carve-php')
  * position fixes dropped the finding count below 40 and the document came back
  * into view.
  */
-const DISPLAY_LIMIT = 8
+const DISPLAY_LIMIT = Number(process.env.CARVE_DISPLAY_LIMIT ?? 8)
 
 const POS_KEYS = ['startLine', 'endLine', 'startColumn', 'endColumn', 'startOffset', 'endOffset']
 


### PR DESCRIPTION
One line, plus the reason it is worth having.

`scripts/ast-conformance.mjs` prints the top 8 distinct findings and counts the rest. Sensible default - the alternative is 40 lines of noise. But there is no way to see the rest, and the rest is where the interesting ones were.

## What it hid

While placing carve-rs's figure captions (markup-carve/carve-rs#365), anchoring alone produced 24 spans with correct lines and columns and offsets of `0..0` - present, and selecting nothing.

Every one landed outside the top 8. The report read the same shape before and after:

```
267 findings, 26 distinct     ... and 18 more distinct findings not shown
253 findings, 42 distinct     ... and 34 more distinct findings not shown
```

The total went **down** while the findings got **worse** - from missing positions to wrong ones. A missing position is a gap a consumer can branch on; a span that selects nothing is a lie. The cap made them indistinguishable, and I only found them by editing this file locally.

`CARVE_DISPLAY_LIMIT=45` raises it. The default is unchanged, so no run that does not ask for it looks any different.

Same shape as the collection cap this file already carries a long note about: capping DISPLAY is fine, but only if the display can be opened.

Spec suite green: 618 pass.