### PR TITLE
feat(playground): share the current document as a link

### DIFF
--- a/docs/.vitepress/share-link.js
+++ b/docs/.vitepress/share-link.js
@@ -1,0 +1,108 @@
+/**
+ * Share links for the playground.
+ *
+ * A playground document round-trips through the URL fragment, so a link is
+ * bookmarkable and sendable without a server: the fragment never leaves the
+ * browser, which also keeps the source out of request logs and out of
+ * VitePress's router (we write it with history.replaceState).
+ *
+ * Encoding: JSON -> UTF-8 -> deflate-raw -> base64url, carried as `#s=`.
+ * Where CompressionStream is unavailable the same JSON goes in uncompressed as
+ * `#p=`, so an older browser still reads and writes links, just longer ones.
+ * Decoding accepts either key regardless of what this browser would produce.
+ */
+
+const KEY_DEFLATED = 's'
+const KEY_PLAIN = 'p'
+
+/** Encoded-fragment ceiling. Browsers and chat clients truncate long URLs at
+ *  wildly different points; past this a link is more likely to arrive broken
+ *  than to work, so the caller is told rather than handed a lie. */
+export const MAX_ENCODED_LENGTH = 16000
+
+function toBase64Url(bytes) {
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function fromBase64Url(text) {
+  const padded = text.replace(/-/g, '+').replace(/_/g, '/')
+  const binary = atob(padded)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes
+}
+
+async function through(bytes, stream) {
+  const writer = stream.writable.getWriter()
+  void writer.write(bytes)
+  void writer.close()
+  const chunks = []
+  let total = 0
+  const reader = stream.readable.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.length
+  }
+  const out = new Uint8Array(total)
+  let at = 0
+  for (const chunk of chunks) {
+    out.set(chunk, at)
+    at += chunk.length
+  }
+  return out
+}
+
+const canCompress = () => typeof CompressionStream === 'function'
+const canDecompress = () => typeof DecompressionStream === 'function'
+
+/**
+ * Encode a playground state into a URL fragment (without the leading `#`).
+ * Returns null when the result is too long to be a usable link.
+ */
+export async function encodeShare(state) {
+  const payload = JSON.stringify({ v: 1, ...state })
+  const bytes = new TextEncoder().encode(payload)
+  if (canCompress()) {
+    const deflated = await through(bytes, new CompressionStream('deflate-raw'))
+    const encoded = `${KEY_DEFLATED}=${toBase64Url(deflated)}`
+    return encoded.length > MAX_ENCODED_LENGTH ? null : encoded
+  }
+  const encoded = `${KEY_PLAIN}=${toBase64Url(bytes)}`
+  return encoded.length > MAX_ENCODED_LENGTH ? null : encoded
+}
+
+/**
+ * Decode a fragment back into a playground state, or null if it carries no
+ * share payload.
+ *
+ * A malformed payload is not an error the visitor can act on, so it decodes to
+ * null and the playground opens on its default document. Throwing here would
+ * take the page down over a truncated link.
+ */
+export async function decodeShare(fragment) {
+  const params = new URLSearchParams((fragment ?? '').replace(/^#/, ''))
+  const deflated = params.get(KEY_DEFLATED)
+  const plain = params.get(KEY_PLAIN)
+  if (deflated === null && plain === null) return null
+  try {
+    let bytes
+    if (deflated !== null) {
+      if (!canDecompress()) return null
+      bytes = await through(fromBase64Url(deflated), new DecompressionStream('deflate-raw'))
+    } else {
+      bytes = fromBase64Url(plain)
+    }
+    const state = JSON.parse(new TextDecoder().decode(bytes))
+    if (state === null || typeof state !== 'object') return null
+    if (typeof state.source !== 'string') return null
+    // The fragment is attacker-supplied: read the fields we know and ignore
+    // everything else, rather than spreading a decoded object into app state.
+    return { source: state.source, engine: state.engine === 'rust' ? 'rust' : 'js' }
+  } catch {
+    return null
+  }
+}

--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -6,6 +6,8 @@ import { carveToHtml, markdownToCarve } from '@markup-carve/carve'
 import { carveExtensions } from '../../carve-extensions.js'
 // @ts-expect-error - local ESM helper without TS resolution context
 import { renderMathIn } from '../../render-math.js'
+// @ts-expect-error - local ESM helper without TS resolution context
+import { encodeShare, decodeShare } from '../../share-link.js'
 
 // Render the JS engine with every documented extension enabled, so the demo
 // showcases the full feature set (real Mermaid extension, wikilinks, tabs,
@@ -24,6 +26,64 @@ const PHP_SANDBOX_URL = 'https://sandbox.dereuromark.de/sandbox/carve'
 
 const source = ref(DEFAULT_SOURCE)
 const fullscreen = ref(false)
+
+// --- Share links ---
+//
+// The document lives in the URL fragment, so a playground state is
+// bookmarkable and sendable with no server involved. The fragment is written
+// with history.replaceState (never pushState): editing is not navigation, and
+// a per-keystroke history entry would make Back unusable.
+//
+// SECURITY. A shared document is written by whoever sent the link, so it
+// renders with raw HTML DISABLED - otherwise a link would be a way to run
+// script on this origin. That stays off for the rest of the session: once the
+// textarea has held someone else's document, "did the visitor rewrite all of
+// it?" is not a question this component can answer. Reloading the playground
+// without a fragment gives a normal, raw-HTML-enabled session back.
+const fromSharedLink = ref(false)
+const shareStatus = ref<string | null>(null)
+let shareStatusTimer: ReturnType<typeof setTimeout> | undefined
+
+async function applyShareLink(): Promise<void> {
+  if (typeof window === 'undefined') return
+  const state = await decodeShare(window.location.hash)
+  if (!state) return
+  fromSharedLink.value = true
+  source.value = state.source
+  // The Rust engine renders through a WASM binding with no options, so raw
+  // HTML cannot be turned off there. A shared document therefore stays on the
+  // JS engine (see the disabled button in the toolbar).
+  engine.value = 'js'
+}
+
+function shareUrl(encoded: string): string {
+  const { origin, pathname, search } = window.location
+  return `${origin}${pathname}${search}#${encoded}`
+}
+
+function flashShareStatus(message: string): void {
+  shareStatus.value = message
+  clearTimeout(shareStatusTimer)
+  shareStatusTimer = setTimeout(() => (shareStatus.value = null), 2500)
+}
+
+async function copyShareLink(): Promise<void> {
+  const encoded = await encodeShare({ source: source.value, engine: engine.value })
+  if (encoded === null) {
+    flashShareStatus('Too long to share as a link')
+    return
+  }
+  const url = shareUrl(encoded)
+  window.history.replaceState(null, '', url)
+  try {
+    await navigator.clipboard.writeText(url)
+    flashShareStatus('Link copied')
+  } catch {
+    // Clipboard access can be refused (permissions, insecure origin). The
+    // address bar now holds the link either way, so say so instead of failing.
+    flashShareStatus('Link is in the address bar')
+  }
+}
 
 // Import from Markdown: open a paste dialog, then markdownToCarve() rewrites
 // the pasted Markdown into Carve and replaces the source (so it flows through
@@ -123,7 +183,13 @@ const rendered = computed<{ html: string; ms: number | null }>(() => {
     const useWasm = engine.value === 'rust' && wasmToHtml
     const t0 = performance.now()
     let out = (
-      useWasm ? wasmToHtml!(source.value) : carveToHtml(source.value, { extensions: JS_EXTENSIONS })
+      useWasm
+        ? wasmToHtml!(source.value)
+        : carveToHtml(source.value, {
+            extensions: JS_EXTENSIONS,
+            // A document that arrived in a URL is not this visitor's document.
+            allowRawHtml: !fromSharedLink.value,
+          })
     ) as string
     const ms = performance.now() - t0
     // The demo references images with a doc-relative path; resolve it against
@@ -175,9 +241,14 @@ async function renderMermaid(): Promise<void> {
   const mermaid = (await import('mermaid')).default
   const dark = document.documentElement.classList.contains('dark')
   // Re-initialize per render so a theme toggle is picked up.
+  //
+  // `loose` is what makes a diagram's click directives and HTML labels active,
+  // and the rendered SVG goes in through innerHTML. That is fine for a diagram
+  // this visitor typed and not fine for one that arrived in a link, so a
+  // shared document renders under mermaid's own `strict` sanitizer instead.
   mermaid.initialize({
     startOnLoad: false,
-    securityLevel: 'loose',
+    securityLevel: fromSharedLink.value ? 'strict' : 'loose',
     theme: dark ? 'dark' : 'default',
   })
   mermaidInit = true
@@ -404,10 +475,13 @@ function schedulePostProcess(): void {
 watch(html, schedulePostProcess)
 onMounted(() => {
   mounted.value = true
-  void nextTick(postProcessOutput)
+  // Before the first post-process, so a shared document is what gets
+  // highlighted, mermaid-rendered and math-rendered.
+  void applyShareLink().then(() => nextTick(postProcessOutput))
   window.addEventListener('keydown', onKeydown)
 })
 onBeforeUnmount(() => {
+  clearTimeout(shareStatusTimer)
   window.removeEventListener('keydown', onKeydown)
   clearTimeout(debounce)
 })
@@ -444,6 +518,12 @@ void mermaidInit
           type="button"
           :class="{ active: engine === 'rust' }"
           :aria-pressed="engine === 'rust'"
+          :disabled="fromSharedLink"
+          :title="
+            fromSharedLink
+              ? 'The WASM build renders with raw HTML enabled, so it is not offered for a document that arrived in a link'
+              : undefined
+          "
           @click="engine = 'rust'"
         >
           Rust (WASM)
@@ -459,6 +539,13 @@ void mermaidInit
         </a>
       </div>
       <div class="pg-toolbar-right">
+        <span v-if="fromSharedLink" class="pg-shared-note" role="note" title="A document that arrived in a link renders with raw HTML disabled">
+          Shared link: raw HTML off
+        </span>
+        <span v-if="shareStatus" class="pg-share-status" role="status">{{ shareStatus }}</span>
+        <button class="pg-btn" type="button" @click="copyShareLink">
+          Copy link
+        </button>
         <button class="pg-btn pg-import" type="button" @click="openImport">
           Import Markdown
         </button>
@@ -569,6 +656,7 @@ void mermaidInit
 .pg-toolbar-right {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.8rem;
 }
 .pg-status {
@@ -580,6 +668,9 @@ void mermaidInit
 .pg-btn {
   font-size: 0.8rem;
   font-weight: 600;
+  /* The toolbar is tight enough with four controls that a two-word label
+     breaks across lines and doubles the row height. */
+  white-space: nowrap;
   padding: 0.35rem 0.8rem;
   border: 1px solid var(--vp-c-divider);
   border-radius: 8px;
@@ -591,6 +682,25 @@ void mermaidInit
 .pg-btn:hover {
   border-color: var(--vp-c-brand-1);
   color: var(--vp-c-brand-1);
+}
+.pg-share-status {
+  font-size: 0.78rem;
+  color: var(--vp-c-brand-1);
+}
+/* Why the output is not what the sender saw, if their document used raw HTML.
+   Stated rather than hidden: silence would read as a rendering bug. */
+.pg-shared-note {
+  font-size: 0.78rem;
+  color: var(--vp-c-text-2);
+  white-space: nowrap;
+}
+.pg-engine:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+.pg-engine:disabled:hover {
+  border-color: var(--vp-c-divider);
+  color: inherit;
 }
 .pg-btn-primary {
   background: var(--vp-c-brand-1);

--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -41,7 +41,11 @@ const fullscreen = ref(false)
 // it?" is not a question this component can answer. Reloading the playground
 // without a fragment gives a normal, raw-HTML-enabled session back.
 const fromSharedLink = ref(false)
-const shareStatus = ref<string | null>(null)
+// Feedback for the share button. It reports through the icon (plus an
+// aria-live line for screen readers) rather than a text label beside it: a
+// label that appears and disappears would reflow the toolbar row each time.
+const shareState = ref<'idle' | 'copied' | 'error'>('idle')
+const shareMessage = ref('')
 let shareStatusTimer: ReturnType<typeof setTimeout> | undefined
 
 async function applyShareLink(): Promise<void> {
@@ -61,27 +65,35 @@ function shareUrl(encoded: string): string {
   return `${origin}${pathname}${search}#${encoded}`
 }
 
-function flashShareStatus(message: string): void {
-  shareStatus.value = message
+function flashShareStatus(state: 'copied' | 'error', message: string): void {
+  shareState.value = state
+  shareMessage.value = message
   clearTimeout(shareStatusTimer)
-  shareStatusTimer = setTimeout(() => (shareStatus.value = null), 2500)
+  shareStatusTimer = setTimeout(() => {
+    shareState.value = 'idle'
+    shareMessage.value = ''
+  }, 2500)
 }
+
+const shareTitle = computed<string>(() =>
+  shareState.value === 'idle' ? 'Copy a link to this document' : shareMessage.value,
+)
 
 async function copyShareLink(): Promise<void> {
   const encoded = await encodeShare({ source: source.value, engine: engine.value })
   if (encoded === null) {
-    flashShareStatus('Too long to share as a link')
+    flashShareStatus('error', 'Too long to share as a link')
     return
   }
   const url = shareUrl(encoded)
   window.history.replaceState(null, '', url)
   try {
     await navigator.clipboard.writeText(url)
-    flashShareStatus('Link copied')
+    flashShareStatus('copied', 'Link copied')
   } catch {
     // Clipboard access can be refused (permissions, insecure origin). The
     // address bar now holds the link either way, so say so instead of failing.
-    flashShareStatus('Link is in the address bar')
+    flashShareStatus('copied', 'Link is in the address bar')
   }
 }
 
@@ -539,13 +551,52 @@ void mermaidInit
         </a>
       </div>
       <div class="pg-toolbar-right">
-        <span v-if="fromSharedLink" class="pg-shared-note" role="note" title="A document that arrived in a link renders with raw HTML disabled">
-          Shared link: raw HTML off
-        </span>
-        <span v-if="shareStatus" class="pg-share-status" role="status">{{ shareStatus }}</span>
-        <button class="pg-btn" type="button" @click="copyShareLink">
-          Copy link
+        <button
+          class="pg-btn pg-icon-btn"
+          type="button"
+          :class="{ 'is-copied': shareState === 'copied', 'is-error': shareState === 'error' }"
+          :title="shareTitle"
+          aria-label="Copy a link to this document"
+          @click="copyShareLink"
+        >
+          <svg
+            v-if="shareState === 'idle'"
+            viewBox="0 0 24 24"
+            width="15"
+            height="15"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="18" cy="5" r="3" />
+            <circle cx="6" cy="12" r="3" />
+            <circle cx="18" cy="19" r="3" />
+            <line x1="8.6" y1="10.7" x2="15.4" y2="6.3" />
+            <line x1="8.6" y1="13.3" x2="15.4" y2="17.7" />
+          </svg>
+          <svg
+            v-else
+            viewBox="0 0 24 24"
+            width="15"
+            height="15"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <polyline v-if="shareState === 'copied'" points="20 6 9 17 4 12" />
+            <template v-else>
+              <line x1="6" y1="6" x2="18" y2="18" />
+              <line x1="18" y1="6" x2="6" y2="18" />
+            </template>
+          </svg>
         </button>
+        <span class="pg-sr-only" role="status" aria-live="polite">{{ shareMessage }}</span>
         <button class="pg-btn pg-import" type="button" @click="openImport">
           Import Markdown
         </button>
@@ -566,7 +617,17 @@ void mermaidInit
         />
       </div>
       <div class="pane">
-        <label>Rendered HTML</label>
+        <div class="pane-label-row">
+          <label>Rendered HTML</label>
+          <span
+            v-if="fromSharedLink"
+            class="pg-shared-note"
+            role="note"
+            title="This document arrived in a link, so raw HTML is not rendered and the Rust engine is not offered"
+          >
+            shared link: raw HTML off
+          </span>
+        </div>
         <div
           ref="outputEl"
           class="output vp-doc carve-render"
@@ -683,14 +744,39 @@ void mermaidInit
   border-color: var(--vp-c-brand-1);
   color: var(--vp-c-brand-1);
 }
-.pg-share-status {
-  font-size: 0.78rem;
+/* Share button: icon only, so the toolbar keeps the one-row layout it had
+   before. It is square, and the success/failure states only recolor it - a
+   state that changed the button's width would shift the whole row. */
+.pg-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  padding: 0.35rem 0;
+}
+.pg-icon-btn.is-copied {
+  border-color: var(--vp-c-brand-1);
   color: var(--vp-c-brand-1);
 }
+.pg-icon-btn.is-error {
+  border-color: var(--vp-c-danger-1, #d64550);
+  color: var(--vp-c-danger-1, #d64550);
+}
+/* The icon carries the outcome visually; this carries it for a screen reader. */
+.pg-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
 /* Why the output is not what the sender saw, if their document used raw HTML.
-   Stated rather than hidden: silence would read as a rendering bug. */
+   Stated rather than hidden: silence would read as a rendering bug. It sits in
+   the rendered pane's label row, beside what it describes, because a sentence
+   in the toolbar wraps the button row onto a second line. */
 .pg-shared-note {
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   color: var(--vp-c-text-2);
   white-space: nowrap;
 }

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -7,6 +7,12 @@ description: Live Carve to HTML preview, in your browser.
 
 Type Carve on the left, see the rendered HTML on the right (and the raw HTML below). Everything runs client-side, no network round-trip — the same [reference parser](https://github.com/markup-carve/carve-js) that backs the spec corpus.
 
+**Copy link** puts the whole document in the URL fragment, so a playground state is bookmarkable and sendable. The fragment never reaches a server: it is compressed and base64-encoded in the browser, and decoded there again. Very large documents are refused rather than turned into a link that arrives truncated.
+
+::: tip Opening someone else's link
+A document that arrives in a link renders with **raw HTML disabled** — raw blocks show as escaped text instead of running. A link is written by whoever sent it, and enabling raw HTML would make one a way to run script on this site. For the same reason the Rust (WASM) engine is not offered for a shared document: its binding has no switch for raw HTML. Reload the playground without the fragment for a normal session.
+:::
+
 <Playground />
 
 ## Vite Plugin Dogfood

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -7,10 +7,10 @@ description: Live Carve to HTML preview, in your browser.
 
 Type Carve on the left, see the rendered HTML on the right (and the raw HTML below). Everything runs client-side, no network round-trip — the same [reference parser](https://github.com/markup-carve/carve-js) that backs the spec corpus.
 
-**Copy link** puts the whole document in the URL fragment, so a playground state is bookmarkable and sendable. The fragment never reaches a server: it is compressed and base64-encoded in the browser, and decoded there again. Very large documents are refused rather than turned into a link that arrives truncated.
+::: details Sharing a document as a link
+The **share button** in the toolbar puts the whole document in the URL fragment, so a playground state is bookmarkable and sendable. The fragment never reaches a server: it is compressed and base64-encoded in the browser, and decoded there again. Very large documents are refused rather than turned into a link that arrives truncated.
 
-::: tip Opening someone else's link
-A document that arrives in a link renders with **raw HTML disabled** — raw blocks show as escaped text instead of running. A link is written by whoever sent it, and enabling raw HTML would make one a way to run script on this site. For the same reason the Rust (WASM) engine is not offered for a shared document: its binding has no switch for raw HTML. Reload the playground without the fragment for a normal session.
+**Opening someone else's link.** A document that arrives in a link renders with **raw HTML disabled** — raw blocks show as escaped text instead of running. A link is written by whoever sent it, and enabling raw HTML would make one a way to run script on this site. For the same reason the Rust (WASM) engine is not offered for a shared document: its binding has no switch for raw HTML. Reload the playground without the fragment for a normal session.
 :::
 
 <Playground />

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bump-carve-pin": "node scripts/bump-carve-pin.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },

--- a/tests/share-link.test.mjs
+++ b/tests/share-link.test.mjs
@@ -1,0 +1,89 @@
+/*
+ * Playground share links.
+ *
+ * The fragment a share link carries is attacker-supplied by definition - it
+ * arrives from whoever sent the URL. These check the two properties that
+ * matter: a document survives the round trip byte for byte, and nothing a
+ * fragment can say reaches the playground beyond the two fields it is allowed
+ * to set.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { encodeShare, decodeShare, MAX_ENCODED_LENGTH } from '../docs/.vitepress/share-link.js'
+
+const roundTrip = async (state) => decodeShare('#' + (await encodeShare(state)))
+
+test('a document round-trips through the fragment', async () => {
+  const source = '# Title\n\n::: note\nbody with *bold* and /italic/\n:::\n'
+  assert.deepEqual(await roundTrip({ source, engine: 'js' }), { source, engine: 'js' })
+})
+
+test('the engine rides along', async () => {
+  assert.equal((await roundTrip({ source: 'x', engine: 'rust' })).engine, 'rust')
+})
+
+test('non-ASCII and newlines survive', async () => {
+  const source = 'Grüße — 日本語 🎉\n\n\ttabbed\n   trailing   \n'
+  assert.equal((await roundTrip({ source, engine: 'js' })).source, source)
+})
+
+test('an empty document is still a document', async () => {
+  assert.equal((await roundTrip({ source: '', engine: 'js' })).source, '')
+})
+
+test('a fragment carrying no payload decodes to null', async () => {
+  assert.equal(await decodeShare(''), null)
+  assert.equal(await decodeShare('#'), null)
+  assert.equal(await decodeShare('#other=1'), null)
+  assert.equal(await decodeShare(undefined), null)
+})
+
+test('a malformed payload decodes to null rather than throwing', async () => {
+  assert.equal(await decodeShare('#s=not-base64-@@@'), null)
+  assert.equal(await decodeShare('#p=' + Buffer.from('not json').toString('base64url')), null)
+  assert.equal(await decodeShare('#p=' + Buffer.from('[1,2,3]').toString('base64url')), null)
+  assert.equal(await decodeShare('#p=' + Buffer.from('{"v":1}').toString('base64url')), null)
+})
+
+test('only the known fields are read out of a payload', async () => {
+  const hostile = JSON.stringify({
+    v: 1,
+    source: 'ok',
+    engine: 'php',
+    allowRawHtml: true,
+    extensions: ['everything'],
+    __proto__: { polluted: true },
+  })
+  const state = await decodeShare('#p=' + Buffer.from(hostile).toString('base64url'))
+  assert.deepEqual(state, { source: 'ok', engine: 'js' })
+  assert.equal(Object.keys(state).length, 2)
+})
+
+test('an uncompressed payload decodes even where this browser would deflate', async () => {
+  const source = '# from an older browser\n'
+  const encoded = Buffer.from(JSON.stringify({ v: 1, source, engine: 'js' })).toString('base64url')
+  assert.deepEqual(await decodeShare('#p=' + encoded), { source, engine: 'js' })
+})
+
+test('a document too large for a usable URL encodes to null', async () => {
+  // Deterministic but not periodic, so deflate cannot bring it back under the
+  // ceiling the way a repeating sequence would.
+  let seed = 123456789
+  const source = Array.from({ length: 40000 }, () => {
+    seed ^= seed << 13
+    seed ^= seed >>> 17
+    seed ^= seed << 5
+    return String.fromCharCode(33 + (seed >>> 0) % 90)
+  }).join('')
+  assert.equal(await encodeShare({ source, engine: 'js' }), null)
+})
+
+test('a long but compressible document still fits', async () => {
+  const source = '# Heading\n\nrepeated paragraph text.\n\n'.repeat(500)
+  const encoded = await encodeShare({ source, engine: 'js' })
+  assert.ok(encoded !== null)
+  assert.ok(encoded.length <= MAX_ENCODED_LENGTH)
+  assert.equal((await decodeShare('#' + encoded)).source, source)
+})


### PR DESCRIPTION
The **share button** puts the whole playground state in the URL fragment, so an example is bookmarkable and sendable - the thing the PHP sandbox already offers.

JSON → UTF-8 → `deflate-raw` → base64url, carried as `#s=`. Where `CompressionStream` is missing the same JSON goes in uncompressed as `#p=`, and decoding accepts either key regardless of what the current browser would produce. Nothing reaches a server: a fragment is not sent with the request, which also keeps the document out of access logs.

The fragment is written with `replaceState`, not `pushState` - editing is not navigation, and a history entry per copy would make Back unusable. Past a 16k encoded ceiling the button reports that the document is too long rather than handing back a link that arrives truncated. A short document is a short link: the demo used for the screenshots is 171 characters.

## In the toolbar

It is an icon button, square and fixed width, so the toolbar keeps its single row. Success and failure only recolor it and swap the glyph, so feedback never reflows the row; the message goes to the `title` and to a visually-hidden `aria-live` line. The page prose folds into a `::: details` block - three paragraphs about a button were pushing the playground below the fold.

## Opening someone else's link

A document that arrives in a link is written by whoever sent it, so it renders with **raw HTML disabled**. The playground allows raw HTML, so without this a link would be a way to run script on the docs origin. Two things follow from the same fact:

- **mermaid** renders a shared document under its `strict` sanitizer instead of `loose`. Click directives and HTML labels are exactly what `loose` turns on, and the rendered SVG goes into the page through `innerHTML`.
- **the Rust engine is not offered** for a shared document. That WASM binding takes no options, so raw HTML cannot be turned off there at all. The button is disabled with a title saying why.

The restriction holds for the rest of the session: once the textarea has held someone else's document, "did the visitor rewrite all of it?" is not a question this component can answer. Reloading without the fragment gives a normal session back. The rendered pane's label row says which mode it is in - a raw block rendering as escaped text with no explanation reads as a rendering bug.

The decoder treats the fragment as hostile: a malformed payload decodes to `null` and the playground opens on its default document instead of throwing, and only `source` and `engine` are read out of the decoded object, `engine` through an allowlist.

## Checks

Driven headless against the built site: copy → reopen restores the source byte for byte, a raw block that renders as `<b>` in a typed document comes back escaped in a shared one, the notice and the disabled engine button appear, a garbage fragment falls back to the default document with no console errors, and a shared mermaid diagram still renders under `strict`.

The codec is a plain module rather than component-internal so it can be tested directly - ten cases in `tests/share-link.test.mjs`: round trips including non-ASCII and trailing whitespace, the empty document, an absent payload, four malformed payloads, the field allowlist, the plain-text fallback, and both sides of the size ceiling.