### PR TITLE
spec: a definition list's entries are nodes (PART 12 §8)

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -161,24 +161,51 @@ spans that do not cover the text they claim.
 
 | engine | shape | positions |
 |---|---|---|
-| carve-js | conformant over the corpus | blocks and inlines, except reassembled regions (table cells, line-block content) and the synthesized `frontmatter` / `footnote` wire nodes |
-| carve-php | field-name divergences remain - `attrs` published as a flat map, `figure` carrying `children` instead of `target` + `caption`, `mention` exposing its rendering internals ([carve-php#510](https://github.com/markup-carve/carve-php/issues/510)) | recorded behind a parse option, enabled whenever it serializes |
-| carve-rs | conformant | blocks only; the inline half is in progress ([carve-rs#352](https://github.com/markup-carve/carve-rs/issues/352)) |
-| carve-rb | publishes carve-rs's tree through a serializer forked into the binding; `emphasis` carries a `kind` the type already encodes, and `fromCrossref` is spelled `from_crossref` ([carve-rb#26](https://github.com/markup-carve/carve-rb/issues/26)) | whatever carve-rs records |
+| carve-js | conformant | blocks and inlines, except reassembled regions (table cells, line-block content) |
+| carve-rs | conformant | blocks and most inlines; reconstructed regions and a definition list's own parts are unplaced ([carve-rs#333](https://github.com/markup-carve/carve-rs/issues/333)) |
+| carve-php | two field-name divergences left: the root carries `abbreviations`, and `inline_extension` publishes `extensionType`/`children` ([carve-php#510](https://github.com/markup-carve/carve-php/issues/510)) | recorded behind a parse option, enabled whenever it serializes |
+| carve-rb / carve-py / carve-go / carve-wasm | publish carve-rs's bytes | whatever carve-rs records |
 
 The gaps are listed rather than smoothed over on purpose: "six implementations"
 is only a claim worth making if the disagreements are visible.
 
-## Open questions
+## Definition lists
 
-Two shapes are not settled, and the schema records the reference form rather than
-pretending otherwise:
+A definition list's `items` hold the `<dt>` / `<dd>` sequence as nodes, in
+document order:
 
-**Definition-list entries are plain objects**, carrying `terms` and
-`definitions`, with no `type` and no `pos` - so a consumer cannot navigate to a
-term. The profile vocabulary does list `definition_term` and
-`definition_description`, and carve-php emits them as nodes.
+```json
+{"type": "definition_list", "items": [
+  {"type": "definition_term", "children": [ ... ]},
+  {"type": "definition_term", "children": [ ... ]},
+  {"type": "definition_description", "children": [ ... ]}
+]}
+```
 
-**Citation items are plain objects** for the same reason.
+A run of terms belongs to the descriptions that follow it - the rule the
+rendered list already shows. The grouping is **not** published, for three
+reasons:
 
-Both are the last places where content in the tree is not a node.
+- a plain `{terms, definitions}` object can carry no `pos`, which left a term
+  the only content in a serialized document an editor could not navigate to -
+  the same argument §7 used to move frontmatter and footnote definitions out of
+  root fields;
+- `definition_term` and `definition_description` are in the [normative block
+  vocabulary](/profiles), so a profile can name them. Under the object form
+  those two entries named nothing and a profile denying either was a silent
+  no-op;
+- the grouping was **not a shared fact**. Given the same four lines, carve-js
+  published one entry with two terms and two definitions while carve-rs
+  published three entries split differently - and all three engines rendered
+  the same `<dl>`. A structure two producers disagree about, which no output
+  depends on, is an internal.
+
+## Open question
+
+**Citation items are plain objects**, carrying `key`, `prefix`, `locator` and
+`suffix` with no `type` and no `pos`. The definition-list argument applies only
+partly: a citation item is not in the profile vocabulary, so nothing names it
+and no denial is silently lost - but a locator is still content a consumer might
+want to navigate to.
+
+It is the last place where content in the tree is not a node.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "mermaid": "^11.15.0"
       },
       "devDependencies": {
-        "@markup-carve/carve": "github:markup-carve/carve-js#1bbf01ff386e66f9e17a6565e4ff18f07a22cdbb",
+        "@markup-carve/carve": "github:markup-carve/carve-js#479bdf9f189f79f3e0c9528b92442b3bc3f76915",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.35.0",
@@ -968,8 +968,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#1bbf01ff386e66f9e17a6565e4ff18f07a22cdbb",
-      "integrity": "sha512-+mb2b7cBwzswam4a+WiUzd96EuZpNiCDXklgT1afuBl7H4QoqCSVZtBjZauOsXpNZJp0aC2j59LGf7Zf3HZAyg==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#479bdf9f189f79f3e0c9528b92442b3bc3f76915",
+      "integrity": "sha512-BQyRfKaJYcoRAfk1RdTChkeYhdQryeErxi8bdbONzIkyhDeK/NWUTSecfogX9WzFnFA29hPo73eDmLnHi0T1bA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },
   "devDependencies": {
-    "@markup-carve/carve": "github:markup-carve/carve-js#1bbf01ff386e66f9e17a6565e4ff18f07a22cdbb",
+    "@markup-carve/carve": "github:markup-carve/carve-js#479bdf9f189f79f3e0c9528b92442b3bc3f76915",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.35.0",

--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -75,44 +75,6 @@
       },
       "additionalProperties": false
     },
-    "definition_item": {
-      "type": "object",
-      "title": "Definition-list entry",
-      "description": "One `:: term` / `:  definition` entry. These are PLAIN OBJECTS in the reference shape, not nodes: they carry no `type` and no `pos`, so a consumer cannot navigate to a term. The profile vocabulary does list `definition_term` and `definition_description`, and carve-php emits them as nodes - the two are not reconciled yet.",
-      "required": [
-        "terms",
-        "definitions"
-      ],
-      "properties": {
-        "terms": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/$defs/inlineNode"
-            }
-          }
-        },
-        "definitions": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/$defs/blockNode"
-            }
-          }
-        },
-        "definitionLines": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "minimum": 1
-          },
-          "description": "1-based source line of each definition's marker line, parallel to `definitions`."
-        }
-      },
-      "additionalProperties": false
-    },
     "citation": {
       "type": "object",
       "title": "Citation item",
@@ -665,7 +627,7 @@
     "definition_list": {
       "type": "object",
       "title": "definition_list (block)",
-      "description": "Its items are plain objects rather than nodes in the reference shape - see `definition_item`.",
+      "description": "Its items are the `<dt>` / `<dd>` sequence, in document order: a run of `definition_term` nodes followed by the `definition_description` nodes they share. The grouping is not published because it is not a shared fact - two engines that published it grouped the same document differently while rendering the same list - and because a plain object can carry no `pos`, which left a term the only content in a serialized document an editor could not navigate to (PART 12 §4).",
       "required": [
         "type",
         "items"
@@ -677,7 +639,68 @@
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/definition_item"
+            "anyOf": [
+              {
+                "$ref": "#/$defs/definition_term"
+              },
+              {
+                "$ref": "#/$defs/definition_description"
+              }
+            ]
+          }
+        },
+        "attrs": {
+          "$ref": "#/$defs/attrs"
+        },
+        "pos": {
+          "$ref": "#/$defs/pos"
+        }
+      },
+      "additionalProperties": false
+    },
+    "definition_term": {
+      "type": "object",
+      "title": "definition_term (block)",
+      "description": "A `<dt>`: the inline content of one `:: term` line. Consecutive terms belong to the descriptions that follow them, which is what the rendered list shows.",
+      "required": [
+        "type",
+        "children"
+      ],
+      "properties": {
+        "type": {
+          "const": "definition_term"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/inlineNode"
+          }
+        },
+        "attrs": {
+          "$ref": "#/$defs/attrs"
+        },
+        "pos": {
+          "$ref": "#/$defs/pos"
+        }
+      },
+      "additionalProperties": false
+    },
+    "definition_description": {
+      "type": "object",
+      "title": "definition_description (block)",
+      "description": "A `<dd>`: the block content of one `:  definition`. It belongs to the run of terms before it.",
+      "required": [
+        "type",
+        "children"
+      ],
+      "properties": {
+        "type": {
+          "const": "definition_description"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/blockNode"
           }
         },
         "attrs": {
@@ -1762,7 +1785,9 @@
             "block_quote",
             "code_block",
             "comment",
+            "definition_description",
             "definition_list",
+            "definition_term",
             "div",
             "figure",
             "footnote",
@@ -1861,6 +1886,21 @@
           "if": {
             "properties": {
               "type": {
+                "const": "definition_description"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "$ref": "#/$defs/definition_description"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
                 "const": "definition_list"
               }
             },
@@ -1870,6 +1910,21 @@
           },
           "then": {
             "$ref": "#/$defs/definition_list"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "definition_term"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "$ref": "#/$defs/definition_term"
           }
         },
         {

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3548,4 +3548,53 @@ EOF = (* end of file *) ;
 
       Definitions appear in DOCUMENT ORDER by source position. Numbering is a
       resolution result and stays on the reference (§5).
+
+   8. A DEFINITION LIST'S ENTRIES ARE NODES -- NORMATIVE. `definition_list`
+      carries `items`: the `<dt>` / `<dd>` sequence in DOCUMENT ORDER, as
+      `definition_term` and `definition_description` nodes.
+
+        {"type":"definition_list","items":[
+          {"type":"definition_term","children":[...]},
+          {"type":"definition_term","children":[...]},
+          {"type":"definition_description","children":[...]}]}
+
+      A `definition_term` carries INLINE children, a `definition_description`
+      BLOCK children, and either may carry `attrs` and `pos` like any other
+      node. A run of terms belongs to the descriptions that follow it, which is
+      the rule the rendered list already shows -- so the grouping is derivable
+      and is not published.
+
+      NOT publishing it is the decision, and it has three reasons.
+
+      A plain `{terms, definitions}` object CANNOT CARRY `pos`. §4 requires one
+      on every node but the root because a tree without positions can only be
+      re-parsed rather than navigated, and a term is exactly what an editor
+      jumps to and a language server renames. Under the object form a term was
+      the only content in a serialized document that could not be navigated to
+      -- the same argument §7 makes for frontmatter and footnote definitions,
+      which is why they are block nodes rather than root fields.
+
+      `definition_term` and `definition_description` are in the profiles.md
+      block vocabulary, so a profile can NAME them. Under the object form those
+      two entries named nothing: a host writing `denyBlock(['definition_term'])`
+      got silence, which profiles.md calls the specific failure a normative
+      vocabulary exists to prevent.
+
+      And the grouping was NOT A SHARED FACT. Given
+
+        :: a
+        :: b
+        :  x
+        :  y
+
+      carve-js published one entry with two terms and two definitions,
+      carve-rs published three entries split differently, and carve-php
+      published the flat node sequence -- while all three rendered the same
+      `<dl>`. A structure two producers disagree about, which no output depends
+      on, is an internal; §1 already says an implementation whose internals
+      differ maps on the way out.
+
+      An engine whose parser groups differently therefore has one more thing to
+      fix than the serializer: carve-rs opened a new entry per `::` line, so
+      §6's round trip only holds once the parser groups the way the list shows.
 *)


### PR DESCRIPTION
The last schema divergence in the ecosystem, and it was three-way:

| engine | published for `:: a` / `:: b` / `:  x` / `:  y` |
|---|---|
| carve-js | one entry: 2 terms, 2 definitions |
| carve-rs | **three** entries, split differently |
| carve-php | the flat `definition_term` / `definition_description` sequence |

All three rendered the same `<dl>`.

## PART 12 §8 settles it on the nodes

Three reasons, none of them "the reference wins":

1. **A plain object cannot carry `pos`.** §4 requires one on every node but the root, because a tree without positions can only be re-parsed rather than navigated - and a term is exactly what an editor jumps to and a language server renames. Under the object form a term was the only content in a serialized document that could not be navigated to. That is the same argument §7 makes for frontmatter and footnote definitions, which is why they are block nodes rather than root fields.
2. **The vocabulary already names them.** `definition_term` and `definition_description` are in the profiles.md block list, so a profile can deny them - and under the object form `denyBlock(['definition_term'])` got silence, which profiles.md itself calls the specific failure a normative vocabulary exists to prevent.
3. **The grouping was not a shared fact.** Two producers grouped the same four lines differently while rendering the same list. A structure two producers disagree about, which no output depends on, is an internal - and §1 already says internals map on the way out.

The grouping stays derivable: a run of terms belongs to the descriptions that follow it, which is the rule the rendered list shows.

## What changed

- `resources/ast-schema.json`: `definition_list.items` holds `definition_term` | `definition_description`; the `definition_item` definition is gone; both types join the block dispatcher.
- `docs/ast-json.md`: a "Definition lists" section replaces half the "Open questions" section. Citation items remain open, with the asymmetry stated - they are *not* in the vocabulary, so nothing names them and no denial is lost, though a locator is still content.
- The status table is refreshed against measured output.

## Ordering

**Merge after markup-carve/carve-js#492**, then the pin moves to it. Against that branch: `npm test` 618 pass / 0 fail, executable-spec gate 504/504.

Companion engine work: carve-js#492 (wire mapping), carve-rs#374 (wire mapping **and** the parser grouping - §6's round trip only holds once an engine groups the way the list shows).

Measured after all three: carve-js 4 findings, carve-rs 391 → **171**, carve-php 424 → **99**, and every one of those is a missing position rather than a shape.
