### PR TITLE
A line block preserves medial gaps, not only the indent (PART 9 §23)

### DIFF
--- a/docs/examples/core.md
+++ b/docs/examples/core.md
@@ -3617,6 +3617,26 @@ Roses are red,
 
 ::::
 
+An inner run of two or more spaces is a medial gap - the alignment a caesura or a column of aligned text is made of - and is preserved the same way. A lone inner space stays an ordinary collapsible space, so a long line can still wrap between words.
+
+:::: compare
+
+```carve
+::: |
+Two roads    diverged in a yellow wood,
+And looked   down one as far as I could
+:::
+```
+
+```html
+<div class="line-block">
+  <p>Two roads&nbsp;&nbsp;&nbsp;&nbsp;diverged in a yellow wood,<br>
+And looked&nbsp;&nbsp;&nbsp;down one as far as I could</p>
+</div>
+```
+
+::::
+
 A blank line separates stanzas; each stanza is its own paragraph inside the block.
 
 :::: compare

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2800,11 +2800,20 @@ EOF = (* end of file *) ;
       - STANZAS. A blank line ends a stanza; each stanza is its own `<p>` inside
         the single `<div class="line-block">`.
       - LEADING WHITESPACE. Each body line's leading whitespace is PRESERVED
-        (unlike ordinary paragraph content, which is trimmed). In HTML each
-        leading space serializes as a NBSP (`&nbsp;`, U+00A0), so indentation is
-        visible with no external CSS (matching Pandoc). Plain-text / ANSI
-        renderers emit the literal spaces. A tab in the leading run follows the
-        tab-stop rule (PART 9 §24).
+        (unlike ordinary paragraph content, which is trimmed), down to a single
+        column. In HTML each leading space serializes as a NBSP (`&nbsp;`,
+        U+00A0), so indentation is visible with no external CSS (matching
+        Pandoc). Plain-text / ANSI renderers emit the literal spaces. A tab in
+        the leading run follows the tab-stop rule (PART 9 §24).
+      - MEDIAL GAPS. An INNER or TRAILING run of TWO OR MORE columns is
+        preserved the same way and serializes as the same NBSPs. This is the
+        inline alignment verse and address blocks are made of -- the caesura of
+        Old English verse, a column of aligned text -- and collapsing it loses
+        the per-line layout the block exists to keep (matching Pandoc, where
+        every space the author writes is significant). A LONE inner space is NOT
+        preserved: it stays an ordinary, collapsible space so a long line can
+        still wrap between words. Tab arithmetic is the leading run's, counted
+        from the column the run starts at.
       - REFERENCE COLUMN. Leading whitespace is measured RELATIVE TO THE FENCE
         indent, not absolute column 0: a `line-block` nested in a list has the
         container's structural indent stripped first (the list dedents to its

--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -77,6 +77,51 @@ export function renderDoc(doc) {
   return html
 }
 
