### PR TITLE
spec: the column-zero note, and what a definition term actually is

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -516,12 +516,13 @@ definition_term = "::", space, inline_content, newline, {term_continuation_line}
 term_continuation_line = inline_content, newline ;
 (* A term folds a following plain line as a soft break; a blank line, a new
    `::`/`:  ` marker, or a block opener ends it. A term holds inline content
-   only -- no block body. (This used to read "like a heading". A heading no
-   longer folds anything -- see SINGLE-LINE HEADINGS -- so the analogy is gone,
-   and the term KEEPS its fold deliberately: what made the heading's fold a
-   defect was having TWO ways to spill, one of them silent, and a term has only
-   this one. Wrapping a long term stays possible; §434's follow-up question is
-   answered here rather than left open.) *)
+   only -- no block body. (This used to read "like a heading", which was never
+   the right comparison: a term is the KEY half of a key-value entry, not a
+   title, and it is bound to the definition beneath it rather than to a section
+   of the document. It KEEPS its fold. What made the heading's fold a defect was
+   having TWO ways to spill onto the next line, one of them silent -- a term has
+   exactly one, so a long key stays wrappable at no cost. §434's follow-up
+   question is answered here rather than left open.) *)
 definition_body = (':', space, space, first_block_content)
                 | (':', space, space, inline_content, newline,
                    { definition_continuation

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -196,9 +196,9 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
 (* COLUMN ZERO -- NORMATIVE. A heading_marker sits at COLUMN 0 of its line (no
    leading spaces or tabs); carve does NOT accept CommonMark's 0-3 space indent.
    An indented `#`-line is ordinary paragraph text: "   # H" is <p># H</p>, not
-   a heading. This applies to a continuation line too -- an indented
-   heading_marker is not a continuation marker, so it folds into the heading as
-   literal text rather than being stripped. (Within a container the column is
+   a heading -- including one written directly under an open heading, which used
+   to fold in as literal text and now simply starts its own paragraph (see
+   SINGLE-LINE HEADINGS). (Within a container the column is
    measured after the container's own markers are stripped, e.g. "> # H" is a
    quoted heading.) Matches Djot (which dropped CommonMark's indent fuzz);
    pinned by corpus 101-heading-marker-column-zero. *)


### PR DESCRIPTION
Two `grammar.ebnf` comment spots #458 and #461 both missed. Comments only, no
rule changes: 638/638 tests, `core:check` 514/514 conformant, 0 refused, 0
defects.

**COLUMN ZERO still described folding.** It said an indented `#`-line under an
open heading "folds into the heading as literal text rather than being
stripped". There is nothing to fold into now - it starts its own paragraph, like
any other indented `#`-line. The column-zero rule itself is unchanged.

**The definition-term note explained a term by contrast with headings.** That is
how the dead "like a heading" comparison got there in the first place, and
answering #434's follow-up in those terms kept the frame. A term is the **key
half of a key-value entry** - bound to the definition beneath it, not to a
section of the document. That is why it is not a title, and why the heading rule
was never going to apply to it.

The behavior is unchanged and stays unchanged: a term keeps its fold. What made
the heading's fold a defect was having two ways to spill onto the next line, one
of them silent; a term has exactly one, so a long key stays wrappable at no
cost. #434's follow-up question is answered at the rule rather than left open.

These were commits on #459 (closed in favour of #461, which carries the three
prose files); rebased onto main so they are not lost.
