### PR TITLE
chore: point the carve-js pin at main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "mermaid": "^11.15.0"
       },
       "devDependencies": {
-        "@markup-carve/carve": "github:markup-carve/carve-js#af5a4002571206bbf121e3ae71da32c25cf2e962",
+        "@markup-carve/carve": "github:markup-carve/carve-js#50bddaf9161daba542a0befbe6fe22f0e49cb52e",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.35.0",
@@ -968,7 +968,7 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#af5a4002571206bbf121e3ae71da32c25cf2e962",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#50bddaf9161daba542a0befbe6fe22f0e49cb52e",
       "integrity": "sha512-IW664CtAYI+hBPANpeEA/1Thxy1qSPr/Dl3mPKJBhvKsGtz7+WG4tGpPdZ6O7Hkzw0yPzUxczoU7RjOyMIfbMg==",
       "dev": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },
   "devDependencies": {
-    "@markup-carve/carve": "github:markup-carve/carve-js#af5a4002571206bbf121e3ae71da32c25cf2e962",
+    "@markup-carve/carve": "github:markup-carve/carve-js#50bddaf9161daba542a0befbe6fe22f0e49cb52e",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.35.0",


### PR DESCRIPTION
markup-carve/carve-js#524 merged after #469 was opened, so main is pinned at that PR's branch-head commit rather than at a commit on carve-js main. Same content, but a branch head is not a thing to depend on - the branch is deleted now. Points at the merge commit instead.

Corpus and the executable spec are unchanged by it.