### PR TITLE
docs: give the three dismissed link-syntax headings distinct anchors

### DIFF
--- a/docs/dismissed-syntax.md
+++ b/docs/dismissed-syntax.md
@@ -4,7 +4,7 @@ Ideas that were considered during Carve's design but ultimately rejected. Docume
 
 ---
 
-## Link Syntax: `"text"(url)`
+## Link Syntax: `"text"(url)` (quoted text)
 
 **Proposed:**
 ```
@@ -28,7 +28,7 @@ Visit "Google"(https://google.com "Search engine") today.
 
 ---
 
-## Link Syntax: `[text -> url]`
+## Link Syntax: `[text -> url]` (arrow)
 
 **Proposed:**
 ```
@@ -47,7 +47,7 @@ Visit [Google -> https://google.com] for search.
 
 ---
 
-## Link Syntax: `[[url | text]]`
+## Link Syntax: `[[url | text]]` (wiki-style)
 
 **Proposed (wiki-style):**
 ```


### PR DESCRIPTION
Two headings in `dismissed-syntax.md` slugify to the same id.

`Link Syntax: "text"(url)` and `Link Syntax: [text -> url]` both reduce to `link-syntax-text-url` once slugification strips the punctuation that is the only thing distinguishing them. Confirmed in the built site today:

```
id="link-syntax-text-url"
id="link-syntax-text-url-1"      <- the arrow section
id="link-syntax-url-text"
```

So the arrow section's anchor is `link-syntax-text-url-1`, a positional number rather than anything about the section.

Two costs:

- A link to `#link-syntax-text-url` silently resolves to the first of the two, with nothing on the page indicating the other exists.
- The suffix is assigned by document order, so inserting a heading above renumbers it and breaks any external link pointing at it.

## The change

The file already has a convention for qualifying a shared category - `Emphasis: **bold** (double asterisk)` and `Emphasis: _italic_ (underscore for emphasis)` - so each link-syntax heading now names its form:

```
## Link Syntax: `"text"(url)` (quoted text)
## Link Syntax: `[text -> url]` (arrow)
## Link Syntax: `[[url | text]]` (wiki-style)
```

The third does not collide, but is qualified too so the trio stays parallel.

Resulting ids, from a full `docs:build`:

```
id="link-syntax-text-url-quoted-text"
id="link-syntax-text-url-arrow"
id="link-syntax-url-text-wiki-style"
```

Nothing in the repository linked to the old anchors, so no inbound links needed updating.

## How this surfaced

Rendering the docs through CarvePress, whose linter reports duplicate heading slugs rather than silently deduplicating them. Worth noting for the eventual migration: the two renderers disambiguate with different suffixes - VitePress appends `-1`, Carve appends `-2` - so any link written against a deduplicated anchor would break on the move. Naming the sections removes that class of breakage entirely.

A sweep of the built site found this to be the only heading collision across the documentation.