### PR TITLE
spec: a bare-dot ordered marker gets a field, so it survives the wire

### DIFF
--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -2080,6 +2080,10 @@
           ],
           "description": "Ordered-marker delimiter AS AUTHORED (PART 11 section 6). Absent means the default `.`."
         },
+        "bareMarker": {
+          "const": true,
+          "description": "Ordered list written with the BARE dot marker (`. item`), which carries no number, AS AUTHORED (PART 11 section 6). Absent means the author numbered it. Without this the bare form decodes as `1. item`: `delim` and `bulletChar` carry marker flavor for every other form, and this was the one authored distinction with no field to hold it (carve#480)."
+        },
         "bulletChar": {
           "enum": [
             "-",

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3666,8 +3666,13 @@ EOF = (* end of file *) ;
         text       `value`
         heading    `level`, `children`
         list       `ordered`, `tight`, `start`, `items`, and the AUTHOR-CHOICE
-                   fields `bulletChar` and `delim` (PART 11 §6) when the author's
-                   spelling is not the default
+                   fields `bulletChar`, `delim` and `bareMarker` (PART 11 §6)
+                   when the author's spelling is not the default. `bareMarker`
+                   is `true` for an ordered list written with the BARE dot form
+                   (`. item`), which carries no number; absent means the author
+                   numbered it. Without it the bare form has nowhere to live on
+                   the wire and decodes as `1. item`, losing authored form that
+                   every other marker flavor keeps (carve#480)
         strong     `children`, and `boldItalic` when the author wrote the
                    combined `/*…*/` form rather than nesting `*` around `/`
       An implementation MUST NOT invent a synonym, and MUST NOT expose an


### PR DESCRIPTION
Closes #480, taking **option 1** - a field alongside the ones it belongs with.

`list` already carries `delim` (`.` vs `)`) and `bulletChar` (`-` vs `*`), so marker flavor
is spec surface for every list form except one. The bare dot had no field at all:

```
authored   . first / . second / . third
decoded    1. first / 2. second / 3. third
```

`bareMarker: true` closes it, absent when the author numbered the list.

## Not one engine's bug

I filed this from carve-php, and that framing was wrong. **carve-js publishes an identical
payload for `. first` and `1. first`** and loses the form on decode exactly the same way:

```json
{"type":"list","ordered":true,"tight":true,"delim":"."}   // both forms
```

So no engine could preserve it without inventing a field - which is precisely the
divergence PART 12 exists to prevent. The format was the only place to fix it.

## Why this shape

Chosen over the two alternatives in the issue:

- **Overloading `delim` with an empty value** would give a punctuation field a
  non-punctuation meaning, and consumers already switch on it as punctuation.
- **Declaring the bare dot a rendering of `1.` with no authored identity** contradicts a
  feature two engines have already shipped, and PART 11 §6 treats every other marker
  spelling as author choice worth preserving.

`const: true` rather than a boolean, so the field is only ever present to mean something -
consistent with `delim` and `bulletChar`, which are absent at their defaults.

Spec suite: 683 tests, 0 failures. Engine work follows in carve-js, carve-php and carve-rs.