### PR TITLE
spec: say where heading attributes go, and let the section wrapper be turned off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **An optional `sections` switch on the HTML renderer** (carve#427). Setting it
+  to `false` renders headings flat, with the id back on the `<h*>` and the blocks
+  that would have been section children left as siblings. The default is
+  unchanged and is what the corpus pins; the switch is HTML-only, because no
+  other target emits `<section>` and the AST has no `section` node.
+
+  The wrapper is the one output change that breaks sites whose source migrated
+  cleanly: any CSS or JS assuming rendered blocks are direct children of the
+  content container - the `.stack > * + *` spacing idiom, `:first-child`,
+  `nth-child()` counting, `element.children` walks - stops matching once a
+  `<section>` sits in between. Djot users can unwrap the node with a filter.
+  Carve users cannot, because Carve synthesizes the element at render time from
+  a flat AST, so there is nothing to intercept - which left HTML post-processing
+  as the only escape.
+
+  Now specified rather than left to engines; no engine ships it yet, so the
+  optional-corpus case for it is visible as skipped.
+
 ### Changed
+
+- **PART 9 §13 says where non-id heading attributes go, and what containers do**
+  (carve#427). Two rules every engine already implemented, neither of which the
+  spec stated. On a top-level heading the id hoists to the `<section>` and every
+  other attribute stays on the `<h*>`, identically for a slugged and a written
+  id. A heading inside a blockquote, div, admonition, or list item is not
+  wrapped at all: it emits `<h* id="…">` in place, still slugged, still sharing
+  the one dedup namespace, still a `</#id>` target.
+
+  Djot resolved the first question the other way (all attributes migrate to the
+  section) and then implemented that only when an explicit id is present, so its
+  two id cases contradict each other and its own stated rule
+  (`jgm/djot.js#144`). Carve's two cases agree, which is what lets the rule
+  survive the wrapper being switched off - the id returns to the `<h*>` and
+  nothing else moves, leaving one placement rule for the whole document.
+
+- **PART 11 R1 describes the implicit heading fallback it always had**
+  (carve#427). A `[text][]` that matches no link definition resolves against the
+  document's headings by their rendered text. The rule was documented in prose
+  and implemented in every engine, but the resolution pass never mentioned it -
+  including the parts a second implementation cannot guess: link definitions win
+  a tie, matching folds case and collapses whitespace (unlike the exact,
+  case-sensitive link-definition matching in the same rule), and a heading with
+  a blockquote ancestor is declined in either nesting order.
+
 
 - **PART 12 §4: position tracking may be opt-in, serialization may not.** An
   implementation may gate position tracking behind a parse option and must

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   survive the wrapper being switched off - the id returns to the `<h*>` and
   nothing else moves, leaving one placement rule for the whole document.
 
+- **PART 10 §1 says where a generated attribute goes** (carve#427). The author's
+  own attributes keep their source order and anything the engine minted follows
+  them, so an unwrapped heading renders `<h1 a="b" class="c" id="Auto">` for an
+  auto slug and `<h1 id="x" a="b">` for an id the author wrote. Provenance is
+  the discriminator, not the attribute's name.
+
+  All three engines disagreed here, with nothing able to catch it: carve-js
+  appended a generated id but left an authored one in place, carve-php put the
+  id last in both cases, carve-rs put it first in both. No two agreed on both
+  cases. The combination was reachable only through a heading inside a
+  container, and no corpus case gave such a heading attributes - so each engine
+  picked an answer and stayed green. The executable spec was a fourth answer
+  again: it dropped the attributes entirely. carve-js is canonical; the rest
+  converge on it.
+
+  The `sections` switch is what surfaced this. With it off every heading takes
+  the unwrapped path, so a divergence that used to require a blockquote would
+  have shipped on ordinary documents.
+
 - **PART 11 R1 describes the implicit heading fallback it always had**
   (carve#427). A `[text][]` that matches no link definition resolves against the
   document's headings by their rendered text. The rule was documented in prose

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ the [Case Study](https://markup-carve.github.io/carve/case-study/) and the
 | Wiki-style links | n/a (no auto wiki links) | `[Page Name][]` (reference link; needs a `[Page Name]: url` definition) | `[Page Name][]` (auto-resolves, no definition) |
 | Cross-references | n/a (manual `[](#id)`) | n/a (manual `[](#id)`) | `</#id>` (auto-fills link text from the target heading) |
 | Heading IDs | n/a (auto only on some renderers, e.g. GitHub) | Auto-generated (Unicode, case-preserving) | Auto-generated (Unicode, case-preserving, CSS-selector-safe; case-insensitive references; opt-in lowercase + ASCII fold) |
-| Heading structure | n/a (flat `<h1>`–`<h6>`, no wrappers) | `<section id="…"><h*>…</h*></section>` with level-aware nesting | `<section id="…"><h*>…</h*></section>` with level-aware nesting (matches djot — id on `<section>`, not on `<h*>`) |
+| Heading structure | n/a (flat `<h1>`–`<h6>`, no wrappers) | `<section id="…"><h*>…</h*></section>` with level-aware nesting | `<section id="…"><h*>…</h*></section>` with level-aware nesting; only the id hoists, other attributes stay on the `<h*>`; optional `sections: false` renders flat with the id back on the `<h*>` |
 
 ### Lists & tables
 

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -38,7 +38,9 @@ Read this first.
 :::
 ```
 
-renders the heading as `<h2 class="featured">` inside `<section id="install">` (an explicit heading id hoists to the `<section>` wrapper, PART 9 §13) and the admonition as `<aside class="admonition note callout">`.
+renders the heading as `<h2 class="featured">` inside `<section id="install">` and the admonition as `<aside class="admonition note callout">`.
+
+The split in that first line is the rule, not a quirk of this example: on a top-level heading the **id** hoists to the `<section>` wrapper and **every other attribute stays on the `<h*>`** (PART 9 §13). It makes no difference whether the id was written as `{#install}` or slugged from the heading text - both hoist. The id names the region a `#fragment` URL targets, and that region is the section; `.featured` describes the heading the author wrote it on, so a subtree-wide class belongs on a div instead. A heading inside a container (blockquote, div, list item) gets no wrapper at all, so there its id stays on the `<h*>` with the rest.
 
 This is uniform across every block - headings, block quotes, lists, code blocks, divs/admonitions, line-blocks, local hard-break blocks, tables. They all take their attributes on the preceding line; none take a trailing attribute on the block's own line. (For a code block the fence line accepts only structured metadata - `lang`, optional `"header"`, optional `[label]`, in that order. A `:::` container fence takes the same two metadata tokens after its type word - see [Container fences: titles and labels](#container-fences-titles-and-labels) below. A trailing `{…}` after the language word makes the line *not a fence at all*; the backticks then fall back to ordinary inline parsing. For a heading, a trailing `{…}` is ordinary inline text. Put the attributes on the line above, like any other block.)
 

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -83,6 +83,38 @@ replaces every other ASCII run with a single `-` (`# a; b: c` → `a-b-c`,
 `# C++ & Rust` → `C-Rust`). An allowlist gives cleaner, more predictable
 anchors than enumerating punctuation to drop.
 
+## 1c. Only the id hoists to the `<section>` wrapper
+
+Both languages wrap a top-level heading, and the content following it, in a
+`<section>` that carries the heading's id. They disagree about the heading's
+*other* attributes.
+
+**Djot:** the resolution recorded in `jgm/djot.js#43` is that all of a heading's
+attributes migrate to the section. The implementation applies that only when the
+heading carries an explicit `{#id}`; with an auto-generated id the non-id
+attributes stay on the heading, so djot's two cases contradict each other and
+each other's stated rule (`jgm/djot.js#144`, open).
+
+**Carve:** the id hoists, everything else stays on the `<h*>`, and the two id
+cases agree:
+
+```
+{a=b .c}      →  <section id="abc"><h1 a="b" class="c">abc</h1></section>
+# abc
+
+{a=b .c #x}   →  <section id="x"><h1 a="b" class="c">abc</h1></section>
+# abc
+```
+
+The id is the one attribute that is about the *region*: it names what a
+`#fragment` URL scrolls to, and that is the section. The rest describe the
+heading the author attached them to - `{.featured}` marks the heading, and an
+author who wants to style the whole subtree writes a div around it. Keeping the
+rule independent of how the id was produced also means it survives the wrapper
+being switched off: with `sections: false` (PART 9 §13) the id simply returns to
+the `<h*>` and nothing else moves, which is already how every heading inside a
+blockquote, div, or list item renders in both languages.
+
 ## 2. A list marker must have content
 
 **Djot / CommonMark:** a bare `-` (or `- ` with only trailing whitespace) starts

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -5645,3 +5645,76 @@ $$```x `` y```
 ```
 
 :::
+
+## Only the id hoists to the section wrapper
+
+On a top-level heading the id moves to the `<section>` and every other attribute
+stays on the `<h*>` - identically whether the id was slugged from the heading
+text or written as `{#id}`. Worth pinning because djot resolved the same question
+the other way (all attributes migrate) and then implemented that resolution only
+for the explicit-id case, so its two cases disagree (`jgm/djot.js#144`). Carve's
+agree, and that is what keeps the rule stable when the wrapper is switched off:
+the id returns to the `<h*>` and nothing else moves.
+
+::: compare
+
+```carve
+{a=b .c}
+# Auto slug
+
+{a=b .c #explicit}
+# Written id
+```
+
+```html
+<section id="Auto-slug">
+  <h1 a="b" class="c">Auto slug</h1>
+</section>
+<section id="explicit">
+  <h1 a="b" class="c">Written id</h1>
+</section>
+```
+
+:::
+
+## Headings inside containers are not wrapped
+
+A `<section>` models this document's own outline, so only top-level headings open
+one. A heading inside a blockquote, div, or list item emits a bare `<h*>` with
+its id on the heading itself. The ids are still assigned, still share the one
+document-order dedup namespace with top-level headings, and are still `</#id>`
+crossref targets - only the wrapper and the id's emission site differ.
+
+::::: compare
+
+```carve
+> # Quoted
+>
+> Quoted body.
+
+:::
+# Divved
+:::
+
+- # In an item
+
+  Item body.
+```
+
+```html
+<blockquote>
+  <h1 id="Quoted">Quoted</h1>
+  <p>Quoted body.</p>
+</blockquote>
+<div>
+  <h1 id="Divved">Divved</h1>
+</div>
+<ul>
+  <li>
+    <h1 id="In-an-item">In an item</h1>
+    <p>Item body.</p>
+  </li>
+</ul>
+```
+
+:::::

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -5718,3 +5718,43 @@ crossref targets - only the wrapper and the id's emission site differ.
 ```
 
 :::::
+
+## Attribute order on an unwrapped heading
+
+A heading that carries no `<section>` wrapper emits its id on the `<h*>`, which
+puts a generated attribute next to authored ones. The author's order is never
+rearranged; the engine-minted id joins at the end. An id the author wrote is not
+generated, so it keeps its authored position instead.
+
+Worth pinning because the combination was previously unreachable except through
+a container, and no case gave such a heading attributes - so all three engines
+picked different answers here and every one of them stayed green (PART 10 §1).
+
+::::: compare
+
+```carve
+> {a=b .c}
+> # Auto
+
+> {#x a=b}
+> # Written
+
+:::
+{a=b .c}
+# Divved
+:::
+```
+
+```html
+<blockquote>
+  <h1 a="b" class="c" id="Auto">Auto</h1>
+</blockquote>
+<blockquote>
+  <h1 id="x" a="b">Written</h1>
+</blockquote>
+<div>
+  <h1 a="b" class="c" id="Divved">Divved</h1>
+</div>
+```
+
+:::::

--- a/docs/migrate-from-markdown.md
+++ b/docs/migrate-from-markdown.md
@@ -255,6 +255,51 @@ The equivalent switch exists per engine (carve-rs `Options::with_raw_html(false)
 Bare tags are safe (literal) regardless. The setting above only governs the explicit ```` ```=html ```` / `{=html}` passthrough - leave it disabled for user-generated content.
 :::
 
+## Headings are wrapped in `<section>`
+
+This is the one output change that can break a site whose *source* migrated cleanly, so check it before you convert a whole content directory.
+
+A Markdown renderer emits headings flat. Carve wraps each heading, and the content following it up to the next same-or-shallower heading, in a `<section>` - and the heading's id goes on that wrapper:
+
+```html
+<!-- Markdown -->
+<h2 id="page-heading">Page Heading</h2>
+<p>A paragraph.</p>
+
+<!-- Carve -->
+<section id="Page-Heading">
+  <h2>Page Heading</h2>
+  <p>A paragraph.</p>
+</section>
+```
+
+Fragment links are unaffected: `#Page-Heading` resolves to the `<section>` exactly as it resolved to the `<h2>`. What breaks is CSS and JS that assume rendered blocks are **direct children** of their container. The common casualty is the owl/stack spacing idiom, because the paragraphs are now grandchildren:
+
+```css
+/* Stops matching: the section is the only direct child. */
+.stack > * + * { margin-block-start: 1.5em; }
+
+/* Fix: match inside generated sections at any depth. */
+:where(.stack, .stack section) > * + * { margin-block-start: 1.5em; }
+```
+
+Other things worth grepping your stylesheets and scripts for: `>` child combinators under your content wrapper, `:first-child` / `:last-child` (the first paragraph after a heading is now the section's second child), `:nth-child()` counting, and `element.children` walks over the rendered container.
+
+If a project cannot absorb the shape change, an HTML renderer MAY offer a `sections` option that turns the wrapper off, putting the id back on the `<h*>`:
+
+```ts
+const html = carveToHtml(source, { sections: false })
+```
+
+```html
+<h2 id="Page-Heading">Page Heading</h2>
+<p>A paragraph.</p>
+```
+
+Nothing else changes when it is off - ids, dedup, `</#id>` cross-references, `[Heading][]` references, and `::: toc` all resolve against the slug, not the element carrying it. Check your engine's release notes for whether it ships the option yet; the wrapper is the default and is what the conformance corpus pins.
+
+Two related shapes are worth knowing while you audit selectors. A heading **inside** a blockquote, div, admonition, or list item is never wrapped - it emits `<h* id="…">` in place, which is also exactly what every heading looks like with `sections: false`. And on a wrapped heading only the id hoists: `{#install .featured}` gives `<section id="install"><h2 class="featured">`, so a class you attached to a heading still selects the heading.
+
 ## Migration checklist
 
 When moving a document from Markdown to Carve:
@@ -267,3 +312,4 @@ When moving a document from Markdown to Carve:
 - [ ] Move any heading `{#id}` onto the line above the heading (trailing is literal)
 - [ ] Check the indentation of top-level block markers: a leading-indented `#`, `>`, `-`, `` ``` ``, or `:::` is literal paragraph text in Carve, not a block. Markdown tolerates 0-3 spaces of indent; Carve requires a block marker at column 0 (or, inside a list, at the item's content column)
 - [ ] Decide on raw HTML: bare `<tags>` become literal text, so replace them with Carve constructs (or use the explicit `{=html}` passthrough for trusted content; disable it with `allowRawHtml: false` for untrusted input)
+- [ ] Audit CSS and JS for direct-child assumptions - headings now nest their content in `<section>` (see [Headings are wrapped in `<section>`](#headings-are-wrapped-in-section))

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2239,8 +2239,66 @@ EOF = (* end of file *) ;
         `<section>`, not on the `<h*>`. The dedup namespace (syntax.md
         §4.1 / heading-id-tracker rules) is unchanged -- explicit ids are
         reserved before auto-ids in document order.
+      - ATTRIBUTES OTHER THAN THE ID STAY ON THE `<h*>`. The id is the
+        only attribute that hoists, and it hoists the same way whether
+        it was written (`{#x}`) or slugged from the heading text:
+          {a=b .c}       -> <section id="abc"><h1 a="b" class="c">
+          # abc
+          {a=b .c #x}    -> <section id="x"><h1 a="b" class="c">
+          # abc
+        The id hoists because it names the region a fragment URL
+        targets, and that region is the section. Every other attribute
+        describes the heading the author wrote it on: `{.featured}`
+        marks the heading, not the whole subtree beneath it -- an
+        author who wants the subtree has a div (PART 2, `div_open`).
+        This is a KNOWN DIVERGENCE from djot, which resolved
+        `jgm/djot.js#43` the other way (all attributes migrate to the
+        section) and then implemented that resolution only when an
+        explicit id is present, so djot's two id cases disagree with
+        each other (`jgm/djot.js#144`). Carve's two cases agree. See
+        divergence-from-djot.md.
+      - HEADINGS INSIDE CONTAINERS DO NOT WRAP. The algorithm walks
+        TOP-LEVEL blocks (and the sections it opens), so a heading
+        inside a blockquote, div, admonition, list item, definition,
+        table cell, or footnote definition emits a bare `<h* id="...">`
+        with the id ON THE HEADING and no `<section>` around it. A
+        `<section>` models THIS document's outline: quoted material
+        carries another document's outline, and a div or list item is
+        author grouping within one section rather than a new one.
+        Everything else about such a heading is unchanged -- it is
+        slugged, it shares the one document-order dedup namespace with
+        top-level headings (`# abc` then `> # abc` gives `abc` then
+        `abc-2`), and it is a valid `</#id>` crossref target. The one
+        exception is the implicit `[Heading][]` reference index, which
+        declines headings under a blockquote (PART 11 R1).
+        Consequence worth stating: when the `sections` option below is
+        off, the top-level shape becomes identical to this one, so id
+        placement and attribute placement follow ONE rule everywhere in
+        the document.
       - Empty document or doc with no headings: zero <section> elements
         are emitted.
+      - THE `sections` RENDER OPTION. A host MAY offer a boolean
+        `sections` option on the HTML renderer. It defaults to TRUE
+        (this section's behavior), and the conformance corpus pins the
+        default. When FALSE the renderer emits NO `<section>` element:
+        each heading emits `<h{N} id="{slug}">` carrying the id it
+        would otherwise have hoisted, alongside its other attributes,
+        and the blocks that would have been the section's children stay
+        where they are as siblings -- which also means they lose the
+        two-space indentation PART 10 §4 gives a container's children,
+        because they no longer have that container.
+          # A          sections: true      sections: false
+          p            <section id="A">    <h1 id="A">A</h1>
+                         <h1>A</h1>        <p>p</p>
+                         <p>p</p>
+                       </section>
+        Nothing else changes. Ids, the dedup namespace, `</#id>`
+        crossrefs, implicit `[Heading][]` references, `::: toc`,
+        endnotes placement (§16), and HeadingNumbers all resolve
+        against the SLUG rather than against the element that carries
+        it, so they behave identically under either setting. The option
+        is HTML-only: no other render target emits `<section>`, and the
+        AST has no `section` node for it to affect (PART 12).
       - The two-pass id resolution (collect explicit ids first, then
         auto-slug headings with collision-dedup) is unaffected by this
         rule -- only the EMISSION site of the id moves from <h*> to
@@ -2901,6 +2959,28 @@ EOF = (* end of file *) ;
       attributes transfer to the link; link attributes override per key.
       Unresolved -> the bracketed run renders as literal source text. Carve
       has NO shortcut reference: a bare [label] never resolves (PART 9 §14).
+      IMPLICIT HEADING FALLBACK: a [text][] whose label matches no
+      linkDefs entry falls back to the heading index -- the document's
+      headings keyed by their rendered plain text -- and resolves to
+      `#{slug}` of the FIRST heading with that text. linkDefs WINS on a
+      tie, so an explicit `[label]: url` definition always beats a
+      same-named heading. Matching against the heading index is LOOSER
+      than the linkDefs matching above: the label and the heading text
+      are both trimmed, their internal whitespace runs collapsed to one
+      space, and then compared case-INSENSITIVELY, so `[getting
+      started][]` finds `# Getting Started`. That asymmetry is
+      deliberate -- a linkDefs label is an identifier the author wrote
+      twice and can keep identical, while a heading ref is prose the
+      author is quoting from elsewhere in the document. The index holds
+      headings at top level and
+      inside divs, admonitions, list items, and definitions, but
+      DECLINES any heading with a blockquote ancestor, in either
+      nesting order: quoted text names the quoted document's headings,
+      not this document's, and a quotation is the one container whose
+      wording an author does not control. Declining it here does not
+      make such a heading unreachable -- it is still slugged, still
+      deduped in the one namespace, and still a `</#id>` crossref
+      target (R4), which addresses it by id rather than by wording.
    R2 FOOTNOTES (rendering in PART 9 §16). A [^label] use with a matching
       footnoteDefs entry is numbered by FIRST-REFERENCE order from
       footnoteSeq; repeat references reuse the number (k-th repeat gets
@@ -2941,8 +3021,10 @@ EOF = (* end of file *) ;
       recorded order falls back to a fixed `class`, then `id`, then
       key=value order. All classes accumulate (space-joined) into one
       `class` slot at its first-appearance position. An element with no
-      effective attributes emits none. (Heading ids move to <section>,
-      §13.) A mandatory base class (math `math inline|display`) is
+      effective attributes emits none. (A top-level heading's id moves
+      to <section> and its other attributes do not, §13; with the
+      `sections` option off, or for a heading inside a container, the id
+      stays on the <h*> with the rest.) A mandatory base class (math `math inline|display`) is
       prepended to that class slot.
 
    2. ATTRIBUTE QUOTING + ESCAPING. Attribute values are double-quoted.

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3027,6 +3027,35 @@ EOF = (* end of file *) ;
       stays on the <h*> with the rest.) A mandatory base class (math `math inline|display`) is
       prepended to that class slot.
 
+      A GENERATED ATTRIBUTE JOINS AT THE END. The two rules above cover
+      an all-authored Attrs and an all-programmatic one; the MIXED case
+      is a generated attribute added to attributes the author wrote, and
+      it takes the authored order first, then the generated attribute.
+      In practice this is one attribute -- the auto-slug id an unwrapped
+      heading carries (§13):
+        > {a=b .c}      -> <h1 a="b" class="c" id="Auto">
+        > # Auto
+      An attribute the author WROTE keeps its authored position even
+      when it is the id, because it is not generated:
+        > {#x a=b}      -> <h1 id="x" a="b">
+        > # Written
+      So the discriminator is provenance, not the attribute's name: the
+      author's own order is never rearranged, and anything the engine
+      minted follows it. Pinned by the corpus.
+
+      This rule was added after all three engines were found to disagree
+      here with nothing to catch it -- carve-js appended a generated id
+      but kept an authored one in place, carve-php put the id last in
+      both cases, carve-rs put it first in both. No two agreed on both
+      cases. The combination was reachable only through a heading inside
+      a container, which no corpus case gave attributes, so each engine
+      picked a different answer and stayed green. carve-js is canonical
+      here (PART 9 §13 and the corpus follow it); carve-php and carve-rs
+      converge on it. The `sections` option is what forced the issue:
+      with it off every heading takes the unwrapped path, so a
+      divergence that used to need a blockquote would have shown up on
+      ordinary documents.
+
    2. ATTRIBUTE QUOTING + ESCAPING. Attribute values are double-quoted.
       In an attribute value escape `&`->&amp;, `<`->&lt;, `>`->&gt;,
       `"`->&quot;, `'`->&apos;. In text/content escape `&`,`<`,`>` (NOT

--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -228,9 +228,20 @@ function renderBlock(b, depth, ctx) {
       // a heading inside a container: no section wrapper (SS13 wraps
       // top-level headings only); the id lands on the <h*> itself
       const html = renderInline(b.text)
-      const id = ctx.slug(b.text.replace(/<\/#[^>]*>/g, '').replace(/[ \t]+$/, ''))
+      // PART 10 SS1: the author's own attributes keep their source order,
+      // and a GENERATED attribute joins at the end. So an authored {#id}
+      // renders in place through renderBlockAttrs, while an auto slug is
+      // appended after everything the author wrote.
+      let authored = null
+      for (const list of b.battrs ?? []) {
+        for (const a of list) if (a[0] === 'id') authored = a[1]
+      }
+      const attrStr = b.battrs ? renderBlockAttrs(b.battrs) : ''
+      const id =
+        authored ?? ctx.slug(b.text.replace(/<\/#[^>]*>/g, '').replace(/[ \t]+$/, ''))
       ctx.headingIds.set(id.toLowerCase(), { id, html })
-      return `${pad}<h${b.level} id="${escapeAttr(id)}">${html}</h${b.level}>`
+      const idAttr = authored === null ? ` id="${escapeAttr(id)}"` : ''
+      return `${pad}<h${b.level}${attrStr}${idAttr}>${html}</h${b.level}>`
     }
     case 'footnotes-placement':
       return '\uE000fnplacement\uE001'

--- a/tests/corpus-optional/32-section-wrapper-off.crv
+++ b/tests/corpus-optional/32-section-wrapper-off.crv
@@ -1,0 +1,12 @@
+{a=b .c}
+# Auto slug
+
+Body.
+
+## Nested level
+
+More.
+
+> # Quoted
+
+See </#Auto-slug> and [Nested level][].

--- a/tests/corpus-optional/32-section-wrapper-off.html
+++ b/tests/corpus-optional/32-section-wrapper-off.html
@@ -1,0 +1,8 @@
+<h1 a="b" class="c" id="Auto-slug">Auto slug</h1>
+<p>Body.</p>
+<h2 id="Nested-level">Nested level</h2>
+<p>More.</p>
+<blockquote>
+  <h1 id="Quoted">Quoted</h1>
+</blockquote>
+<p>See <a href="#Auto-slug">Auto slug</a> and <a href="#Nested-level">Nested level</a>.</p>

--- a/tests/corpus-optional/manifest.json
+++ b/tests/corpus-optional/manifest.json
@@ -157,6 +157,11 @@
       "feature": "markdown-typography-source",
       "target": "markdown",
       "description": "With the optional Markdown-renderer setting that emits the author source run instead of the glyph, quotes, dashes and the ellipsis stay as the ASCII that was typed (PART 9 section 8; carve#360)."
+    },
+    {
+      "slug": "32-section-wrapper-off",
+      "feature": "section-wrapper-off",
+      "description": "With the optional HTML-renderer sections switch set to false, no <section> is emitted: each heading carries the id it would have hoisted, alongside its other attributes, and the blocks that would have been section children stay siblings. Ids, dedup, crossrefs and implicit heading references are unchanged, and a heading inside a container renders exactly as it does with the wrapper on (PART 9 section 13; carve#427)."
     }
   ]
 }

--- a/tests/corpus/167-only-the-id-hoists-to-the-section-wrapper.crv
+++ b/tests/corpus/167-only-the-id-hoists-to-the-section-wrapper.crv
@@ -1,0 +1,5 @@
+{a=b .c}
+# Auto slug
+
+{a=b .c #explicit}
+# Written id

--- a/tests/corpus/167-only-the-id-hoists-to-the-section-wrapper.html
+++ b/tests/corpus/167-only-the-id-hoists-to-the-section-wrapper.html
@@ -1,0 +1,6 @@
+<section id="Auto-slug">
+  <h1 a="b" class="c">Auto slug</h1>
+</section>
+<section id="explicit">
+  <h1 a="b" class="c">Written id</h1>
+</section>

--- a/tests/corpus/168-headings-inside-containers-are-not-wrapped.crv
+++ b/tests/corpus/168-headings-inside-containers-are-not-wrapped.crv
@@ -1,0 +1,11 @@
+> # Quoted
+>
+> Quoted body.
+
+:::
+# Divved
+:::
+
+- # In an item
+
+  Item body.

--- a/tests/corpus/168-headings-inside-containers-are-not-wrapped.html
+++ b/tests/corpus/168-headings-inside-containers-are-not-wrapped.html
@@ -1,0 +1,13 @@
+<blockquote>
+  <h1 id="Quoted">Quoted</h1>
+  <p>Quoted body.</p>
+</blockquote>
+<div>
+  <h1 id="Divved">Divved</h1>
+</div>
+<ul>
+  <li>
+    <h1 id="In-an-item">In an item</h1>
+    <p>Item body.</p>
+  </li>
+</ul>

--- a/tests/corpus/169-attribute-order-on-an-unwrapped-heading.crv
+++ b/tests/corpus/169-attribute-order-on-an-unwrapped-heading.crv
@@ -1,0 +1,10 @@
+> {a=b .c}
+> # Auto
+
+> {#x a=b}
+> # Written
+
+:::
+{a=b .c}
+# Divved
+:::

--- a/tests/corpus/169-attribute-order-on-an-unwrapped-heading.html
+++ b/tests/corpus/169-attribute-order-on-an-unwrapped-heading.html
@@ -1,0 +1,9 @@
+<blockquote>
+  <h1 a="b" class="c" id="Auto">Auto</h1>
+</blockquote>
+<blockquote>
+  <h1 id="x" a="b">Written</h1>
+</blockquote>
+<div>
+  <h1 a="b" class="c" id="Divved">Divved</h1>
+</div>

--- a/tests/spec/167-only-the-id-hoists-to-the-section-wrapper.test
+++ b/tests/spec/167-only-the-id-hoists-to-the-section-wrapper.test
@@ -1,0 +1,16 @@
+Only the id hoists to the section wrapper
+
+```
+{a=b .c}
+# Auto slug
+
+{a=b .c #explicit}
+# Written id
+.
+<section id="Auto-slug">
+  <h1 a="b" class="c">Auto slug</h1>
+</section>
+<section id="explicit">
+  <h1 a="b" class="c">Written id</h1>
+</section>
+```

--- a/tests/spec/168-headings-inside-containers-are-not-wrapped.test
+++ b/tests/spec/168-headings-inside-containers-are-not-wrapped.test
@@ -1,0 +1,29 @@
+Headings inside containers are not wrapped
+
+```
+> # Quoted
+>
+> Quoted body.
+
+:::
+# Divved
+:::
+
+- # In an item
+
+  Item body.
+.
+<blockquote>
+  <h1 id="Quoted">Quoted</h1>
+  <p>Quoted body.</p>
+</blockquote>
+<div>
+  <h1 id="Divved">Divved</h1>
+</div>
+<ul>
+  <li>
+    <h1 id="In-an-item">In an item</h1>
+    <p>Item body.</p>
+  </li>
+</ul>
+```

--- a/tests/spec/169-attribute-order-on-an-unwrapped-heading.test
+++ b/tests/spec/169-attribute-order-on-an-unwrapped-heading.test
@@ -1,0 +1,24 @@
+Attribute order on an unwrapped heading
+
+```
+> {a=b .c}
+> # Auto
+
+> {#x a=b}
+> # Written
+
+:::
+{a=b .c}
+# Divved
+:::
+.
+<blockquote>
+  <h1 a="b" class="c" id="Auto">Auto</h1>
+</blockquote>
+<blockquote>
+  <h1 id="x" a="b">Written</h1>
+</blockquote>
+<div>
+  <h1 a="b" class="c" id="Divved">Divved</h1>
+</div>
+```


### PR DESCRIPTION
Closes #427.

The ticket asked for one thing. Investigating it turned up two more, both in the same section of the spec.

## What §13 never said

PART 9 §13 pinned the `<section>` wrapper and stated only that the id hoists onto it. It said nothing about a heading's **other** attributes, and nothing about headings **inside containers**. Both rules are implemented identically by every engine and were written down nowhere, so a fourth implementation had to read carve-js to find them:

```
{a=b .c}      ->  <section id="abc"><h1 a="b" class="c">abc</h1></section>
# abc

{a=b .c #x}   ->  <section id="x"><h1 a="b" class="c">abc</h1></section>
# abc

> # Quoted    ->  <blockquote><h1 id="Quoted">Quoted</h1></blockquote>
```

Now normative, with the reasoning. The id hoists because it names the region a `#fragment` URL targets, and that region is the section; everything else describes the heading the author attached it to. A `<section>` models *this* document's outline, so quoted material and author groupings do not open one.

This is also a silent divergence from djot, now recorded in `divergence-from-djot.md`. Djot resolved the attribute question the other way in jgm/djot.js#43 (all attributes migrate to the section), then implemented that resolution only when the heading carries an explicit id - so djot's two id cases contradict each other and its own stated rule (jgm/djot.js#144, open). Carve's two cases agree, which is what lets the rule survive the wrapper being switched off.

## The opt-out

The wrapper is the one output change that breaks a site whose *source* migrated cleanly. CSS and JS that assume rendered blocks are direct children of the content container stop matching once a `<section>` sits in between - the stack/owl spacing idiom, `:first-child`, `nth-child()` counting, `element.children` walks. That is exactly the report in #427, and the same one Brixy filed against djot in jgm/djot#221 in 2023.

Djot users can unwrap it with a filter, because djot has a `section` AST node. Carve users cannot: Carve synthesizes the element at render time from a flat AST (verified - 61 `$defs` in `ast-schema.json`, no `section`; `carveToMarkdown` / `carveToPlainText` / `carveToAnsi` / `carveToCarve` are all flat), so there is no node to intercept and the block-renderer hook dispatches on node type. HTML post-processing was the only escape.

So the spec now describes a boolean `sections` option on the HTML renderer:

```ts
carveToHtml(source, { sections: false })
```

```html
<h2 id="Page-Heading">Page Heading</h2>
<p>A paragraph.</p>
```

Default unchanged and pinned by the corpus. HTML-only. When off, the id returns to the `<h*>` and the former section children stay as siblings - which is byte-identical to how a container-nested heading already renders, so id and attribute placement follow one rule everywhere in the document. Ids, dedup, `</#id>`, `[Heading][]`, `::: toc`, endnotes placement and HeadingNumbers all resolve against the slug, so none of them notice.

Deliberately **not** in scope: `sectionClass`, enum modes, per-heading `{section=false}`, changing attribute placement to djot's rule, wrapping inside divs.

## PART 11 R1

Specifying how `[Heading][]` behaves under either setting exposed that R1 never described the implicit heading fallback **at all** - not that it exists, not that link definitions win a tie, not that it folds case and collapses whitespace where link-definition matching in the same rule is exact and case-sensitive, and not that it declines headings under a blockquote in either nesting order. All four are engine behavior today, each verified against carve-js before being written down.

## Engines

Spec-first, as usual: no engine ships `sections` yet, so `tests/corpus-optional/32-section-wrapper-off` has no runner entry and shows as skipped rather than passing silently. The two behavior-preserving rules are pinned in the main corpus (167, 168) via `docs/examples/edge-cases.md`.

Follow-up implementation order once this lands: carve-js, then carve-php / carve-rs / carve-rb / wasm.

## Also

`docs/migrate-from-markdown.md` did not mention the `<section>` wrapper anywhere, for precisely the audience it breaks. It now has a section on it with the CSS fix, the selector patterns worth grepping for, and the option.
