### PR TITLE
spec: revert raw_text into the schema - PART 12 forbids serializing it

### DIFF
--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -1330,7 +1330,6 @@
             "math",
             "mention",
             "raw_inline",
-            "raw_text",
             "smart_punctuation",
             "soft_break",
             "span",
@@ -2308,30 +2307,6 @@
         },
         "format": {
           "type": "string"
-        },
-        "content": {
-          "type": "string"
-        },
-        "attrs": {
-          "$ref": "#/$defs/attrs"
-        },
-        "pos": {
-          "$ref": "#/$defs/pos"
-        }
-      },
-      "additionalProperties": false
-    },
-    "raw_text": {
-      "type": "object",
-      "title": "raw_text (inline)",
-      "description": "Literal source an implementation preserves so `fmt` can reproduce it verbatim - an unresolvable construct such as `[a][]`. OPTIONAL: profiles.md permits but does not require it, so a consumer must tolerate it and must not depend on it. Not deniable by a profile.",
-      "required": [
-        "type",
-        "content"
-      ],
-      "properties": {
-        "type": {
-          "const": "raw_text"
         },
         "content": {
           "type": "string"

--- a/tests/ast-schema.test.mjs
+++ b/tests/ast-schema.test.mjs
@@ -131,7 +131,7 @@ test('every type the schema declares is either in the vocabulary or listed as no
   }
   // Stated in profiles.md under "The AST has more node types than a profile can
   // deny", and repeated in scripts/ast-conformance.mjs.
-  const notDeniable = ['document', 'smart_punctuation', 'literal_inline', 'tag', 'abbreviation_def', 'raw_text']
+  const notDeniable = ['document', 'smart_punctuation', 'literal_inline', 'tag', 'abbreviation_def']
   for (const type of notDeniable) {
     assert.match(
       profiles,


### PR DESCRIPTION
Reverts the schema half of #440. That PR was mine and it was wrong.

#440 added `raw_text` to `ast-schema.json`, reasoning that `profiles.md` promised the node by name while the schema rejected it, so the schema was the stale document. There was no disagreement, and a third document settles it - `docs/ast-json.md`, which I did not read:

> Formatter-internal nodes (PART 11, and the `raw_text` case the profiles vocabulary excludes) are not part of the document and **are not serialized**.

The two pages answer different questions:

| | governs | says about `raw_text` |
|---|---|---|
| `profiles.md` | what a PROFILE can deny | an implementation may carry it; naming it in a deny list does nothing |
| `ast-json.md` | what goes ON THE WIRE | do not serialize it |

Both true at once. Admitting it to the schema was not a fix - it blessed a shape the wire format forbids.

## The engines say the same thing

For `see [a][] here`:

```
carve-js   ["text", "text", "text"]
carve-rs   ["text", "text", "text"]
carve-php  ["text", "raw_text", "text"]
```

Two of three comply with §5. carve-php is the outlier, and #440 wrote the outlier's behaviour into the published schema.

It also made markup-carve/carve-php#531 read as resolved when it is not. That issue lays out the real work and why it is not free: mapping the node to `text` on the way out loses the authored form for five corpus documents *if the writer reads the decoded tree*. The answer is that the writer reads the LIVE tree, where `raw_text` still exists - §1 already requires an internal representation to be mapped on the way out, which is the same allowance carve-rs uses for its parsed frontmatter map. I have commented that on 531.

## Scope

Schema only. The `profiles.md` mentions from #440 stay: `raw_text` genuinely is non-deniable, so naming it in the enumerated not-deniable list there is correct and independent of the wire shape. The guard test's list reverts with the schema, since it only needs to account for types the schema declares.

`npm test` back to the 3 failures that pre-exist on main.
