### PR TITLE
spec: bound the ingest path, and say why the parser's number is the wrong one

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -144,6 +144,51 @@ the text they claim.
 that loses a field is not a lossy convenience; it is a consumer breaking silently
 one document later. Both halves are checked over the whole corpus.
 
+## How deep an ingested AST may nest
+
+Reading a serialized AST is a recursive descent over structure someone else
+wrote, so it needs a bound for the same reason [parsing does](/security). §9
+states the property rather than a number:
+
+1. an implementation **must accept any AST its own parser can produce** at the
+   nesting cap - `carve --json | carve --from-json` may not fail on a document
+   the same build just parsed;
+2. it **must reject deeper input with an error of its own** - not truncation,
+   not a crash, not whatever the JSON library raised;
+3. the bound **may be counted in any unit**, because 1 and 2 are the whole
+   contract.
+
+The trap is that an ingest bound is not in the same unit as the parser's cap,
+and the conversion factor is not a constant. One AST level costs two JSON
+structural levels for a blockquote or div (the object plus its `children`
+array) and four for a list. Measured against carve-js at the cap of 200,
+counting the root as level 1:
+
+| shape | structural depth |
+|---|---|
+| blockquote chain | 406 |
+| list ladder | 806 |
+| table under blockquotes | 406 |
+
+The exact figures shift by one with the counting convention; the ratio is the
+point. A list ladder at the cap is four times the parser's own number.
+
+So a bound must be **derived** from the parser's cap by the worst per-level
+cost of the encoding, never restated as the same number. All three engines got
+this wrong in a different way - carve-rs bounded structural depth by the AST
+number and rejected its own encoder's output
+([carve-rs#389](https://github.com/markup-carve/carve-rs/issues/389)), carve-php
+inherited `json_decode`'s 512 and surfaced a raw `JsonException`
+([carve-php#556](https://github.com/markup-carve/carve-php/issues/556)), and
+carve-js had no bound at all until a `RangeError` somewhere past 1500
+([carve-js#498](https://github.com/markup-carve/carve-js/issues/498)). Two of
+the three rejected documents their own parser produces, which is why rule 1 is
+first.
+
+The root type is not a leniency point either: §7 fixes it at `document` and the
+schema pins it as a `const`. Accepting `doc` means half-reading a ProseMirror
+payload instead of rejecting it.
+
 ## What is not in it
 
 Formatter-internal nodes (PART 11, and the `raw_text` case the profiles

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3723,4 +3723,49 @@ EOF = (* end of file *) ;
       An engine whose parser groups differently therefore has one more thing to
       fix than the serializer: carve-rs opened a new entry per `::` line, so
       §6's round trip only holds once the parser groups the way the list shows.
+
+   9. HOW DEEP AN INGESTED AST MAY NEST -- NORMATIVE. Reading a serialized AST
+      is a recursive descent over attacker-controlled structure, so it needs a
+      bound for the same reason the parser does (PART 9 §25, RESOURCE BOUNDS).
+      This states the PROPERTY rather than a number, because the number cannot
+      be shared -- see the trap below.
+
+      (a) An implementation MUST ACCEPT any AST ITS OWN PARSER CAN PRODUCE at
+          MAX_NESTING_DEPTH. Serialize-then-deserialize is an identity on
+          those documents, which is §6 restricted to the deepest input the
+          parser admits. `parse` piped into ingest MUST NOT fail on a document
+          the same build just parsed.
+
+      (b) It MUST REJECT deeper input with AN ERROR OF ITS OWN: a typed,
+          documented failure naming the depth bound. Not truncation, not a
+          crash, and not whatever its JSON library happened to raise. An
+          ingest that accepts a tree and then silently renders only part of it
+          is the worst of the three, because the caller is told nothing.
+
+      (c) The bound MAY be counted in WHATEVER UNIT suits the implementation
+          -- JSON structural levels, AST node levels, recursion frames --
+          because (a) and (b) are the whole of what a caller can rely on. An
+          implementation MUST NOT publish its unit as a shared contract.
+
+      THE TRAP, stated once, because all three reference engines fell into a
+      different corner of it: an ingest bound is NOT measured in the same unit
+      as MAX_NESTING_DEPTH, and the conversion factor is NOT A CONSTANT. One
+      AST level costs two JSON structural levels for a blockquote or div (the
+      object plus its `children` array) and four for a list (list, items,
+      item, children); in node terms a list level costs two nodes and a div
+      level one. At MAX_NESTING_DEPTH = 200 a blockquote chain therefore
+      encodes past 400 structural levels and a list ladder past 800 -- four
+      times the parser's own number, from the same document depth.
+
+      So neither MAX_NESTING_DEPTH nor "MAX_NESTING_DEPTH plus a small margin"
+      is a safe bound in either unit. An implementation MUST DERIVE its bound
+      from MAX_NESTING_DEPTH by the worst per-level cost of its own encoding,
+      and MUST NOT restate the parser's number as its ingest number -- a
+      second copy of a value is exactly how (a) gets violated. A bound written
+      down twice diverges; one derived from the other cannot.
+
+      The root type is not a leniency point: §7 fixes it at `document`, and
+      the schema pins it as a `const`. An ingest accepting some other root
+      (`doc`, say, which is ProseMirror's) will half-read a foreign format
+      rather than reject it.
 *)


### PR DESCRIPTION
Closes #445.

PART 12 described the exchange format but never said how deep an ingested AST may nest.
All three engines got it wrong in a different way, and two of the three rejected documents
their own parser produces:

| engine | behavior |
|---|---|
| carve-rs | bounded JSON structural depth by the AST-level number, so it rejected the output its own encoder produced |
| carve-php | inherited `json_decode`'s 512 and surfaced a raw `JsonException` |
| carve-js | no bound at all until a `RangeError` somewhere past 1500 |

New **§9** states the property rather than a number:

1. accept any AST the implementation's own parser can produce at `MAX_NESTING_DEPTH`;
2. reject deeper input with a typed error of its own - not truncation, not a crash, not
   whatever the JSON library raised;
3. count the bound in whatever unit suits, because 1 and 2 are the whole contract.

**The number cannot be shared, and that is the part worth writing down.** An ingest bound
is not in the parser's unit and the conversion factor is not a constant: one AST level
costs two structural levels for a blockquote, four for a list. At the cap a list ladder
encodes past 800 structural levels - four times the parser's own 200. So a bound must be
*derived* from `MAX_NESTING_DEPTH` by the worst per-level cost of the encoding. Restating
the parser's number as the ingest number is precisely what produced two of the three
failures: a value written down twice diverges, one derived from the other cannot.

Rule 1 is deliberately first. The failure it forbids - accept a tree, then render only
part of it - tells the caller nothing at all, which is worse than either rejecting or
crashing.

Also settles the smaller question raised in the issue: the root type is not a leniency
point. §7 fixes it at `document` and the schema pins it as a `const`, so accepting `doc`
half-reads a ProseMirror payload rather than rejecting it.

The depth figures were re-measured against carve-js rather than carried over from the
issue - they move by one with the counting convention, so the normative text states the
ratio and the doc states the measurement with its convention named.