### PR TITLE
spec: the layout automaton's term comment said 'like a heading' too

### DIFF
--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -654,8 +654,10 @@ function parseBlocksImpl(lines, state, top, inItem = false) {
         const cur0 = unlazy(lines[i] ?? '')
         let dm
         if ((dm = /^:: (.*)$/.exec(cur0))) {
-          // term (dt): folds plain wrapped continuation lines like a heading so
-          // a wrapped term line does not strand its definition.
+          // term (dt): folds plain wrapped continuation lines so a wrapped term
+          // line does not strand its definition. (This used to say "like a
+          // heading". A heading ends at its newline and folds nothing; the term
+          // is the key half of a key-value entry, and keeps its fold.)
           let dt = dm[1].trim()
           i++
           while (i < n) {


### PR DESCRIPTION
The last one. `scripts/spec/layout.mjs` explained the definition-term fold with the same dead comparison the grammar carried until #462.

A heading ends at its newline and folds nothing; the term is the key half of a key-value entry, and keeps its fold. Comment only - 638/638 tests, `core:check` unchanged at 514/514 conformant, 0 refused, 0 defects.

Completes the sweep behind #451: the only remaining matches for the old wording in this repo are the divergence table documenting the change itself, and `docs/edge-cases.md`, which #461 covers.