### PR TITLE
chore: bump the carve-js pin past the single-line-heading change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "mermaid": "^11.15.0"
       },
       "devDependencies": {
-        "@markup-carve/carve": "github:markup-carve/carve-js#5e43fc1b5883e26d9eaf87df235566372e22a4e0",
+        "@markup-carve/carve": "github:markup-carve/carve-js#a02bca62a830904e80061cbaf0141c04c83d074c",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.35.0",
@@ -968,8 +968,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#5e43fc1b5883e26d9eaf87df235566372e22a4e0",
-      "integrity": "sha512-cL69Ou28foh1hFWmxMbfExmiLJ2x57aIwG6wzILA0pnKo4cp9wlYCIFRYym8RTzwZwNy4dvyNyBhl2YUC52ceg==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#a02bca62a830904e80061cbaf0141c04c83d074c",
+      "integrity": "sha512-cpzZkv5xWFThtoHtWj79xc51S9SyeeDxBOwaNxhisc8hInyF2CXhr5Y8lAffW/5KLhYEAtt4oTxhXusv67jC8g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },
   "devDependencies": {
-    "@markup-carve/carve": "github:markup-carve/carve-js#5e43fc1b5883e26d9eaf87df235566372e22a4e0",
+    "@markup-carve/carve": "github:markup-carve/carve-js#a02bca62a830904e80061cbaf0141c04c83d074c",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.35.0",


### PR DESCRIPTION
The pinned reference build is what the PART 11 round-trip suite, the Tier-2
optional corpus and the prose examples run against, and it was three merges
behind: `5e43fc1` -> `a02bca6`.

That brings single-line headings (#451), the unclosed-container lint diagnosis
(markup-carve/carve-js#515) and the exact-length colon-fence closers
(markup-carve/carve-js#505).

**It also clears the two failures main was carrying.**
`09-nested-containers` and `10-container-under-a-list-item` were failing
`fmt(x) == expected bytes` because the pinned build still sized a container
fence by the old rule. The suite is **638/638** on this pin, up from 636/638.

`core:check` is unchanged at 514/514 conformant, 0 refused, 0 defects, 0
sentinel leaks - the executable spec is the corpus oracle and does not move with
the pin. `corpus:build` produces no diff.

Engine side of #451, now merged: markup-carve/carve-js#513,
markup-carve/carve-php#586, markup-carve/carve-rs#420,
markup-carve/tree-sitter-carve#30.
