### PR TITLE
spec: a container closer pairs with its opener's width (proposal for #439)

### DIFF
--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -511,17 +511,23 @@ ASCII before slugging (section 1 above), so `# Don't repeat yourself` gives
 `Don-t-repeat-yourself` whether the heading
 renders with a curly apostrophe or a straight one.
 
-## 13. Container nesting is strict, and an unclosed opener is text
+## 13. A container closer pairs with its opener's width
 
-Both languages spell a container `:::` and close it with a bare colon fence,
-and both require the closer to be at least as long as its opener. Three rules
-around that agreement differ, in both directions.
+Both languages spell a container `:::` and close it with a bare colon fence.
+Djot requires the closer to be at least as long as its opener; Carve requires
+it to be **exactly** as long, matched against the innermost open fence.
 
-**Equal-length fences.** Djot nests them: an inner `:::` inside an outer `:::`
-is a child container. Carve does not - a container has to be strictly wider
-than every container below it. At equal length the inner opener is neither a
-closer (a closer must be bare, and `::: tip` carries a type word) nor an
-opener, so it stays content:
+That one guard makes nesting direction-neutral. Only *different* lengths are
+needed, so both of these nest:
+
+```
+:::: note        :::  note
+::: tip          :::: tip
+:::              ::::
+::::             :::
+```
+
+and so do equal-length fences, because the inner opener is not bare:
 
 ```
 ::: note
@@ -533,52 +539,39 @@ Inner.
 
 ```html
 <aside class="admonition note">
-  <p>::: tip
-Inner.</p>
+  <aside class="admonition tip">
+    <p>Inner.</p>
+  </aside>
 </aside>
-<p>:::</p>
 ```
 
-**A bare closer closes one container.** Djot's closes every container open
-above it of equal-or-lesser length, so a single `:::` under three openers
-closes all three. In Carve it closes the one block it matches, and the
-openers left over fall under the unclosed rule below.
+**A bare closer closes one container**, as in Djot's equal-length case: it
+pairs with the innermost open fence of its width. Djot additionally lets a
+longer closer close several shorter containers at once; Carve does not, since
+a longer run is simply not that container's closer.
 
-**An unclosed opener.** Djot closes the container at end of file, so the block
-still renders. Carve opens nothing: the opener line and its body stay a
-paragraph, `:::` and all.
+**An unclosed opener** closes at end of file in both languages. Carve used to
+open nothing here - the opener line and its body stayed a paragraph - and that
+changed with the width rule ([carve#439](https://github.com/markup-carve/carve/issues/439)):
+a mistyped closer turning the tail of a document into text is too loud a
+failure to pair with a stricter closer, so the container is completed and an
+implementation reports a diagnostic instead.
 
-```
-::: note
-X
-```
+This is deliberately NOT the `%%%` comment-block rule (PART 9 §28), where an
+opener with no closer ahead opens nothing. A comment's content is invisible, so
+auto-closing one would hide the rest of the file; a container's content still
+renders.
 
-```html
-<p>::: note
-X</p>
-```
+**The canonical direction is `:::` outermost**, one colon wider per level -
+what `carve fmt` emits and what the docs teach. That is a writer rule, not a
+parser rule: nothing rejects the other direction, so no document needs
+migrating. It is canonical because adding a nesting level is then a local edit
+rather than a rewrite of the whole chain, and because an admonition always
+opens `::: note` however deep it later sits.
 
-**Why.** Carve's fence width is a *depth* count, not the quoting device it is
-on a code fence: a container's fence must outrank its whole subtree, which is
-what makes `::::` reliably contain `:::` and lets a canonical writer size a
-fence from the tree alone. Equal-length nesting breaks that, because the same
-width would mean two different depths. The unclosed rule is the general Carve
-principle that a construct which never completes is not silently completed for
-you - the same call as `%%%` comment blocks (PART 9 §28), where an opener with
-no closer ahead degrades to line comments rather than swallowing the rest of
-the document.
-
-The cost is that a mistyped closer turns the tail of a document into text
-instead of producing a slightly wrong container. That trade, and whether the
-depth count should run the other way (`:::` outermost, one colon added per
-level), is the open question in
-[carve#439](https://github.com/markup-carve/carve/issues/439). All four forms
-are pinned in the corpus as `68-nested-containers*`, so any move shows up as a
-fixture diff rather than as a silent behavior change.
-
-One form is garbage in both languages: widening the *inner* fence. `::::`
-under an open `:::` is a bare closer of greater length, so it ends the outer
-container rather than starting a child, in Carve and in Djot alike.
+All four previously-degenerate forms are pinned in the corpus as
+`68-nested-containers*`, so each one flipped as a visible fixture diff rather
+than as a silent behavior change.
 
 ## What Carve adds on top (not breaks)
 

--- a/docs/examples/core.md
+++ b/docs/examples/core.md
@@ -2652,8 +2652,9 @@ not a div
 
 ```html
 <p>::: {.sidebar}
