### PR TITLE
feat: bare-dot ordered markers (proposal for #315)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -52,6 +52,7 @@ Bare delimiters work only at word boundaries; force one intraword with the brace
 
 - unordered      1. ordered  (dialects: a. A. i. I. and the ) delimiter;
 - [ ] task        - [x] done  more task states: [-] [_] [>] [?])
+. bare dot                   (decimal from 1; only `.` may drop its value)
 -{.c} styled item            (attrs abutting the marker target the <li>)
 
 - step one                   (lone + attaches the next flush-left block

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -618,6 +618,11 @@ as more than restyled Djot:
 - **Inline footnotes** - `^[content]` carries a note in place (pandoc-style),
   numbered into the same endnotes as a reference `[^label]`. Canonical djot has
   only reference footnotes; `^[…]` is a carve addition (grammar §16).
+- **Bare-dot ordered markers** - `. item` is a decimal ordered item counting
+  from 1, the AsciiDoc-style shorthand for the list nobody numbers by hand. It
+  is a spelling of decimal-dot, not a dialect, so it mixes with `1.` in one
+  list; only `.` may drop its value, since a leading `) ` collides with prose
+  parentheticals far more often (grammar, ordered_marker).
 - **Boolean attributes** - a bare word in `{…}` (`[Tab]{kbd}`, `{.note open}`)
   is a value-less attribute rendered `name=""`. Canonical djot rejects bare
   words (the whole block stays literal); carve accepts them, following djot-php

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -6147,3 +6147,71 @@ See [Defined][].
 ```
 
 :::
+
+
+## Bare-dot ordered markers
+
+An ordered marker may drop its value when the delimiter is `.`: a bare `. `
+counts from 1, the AsciiDoc-style shorthand for the list nobody numbers by hand.
+
+::: compare
+
+```carve
+. first
+. second
+. third
+```
+
+```html
+<ol>
+  <li>first</li>
+  <li>second</li>
+  <li>third</li>
+</ol>
+```
+
+:::
+
+The bare dot is a **spelling, not a dialect**: it *is* decimal-dot, so it opens
+and continues one list with the explicit form. Only `.` may drop its value -
+a leading `) ` collides with prose parentheticals far more often than a leading
+`. ` does, the same asymmetry that keeps `(1)` from being a marker.
+
+::: compare
+
+```carve
+1. explicit
+. continues the same list
+
+) not a marker, and never opens one
+```
+
+```html
+<ol>
+  <li>explicit</li>
+  <li>continues the same list</li>
+</ol>
+<p>) not a marker, and never opens one</p>
+```
+
+:::
+
+Carrying no value, it cannot set a start - `3.` is how that is written - and
+li-attributes attach to it exactly as they do to every other marker, because
+the shape is marker, then attributes, then the required space.
+
+::: compare
+
+```carve
+.{#x} attributed
+. plain
+```
+
+```html
+<ol>
+  <li id="x">attributed</li>
+  <li>plain</li>
+</ol>
+```
+
+:::

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -432,7 +432,40 @@ ordered_item = ordered_marker, [item_attributes], space, list_item_content ;
    parenthesized `(1)` / `(a)` form is INTENTIONALLY NOT a marker -- it is
    too easily confused with a prose parenthetical -- so `(1) text` stays
    literal paragraph text (pinned by corpus parenthesized-ordered-marker). *)
-ordered_marker = (digit+ | letter | roman_numeral), ('.' | ')') ;
+ordered_marker = (digit+ | letter | roman_numeral), ('.' | ')')
+               | '.' ;
+(* BARE DOT -- NORMATIVE (Carve addition; no Djot or CommonMark equivalent).
+   The VALUE may be omitted when the delimiter is `.`: a bare `. ` is a decimal
+   ordered marker counting from 1, the AsciiDoc-style shorthand.
+
+     . first          -> <ol><li>first</li><li>second</li></ol>
+     . second
+
+   ONLY `.` MAY DROP ITS VALUE. `) text` stays paragraph text: a leading `) `
+   collides with prose parentheticals far more often than a leading `. ` does,
+   which is the same asymmetry that keeps `(1)` from being a marker.
+
+   IT IS A SPELLING, NOT A DIALECT. The bare dot IS decimal-dot, so it opens
+   and continues one list with the explicit form -- `. a` then `2. b` is one
+   `<ol>`, and so is `1. a` then `. b`. It carries no value, so it cannot set a
+   start: the `<ol>` omits `start` and `type`, and `3.` is how a start is
+   written. li-attributes attach exactly as they do to every other marker
+   (`.{#x} text`), because the shape is marker, [attributes], space, content
+   and the block sits BEFORE the required space rather than competing with it.
+
+   COST -- NORMATIVE. After a blank line a paragraph beginning `. ` opens a
+   list, where it was prose before; so does one beginning with `.{` plus a
+   valid attribute block and a space. Escape the marker (`\. text`) to keep the
+   line prose.
+
+   AUTHORED FORM (PART 11 §6). The two spellings parse to the same list, so a
+   canonical writer cannot tell them apart from the tree alone and MUST record
+   which one opened the list to write it back. Author NUMBERING is not authored
+   form and never was -- `1.`/`1.`/`1.` comes back renumbered. Whether that
+   record is published in the serialized AST (PART 12) is a separate question:
+   it is not part of the interchange shape until the schema names it, so an
+   implementation that keeps it internally still round-trips source -> fmt and
+   loses only the spelling through a JSON round trip. *)
 roman_numeral = ('i' | 'v' | 'x' | 'l' | 'c' | 'd' | 'm')+
               | ('I' | 'V' | 'X' | 'L' | 'C' | 'D' | 'M')+ ;
 

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -42,7 +42,10 @@ const FOOTNOTE_DEF = /^\[\^([^\]]+)\]: [ \t]*(\S.*)$/
 const ABBR_DEF = /^\*\[([^\]]+)\]: \s*(.+)$/
 const CAPTION = /^\^ (.*)$/
 const BULLET = /^([ \t]*)([-*])(\{[^}]*\})? (?:\[([ xX_>?-])\] )?(.+)$/
