### PR TITLE
spec: pin where a render annotation goes, and run the sections case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   survive the wrapper being switched off - the id returns to the `<h*>` and
   nothing else moves, leaving one placement rule for the whole document.
 
+- **PART 10 §1 also says a render annotation goes after the generated
+  attribute** (carve#427). `data-source-line` records where a block was written
+  rather than describing the element, so it is emitted last of all:
+  `<h2 id="Nested" data-source-line="1">`.
+
+  A third category, and stating it is what stops an engine being conformant and
+  divergent at once. An engine that appends the stamp at render time gets the
+  order for free; one that attaches it at parse time carries it inside the
+  authored run, where "generated last" alone puts the id behind it. carve-rs did
+  exactly that, and a test caught it rather than this text.
+
 - **PART 10 §1 says where a generated attribute goes** (carve#427). The author's
   own attributes keep their source order and anything the engine minted follows
   them, so an unwrapped heading renders `<h1 a="b" class="c" id="Auto">` for an

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3043,6 +3043,21 @@ EOF = (* end of file *) ;
       author's own order is never rearranged, and anything the engine
       minted follows it. Pinned by the corpus.
 
+      A RENDER ANNOTATION IS EMITTED LAST -- after the generated
+      attribute, not merely after the authored ones. The one such
+      annotation in the core is `data-source-line` (§13-adjacent, the
+      `sourceLine` render option), which records where a block was
+      written rather than describing the element:
+        > ## Nested   -> <h2 id="Nested" data-source-line="1">
+      This is a THIRD category, and stating it is what stops an engine
+      from being conformant and divergent at once. An engine that
+      appends the stamp at RENDER time (carve-js) gets the order for
+      free, because the stamp is written outside the attribute walk. An
+      engine that attaches it at PARSE time (carve-rs) carries it inside
+      the authored run, where the "generated last" rule alone would put
+      the id behind it -- which is exactly what carve-rs did until it
+      was caught by a test rather than by this text.
+
       This rule was added after all three engines were found to disagree
       here with nothing to catch it -- carve-js appended a generated id
       but kept an authored one in place, carve-php put the id last in

--- a/tests/corpus-optional/33-source-line-after-generated-id.crv
+++ b/tests/corpus-optional/33-source-line-after-generated-id.crv
@@ -1,0 +1,4 @@
+> ## Quoted
+
+{a=b}
+## Attributed

--- a/tests/corpus-optional/33-source-line-after-generated-id.html
+++ b/tests/corpus-optional/33-source-line-after-generated-id.html
@@ -1,0 +1,4 @@
+<blockquote data-source-line="1">
+  <h2 id="Quoted" data-source-line="1">Quoted</h2>
+</blockquote>
+<h2 a="b" id="Attributed" data-source-line="4">Attributed</h2>

--- a/tests/corpus-optional/manifest.json
+++ b/tests/corpus-optional/manifest.json
@@ -162,6 +162,11 @@
       "slug": "32-section-wrapper-off",
       "feature": "section-wrapper-off",
       "description": "With the optional HTML-renderer sections switch set to false, no <section> is emitted: each heading carries the id it would have hoisted, alongside its other attributes, and the blocks that would have been section children stay siblings. Ids, dedup, crossrefs and implicit heading references are unchanged, and a heading inside a container renders exactly as it does with the wrapper on (PART 9 section 13; carve#427)."
+    },
+    {
+      "slug": "33-source-line-after-generated-id",
+      "feature": "source-line-after-generated-id",
+      "description": "The data-source-line render annotation is emitted AFTER the generated heading id, not merely after the author's attributes (PART 10 section 1). An engine that stamps the line at parse time carries it inside the authored run, where the generated-last rule alone would put the id behind it; carve-rs did exactly that until a test caught it (carve#427)."
     }
   ]
 }

--- a/tests/optional-corpus.test.mjs
+++ b/tests/optional-corpus.test.mjs
@@ -77,6 +77,15 @@ const featureRunners = {
   'citations-numbered': (source, render) => render(source, { extensions: [citations()] }),
   'citations-author-date': (source, render) =>
     render(source, { extensions: [citations({ mode: 'author-date' })] }),
+  /*
+   * The one feature here that is a RENDER OPTION rather than an extension: it
+   * takes no extension instance, just the switch. Kept in the same table so an
+   * engine without the option shows up as a skipped case rather than silently
+   * passing on wrapped output.
+   */
+  'section-wrapper-off': (source, render) => render(source, { sections: false }),
+  'source-line-after-generated-id': (source, render) =>
+    render(source, { sections: false, sourceLine: true }),
   'code-callouts': (source, render) => render(source, { extensions: [codeCallouts()] }),
   details: (source, render) => render(source, { extensions: [details()] }),
   'list-table': (source, render) => render(source, { extensions: [listTable()] }),


### PR DESCRIPTION
Two follow-ups to #430, now that carve-js ships the option.

## The third attribute category

PART 10 §1 split attributes into what the author wrote and what the engine generated, and said the generated one goes last. It did not name a third category. `data-source-line` records where a block was *written* rather than describing the element, and it belongs after both:

```
> ## Nested   ->  <h2 id="Nested" data-source-line="1">
```

Whether an engine gets that for free depends on where it attaches the stamp. carve-js appends it at render time, outside the attribute walk, so it is last by construction. carve-rs attaches it at **parse** time, so it rides inside the authored run - and "generated last" on its own put the id behind it.

carve-rs shipped the wrong order in markup-carve/carve-rs#379 until an existing test caught it. That is the argument for the sentence: as written, the rule let an implementation be conformant and divergent at the same time, and only carve-js's internal structure was enforcing the real contract.

Corpus case 33 pins it in the two shapes that reach the unwrapped path - a quoted heading, and an attributed heading with the wrapper off.

## Case 32 now runs

The optional-corpus runner gains its `section-wrapper-off` entry, so the case #430 added executes instead of being skipped.

It is the only feature in that table backed by a render option rather than an extension, so there is a note where the entry sits: an engine without the option should surface as a skipped case rather than quietly passing on wrapped output.

No pin bump needed - main's carve-js pin already descends from the commit that merged the option.