-not a div
-:::</p>
+not a div</p>
+<div>
+</div>
 ```
 
 ::::
@@ -2691,8 +2692,9 @@ not a div
 
 ```html
 <p>::: 123
-not a div
-:::</p>
+not a div</p>
+<div>
+</div>
 ```
 
 ::::
@@ -3671,8 +3673,9 @@ two
 ```html
 <p>::: {.line-block}
 one
-two
-:::</p>
+two</p>
+<div>
+</div>
 ```
 
 ::::

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -534,10 +534,10 @@ Inner.
 
 ```html
 <aside class="admonition note">
-  <p>::: tip
-Inner.</p>
+  <aside class="admonition tip">
+    <p>Inner.</p>
+  </aside>
 </aside>
-<p>:::</p>
 ```
 
 ::::
@@ -561,10 +561,10 @@ Inner
 ```html
 <div>
   <p>Outer</p>
+  <div>
+    <p>Inner</p>
+  </div>
 </div>
-<p>Inner
-::::
-:::</p>
 ```
 
 :::::
@@ -581,8 +581,9 @@ X
 ```
 
 ```html
-<p>::: note
-X</p>
+<aside class="admonition note">
+  <p>X</p>
+</aside>
 ```
 
 ::::
@@ -603,10 +604,12 @@ X
 ```
 
 ```html
-<p>::::: a
-:::: b</p>
-<div class="c">
-  <p>X</p>
+<div class="a">
+  <div class="b">
+    <div class="c">
+      <p>X</p>
+    </div>
+  </div>
 </div>
 ```
 
@@ -1474,9 +1477,10 @@ body
 ```
 
 ```html
-<p>text
-:::note
-body</p>
+<p>text</p>
+<aside class="admonition note">
+  <p>body</p>
+</aside>
 ```
 
 ::::
@@ -1622,9 +1626,10 @@ stuff
 ```
 
 ```html
-<p>Text
-:::
-stuff</p>
+<p>Text</p>
+<div>
+  <p>stuff</p>
+</div>
 ```
 
 ::::
@@ -3503,10 +3508,12 @@ ordinary nested list:
 
 ```html
 <ul>
-  <li>::: note
-    <ul>
-      <li>para text</li>
-    </ul>
+  <li>
+    <aside class="admonition note">
+      <ul>
+        <li>para text</li>
+      </ul>
+    </aside>
   </li>
 </ul>
 ```
@@ -3527,13 +3534,16 @@ paragraph:
 
 ```html
 <ul>
-  <li>::: note
-    <ul>
-      <li>para text</li>
-    </ul>
+  <li>
+    <aside class="admonition note">
+      <ul>
+        <li>para text</li>
+      </ul>
+    </aside>
   </li>
 </ul>
-<p>:::</p>
+<div>
+</div>
 ```
 
 ::::
@@ -5458,9 +5468,12 @@ opener line - folds into the item as literal text rather than an admonition.
 
 ```html
 <ul>
-  <li>::: note
-- para text
-:::</li>
+  <li>
+    <aside class="admonition note">
+      <p>- para text
+:::</p>
+    </aside>
+  </li>
 </ul>
 ```
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -634,15 +634,17 @@ caption_slot = [blank_line], caption ;
    in the resolution pass. A caption with no bare `#` is unchanged. *)
 
 (* --- Admonitions --- *)
-(* A fence is a run of 3+ colons. A longer opener nests shorter blocks. *)
+(* A fence is a run of 3+ colons. A closer PAIRS WITH ITS OPENER'S WIDTH. *)
 colon_fence = ":::", {":"} ;
 colon_fence_close = colon_fence:close
-                    where len(close) >= len(open) ;
+                    where len(close) = len(open) ;
 (* FORMAL (PART 9 §12, now a guard): `open` is the colon_fence captured by
    the enclosing block's opener (admonition_open / div_open /
    line_block_open / local_hard_break_block_open). A block is closed only
-   by a bare fence of equal-or-greater length, so a `:::` inside a `::::`
-   block is content. Equal-length fences do not nest. *)
+   by a bare fence of the SAME length, matched against the INNERMOST open
+   fence -- so nesting needs only DIFFERENT lengths, in either direction
+   (carve#439). A bare fence is a CLOSER whenever a container of its width
+   is open; only a non-bare fence line of that width opens a nested one. *)
 
 admonition = admonition_open, newline,
              {block - admonition_close},
