### PR TITLE
spec: say which fences are callouts, and that it is a trust class

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -53,6 +53,31 @@ An **`admonition`** is likewise its own type rather than a `div` carrying a
 class. A profile that wants to deny callouts while allowing generic
 containers has no way to express that if the kind lives in a class string.
 
+Which fences are callouts is the **Tier-1 canonical list** - `note`, `tip`,
+`warning`, `danger`, `info`, `success`, `example`, `quote`. A fence opened with
+any other word (`::: sidebar`, `::: figure-group`, a name your own extension
+claims) is a **generic container**: it renders as `<div class="name">` rather
+than an `<aside class="admonition name">`, and it is classified as **`div`** for
+profiles. So `denyBlock(['admonition'])` removes callouts and leaves those
+containers standing, which is the capability the paragraph above promises:
+
+```js
+const p = Profile.full()
+p.denyBlock(['admonition'])
+applyProfile(parse('::: note\nbody\n:::\n'), p).violations     // [{ nodeType: 'admonition', ... }]
+applyProfile(parse('::: sidebar\nbody\n:::\n'), p).violations  // []
+```
+
+This is a TRUST CLASS, not an AST type. A serialized AST publishes `::: sidebar`
+as an `admonition` node carrying `kind: "sidebar"`, because that is what the
+parser built; the profile classifies it as `div` because that is the capability
+it carries. The two vocabularies are different sizes and the next section says
+why - `tag` is the same shape, its own AST type classified as `mention`.
+
+Denying `div` still removes callouts, through the subtype rule: an `admonition`
+answers to its own name and to `div`. A host that wants today's "deny every
+named fence" behavior denies both.
+
 ### The AST has more node types than a profile can deny
 
 This page answers "what can a profile deny", which is a smaller set than "what


### PR DESCRIPTION
Settles #431.

This page justifies `admonition` being its own type by saying a profile must be able to

> deny callouts while allowing generic containers

and never says which fences are callouts. Read literally, every named fence is one - so "generic containers" shrinks to unnamed `:::` fences, which nobody writes, and the capability the paragraph promises does not exist.

## The Tier-1 list already decided this everywhere else

`note`, `tip`, `warning`, `danger`, `info`, `success`, `example`, `quote` render as `<aside class="admonition kind">`; every other name renders as `<div class="name">`. `migrate-from-markdown.md` states it, and all three engines implement it at render time. Profiles were the one place it was never applied:

```
::: sidebar   renders  <div class="sidebar">           classified  admonition   <- the gap
::: note      renders  <aside class="admonition note">  classified  admonition
```

## Stated as a trust class, not an AST type

These are different questions, and conflating them has already caused one bug. carve-php derived its published wire type from the profile classifier, so changing the trust class silently changed the serialized AST - it started publishing `{"type":"div","kind":"sidebar"}`, a `div` carrying a field the schema does not give it. Fixed in markup-carve/carve-php#543.

So the page now says both halves explicitly. A serialized AST publishes `::: sidebar` as an `admonition` carrying `kind: "sidebar"`, because that is what the parser built. The profile classifies it as `div`, because that is the capability it carries. `tag` is the same shape - its own AST type, classified as `mention` - and the section immediately below already explains why the two vocabularies differ in size.

## Migration

This **widens** `denyBlock(['admonition'])` for anyone relying on it to remove generic containers as well as callouts.

The subtype rule keeps the safe default one step away: an `admonition` answers to `div` as well as to its own name, so `denyBlock(['div'])` still removes callouts, and a host that wants today's "deny every named fence" denies both. The engine changes carry the migration note in their changelogs.

## Engine state

carve-php already behaves this way (markup-carve/carve-php#513). carve-js and carve-rs classify every named fence as `admonition` and need the same change - that divergence is what #431 was filed about, measured there. Those ports follow this PR.
