### PR TITLE
chore: bump the carve-js pin past the container-fence fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "mermaid": "^11.15.0"
       },
       "devDependencies": {
-        "@markup-carve/carve": "github:markup-carve/carve-js#479bdf9f189f79f3e0c9528b92442b3bc3f76915",
+        "@markup-carve/carve": "github:markup-carve/carve-js#1a5f8e8efbfdd5a8d51fcdcd8e57b27ce59a756c",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.35.0",
@@ -968,8 +968,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#479bdf9f189f79f3e0c9528b92442b3bc3f76915",
-      "integrity": "sha512-BQyRfKaJYcoRAfk1RdTChkeYhdQryeErxi8bdbONzIkyhDeK/NWUTSecfogX9WzFnFA29hPo73eDmLnHi0T1bA==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#1a5f8e8efbfdd5a8d51fcdcd8e57b27ce59a756c",
+      "integrity": "sha512-oXWi034E1XnVN8A/St79qoWljDfLz+exapyEkv/hUglF9ZHUkerWMmuBlIzgNnIsaDZ6aKiyB/JJcXybe9Zthg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },
   "devDependencies": {
-    "@markup-carve/carve": "github:markup-carve/carve-js#479bdf9f189f79f3e0c9528b92442b3bc3f76915",
+    "@markup-carve/carve": "github:markup-carve/carve-js#1a5f8e8efbfdd5a8d51fcdcd8e57b27ce59a756c",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.35.0",


### PR DESCRIPTION
Moves the pinned reference build three commits on, picking up markup-carve/carve-js#497 (a container fence covers its subtree, not the next level) and markup-carve/carve-js#495 (a non-Tier-1 named fence classifies as `div`).

The fence fix is the one this repo needs. markup-carve/carve#442 asks for round-trip corpus cases nesting containers three and four levels deep, and they cannot land until the PINNED writer sizes a fence from the subtree - with the old build those cases would redden this repo's CI while documenting an engine bug rather than a rule of the format. There is no xfail mechanism in the round-trip harness, unlike the HTML corpus, so a case either passes or breaks the build.

Verification:

- `npm test` 627 tests, 0 failures
- `npm run core:check` clean - 507 corpus inputs, 507 conformant, 0 refused, 0 defects, 0 sentinel leaks

Worth noting for the record: I earlier reported 3 pre-existing test failures on main in a comment on markup-carve/carve#442. That was measured under an older spec-submodule state and is no longer true - main is green at 623 passing, verified in a clean worktree. The bump does not fix anything; it only unblocks 442.