### PR TITLE
test: the formatter preserves every corpus document, not just ten of them

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bump-carve-pin": "node scripts/bump-carve-pin.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/corpus-fmt-roundtrip.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },

--- a/tests/corpus-fmt-roundtrip.test.mjs
+++ b/tests/corpus-fmt-roundtrip.test.mjs
@@ -1,0 +1,84 @@
+/*
+ * The formatter preserves the document, over the WHOLE corpus.
+ *
+ * tests/corpus-roundtrip/ pins the canonical writer against ten hand-written
+ * documents, chosen for their escaping decisions. That is the right shape for
+ * pinning bytes, and it is a thin sample: the corpus has 500+ documents that
+ * exercise every construct in the language, and none of them were ever put
+ * through the writer.
+ *
+ * The cost of that gap is not hypothetical. carve-rs turns
+ *
+ *     > a
+ *     >
+ *     > %%%
+ *     > x
+ *     > %%%
+ *
+ * into source where the commented-out `x` renders as a visible paragraph
+ * (carve-rs#432) - and the corpus ALREADY contains documents that expose it
+ * (70-blocks-that-render-to-nothing and -3). They pass every gate, because the
+ * HTML fixtures compare the FIRST render and nothing re-renders the formatter's
+ * output. The documents were there; the property was not checked.
+ *
+ * Two properties, both from PART 11 §1:
+ *
+ *   toHtml(fmt(x)) == toHtml(x)   formatting does not change what the document
+ *                                 says. This is the one that catches content
+ *                                 disclosure - a writer bug that turns hidden
+ *                                 text visible fails here and nowhere else.
+ *
+ *   fmt(fmt(x)) == fmt(x)         formatting settles. A writer that does not
+ *                                 is worse than one that loses a field: every
+ *                                 run produces a diff.
+ *
+ * This checks the REFERENCE engine only, because that is what this repo pins.
+ * The same properties across the other engines are `compare:impls --roundtrip`,
+ * which needs their checkouts and runs in the conformance workflow.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { carveToCarve, carveToHtml } from '@markup-carve/carve'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const corpusDir = resolve(here, 'corpus')
+
+const documents = readdirSync(corpusDir)
+  .filter((f) => f.endsWith('.crv'))
+  .sort()
+  .map((f) => ({ slug: f.replace(/\.crv$/, ''), source: readFileSync(resolve(corpusDir, f), 'utf8') }))
+
+test('the corpus is non-empty, so a broken glob cannot pass as a clean run', () => {
+  assert.ok(documents.length > 100, `found ${documents.length} corpus documents`)
+})
+
+test('formatting never changes what a corpus document says', () => {
+  const changed = []
+  for (const { slug, source } of documents) {
+    const formatted = carveToCarve(source)
+    if (carveToHtml(formatted).trim() !== carveToHtml(source).trim()) changed.push(slug)
+  }
+  assert.deepEqual(
+    changed,
+    [],
+    `these documents render differently after formatting - the writer changed the document, ` +
+      `not just its spelling:\n  ${changed.join('\n  ')}`,
+  )
+})
+
+test('formatting a corpus document settles on the first pass', () => {
+  const unsettled = []
+  for (const { slug, source } of documents) {
+    const once = carveToCarve(source)
+    if (carveToCarve(once) !== once) unsettled.push(slug)
+  }
+  assert.deepEqual(
+    unsettled,
+    [],
+    `formatting these twice differs from formatting once, so every run produces a diff:\n  ` +
+      unsettled.join('\n  '),
+  )
+})


### PR DESCRIPTION
The formatter is now checked against every corpus document, not ten of them.

## The gap

`tests/corpus-roundtrip/` pins the canonical writer against ten hand-written documents, chosen for their escaping decisions. Right shape for pinning bytes, thin sample: the corpus has 500+ documents covering every construct in the language, and **none had ever been through the writer**.

## Why it matters, concretely

carve-rs turns

```
> a
>
> %%%
> x
> %%%
```

into source where the commented-out `x` renders as a **visible paragraph** (markup-carve/carve-rs#432 - content the author hid, published by running the formatter).

The corpus **already contains** documents that expose it: `70-blocks-that-render-to-nothing` and `-3`. They pass every gate today, because the HTML fixtures compare the **first** render and nothing re-renders the formatter's output.

The documents were there. The property was not checked.

## What this adds

Two properties from PART 11 §1, over all 524 documents:

| property | what it catches |
| --- | --- |
| `toHtml(fmt(x)) == toHtml(x)` | the writer changing what the document *says* - including a bug that turns hidden text visible, which fails here and nowhere else |
| `fmt(fmt(x)) == fmt(x)` | a writer that never settles, so every run produces a diff |

Plus a guard that the corpus glob found something, so a broken path cannot pass as a clean run - the same failure mode as a skipped engine reading like a passing one.

## Scope and verification

- Reference engine only, because that is what this repo pins. The same properties for the other engines are `compare:impls --roundtrip`, which needs their checkouts and belongs in the conformance workflow (#476).
- **It lands green**: the reference engine passes both properties on all 524 documents today, so this guards forward rather than papering over a backlog.
- **Verified it can fail**: inverting the comparison fails the corpus; restoring it passes.

683 tests, 0 failures.
