### PR TITLE
spec: say that links-never-nest binds every target, not just HTML

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1067,7 +1067,21 @@ link_text = inline_content ;
    outermost link's destination applies. So `[[x](y)](z)` links `x` to `z`,
    and `[a https://b c](/u)` (with an autolink extension) links the literal
    text `a https://b c` to `/u` rather than emitting a nested anchor. Mirrors
-   CommonMark "links may not contain other links". *)
+   CommonMark "links may not contain other links".
+
+   This is a property of the DOCUMENT, and therefore binds EVERY target that
+   can express a link -- HTML, Markdown and ANSI alike, exactly as the
+   smart-typography switch above applies to every target. Nested output is
+   not merely redundant: `[see [H](#H)](/outer)` is not valid Markdown, so a
+   consumer reparsing it gets something other than what the document says,
+   and a nested ANSI link sequence ends with its own reset, which closes the
+   outer link's styling early.
+
+   An implementation that resolves a construct into a link AFTER the pass
+   that enforces this -- a cross-reference is the usual case, since `</#id>`
+   need not be resolved during parsing -- must apply the rule at that later
+   point too, in every such target and not only in the one whose output makes
+   the nesting visible as markup (carve-rs#436). *)
 link_destination = {destination_escape | balanced_parens
                    | (url_char - '(' - ')') | '\' | unicode_url_char}+ ;
 balanced_parens = '(', {destination_escape | balanced_parens


### PR DESCRIPTION
The links-never-nest constraint in PART 3 says an inner link is replaced by its text "rather than emitting a nested anchor". "Anchor" is an HTML artifact, and every example around it is HTML.

carve-rs read it that way. Its parser enforces the rule in one post-resolution pass over the tree - but a cross-reference is not resolved during parsing, so the tree still holds a `heading_ref` node when that pass runs, and each renderer turns it into a link itself, afterwards. Only the HTML renderer re-checked. For `# H` + `[see </#H>](/outer)`:

| target | before |
| --- | --- |
| HTML | `<p><a href="/outer">see H</a></p>` |
| Markdown | `[see [H](#H)](/outer)` |
| ANSI | an inner underline/blue sequence nested inside the outer one |

Neither non-HTML form is merely redundant. A link inside a link is not valid Markdown, so a consumer reparsing the output gets something other than what the document says. A nested ANSI sequence ends with its own reset, which closes the outer link's styling early and leaves the rest of the label unstyled in a terminal.

This states the rule the way the smart-typography switch a few hundred lines down is already stated - a property of the document, binding every target - and adds the case that let it escape: a construct that becomes a link only *after* the enforcing pass must be checked again at that later point, in every target rather than only in the one whose output makes the nesting visible as markup.

No corpus or grammar production changes; this is normative prose on an existing constraint. Engine fix: markup-carve/carve-rs#437.
