### PR TITLE
spec: braces alone on a list-item marker line are an attribute line

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -5854,3 +5854,40 @@ picked different answers here and every one of them stayed green (PART 10 §1).
 ```
 
 :::::
+
+## Attribute braces on a list-item marker line
+
+Three shapes that look alike and mean different things (PART 9 §15 A8). What
+decides is whether content follows the brace run on that line, not the column
+the braces sit in.
+
+`-{…} text` with no space after the marker attributes the **item**. With a
+space and text after the braces, the braces are part of that text. With a space
+and *nothing* after them, it is an ordinary attribute line that floats to the
+next block - a container does not get its own attribute rules.
+
+Worth pinning because the two halves were each pinned already and their boundary
+was not: carve-rs read the third shape as literal text while the other engines
+read it as an attribute line, and neither could be shown wrong (carve#454).
+
+::: compare
+
+```carve
+-{.item} An attributed item.
+- {.c} literal text
+
+- {a=b .c}
+  # Attributed heading
+```
+
+```html
+<ul>
+  <li class="item"><p>An attributed item.</p></li>
+  <li><p>{.c} literal text</p></li>
+  <li>
+    <h1 a="b" class="c" id="Attributed-heading">Attributed heading</h1>
+  </li>
+</ul>
+```
+
+:::

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2404,6 +2404,26 @@ EOF = (* end of file *) ;
          included) -- the preceding block-attribute line is the sole
          block-level attribute channel. A trailing `{…}` on a heading line
          is literal inline content (PART 2, headings).
+      A8 ON A LIST-ITEM MARKER LINE, ALONE MEANS ATTRIBUTE LINE. A
+         `-{…} text` with no space after the marker attributes the LIST
+         ITEM (PART 2, list items; the marker still needs content, so a
+         bare `-{…}` is not a list item at all). WITH a space, what follows
+         the brace run on that line decides:
+           - {.c} text      -> literal: <li>{.c} text</li>
+           - {a=b .c}       -> an A1 attribute line, floating (A2) to the
+             # H               heading below: <li><h1 a="b" class="c" …>
+         The discriminator is whether CONTENT FOLLOWS the braces on that
+         line, not the column they sit in. Braces trailed by text are part
+         of that text; braces alone are a line of their own that happens to
+         start after a marker, and A1/A2 apply to it exactly as they would
+         at the top level -- a container does not get its own attribute
+         rules.
+         Decided in carve#454. The two halves were each pinned (corpus
+         88-list-item-attributes-7 for the literal form, 84 for A1/A2) and
+         their boundary was not, so carve-rs read the marker line as
+         literal while carve-js, carve-php and the executable spec read it
+         as an attribute line. None of them could be shown wrong until the
+         boundary was stated.
       Implementation status: php, js, and rs implement §15 in full. Pinned
       by corpus 84-block-attribute-lines.
 

--- a/tests/corpus/170-attribute-braces-on-a-list-item-marker-line.crv
+++ b/tests/corpus/170-attribute-braces-on-a-list-item-marker-line.crv
@@ -1,0 +1,5 @@
+-{.item} An attributed item.
+- {.c} literal text
+
+- {a=b .c}
+  # Attributed heading

--- a/tests/corpus/170-attribute-braces-on-a-list-item-marker-line.html
+++ b/tests/corpus/170-attribute-braces-on-a-list-item-marker-line.html
@@ -1,0 +1,7 @@
+<ul>
+  <li class="item"><p>An attributed item.</p></li>
+  <li><p>{.c} literal text</p></li>
+  <li>
+    <h1 a="b" class="c" id="Attributed-heading">Attributed heading</h1>
+  </li>
+</ul>

--- a/tests/spec/170-attribute-braces-on-a-list-item-marker-line.test
+++ b/tests/spec/170-attribute-braces-on-a-list-item-marker-line.test
@@ -1,0 +1,17 @@
+Attribute braces on a list-item marker line
+
+```
+-{.item} An attributed item.
+- {.c} literal text
+
+- {a=b .c}
+  # Attributed heading
+.
+<ul>
+  <li class="item"><p>An attributed item.</p></li>
+  <li><p>{.c} literal text</p></li>
+  <li>
+    <h1 a="b" class="c" id="Attributed-heading">Attributed heading</h1>
+  </li>
+</ul>
+```


### PR DESCRIPTION
Closes #454, decided as option 2.

Two rules were each pinned and their boundary was not:

- corpus `88-list-item-attributes-7`: a space after the marker makes braces literal — `- {.c} text` → `<li>{.c} text</li>`
- §15 A1/A2: a `{…}` alone on a line floats forward to the next block

Nothing said which applies to:

```
- {a=b .c}
  # H
```

carve-rs read it as literal and dropped the attributes; carve-js, carve-php and the executable spec attached them to the heading. Neither could be shown wrong.

## The rule

**A8**: the discriminator is whether *content follows* the braces on that line, not the column they sit in. Braces trailed by text are part of that text; braces alone are a line of their own that happens to begin after a marker, and A1/A2 apply exactly as at the top level.

The property that decides it: **a container does not get its own attribute rules.** The alternative reading would have made §15 conditional on where a block sits.

## Pinned

Corpus case 170 puts all three shapes in one document, including the no-space `-{.item} text` form that attributes the *item*, so the boundary is visible in one place rather than inferred from two cases in different files. (Worth noting a bare `-{…}` with no content is not a list item at all — a marker needs content — which is why the pinned example carries text.)

513/513 conformant, 637 tests pass.

**carve-rs is the engine that changes**; follow-up there.