### PR TITLE
ci: run the cross-engine checkers, and make an unmeasured engine visible

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -109,6 +109,23 @@ const phpDir = process.env.CARVE_PHP_DIR ?? resolve(root, '../carve-php')
  */
 const DISPLAY_LIMIT = Number(process.env.CARVE_DISPLAY_LIMIT ?? 8)
 
+/**
+ * Engines that were not measured at all.
+ *
+ * A skip used to read as one line of prose in the middle of the output, so a
+ * run with no satellites present looked almost exactly like a run where every
+ * satellite passed - and since this script does not run in CI (carve#475),
+ * that was the normal case. `test/corpus.test.ts` already carries the same
+ * lesson in a comment: silently skipped "is exactly how 14 spec categories once
+ * went unvalidated".
+ */
+const notMeasured = []
+
+function skip(label, reason) {
+  notMeasured.push(`${label} (${reason})`)
+  console.log(`${label}: NOT MEASURED - ${reason}\n`)
+}
+
 const POS_KEYS = ['startLine', 'endLine', 'startColumn', 'endColumn', 'startOffset', 'endOffset']
 
 function* walk(node, path = '$') {
@@ -333,9 +350,9 @@ if (rsBinary) {
   }
   report(`carve-rs (over ${rsBinary.replace(rsDir + '/', '')}, ${satelliteSamples.length} documents)`, rsFindings)
 } else if (existsSync(rsDir)) {
-  console.log('carve-rs: checkout found but not built (cargo build --release), not checked\n')
+  skip('carve-rs', 'checkout found but not built - run cargo build --release there')
 } else {
-  console.log('carve-rs: checkout not found, not checked\n')
+  skip('carve-rs', 'checkout not found')
 }
 
 // ---- carve-rb: serializes carve-rs's tree ----------------------------------
@@ -364,7 +381,7 @@ if (existsSync(resolve(rbDir, 'lib/carve'))) {
   }
   report(`carve-rb (over carve-rs, ${satelliteSamples.length} documents)`, rbFindings)
 } else {
-  console.log('carve-rb: checkout not found, not checked\n')
+  skip('carve-rb', 'checkout not found')
 }
 
 // ---- carve-php: serializes through bin/carve --json -------------------------
@@ -395,9 +412,9 @@ if (existsSync(resolve(phpDir, 'bin/carve'))) {
   }
   report(`carve-php (over bin/carve --json, ${satelliteSamples.length} documents)`, phpFindings)
 } else if (existsSync(phpDir)) {
-  console.log('carve-php: checkout found but bin/carve is missing, not checked\n')
+  skip('carve-php', 'checkout found but bin/carve is missing')
 } else {
-  console.log('carve-php: checkout not found, not checked\n')
+  skip('carve-php', 'checkout not found')
 }
 
 function report(label, findings) {
@@ -423,4 +440,22 @@ function report(label, findings) {
     console.log(`  ... and ${hidden} more distinct finding${hidden === 1 ? '' : 's'} not shown`)
   }
   console.log('')
+}
+
+// A closing statement of what was NOT measured, so the coverage of a run is
+// visible at the end rather than inferable from the middle. Without this the
+// only signal was one line per engine, several screens up.
+if (notMeasured.length > 0) {
+  console.log(`NOT MEASURED: ${notMeasured.length} of 3 satellites - ${notMeasured.join(', ')}`)
+  console.log('These engines were not checked at all. This is not a pass.\n')
+  // Opt-in, because the sibling checkouts are not present by default and a
+  // developer running this on carve-js alone should not be failed for it. Once
+  // CI has the checkouts it should set this, so an engine silently dropping out
+  // of the matrix is a red build rather than a line of prose (carve#475).
+  if (process.env.CARVE_REQUIRE_ALL_ENGINES === '1') {
+    console.error('CARVE_REQUIRE_ALL_ENGINES=1 and at least one engine was not measured.')
+    process.exit(1)
+  }
+} else {
+  console.log('All satellites measured.\n')
 }


### PR DESCRIPTION
First half of #475 - the few-line half, which makes the other half honest.

## The problem

```
carve-rb: checkout not found, not checked
```

One line, in the middle of the output, then the run continues and exits 0. A run with **no satellites present** looked almost exactly like a run where **every satellite passed** - and since this script does not run in CI at all, that was the normal case.

## What changes

- a skip is labelled `NOT MEASURED` with its reason
- the run **ends** with a statement of what was not measured, and the words "This is not a pass", instead of leaving the reader to scroll back several screens
- `CARVE_REQUIRE_ALL_ENGINES=1` turns a missing engine into `exit 1`

