### PR TITLE
docs: three prose spots that still describe heading folding

### DIFF
--- a/docs/edge-cases.md
+++ b/docs/edge-cases.md
@@ -499,8 +499,9 @@ and removes the old false positive where a wrapped prose line became a list.
 heading (a bounded title) and starts a top-level **sibling list**. A blockquote
 is *not* ended: a quoted line ends in an open paragraph, so a list marker folds
 into it as lazy continuation — `> q` / `- a` is **one** quote whose paragraph is
-`q\n- a`, not a quote plus a sibling list. Plain text folds into a heading too;
-a list marker does not. This matches Djot.
+`q\n- a`, not a quote plus a sibling list. Nothing folds into a heading at all,
+plain text included - a heading ends at the newline (§18). The blockquote half
+of this matches Djot; the heading half deliberately does not.
 
 **Other carve-outs:**
 

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -1062,9 +1062,12 @@ under the marker.
 
 :::
 
-A heading folds its trailing flush-left plain text as continuation, at any
-nesting depth — even when the heading opens on a deeper sub-list item's marker
-line and the following line is flush left.
+A flush-left line after a heading stays inside the item the heading belongs to,
+at any nesting depth — even when the heading opens on a deeper sub-list item's
+marker line. What it does *not* do is fold into the heading: a heading ends at
+the newline (§18), so the line is the item's own content, which a tight list
+renders unwrapped. Ownership is the rule here; the heading's id is built from
+the heading line alone.
 
 ::: compare
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -31,7 +31,7 @@ Light markup languages are provably not context-free: fence-length matching is a
 | PART 3 inline grammar | [`resources/carve-core.ohm`](https://github.com/markup-carve/carve/blob/main/resources/carve-core.ohm) (Ohm/PEG) |
 | PART 9R resolution + PART 10 serialization | `scripts/spec/html.mjs` |
 
-The executable spec covers the full conformant core: block structure (headings incl. multi-line folding and section wrapping, lists with every ordered dialect, quotes, tables with the span walk, fenced code and colon fences, definition lists, comments, frontmatter, block-attribute lines), the complete inline layer (emphasis with word-boundary guards, links, images, spans, attributes with the security hardening rules, autolinks, math, extensions, mentions/tags, editorial markup, smart typography, footnotes incl. inline notes, crossrefs, raw passthrough), and the resolution passes (references, footnote numbering and endnotes placement, numbered captions, abbreviations).
+The executable spec covers the full conformant core: block structure (headings incl. section wrapping, lists with every ordered dialect, quotes, tables with the span walk, fenced code and colon fences, definition lists, comments, frontmatter, block-attribute lines), the complete inline layer (emphasis with word-boundary guards, links, images, spans, attributes with the security hardening rules, autolinks, math, extensions, mentions/tags, editorial markup, smart typography, footnotes incl. inline notes, crossrefs, raw passthrough), and the resolution passes (references, footnote numbering and endnotes placement, numbered captions, abbreviations).
 
 ```bash
 npm run core:check


### PR DESCRIPTION
#458 caught the normative ones - the grammar's definition-term comparison and the executable spec's coverage note. Three descriptions in the prose still claim the fold #451 removed:

| file | said |
|---|---|
| `docs/grammar.md` | listed "multi-line folding" among what the executable spec covers |
| `docs/edge-cases.md` | "Plain text folds into a heading too", contrasting it with a blockquote - now the opposite of the rule |
| `docs/examples/edge-cases.md` | introduced the nested-lazy cases as folding into the heading. What they actually pin is that the line stays inside the **item**; their expected output changed in #451 and only the prose was left behind |

No fixture changes: `corpus:build` reproduces all 514 pairs byte-identically. 642 spec tests pass, 514/514 executable-spec conformant.

Refs #434, #451
