### PR TITLE
spec: adjacent text runs are coalesced, so the serialized tree is canonical

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -73,6 +73,34 @@ document into invalid text.
 An implementation that cannot place a node **omits `pos` rather than inventing
 one**, and says so. Absent is a fact a consumer can act on; a wrong span is not.
 
+## Adjacent text runs are coalesced
+
+A serialized node's children hold **no two adjacent `text` nodes**. Where a
+producer's internal tree has a run of them, they join into one before
+serialization, concatenating `value` in order:
+
+```
+foo_bar_baz and snake_case stay literal
+```
+
+is one text node, not four. An implementation that splits wherever a delimiter
+failed to open emphasis is publishing its parser's bookkeeping rather than the
+document.
+
+This is normative (§1a) because without it the interop requirement means very
+little: two engines can publish 1 node and 4 for the same characters, both valid
+against the schema, and "read another's output" degrades to "parses".
+Coalescing is what makes the tree **canonical** for a given document - the same
+argument PART 11 makes one layer down for canonical source form - and it is what
+lets a divergence be measured node-for-node instead of argued about.
+
+`escaped_text` is not `text` and does not merge with it: the two stay distinct
+on the wire because an escape is authored form.
+
+The schema cannot express this - JSON Schema has no way to forbid two adjacent
+array entries of the same shape - so it is checked by the shape comparison in
+`scripts/ast-conformance.mjs`.
+
 ## Producing it
 
 ::: code-group

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3643,6 +3643,44 @@ EOF = (* end of file *) ;
       would have resolved the disagreement by deleting a distinction the
       vocabulary makes on purpose (carve#405).
 
+   1a. ADJACENT TEXT RUNS ARE COALESCED -- NORMATIVE. A serialized node's
+      children contain NO two adjacent `text` nodes. Where a producer's internal
+      tree holds a run of them, they are joined into one before serialization,
+      concatenating their `value` in order.
+
+        foo_bar_baz and snake_case stay literal
+
+      is ONE text node, not four. An implementation that splits a run wherever a
+      delimiter failed to open emphasis publishes its parser's bookkeeping, not
+      the document.
+
+      WHY THIS IS NORMATIVE rather than left to each producer. §1 requires that
+      a consumer written against one implementation can read another's output.
+      Without this rule that requirement is satisfied by any tree at all: two
+      engines can publish 1 node and 4 nodes for the same characters, both are
+      valid against the schema, and "read another's output" degrades to
+      "parses". Coalescing is what makes the serialized tree CANONICAL for a
+      given document, which is the same argument PART 11 already makes one layer
+      down for canonical source form.
+
+      It also makes node-for-node comparison meaningful, which is the only way
+      an engine's divergence from the reference can be MEASURED rather than
+      argued about (the shape check in scripts/ast-conformance.mjs).
+
+      SCOPE. The rule is about `text` nodes only, and only about ADJACENCY
+      within one parent's child list. It does not merge across an intervening
+      node, it does not merge other types, and it says nothing about how a
+      producer represents runs internally -- only what it publishes.
+
+      `escaped_text` is NOT `text` and does not merge with it: PART 12 §5 keeps
+      the two distinct on the wire because an escape is authored form, and
+      collapsing them would lose the distinction the type exists to carry.
+
+      The schema cannot express this: a JSON Schema has no way to forbid two
+      adjacent array entries of the same shape. It is checked by the shape
+      comparison in the conformance checker instead, which is why that check is
+      a gate rather than a report.
+
    2. EVERY NODE IS AN OBJECT with a `type` holding the node-type identifier
       from profiles.md - the same snake_case strings PART 9 §8 already calls
       spec surface for kind names. A document is


### PR DESCRIPTION
Decides markup-carve/carve#474 in favour of **option 1: adjacent text runs MUST be
coalesced.**

§1 requires that a consumer written against one implementation can read another's output,
and never said what shape that output has:

```
foo_bar_baz and snake_case stay literal
```

| engine | that paragraph |
|---|---|
| carve-js | **1** text node |
| carve-php | **4** text nodes |

Same characters, same rendering, different tree - and both valid against the schema, which
is why nothing caught it.

## Why normative rather than left to producers

Without the rule the interop requirement is satisfied by *any* tree, and "read another's
output" degrades to "parses". Coalescing is what makes the serialized tree **canonical for
a given document** - the same argument PART 11 already makes one layer down for canonical
source form - and it is what allows a divergence to be *measured* node-for-node instead of
argued about.

## Scope, deliberately narrow

- `text` nodes only, and only adjacency within one parent's child list.
- Does not merge across an intervening node, does not touch other types.
- Says nothing about how a producer represents runs internally - only what it publishes.
- **`escaped_text` stays distinct.** An escape is authored form and §5 keeps the two types
  apart on purpose; merging them would lose the distinction the type exists to carry.

## Why it is prose plus a checker, not schema

JSON Schema cannot forbid two adjacent array entries of the same shape. The shape
comparison in `scripts/ast-conformance.mjs` is what checks it - which is the argument for
that check becoming a gate, and markup-carve/carve#482 is what makes it run at all.

## Work this creates

carve-js already complies (verified: 1 node for the example above). carve-php and carve-rs
are the follow-up, and the measured counts to fix are in #474.

Spec suite: 683 tests, 0 failures.