### PR TITLE
test: compare each engine's AST shape against the reference, not just the schema

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -164,6 +164,73 @@ function checkFrontmatterSurvives(doc, source, findings) {
   }
 }
 
+
+/**
+ * A document's structural signature: the tree of node TYPES, with values,
+ * attributes and positions removed.
+ *
+ * The schema says whether a tree is well formed; it cannot say whether two
+ * engines produced the SAME tree. Both can be valid and structurally
+ * different - which is what PART 12 §1 actually forbids, because "a consumer
+ * written against one implementation MUST be able to read another's output"
+ * is a statement about shape, not about validity.
+ *
+ * That gap let carve-php ship a table cell split into three text nodes where
+ * the reference emits one (carve-php#612), and carve-rs the same cell as five
+ * (carve-rs#413). Every span in both was correct and every document validated,
+ * so nothing here reported anything.
+ */
+function shapeOf(node) {
+  if (Array.isArray(node)) return node.map(shapeOf)
+  if (!node || typeof node !== 'object') return null
+  const children = []
+  // Sorted by key: engines serialize their fields in different orders, and a
+  // signature that inherited that order would report every one of them as a
+  // shape difference.
+  for (const [key, value] of Object.entries(node).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
+    if (POS_KEYS.includes(key) || key === 'pos' || key === 'srcByteLength') continue
+    if (Array.isArray(value)) {
+      const sub = value.map(shapeOf).filter((s) => s !== null)
+      if (sub.length) children.push([key, sub])
+    } else if (value && typeof value === 'object') {
+      const sub = shapeOf(value)
+      if (sub !== null) children.push([key, [sub]])
+    }
+  }
+  return typeof node.type === 'string' || children.length ? { type: node.type ?? '?', children } : null
+}
+
+/** Render a shape as a compact path list, so a mismatch names where it is. */
+function shapePaths(shape, path = '$') {
+  if (!shape) return []
+  const out = [`${path}:${shape.type}`]
+  for (const [key, subs] of shape.children) {
+    subs.forEach((s, i) => out.push(...shapePaths(s, `${path}.${key}[${i}]`)))
+  }
+  return out
+}
+
+/**
+ * Compare an engine's tree against the reference's and report the FIRST place
+ * they diverge, which is the one worth reading.
+ */
+function checkShapeParity(name, doc, findings) {
+  const reference = referenceShapes.get(name)
+  if (!reference) return
+  const mine = shapePaths(shapeOf(doc))
+  const theirs = shapePaths(reference)
+  if (mine.length === theirs.length && mine.every((p, i) => p === theirs[i])) return
+  const at = mine.findIndex((p, i) => p !== theirs[i])
+  const where = at === -1 ? Math.min(mine.length, theirs.length) : at
+  findings.push(
+    `${name}: tree differs from the reference at ${theirs[where] ?? '(end)'} ` +
+      `- reference has ${theirs.length} nodes, this has ${mine.length} ` +
+      `(got ${mine[where] ?? '(end)'})`,
+  )
+}
+
+const referenceShapes = new Map()
+
 function checkDocument(doc, source, findings) {
   checkShape(doc, findings)
   checkFrontmatterSurvives(doc, source, findings)
@@ -289,6 +356,7 @@ for (const { name, source } of samples) {
     continue
   }
   checkDocument(doc, source, jsFindings)
+  referenceShapes.set(name, shapeOf(doc))
 
   // PART 12 §6: serialize then deserialize must equal the parse.
   const round = JSON.parse(JSON.stringify(doc))
@@ -330,6 +398,7 @@ if (rsBinary) {
       continue
     }
     checkDocument(doc, source, rsFindings)
+    checkShapeParity(name, doc, rsFindings)
   }
   report(`carve-rs (over ${rsBinary.replace(rsDir + '/', '')}, ${satelliteSamples.length} documents)`, rsFindings)
 } else if (existsSync(rsDir)) {
@@ -361,6 +430,7 @@ if (existsSync(resolve(rbDir, 'lib/carve'))) {
       continue
     }
     checkDocument(doc, source, rbFindings)
+    checkShapeParity(name, doc, rbFindings)
   }
   report(`carve-rb (over carve-rs, ${satelliteSamples.length} documents)`, rbFindings)
 } else {
@@ -392,6 +462,7 @@ if (existsSync(resolve(phpDir, 'bin/carve'))) {
       continue
     }
     checkDocument(doc, source, phpFindings)
+    checkShapeParity(name, doc, phpFindings)
   }
   report(`carve-php (over bin/carve --json, ${satelliteSamples.length} documents)`, phpFindings)
 } else if (existsSync(phpDir)) {


### PR DESCRIPTION
PART 12 §1 says "a consumer written against one implementation MUST be able to read another's output". Nothing measured it.

`ast:check` validated each engine against the schema and counted missing positions. **Two engines can both be schema-valid and structurally different**, which is precisely what §1 forbids - so the one check that speaks to interop could not see interop failures.

## Not theoretical

It let two divergences reach main and sit there:

- markup-carve/carve-php#612 (mine) - a table cell split into **three** text nodes where the reference emits one
- markup-carve/carve-rs#413 - the same cell as **five**

Every span in both was correct, every document validated. This script reported both engines as conformant.

## What it does

`shapeOf` reduces a document to its tree of node **types** - values, attributes and positions stripped - and each satellite is compared against the reference's. A mismatch names the first diverging path and both node counts, because "reference has 3, this has 6" is the readable part.

The signature sorts keys: engines serialize fields in different orders, and a signature inheriting that order reports every one as a difference. That was 7 false findings before I fixed it - worth mentioning because a check that cries wolf is the failure mode this whole PR is about.

## Reporting, not failing

`report()` prints and does not exit non-zero, so this does not convert an existing divergence into a broken build while the engines still disagree.

## What it immediately found

**67 findings across 40 distinct shapes in carve-php**, and nearly all are one cause:

```
foo_bar_baz and snake_case stay literal
```

| engine | that paragraph |
| --- | --- |
| carve-js | **1** text node |
| carve-php | **4** text nodes |

carve-js coalesces adjacent text runs where a delimiter did not form emphasis; carve-php leaves them split. Same characters, different tree, across most of the corpus.

**PART 12 says nothing about whether that is allowed.** It states the interop requirement and never defines what "the same tree" means at the text-node level - a rule asserted in one place and enforced nowhere. Filed separately as a spec question; this check exists to make it visible rather than to prejudge which engine is right.

659 tests pass.
