### PR TITLE
spec: a mention's attributes render, with the author class merged (PART 10 §1)

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1513,6 +1513,36 @@ name_word = (letter | digit | '_' | '-')+ ;
    (`ping @markus.` -> mention `markus` + literal `.`). Pinned by corpus
    89-mention-and-tag-name-boundaries / 31-mention-ignores-email-addresses. *)
 
+(* ATTRIBUTES ON A MENTION OR TAG (normative, PART 10 §1). The node carries an
+   `attrs` slot (PART 12) and those attributes RENDER, with the author's
+   classes merged onto the structural `mention` / `tag` class and the
+   author's own attribute order preserved after it:
+
+     class="mention user" data-role="lead" id="x"
+
+   On the link form the structural href is second and is never taken from an
+   author attribute:
+
+     <a class="mention user" href="…" data-role="lead" id="x">
+
+   This is the same merge a typed div uses (`class="admonition note x"`) and
+   that math uses (`class="math inline"` alongside `{.foo}`); a mention is not
+   a special case.
+
+   NOT REACHABLE FROM SOURCE, and therefore not corpus-pinnable: an attribute
+   block after a mention stays literal (corpus
+   151-attribute-block-after-a-mention-stays-literal), so `@alice{.x}` never
+   produces an attributed mention. The slot is filled by a decoded wire
+   payload, the ProseMirror bridge (a stock Tiptap mention carries an id), or
+   an application building the node. Each implementation pins this in its own
+   suite; the corpus cannot, because the corpus renders source.
+
+   The rule exists because the alternative loses on round-trip: a writer that
+   spells an attributed mention as `[*\@alice*]{.mention #keepme}` only
+   satisfies toHtml(fmt(x)) == toHtml(x) if those attributes render, and a
+   writer that drops them instead satisfies it by deleting the data from both
+   sides. Resolved in carve-php#575. *)
+
 (* Boundary rules (PSEUDO-PRODUCTIONS -- prose conditions on `mention` /
    `tag` / `symbol`, normative in PART 9 §7, not reachable grammar symbols):
    the marker must be at start of content or preceded by a character that is


### PR DESCRIPTION
Settles markup-carve/carve-php#575. Engine reference: markup-carve/carve-js#522.

## The gap

`mention` has carried an `attrs` slot since PART 12 and nothing said whether it renders. So each engine answered differently:

| engine | output |
| --- | --- |
| carve-js, carve-rs | `<span class="mention">` - ignored |
| carve-php | `<span class="mention" id="x">` - every attribute except `class`, dropped |

Dropping exactly one attribute while rendering its neighbours is wrong under either answer. That is what made this a decision rather than an alignment.

## The rule

They render, and the author's classes merge onto the structural class:

```
class="mention user" data-role="lead" id="x"
<a class="mention user" href="…" data-role="lead" id="x">
```

Not a new rule - a typed div already renders `class="admonition note x"`, and math already renders `class="math inline"` alongside `{.foo}`. A mention stops being the exception.

## Why not the other answer

Round-trip. carve-php's writer spells an attributed mention as `[*\@alice*]{.mention #keepme}` so the written source renders what the node rendered (markup-carve/carve-php#574). That only holds if the attributes render. The alternative - never render them - satisfies the same invariant by making the writer drop them too, which passes by deleting the data from both sides rather than by preserving it.

## Why there is no corpus case

There cannot be one. An attribute block after a mention stays literal (corpus `151-attribute-block-after-a-mention-stays-literal`), so **no source document can produce an attributed mention**. The slot is filled by a decoded wire payload, the ProseMirror bridge (a stock Tiptap mention carries an `id`), or an application building the node.

That is the same blind spot behind markup-carve/carve-php#519 and #524: the conformance gate renders source, so anything reachable only from the wire format is invisible to it. The note says this explicitly, so a future reader reads the missing fixture as deliberate rather than as an oversight, and each engine pins the behavior in its own suite instead.

642 tests, docs build clean.
