### PR TITLE
ci: run the conformance checker, and stop a stale build reading as a current one

### DIFF
--- a/.github/workflows/ast-conformance.yml
+++ b/.github/workflows/ast-conformance.yml
@@ -1,0 +1,118 @@
+name: AST conformance
+
+# `ast:check` is the only thing that measures PART 12 conformance, and until now
+# it ran nowhere (carve#475). It needs the satellite checkouts, which is why it
+# was never wired into ci.yml - so it lives here instead, on a schedule.
+#
+# SCHEDULED rather than per-PR on purpose. What this catches is cross-repo
+# DRIFT: an engine's main moving away from the published AST while this repo's
+# main stands still. That is a daily-cadence problem, and cloning and BUILDING
+# three engines on every PR would add minutes to a gate that would almost always
+# say the same thing. workflow_dispatch is here for when you want it now.
+#
+# CARVE_REQUIRE_ALL_ENGINES=1 turns a missing or unbuildable engine into a red
+# run. That is the whole point of running it here: the checkouts are provisioned
+# deliberately, so one dropping out is a broken job, not a line of prose.
+
+on:
+  schedule:
+    # 04:00 UTC daily, after the downstream bump workflow has had a night to run.
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out carve
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      # Each engine is checked out and BUILT from its own main. A build is not
+      # optional here: the checker reads whatever artifact is on disk, and a
+      # stale one reports the old behavior under the current name - which is
+      # exactly how carve#475's own figures came to be wrong.
+      - name: Check out carve-js
+        uses: actions/checkout@v4
+        with:
+          repository: markup-carve/carve-js
+          path: carve-js
+          submodules: recursive
+
+      - name: Build carve-js
+        working-directory: carve-js
+        run: npm ci && npm run build
+
+      - name: Check out carve-rs
+        uses: actions/checkout@v4
+        with:
+          repository: markup-carve/carve-rs
+          path: carve-rs
+          submodules: recursive
+
+      - name: Build carve-rs
+        working-directory: carve-rs
+        run: cargo build --release
+
+      - name: Check out carve-php
+        uses: actions/checkout@v4
+        with:
+          repository: markup-carve/carve-php
+          path: carve-php
+          submodules: recursive
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+
+      - name: Install carve-php
+        working-directory: carve-php
+        run: composer install --no-interaction --no-progress
+
+      - name: Check out carve-rb
+        uses: actions/checkout@v4
+        with:
+          repository: markup-carve/carve-rb
+          path: carve-rb
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # rb-sys drives bindgen, which needs libclang. Same step carve-rb's own CI
+      # runs; without it `rake compile` fails on a fresh runner.
+      - name: Install libclang (rb-sys bindgen)
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+
+      - name: Build carve-rb
+        working-directory: carve-rb
+        run: |
+          bundle install
+          bundle exec rake compile
+
+      - name: PART 12 conformance
+        env:
+          CARVE_JS_DIR: ${{ github.workspace }}/carve-js
+          CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
+          CARVE_RB_DIR: ${{ github.workspace }}/carve-rb
+          CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
+          # Every engine is checked out and built above, so a missing one is a
+          # broken job rather than a local convenience - which is what this flag
+          # is for. Setting it while knowingly not provisioning an engine would
+          # make the run permanently red, and a permanently red scheduled job
+          # gets muted, which is the failure this whole issue is about.
+          CARVE_REQUIRE_ALL_ENGINES: '1'
+        run: npm run ast:check -- --satellite-limit=520

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -37,7 +37,7 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Ajv2020 } from 'ajv/dist/2020.js'
@@ -108,6 +108,63 @@ const phpDir = process.env.CARVE_PHP_DIR ?? resolve(root, '../carve-php')
  * into view.
  */
 const DISPLAY_LIMIT = Number(process.env.CARVE_DISPLAY_LIMIT ?? 8)