The environment variable is opt-in deliberately: the sibling checkouts are not present by default, and a developer running this against carve-js alone should not be failed for it. Once CI has the checkouts it should set it, so an engine dropping silently out of the matrix is a red build rather than a line of prose.

Verified in all three modes: default with satellites missing exits 0 and says so; strict with satellites missing exits 1; strict with all four present prints `All satellites measured.`

## Precedent

`test/corpus.test.ts` already fixed exactly this failure mode for itself, and its comment names the cost:

> Categories not in IMPLEMENTED are run as `.todo` above and silently skipped, which is exactly how 14 spec categories once went unvalidated.

The same shape was still live in the conformance checker.

## What it was covering

Measured locally over 524 documents, with every engine present and built from its own `main`:

| engine | shape parity | missing pos | schema violations |
| --- | --- | --- | --- |
| carve-js (reference) | 0 | 4 | 0 |
| carve-rs | 25 | 5 | 0 |
| carve-rb | 28 | 5 | 0 |
| carve-php | 65 | 2 | 0 |

Every non-reference engine diverges structurally from the reference, and nothing had ever measured it.

(An earlier revision of this PR body reported carve-rb at 153 schema violations. That was measured through a stale local checkout pinning a pre-PART 12 §8 carve-rs; rebuilt from `origin/main` it has none. Corrected on #475.)

659 tests pass. The remaining half of #475, wiring the checker into CI with the satellite checkouts, is deliberately not in this PR.


---

## Second commit: the checker now runs

`ast:check` ran **nowhere**. That is the other half of #475, and the reason the first half matters - a silent skip only hurts if something is meant to be watching.

`.github/workflows/conformance.yml` clones and builds carve-js, carve-rs, carve-php and carve-rb, then runs the checker with `CARVE_REQUIRE_ALL_ENGINES=1`.

**Nightly, not per-PR.** It builds four repos; per-PR would be minutes of CI on every change for a property that moves at roughly a daily cadence. Also on demand, and on any PR touching `ast-conformance.mjs` or `ast-schema.json` - a change to the checker or the contract it enforces should be measured before it is trusted.

**It does not gate on findings.** The checker currently reports 25, 28 and 65 shape divergences for carve-rs, carve-rb and carve-php, and whether those are defects *at all* is the open question in #474: is the serialized tree canonical for a document, or only its rendering? Failing the build on an undecided question trains people to ignore the job. Once #474 lands, the natural next step is a committed baseline so the number cannot silently grow.

What it **does** fail on is an engine that is missing or fails to build - which without `CARVE_REQUIRE_ALL_ENGINES` would drop out of the matrix and leave a green run, exactly reproducing the bug this PR fixes.

One detail worth review: the carve-rb build needs `BINDGEN_EXTRA_CLANG_ARGS` pointing at the runner's gcc include directory or bindgen cannot find `stdarg.h`. The path is derived with `find` rather than hardcoded, because that variable **replaces** the default clang args rather than appending, so a wrong guess silently drops the real include path.

The workflow is valid YAML and the step order matches how I ran the same sequence locally, but a workflow cannot be truly tested until it runs on a runner - worth a look before merge.


---

## Third commit: the formatter gate

`compare-impls` has had a `--roundtrip` mode all along - format each document, then treat that output as fresh input. Across the three engines over the corpus it reports **exactly one** failure:

```
ROUNDTRIP DIFF 70-blocks-that-render-to-nothing (core): rust, js, php
```

That is markup-carve/carve-rs#432: `carve fmt` on a blockquote containing a comment emits source in which the commented-out text renders as a **visible paragraph**. Content the author hid, published by running the formatter.

The check that catches it exists, works, names the right document, and produces no noise. It has never run.

This adds `--fail-on-diff` (opt-in, so local runs stay informational) and wires both modes into the workflow:

| step | behavior | why |
| --- | --- | --- |
| `--roundtrip --fail-on-diff` | **gates** | a formatter changing what a document says is wrong under every reading of PART 11 - no design question first, and the mode is clean apart from that one bug |
| default mode | **reports** | its 16 diffs need decisions (#474, #478), and gating on unresolved questions teaches people to ignore the job - which is how these checkers came to be unwired |

**The gating step is expected RED until carve-rs#432 is fixed.** That is deliberate. It has been green by not running while a formatter disclosed hidden content.

Verified in both directions rather than reasoned about:

- failing document out of scope: `No round-trip differences`, exit 0
- failing document in scope: `1 round-trip difference(s)`, exit 1

Spec suite still 659 passing after the script change.