### PR TITLE
docs: the last two labels that still said headings fold

### DIFF
--- a/docs/edge-cases.md
+++ b/docs/edge-cases.md
@@ -542,7 +542,7 @@ Normative statement: `resources/grammar.ebnf` PART 9 §10. Verified by corpus
 
 ---
 
-## 18. Multi-Line Headings (Text Folds INTO an Open Heading)
+## 18. Single-Line Headings (Nothing Folds INTO a Heading)
 
 **Rule (normative, grammar PART 2):** a heading **ends at the newline**.
 Nothing folds into it - the next line begins whatever block it begins, exactly

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2137,11 +2137,12 @@ EOF = (* end of file *) ;
          \n - item" folds into ONE quote whose paragraph is
          "quoted\n- item" (NOT quote + <ul>); "> text \n > # H" is a quoted
          heading; a quoted bullet ("> p \n > - x") folds the same way.
-         HEADING is the SOLE exception: a bounded title holds no block, so
-         a list marker ENDS an open heading and starts a sibling list
-         ("# H \n - item" -> heading + <ul>), any block-opener ends it, and
-         only plain text (or a same-`#` marker line) folds in (PART 2,
-         MULTI-LINE HEADINGS) -- matching djot.
+         HEADING is the SOLE exception: a bounded title holds no block and
+         ENDS AT THE NEWLINE, so nothing folds into it at all -- a list
+         marker starts a sibling list ("# H \n - item" -> heading + <ul>),
+         and every other line likewise begins its own block (PART 2,
+         SINGLE-LINE HEADINGS). Djot folds a plain or same-`#` line in; this
+         is the deliberate divergence, not a restatement of it.
 
    11. LIST MARKER CHANGE STARTS A NEW LIST -- OPERATIONAL (governs `list`
       in PART 2). §10 decides FIRST whether marker lines establish a list


### PR DESCRIPTION
Both are section **labels** rather than prose, which is why #458 and #461 missed them - the bodies underneath were already correct.

| where | said | body underneath |
|---|---|---|
| `docs/edge-cases.md` §18 | "Multi-Line Headings (Text Folds INTO an Open Heading)" | "a heading **ends at the newline**. Nothing folds into it" |
| `resources/grammar.ebnf` §10 | cited "PART 2, MULTI-LINE HEADINGS" for "only plain text (or a same-`#` marker line) folds in" | PART 2 now says nothing folds in |

The grammar one is the worse of the two: it stated Djot's rule as Carve's and cited a section that says the opposite. Rewritten to state the divergence rather than restate it.

No fixture changes: `corpus:build` reproduces all 514 pairs byte-identically. 638 spec tests pass, 514/514 conformant.

Refs #434, #451