+
+/**
+ * Describe a built artifact, and say plainly when it is OLDER THAN ITS SOURCE.
+ *
+ * This is the failure that made carve#475's own table wrong. The checker reads
+ * whatever build is on disk and reports it as the engine's conformance, with
+ * nothing in the output to say how old it is. An Aug 1 build of carve-rs
+ * reported 144 schema violations - the pre-node definition-list shape the engine
+ * had already stopped emitting - while the same checkout, rebuilt, reported 4
+ * findings. Both runs looked identical.
+ *
+ * A stale build reading as a current one is strictly worse than the skip this
+ * script already reports, because it produces a NUMBER, and a number gets
+ * believed and filed.
+ */
+function buildStatus(artifact, sourceDir, extensions) {
+  let built
+  try {
+    built = statSync(artifact).mtimeMs
+  } catch {
+    return { text: 'build date unknown', stale: false }
+  }
+  const stamp = new Date(built).toISOString().slice(0, 16).replace('T', ' ')
+
+  let newestSource = 0
+  const walk = (dir, depth) => {
+    if (depth > 6) return
+    let entries
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === 'target' || entry.name[0] === '.') continue
+      const full = resolve(dir, entry.name)
+      if (entry.isDirectory()) walk(full, depth + 1)
+      else if (extensions.some((ext) => entry.name.endsWith(ext))) {
+        try {
+          newestSource = Math.max(newestSource, statSync(full).mtimeMs)
+        } catch {
+          /* unreadable file tells us nothing */
+        }
+      }
+    }
+  }
+  walk(sourceDir, 0)
+
+  const stale = newestSource > built
+  return {
+    text: stale ? `built ${stamp}, STALE - source is newer, rebuild before believing this` : `built ${stamp}`,
+    stale,
+  }
+}
+
+const staleBuilds = []
+
 
 /**
  * Engines that were not measured at all.
@@ -417,7 +474,12 @@ if (rsBinary) {
     checkDocument(doc, source, rsFindings)
     checkShapeParity(name, doc, rsFindings)
   }
-  report(`carve-rs (over ${rsBinary.replace(rsDir + '/', '')}, ${satelliteSamples.length} documents)`, rsFindings)
+  const rsBuild = buildStatus(rsBinary, resolve(rsDir, 'src'), ['.rs'])
+  if (rsBuild.stale) staleBuilds.push('carve-rs')
+  report(
+    `carve-rs (over ${rsBinary.replace(rsDir + '/', '')} [${rsBuild.text}], ${satelliteSamples.length} documents)`,
+    rsFindings,
+  )
 } else if (existsSync(rsDir)) {
   skip('carve-rs', 'checkout found but not built - run cargo build --release there')
 } else {
@@ -449,7 +511,20 @@ if (existsSync(resolve(rbDir, 'lib/carve'))) {
     checkDocument(doc, source, rbFindings)
     checkShapeParity(name, doc, rbFindings)
   }
-  report(`carve-rb (over carve-rs, ${satelliteSamples.length} documents)`, rbFindings)
+  // The compiled extension, not the Ruby source: carve-rb wraps carve-rs
+  // through a native build, so a stale `.so` reports the PARSER's old behavior
+  // under the binding's name.
+  const rbSo = ['lib/carve/carve.so', 'lib/carve/carve.bundle']
+    .map((path) => resolve(rbDir, path))
+    .find((path) => existsSync(path))
+  const rbBuild = rbSo
+    ? buildStatus(rbSo, resolve(rbDir, 'ext'), ['.rs', '.rb', '.toml'])
+    : { text: 'no compiled extension found', stale: false }
+  if (rbBuild.stale) staleBuilds.push('carve-rb')
+  report(
+    `carve-rb (over carve-rs [${rbBuild.text}], ${satelliteSamples.length} documents)`,
+    rbFindings,
+  )
 } else {
   skip('carve-rb', 'checkout not found')
 }
@@ -529,4 +604,16 @@ if (notMeasured.length > 0) {
   }
 } else {
   console.log('All satellites measured.\n')
+}
+
+// A stale build is not a skip and not a pass: it is a NUMBER produced by code
+// nobody is running any more. Say so at the end, where the not-measured roll-up
+// already is, rather than leaving it to be noticed in a label several screens up.
+if (staleBuilds.length > 0) {
+  console.log(`STALE BUILDS: ${staleBuilds.join(', ')} - findings above are from an OLD build.`)
+  console.log('Rebuild those engines and re-run before recording any number from this run.\n')
+  if (process.env.CARVE_REQUIRE_ALL_ENGINES === '1') {
+    console.error('CARVE_REQUIRE_ALL_ENGINES=1 and at least one engine was measured from a stale build.')
+    process.exit(1)
+  }
 }


### PR DESCRIPTION
Closes #475.

`ast:check` is the only thing that measures PART 12 conformance and it ran in **no workflow
at all**. It needs the satellite checkouts, which is why it was never in `ci.yml` - so it
gets its own scheduled job that clones and **builds** all four engines and sets
`CARVE_REQUIRE_ALL_ENGINES=1`.

Scheduled rather than per-PR because what it catches is cross-repo *drift* - an engine's
main moving away from the published AST while this repo stands still - which is a
daily-cadence problem. Building three engines on every PR would add minutes to a gate that
would nearly always say the same thing.

carve-rb is provisioned too rather than left out with the require flag on. A scheduled job
that can never go green gets muted, which is this same issue wearing different clothes.

The issue's second half - "skipping is indistinguishable from passing" - **is already fixed
on main** (`NOT MEASURED`, the roll-up, and the opt-in exit 1). I left it alone.

## The part that is not what the issue asked for, and matters more

**The checker reads whatever artifact is on disk and reports it as the engine's
conformance, with nothing in the output about its age.** That is how this issue's own table
came to be wrong.

Measuring carve-rs against the build that happened to be sitting in its checkout:

| carve-rs build | findings |
|---|---|
| Aug 1 binary (what the checker found) | **286**, incl. 144 schema violations |
| same checkout, rebuilt | **4** |

The 144 were the pre-node definition-list shape (`{terms, definitions}`) that carve#435
settled and the engine had *already stopped emitting*. carve-rb inherited the identical 144
through its equally stale compiled extension - which is also why its numbers looked so
alarming. Both runs looked exactly the same in the output.

So each built engine now reports its build date, compares it against the newest source file
in its own checkout, and says so when the source is newer:

```
carve-rs (over target/release/carve [built 2026-08-01 13:30, STALE - source is newer,
  rebuild before believing this], 30 documents): 5 findings, 5 distinct
carve-rb (over carve-rs [built 2026-08-01 12:38, STALE - ...], 30 documents): 6 findings

STALE BUILDS: carve-rs, carve-rb - findings above are from an OLD build.
Rebuild those engines and re-run before recording any number from this run.
```

Under the require flag a stale build fails the run. A stale build is worse than the skip
this script already reports: **a skip produces no number, and a number gets believed and
filed.**

## On the issue's figures

Worth re-measuring before acting on them. What I can confirm with fresh builds is
carve-rb's shape: **144 schema violations and 227 missing positions** against the issue's
153/229 - so that engine does have a real problem, and it is in the Ruby serialization
layer, since carve-rs underneath is clean at 4 findings. The carve-rs column, though, was
an artifact.

Spec suite: 680 tests, 0 failures.