### PR TITLE
test: round-trip fixtures for container fence width at depth 3 and 4

### DIFF
--- a/tests/corpus-roundtrip/09-nested-containers.crv
+++ b/tests/corpus-roundtrip/09-nested-containers.crv
@@ -1,0 +1,13 @@
+::::: outer
+
+:::: note
+Outer note.
+
+::: |
+Verse one
+Verse two
+:::
+
+::::
+
+:::::

--- a/tests/corpus-roundtrip/09-nested-containers.expected.crv
+++ b/tests/corpus-roundtrip/09-nested-containers.expected.crv
@@ -1,0 +1,10 @@
+::::: outer
+:::: note
+Outer note.
+
+::: |
+Verse one
+Verse two
+:::
+::::
+:::::

--- a/tests/corpus-roundtrip/10-container-under-a-list-item.crv
+++ b/tests/corpus-roundtrip/10-container-under-a-list-item.crv
@@ -1,0 +1,20 @@
+:::::: wrapper
+
+::::: outer
+
+:::: note
+Outer note.
+
+- item one
+
+  ::: tip
+  Hidden under a list item.
+  :::
+
+- item two
+
+::::
+
+:::::
+
+::::::

--- a/tests/corpus-roundtrip/10-container-under-a-list-item.expected.crv
+++ b/tests/corpus-roundtrip/10-container-under-a-list-item.expected.crv
@@ -1,0 +1,15 @@
+:::::: wrapper
+::::: outer
+:::: note
+Outer note.
+
+- item one
+
+  ::: tip
+  Hidden under a list item.
+  :::
+
+- item two
+::::
+:::::
+::::::

--- a/tests/corpus-roundtrip/README.md
+++ b/tests/corpus-roundtrip/README.md
@@ -30,6 +30,16 @@ literal `\@user` / `\#tag` text and a real `@who` mention. If `@` were missing
 from the set, W4 would have nothing to escape with and the literal would
 silently become a mention.
 
+`09` and `10` pin **container fence width**, which is the other thing a writer
+can get wrong without touching a single character of text. A colon fence closes
+on a bare fence of equal-or-greater length, so a container has to be wider than
+every container anywhere below it, not just wider than its direct children.
+`09` nests three of them (div, admonition, line block); `10` nests four and puts
+the innermost one under a list item, where a writer that walks only direct child
+blocks cannot see it. Both documents came back from `fmt` with equal-width
+fences before the writers were fixed, which silently unnests the middle
+container - the failure these two exist to catch.
+
 ## What the byte assertions are worth
 
 `../roundtrip.test.mjs` asserts the PART 11 §1 invariants and the expected bytes


### PR DESCRIPTION
Closes the last piece of #442. Unblocked by #446, which moved the pinned writer past the fence fix.

## What was unpinned

`tests/corpus-roundtrip/` held eight documents and not one of them contained `::::`. So `parse(fmt(x)) == parse(x)` and the byte assertions were only ever exercised over inputs whose fence width cannot be got wrong.

A colon fence closes on a bare fence of equal-or-greater length. A container therefore has to outrank every container anywhere below it, not just its direct children - and that is exactly what every engine's writer got wrong.

## The two cases

**`09-nested-containers`** - div, admonition, line block, three deep.

**`10-container-under-a-list-item`** - four deep, with the innermost container under a list item. This is the shape a writer that walks only direct child blocks cannot see: between the `:::: note` and the `::: tip` there is a list, so a naive scan finds no container below and sizes the fence as if it were a leaf.

## Why they are load-bearing

Run through the pre-fix reference build (`479bdf9`, rebuilt in a worktree for this):

```
:::: outer          :::: wrapper
::: note            :::: outer
Outer note.         ::: note
                    ...
::: |
```

Equal-width fences, so the middle container unnests, and `toHtml(fmt(x)) != toHtml(x)` for both documents. Through the current pin they round-trip byte-exact. A fixture that passes under the bug it was written for is not worth having, so that check came before the commit.

The expected files hold the widths the closer rule requires rather than whatever one writer emits, and carve-rs and carve-php at `origin/main` produce those same bytes - so this pins a cross-engine contract.

## Related

#447 pins the render side and the degenerate forms, and writes the divergence from djot into the docs. The two do not overlap in files.