@@ -1749,7 +1751,7 @@ EOF = (* end of file *) ;
    2. MATCHING FENCES -- FORMALIZED. Stated as `where` guards on the
       productions (GUARD NOTATION, header):
       - code_fence_close: same fence character, len(close) >= len(open);
-      - colon_fence_close (§12): len(close) >= len(open);
+      - colon_fence_close (§12): len(close) = len(open);
       - comment_block_close: len(close) = len(open). Only the LEADING RUN of
         `%` is compared -- trailing text on either fence line is insignificant,
         and an opener with no matching closer ahead opens nothing (§28).
@@ -2160,10 +2162,40 @@ EOF = (* end of file *) ;
       body and the block wraps the nested `<ul>`/`<ol>`. A blank line
       between the opener and the nested list still opens the block, and an
       empty body (opener immediately followed by its closer) opens too. With
-      NO matching closer, the opener degrades to literal text and the marker
-      lines form an ordinary nested list. The corpus pins these
+      NO matching closer, the block still opens and is CLOSED AT THE END OF
+      ITS ENCLOSING SCOPE -- here the end of the list item, since a column-zero
+      `:::` is outside the item and cannot reach in. The corpus pins these
       (docs/examples.md "Fence opener with a nested-list body inside a list
       item").
+
+      CLOSER WIDTH AND UNCLOSED BLOCKS -- NORMATIVE (carve#439).
+
+      A closer PAIRS WITH ITS OPENER'S WIDTH: a bare fence closes a container
+      only when its colon run is EXACTLY as long, matched against the
+      INNERMOST open fence. Nesting therefore needs only DIFFERENT lengths,
+      in EITHER direction -- `::::` outside `:::` and `:::` outside `::::`
+      both nest, and equal-length fences nest too, since the inner opener is
+      not bare. A bare fence is a CLOSER whenever a container of its width is
+      open; only a NON-BARE fence line of that width opens a nested block.
+
+      The CANONICAL direction, which `carve fmt` emits and the docs teach, is
+      `:::` outermost and one colon wider per level. That is a WRITER rule,
+      not a parser rule: nothing rejects the other direction, so no document
+      has to be migrated. It is canonical because adding a nesting level is
+      then a local edit instead of a rewrite of the whole chain, and because
+      an admonition always opens `::: note` however deep it later sits.
+
+      An UNCLOSED container is CLOSED AT END OF FILE (or at the end of its
+      enclosing scope), matching djot. It does NOT degrade to literal text.
+      Degradation turned the whole tail of a document into a paragraph over
+      one mistyped closer, and exact-width closers make that typo likelier,
+      so the two rules change together. Failing visibly is the point: an
+      implementation SHOULD report an unclosed container as a diagnostic.
+
+      This differs from the `%%%` comment block (§28), whose opener with no
+      closer ahead opens NOTHING. A comment's content is invisible, so
+      auto-closing one would hide the rest of the file; a container's content
+      still renders.
 
       The two tiers for a typed block:
 

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -202,12 +202,27 @@ function parseColonOpener(tail) {
   return out
 }
 
+// The matching closer's index, or `lines.length` when there is none: an
+// unclosed container is CLOSED AT END OF FILE (SS12, carve#439), not degraded
+// to literal text.
+//
+// A closer must be EXACTLY as wide as its opener, so nesting needs only
+// different lengths and both directions work. Equal-width nesting then makes
+// depth counting necessary: a bare fence of the opener's width closes, while a
+// NON-BARE fence line of that width opens a nested container, and stopping at
+// the first bare fence would end the outer block on the inner one's closer.
 function findColonCloser(lines, openIdx, len) {
+  let depth = 1
   for (let j = openIdx + 1; j < lines.length; j++) {
     const c = COLON_CLOSER.exec(lines[j])
-    if (c && c[1].length >= len) return j
+    if (c && c[1].length === len) {
+      if (--depth === 0) return j
+      continue
+    }
+    const f = COLON_FENCE.exec(lines[j])
+    if (f && f[1].length === len && parseColonOpener(f[2])) depth++
   }
-  return -1
+  return lines.length
 }
 
 const COMMENT_LINE = /^[ \t]*%%/
@@ -341,10 +356,10 @@ function opensSubBlock(line, rest) {
   if (f) return parseFenceInfo(f[2]) !== null
   const cf = COLON_FENCE.exec(line)
   if (!cf) return false
-  // a colon fence is a BLOCK only when the opener is well-formed AND a closer
-  // follows (PART 9 SS12); otherwise the line is ordinary prose and loosens
-  // the item like any second paragraph
-  return parseColonOpener(cf[2]) !== null && findColonCloser(rest, -1, cf[1].length) !== -1
+  // a colon fence is a BLOCK whenever the opener is well-formed: since
+  // carve#439 an unclosed container closes at end of file rather than falling
+  // back to prose, so no closer lookahead decides this
+  return parseColonOpener(cf[2]) !== null
 }
 
 // the lines after `j` that still belong to the item opened at `baseIndent`,
@@ -418,7 +433,7 @@ function parseBlocksImpl(lines, state, top, inItem = false) {
     if (isTableRow(line)) return true
     {
       const cf = COLON_FENCE.exec(line)
-      if (cf && parseColonOpener(cf[2]) && findColonCloser(lines, idx, cf[1].length) !== -1) return true
+      if (cf && parseColonOpener(cf[2])) return true
     }
     const fence = FENCE.exec(line)
     if (fence && hasCloser(lines, idx)) return true // I4
@@ -766,7 +781,7 @@ function parseBlocksImpl(lines, state, top, inItem = false) {
       if (cf) {
         const opener = parseColonOpener(cf[2])
         const close = opener ? findColonCloser(lines, i, cf[1].length) : -1
-        if (opener && close !== -1) {
+        if (opener) {
           const body = lines.slice(i + 1, close)
           i = close + 1
           if (opener.mode === 'line-block') {
@@ -790,8 +805,9 @@ function parseBlocksImpl(lines, state, top, inItem = false) {
           }
           continue
         }
-        // invalid opener or no closer: ordinary paragraph text (falls
-        // through to the paragraph collector)
+        // invalid opener: ordinary paragraph text (falls through to the
+        // paragraph collector). A VALID opener always opens - an unclosed one
+        // is closed at end of file (SS12, carve#439).
       }
     }
 
@@ -974,7 +990,7 @@ function parseBlocksImpl(lines, state, top, inItem = false) {
         if (isTableRow(lines[i])) break // I1: valid table row
         {
           const cf = COLON_FENCE.exec(lines[i])
-          if (cf && parseColonOpener(cf[2]) && findColonCloser(lines, i, cf[1].length) !== -1) break // I1/I4
+          if (cf && parseColonOpener(cf[2])) break // I1/I4
         }
         const f = FENCE.exec(lines[i])
         if (f && parseFenceInfo(f[2]) && hasCloser(lines, i)) break // I4: interrupts

--- a/tests/corpus/114-fence-opener-with-a-nested-list-body-inside-a-list-item-5.html
+++ b/tests/corpus/114-fence-opener-with-a-nested-list-body-inside-a-list-item-5.html
@@ -1,7 +1,9 @@
 <ul>
-  <li>::: note
-    <ul>
-      <li>para text</li>
-    </ul>
+  <li>
+    <aside class="admonition note">
+      <ul>
+        <li>para text</li>
+      </ul>
+    </aside>
   </li>
 </ul>

--- a/tests/corpus/114-fence-opener-with-a-nested-list-body-inside-a-list-item-6.html
+++ b/tests/corpus/114-fence-opener-with-a-nested-list-body-inside-a-list-item-6.html
@@ -1,8 +1,11 @@
 <ul>
-  <li>::: note
-    <ul>
-      <li>para text</li>
-    </ul>
+  <li>
+    <aside class="admonition note">
+      <ul>
+        <li>para text</li>
+      </ul>
+    </aside>
   </li>
 </ul>
-<p>:::</p>
+<div>
+</div>

--- a/tests/corpus/159-below-content-column-div-body-in-a-list-item-stays-literal.html
+++ b/tests/corpus/159-below-content-column-div-body-in-a-list-item-stays-literal.html
@@ -1,5 +1,8 @@
 <ul>
-  <li>::: note
-- para text
-:::</li>
+  <li>
+    <aside class="admonition note">
+      <p>- para text
+:::</p>
+    </aside>
+  </li>
 </ul>

--- a/tests/corpus/24-generic-divs-2.html
+++ b/tests/corpus/24-generic-divs-2.html
@@ -1,3 +1,4 @@
 <p>::: {.sidebar}
-not a div
-:::</p>
+not a div</p>
+<div>
+</div>

--- a/tests/corpus/24-generic-divs-4.html
+++ b/tests/corpus/24-generic-divs-4.html
@@ -1,3 +1,4 @@
 <p>::: 123
-not a div
-:::</p>
+not a div</p>
+<div>
+</div>

--- a/tests/corpus/41-line-blocks-5.html
+++ b/tests/corpus/41-line-blocks-5.html
@@ -1,4 +1,5 @@
 <p>::: {.line-block}
 one
-two
-:::</p>
+two</p>
+<div>
+</div>

--- a/tests/corpus/68-nested-containers-2.html
+++ b/tests/corpus/68-nested-containers-2.html
@@ -1,5 +1,5 @@
 <aside class="admonition note">
-  <p>::: tip
-Inner.</p>
+  <aside class="admonition tip">
+    <p>Inner.</p>
+  </aside>
 </aside>
-<p>:::</p>

--- a/tests/corpus/68-nested-containers-3.html
+++ b/tests/corpus/68-nested-containers-3.html
@@ -1,6 +1,6 @@
 <div>
   <p>Outer</p>
+  <div>
+    <p>Inner</p>
+  </div>
 </div>
-<p>Inner
-::::
-:::</p>

--- a/tests/corpus/68-nested-containers-4.html
+++ b/tests/corpus/68-nested-containers-4.html
@@ -1,2 +1,3 @@
-<p>::: note
-X</p>
+<aside class="admonition note">
+  <p>X</p>
+</aside>

--- a/tests/corpus/68-nested-containers-5.html
+++ b/tests/corpus/68-nested-containers-5.html
@@ -1,5 +1,7 @@
-<p>::::: a
-:::: b</p>
-<div class="c">
-  <p>X</p>
+<div class="a">
+  <div class="b">
+    <div class="c">
+      <p>X</p>
+    </div>
+  </div>
 </div>

--- a/tests/corpus/79-paragraph-interruption-11.html
+++ b/tests/corpus/79-paragraph-interruption-11.html
@@ -1,3 +1,4 @@
-<p>text
-:::note
-body</p>
+<p>text</p>
+<aside class="admonition note">
+  <p>body</p>
+</aside>

--- a/tests/corpus/79-paragraph-interruption-19.html
+++ b/tests/corpus/79-paragraph-interruption-19.html
@@ -1,3 +1,4 @@
-<p>Text
-:::
-stuff</p>
+<p>Text</p>
+<div>
+  <p>stuff</p>
+</div>

--- a/tests/spec/114-fence-opener-with-a-nested-list-body-inside-a-list-item.test
+++ b/tests/spec/114-fence-opener-with-a-nested-list-body-inside-a-list-item.test
@@ -72,10 +72,12 @@ Fence opener with a nested-list body inside a list item
   - para text
 .
 <ul>
-  <li>::: note
-    <ul>
-      <li>para text</li>
-    </ul>
+  <li>
+    <aside class="admonition note">
+      <ul>
+        <li>para text</li>
+      </ul>
+    </aside>
   </li>
 </ul>
 ```
@@ -86,13 +88,16 @@ Fence opener with a nested-list body inside a list item
 :::
 .
 <ul>
-  <li>::: note
-    <ul>
-      <li>para text</li>
-    </ul>
+  <li>
+    <aside class="admonition note">
+      <ul>
+        <li>para text</li>
+      </ul>
+    </aside>
   </li>
 </ul>
-<p>:::</p>
+<div>
+</div>
 ```
 
 ```

--- a/tests/spec/159-below-content-column-div-body-in-a-list-item-stays-literal.test
+++ b/tests/spec/159-below-content-column-div-body-in-a-list-item-stays-literal.test
@@ -6,8 +6,11 @@ Below-content-column div body in a list item stays literal
  :::
 .
 <ul>
-  <li>::: note
-- para text
-:::</li>
+  <li>
+    <aside class="admonition note">
+      <p>- para text
+:::</p>
+    </aside>
+  </li>
 </ul>
 ```

--- a/tests/spec/24-generic-divs.test
+++ b/tests/spec/24-generic-divs.test
@@ -24,8 +24,9 @@ not a div
 :::
 .
 <p>::: {.sidebar}
-not a div
-:::</p>
+not a div</p>
+<div>
+</div>
 ```
 
 ```
@@ -44,8 +45,9 @@ not a div
 :::
 .
 <p>::: 123
-not a div
-:::</p>
+not a div</p>
+<div>
+</div>
 ```
 
 ```

--- a/tests/spec/41-line-blocks.test
+++ b/tests/spec/41-line-blocks.test
@@ -59,8 +59,9 @@ two
 .
 <p>::: {.line-block}
 one
-two
-:::</p>
+two</p>
+<div>
+</div>
 ```
 
 ```

--- a/tests/spec/68-nested-containers.test
+++ b/tests/spec/68-nested-containers.test
@@ -25,10 +25,10 @@ Inner.
 :::
 .
 <aside class="admonition note">
-  <p>::: tip
-Inner.</p>
+  <aside class="admonition tip">
+    <p>Inner.</p>
+  </aside>
 </aside>
-<p>:::</p>
 ```
 
 ```
@@ -42,18 +42,19 @@ Inner
 .
 <div>
   <p>Outer</p>
+  <div>
+    <p>Inner</p>
+  </div>
 </div>
-<p>Inner
-::::
-:::</p>
 ```
 
 ```
 ::: note
 X
 .
-<p>::: note
-X</p>
+<aside class="admonition note">
+  <p>X</p>
+</aside>
 ```
 
 ```
@@ -63,9 +64,11 @@ X</p>
 X
 :::
 .
-<p>::::: a
-:::: b</p>
-<div class="c">
-  <p>X</p>
+<div class="a">
+  <div class="b">
+    <div class="c">
+      <p>X</p>
+    </div>
+  </div>
 </div>
 ```

--- a/tests/spec/79-paragraph-interruption.test
+++ b/tests/spec/79-paragraph-interruption.test
@@ -106,9 +106,10 @@ text
 :::note
 body
 .
-<p>text
-:::note
-body</p>
+<p>text</p>
+<aside class="admonition note">
+  <p>body</p>
+</aside>
 ```
 
 ```
@@ -180,7 +181,8 @@ Text
 :::
 stuff
 .
-<p>Text
-:::
-stuff</p>
+<p>Text</p>
+<div>
+  <p>stuff</p>
+</div>
 ```


### PR DESCRIPTION
Draft. **Step 2** of the sequencing recorded in markup-carve/carve#439. Step 1 is
markup-carve/carve-js#506.

`colon_fence_close` moves from `len(close) >= len(open)` to `==`, matched against the
**innermost** open fence. That single guard is the whole of the "inversion" proposal:
nesting then needs only *different* lengths, so both directions parse and every existing
well-formed document keeps working.

```
:::: note        :::  note
::: tip          :::: tip
:::              ::::
::::             :::
```

Inversion is a **writer** rule - the canonical direction `carve fmt` emits and the docs
teach - not a parser rule. That split is why this ships without a migration.

**Equal-width nesting needs one thing beyond the guard**, in the automaton as much as in the
engines: the closer scan counts depth. A bare fence is a closer whenever a container of its
width is open; only a *non-bare* fence line of that width opens a nested one. Stopping at
the first bare fence ended the outer container on the inner one's closer.

**Unclosed containers close at end of file** (or at the end of their enclosing scope)
instead of degrading the whole tail of the document to literal text. Exact-width closers
make a mistyped closer likelier, and that failure is too loud to pair with a stricter rule.
This is deliberately *not* the `%%%` rule of §28: a comment's content is invisible, so
auto-closing one would hide the rest of the file, while a container's content still renders.

The executable spec follows in both halves - `findColonCloser` counts depth and returns
end-of-input rather than `-1`. Four call sites that asked "is there a closer ahead" are
**deleted** rather than left as conditions that can no longer be false.

**Twelve fixtures flip**, which is exactly what pinning the degenerate forms in #447 was
for: all four `68-nested-containers` cases plus the generic-div, line-block,
paragraph-interruption and list-item-fence cases that exercised the same rules.

## One disagreement with step 1, found here

For `- ::: note` / `  - para text` (fixture `114-…-5`), this executable spec puts the nested
list **inside** the auto-closed aside - the container runs to the end of its enclosing
scope, which §12 now states explicitly. carve-js#506 closes the aside **immediately**,
leaving it empty with the list as a sibling.

The spec's reading is the intended one, so carve-js#506 needs a follow-up before either
merges. Recording it here rather than letting the two land and disagree.

Not in this PR: carve-php and carve-rs (step 3) and the lint/LSP diagnostic for an unclosed
container (step 4).