+/**
+ * One line of a line block (PART 9 SS23).
+ *
+ * Leading whitespace is preserved down to a single column; an inner or trailing
+ * run of TWO OR MORE columns is a medial gap and is preserved too. A lone inner
+ * space stays an ordinary collapsible space so a long line can still wrap
+ * between words. Preserved columns serialize as `&nbsp;`; a tab advances to the
+ * next multiple of four, counted from the column its run starts at (SS24 C1).
+ */
+function renderLineBlockLine(line) {
+  let out = ''
+  let text = ''
+  let i = 0
+  let column = 0
+  let seenContent = false
+  const flush = () => {
+    if (text !== '') out += renderInline(text)
+    text = ''
+  }
+  while (i < line.length) {
+    const ch = line[i]
+    if (ch !== ' ' && ch !== '\t') {
+      text += ch
+      seenContent = true
+      column++
+      i++
+      continue
+    }
+    let width = 0
+    while (i < line.length && (line[i] === ' ' || line[i] === '\t')) {
+      width += line[i] === '\t' ? 4 - ((column + width) % 4) : 1
+      i++
+    }
+    column += width
+    if (!seenContent || width >= 2) {
+      flush()
+      out += '&nbsp;'.repeat(width)
+    } else {
+      text += ' '
+    }
+  }
+  flush()
+  return out
+}
+
 function renderBlock(b, depth, ctx) {
   const pad = '  '.repeat(depth)
   const ba = b.battrs ? renderBlockAttrs(b.battrs) : ''
@@ -201,10 +246,7 @@ function renderBlock(b, depth, ctx) {
       }
       if (cur.length) stanzas.push(cur)
       const ps = stanzas.map((st) => {
-        const rendered = st.map((l) => {
-          const m = /^( *)(.*)$/.exec(l)
-          return '&nbsp;'.repeat(m[1].length) + renderInline(m[2].replace(/[ \t]+$/, ''))
-        })
+        const rendered = st.map((l) => renderLineBlockLine(l))
         return `${pad2}  <p>${rendered.join('<br>\n')}</p>`
       })
       return `${pad2}<div class="line-block">\n${ps.join('\n')}\n${pad2}</div>`

--- a/tests/corpus/41-line-blocks-3.crv
+++ b/tests/corpus/41-line-blocks-3.crv
@@ -1,6 +1,4 @@
 ::: |
-Stanza one,
-still one.
-
-Stanza two.
+Two roads    diverged in a yellow wood,
+And looked   down one as far as I could
 :::

--- a/tests/corpus/41-line-blocks-3.html
+++ b/tests/corpus/41-line-blocks-3.html
@@ -1,5 +1,4 @@
 <div class="line-block">
-  <p>Stanza one,<br>
-still one.</p>
-  <p>Stanza two.</p>
+  <p>Two roads&nbsp;&nbsp;&nbsp;&nbsp;diverged in a yellow wood,<br>
+And looked&nbsp;&nbsp;&nbsp;down one as far as I could</p>
 </div>

--- a/tests/corpus/41-line-blocks-4.crv
+++ b/tests/corpus/41-line-blocks-4.crv
@@ -1,4 +1,6 @@
 ::: |
-*Bold* and /italic/,
-plain line.
+Stanza one,
+still one.
+
+Stanza two.
 :::

--- a/tests/corpus/41-line-blocks-4.html
+++ b/tests/corpus/41-line-blocks-4.html
@@ -1,4 +1,5 @@
 <div class="line-block">
-  <p><strong>Bold</strong> and <em>italic</em>,<br>
-plain line.</p>
+  <p>Stanza one,<br>
+still one.</p>
+  <p>Stanza two.</p>
 </div>

--- a/tests/corpus/41-line-blocks-5.crv
+++ b/tests/corpus/41-line-blocks-5.crv
@@ -1,4 +1,4 @@
-::: {.line-block}
-one
-two
+::: |
+*Bold* and /italic/,
+plain line.
 :::

--- a/tests/corpus/41-line-blocks-5.html
+++ b/tests/corpus/41-line-blocks-5.html
@@ -1,4 +1,4 @@
-<p>::: {.line-block}
-one
-two
-:::</p>
+<div class="line-block">
+  <p><strong>Bold</strong> and <em>italic</em>,<br>
+plain line.</p>
+</div>

--- a/tests/corpus/41-line-blocks-6.crv
+++ b/tests/corpus/41-line-blocks-6.crv
@@ -1,4 +1,4 @@
-::: \
+::: {.line-block}
 one
 two
 :::

--- a/tests/corpus/41-line-blocks-6.html
+++ b/tests/corpus/41-line-blocks-6.html
@@ -1,4 +1,4 @@
-<div class="hardbreaks">
-  <p>one<br>
-two</p>
-</div>
+<p>::: {.line-block}
+one
+two
+:::</p>

--- a/tests/corpus/41-line-blocks-7.crv
+++ b/tests/corpus/41-line-blocks-7.crv
@@ -1,9 +1,4 @@
-:::: \
-  indented
-next
-
-::: note
-a
-b
+::: \
+one
+two
 :::
-::::

--- a/tests/corpus/41-line-blocks-7.html
+++ b/tests/corpus/41-line-blocks-7.html
@@ -1,8 +1,4 @@
 <div class="hardbreaks">
-  <p>indented<br>
-next</p>
-  <aside class="admonition note">
-    <p>a
-b</p>
-  </aside>
+  <p>one<br>
+two</p>
 </div>

--- a/tests/corpus/41-line-blocks-8.crv
+++ b/tests/corpus/41-line-blocks-8.crv
@@ -1,0 +1,9 @@
+:::: \
+  indented
+next
+
+::: note
+a
+b
+:::
+::::

--- a/tests/corpus/41-line-blocks-8.html
+++ b/tests/corpus/41-line-blocks-8.html
@@ -1,0 +1,8 @@
+<div class="hardbreaks">
+  <p>indented<br>
+next</p>
+  <aside class="admonition note">
+    <p>a
+b</p>
+  </aside>
+</div>

--- a/tests/spec/41-line-blocks.test
+++ b/tests/spec/41-line-blocks.test
@@ -26,6 +26,18 @@ Roses are red,
 
 ```
 ::: |
+Two roads    diverged in a yellow wood,
+And looked   down one as far as I could
+:::
+.
+<div class="line-block">
+  <p>Two roads&nbsp;&nbsp;&nbsp;&nbsp;diverged in a yellow wood,<br>
+And looked&nbsp;&nbsp;&nbsp;down one as far as I could</p>
+</div>
+```
+
+```
+::: |
 Stanza one,
 still one.
 


### PR DESCRIPTION
PART 9 §23 spelled out LEADING whitespace and said nothing about the rest of the line, so the inline alignment verse and address blocks are made of - the caesura of Old English verse, a column of aligned text - was never pinned. `tests/corpus/41-line-blocks-*` had no fixture for it either, so the engines drifted:

| input | carve-php | carve-js | carve-rs |
|-------|-----------|----------|----------|
| `Two roads    diverged` inside `::: \|` | four `&nbsp;` | one space | one space |

carve-php has preserved the gap since its #127 (a port of php-collective/djot-php#244); the other two collapse it. A plain verse input renders differently per engine today.

## The rule

An **inner or trailing run of two or more columns** is preserved exactly as the indent is, and serializes as the same NBSPs. A **lone inner space is not preserved** - it stays collapsible so a long line can still wrap between words, which is what keeps this from becoming "every space is nbsp". Tab arithmetic is the leading run's, counted from the column the run starts at.

This follows Pandoc, where every space an author writes inside a line block is significant, and it follows from what the block is for: the per-line layout IS the content, or there would be no reason to write `::: |` instead of a paragraph.

## What is in here

- `resources/grammar.ebnf` §23 gains a MEDIAL GAPS clause and the leading-whitespace clause says "down to a single column"
- `scripts/spec/html.mjs` renders the rule, so the corpus oracle proves the fixture rather than trusting an engine
- `docs/examples/core.md` gains the pair that generates `41-line-blocks-3`; the later line-block fixtures renumber behind it

`npm test` 683 passing / 4 skipped, `npm run core:check` 528/528 conformant, 0 defects.

`npm run engine:report` lists `41-line-blocks-3` as a pinned-build disagreement, which is the expected state right after a rule lands: markup-carve/carve-js#530 carries the engine change, and the pin bump belongs with that merge. carve-rs follows.