-const ORDERED = /^([ \t]*)([0-9]+|[a-z]+|[A-Z]+)([.)])(\{[^}]*\})? (.+)$/
+// The value is optional before a `.`: a bare `. ` is a decimal marker
+// counting from 1 (PART 9 ordered_marker, BARE DOT). A bare `)` is not a
+// marker, so the empty alternative is guarded by a lookahead at the dot.
+const ORDERED = /^([ \t]*)([0-9]+|[a-z]+|[A-Z]+|(?=\.))([.)])(\{[^}]*\})? (.+)$/
 const CONT_MARKER = /^\+[ \t]*$/
 // marks a lazily-folded line (PART 9 SS10 I2): always paragraph text, never
 // re-classified as structure when an item's content is re-parsed
@@ -87,6 +90,11 @@ function alphaToInt(s) {
 // Classify an ordered marker token into candidate dialects.
 function classifyOrdered(token) {
   const out = []
+  // The bare dot has no value to classify: decimal by definition, starting at 1.
+  if (token === '') {
+    out.push({ dialect: 'decimal', value: 1 })
+    return out
+  }
   if (/^[0-9]+$/.test(token)) {
     out.push({ dialect: 'decimal', value: parseInt(token, 10) })
     return out
@@ -1115,7 +1123,7 @@ function parseListRun(lines, i, blocks, state, peekInterrupts) {
       tight: true,
       items: [],
     }
-    if (head.ordered) {
+    if (head.isOrdered) {
       list.ord = { delim: head.delim, dialects: head.dialects }
     }
     i = collectItems(lines, i, list, state)
@@ -1152,6 +1160,10 @@ function matchMarker(line) {
     if (dialects.length === 0) return null
     return {
       indent: col,
+      // `ordered` carries the marker TOKEN, which is the empty string for a
+      // bare dot - so orderedness is a flag of its own rather than the token's
+      // truthiness, or `. a` would classify as a bullet list.
+      isOrdered: true,
       ordered: m[2],
       delim: m[3],
       attrs: m[4] ?? null,
@@ -1166,11 +1178,11 @@ function matchMarker(line) {
 function sameAxes(list, head) {
   // PART 9 SS11 N1: bullet char, ordered dialect+delim, plain-vs-task
   if (list.ord) {
-    if (!head.ordered || head.delim !== list.ord.delim) return false
+    if (!head.isOrdered || head.delim !== list.ord.delim) return false
     const heads = new Set(head.dialects.map((d) => d.dialect))
     return list.ord.dialects.some((d) => heads.has(d.dialect))
   }
-  if (head.ordered) return false
+  if (head.isOrdered) return false
   if (head.bullet !== list.bullet) return false
   return (head.task !== undefined) === list.task
 }

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -87,6 +87,18 @@ function alphaToInt(s) {
   return s.toLowerCase().charCodeAt(0) - 96
 }
 
+// Does this line OPEN an ordered item? `ORDERED` alone answers on shape, and
+// its optional attribute block is not validated there - so `.{+a+} text`, whose
+// payload yields no attributes, matched as a marker at the boundary checks below
+// while `matchMarker` rejected it and parsed the line as prose. The two now
+// agree: an abutting block that yields nothing is not part of a marker (§15 A8),
+// whatever the marker's value.
+function isOrderedMarkerLine(line) {
+  const m = ORDERED.exec(line)
+  if (!m) return false
+  return !(m[4] && m[4].replace(/[{} ]/g, '') !== '' && parseAttrList(m[4]) === null)
+}
+
 // Classify an ordered marker token into candidate dialects.
 function classifyOrdered(token) {
   const out = []
@@ -572,7 +584,7 @@ function parseBlocksImpl(lines, state, top, inItem = false) {
           bodyLines[bodyLines.length - 1] !== '' &&
           !startsVisibleBlock(lines[i]) &&
           !LINK_DEF.test(lines[i]) && !FOOTNOTE_DEF.test(lines[i]) && !ABBR_DEF.test(lines[i]) &&
-          !BULLET.test(lines[i]) && !ORDERED.test(lines[i]) && !FENCE.test(lines[i]) &&
+          !BULLET.test(lines[i]) && !isOrderedMarkerLine(lines[i]) && !FENCE.test(lines[i]) &&
           !CAPTION.test(lines[i])
         ) {
           // lazy continuation of the definition's open paragraph (SS16)
@@ -679,7 +691,7 @@ function parseBlocksImpl(lines, state, top, inItem = false) {
         !FOOTNOTE_DEF.test(cur) &&
         !ABBR_DEF.test(cur) &&
         !BULLET.test(cur) &&
-        !ORDERED.test(cur) &&
+        !isOrderedMarkerLine(cur) &&
         !FENCE.test(cur) &&
         !CAPTION.test(cur)
       const isEntry = (s) => /^::?[ ]/.test(s) && !/^:::/.test(s)

--- a/tests/corpus/174-bare-dot-ordered-markers-2.crv
+++ b/tests/corpus/174-bare-dot-ordered-markers-2.crv
@@ -1,0 +1,4 @@
+1. explicit
+. continues the same list
+
+) not a marker, and never opens one

--- a/tests/corpus/174-bare-dot-ordered-markers-2.html
+++ b/tests/corpus/174-bare-dot-ordered-markers-2.html
@@ -1,0 +1,5 @@
+<ol>
+  <li>explicit</li>
+  <li>continues the same list</li>
+</ol>
+<p>) not a marker, and never opens one</p>

--- a/tests/corpus/174-bare-dot-ordered-markers-3.crv
+++ b/tests/corpus/174-bare-dot-ordered-markers-3.crv
@@ -1,0 +1,2 @@
+.{#x} attributed
+. plain

--- a/tests/corpus/174-bare-dot-ordered-markers-3.html
+++ b/tests/corpus/174-bare-dot-ordered-markers-3.html
@@ -1,0 +1,4 @@
+<ol>
+  <li id="x">attributed</li>
+  <li>plain</li>
+</ol>

--- a/tests/corpus/174-bare-dot-ordered-markers.crv
+++ b/tests/corpus/174-bare-dot-ordered-markers.crv
@@ -1,0 +1,3 @@
+. first
+. second
+. third

--- a/tests/corpus/174-bare-dot-ordered-markers.html
+++ b/tests/corpus/174-bare-dot-ordered-markers.html
@@ -1,0 +1,5 @@
+<ol>
+  <li>first</li>
+  <li>second</li>
+  <li>third</li>
+</ol>

--- a/tests/spec/174-bare-dot-ordered-markers.test
+++ b/tests/spec/174-bare-dot-ordered-markers.test
@@ -1,0 +1,36 @@
+Bare-dot ordered markers
+
+```
+. first
+. second
+. third
+.
+<ol>
+  <li>first</li>
+  <li>second</li>
+  <li>third</li>
+</ol>
+```
+
+```
+1. explicit
+. continues the same list
+
+) not a marker, and never opens one
+.
+<ol>
+  <li>explicit</li>
+  <li>continues the same list</li>
+</ol>
+<p>) not a marker, and never opens one</p>
+```
+
+```
+.{#x} attributed
+. plain
+.
+<ol>
+  <li id="x">attributed</li>
+  <li>plain</li>
+</ol>
+```


### PR DESCRIPTION
Redoes #347 on current main. That PR prototyped this in
`docs/.vitepress/carve-lib/`, the vendored reference build #388 deleted, so
none of it applies any more - and the corpus is generated now, not hand-written.

## The rule

An ordered marker may drop its value when the delimiter is `.`: a bare `. ` is
a decimal item counting from 1.

```carve
. first
. second
```

**Only `.` may drop its value.** `) text` stays paragraph text - a leading `) `
collides with prose parentheticals far more often than a leading `. ` does,
which is the same asymmetry that keeps `(1)` from being a marker.

**A spelling, not a dialect.** The bare dot *is* decimal-dot, so `1. a` then
`. b` is one list, and so is `. a` then `2. b`. Carrying no value it cannot set
a start (`3.` is what that is for), and li-attributes attach as they do to every
other marker (`.{#x} text`) - the shape is marker, attributes, space, content,
and the block sits before the required space rather than competing with it.

**The cost, stated rather than discovered:** after a blank line a paragraph
beginning `. ` now opens a list, as does one beginning `.{` plus a valid
attribute block and a space. Escaping (`\. text`) keeps the line prose.

## The executable spec follows

`ORDERED` gains the empty alternative as a lookahead at the dot, so a bare `)`
can never match, and `classifyOrdered` answers decimal-from-1 for it.

One thing worth naming: **orderedness moved off the marker token onto a flag of
its own.** The token is the empty string for a bare dot, so every
`if (head.ordered)` read it as falsy and rendered `<ul>`. carve-js#525 has the
same shape of fix in `olKindMatches`.

## Corpus

Three fixtures, generated. The section is **appended** to `edge-cases.md`
rather than filed beside the other list examples in `core.md`: numbering is
positional, so inserting it mid-file renumbered 140 categories and would have
invalidated every engine's allowlist in one commit.

`npm test` 648/648. `core:check`: 524 inputs, 524 conformant, 0 refused, 0
defects - the new fixtures are asserted by the oracle, not skipped.

## Sequencing

Engine half: markup-carve/carve-js#525 (draft). carve-php and carve-rs follow if
this is accepted, and the `carve-js` pin here moves once that lands - which is
also when a bare-dot document first reaches the AST schema gate, the point at
which the `bareMarker` field has to be either named in `ast-schema.json` or kept
off the wire (it is currently kept off).

Still a draft, like #347 was: this is the proposal, not a decision.
