### PR TITLE
spec: §1a's merge is part of parse(x), because §6 says so

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -75,9 +75,8 @@ one**, and says so. Absent is a fact a consumer can act on; a wrong span is not.
 
 ## Adjacent text runs are coalesced
 
-A serialized node's children hold **no two adjacent `text` nodes**. Where a
-producer's internal tree has a run of them, they join into one before
-serialization, concatenating `value` in order:
+A node's children hold **no two adjacent `text` nodes**. Where parsing produced
+a run of them, they join into one, concatenating `value` in order:
 
 ```
 foo_bar_baz and snake_case stay literal
@@ -96,6 +95,18 @@ lets a divergence be measured node-for-node instead of argued about.
 
 `escaped_text` is not `text` and does not merge with it: the two stay distinct
 on the wire because an escape is authored form.
+
+The merge is part of `parse(x)`, not of serialization. [§6](#round-trip)
+requires `parse(x)` serialized and deserialized to equal `parse(x)`, so joining
+runs in the encoder while leaving the tree split satisfies this rule and breaks
+that one on the same document - what comes back holds one node where the tree
+held three.
+
+A merged run keeps a `pos` only where its pieces are **contiguous** in the
+source. Where they are not - the `<` and `>` of an autolink unwrapped inside a
+link label, the delimiter between two halves of a wrapped table cell - the
+merged value is not a slice of the source at any offset, so the node carries no
+position rather than one that selects the wrong text.
 
 The schema cannot express this - JSON Schema has no way to forbid two adjacent
 array entries of the same shape - so it is checked by the shape comparison in

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3683,8 +3683,33 @@ EOF = (* end of file *) ;
 
       SCOPE. The rule is about `text` nodes only, and only about ADJACENCY
       within one parent's child list. It does not merge across an intervening
-      node, it does not merge other types, and it says nothing about how a
-      producer represents runs internally -- only what it publishes.
+      node, and it does not merge other types. It says nothing about how a
+      producer builds a run while parsing -- an inline scanner that accumulates
+      pieces and joins them at the end of the parse is exactly as conformant as
+      one that never split.
+
+      BUT THE MERGE IS PART OF `parse(x)`, NOT OF SERIALIZATION -- NORMATIVE.
+      §6 requires `parse(x)` serialized and deserialized to equal `parse(x)`.
+      An implementation that leaves the run split in the parsed tree and joins
+      it in the encoder satisfies §1a and BREAKS §6 on the same document: what
+      comes back holds one node where the tree held three, so the round trip is
+      not an identity. carve-rs was written that way first and its corpus
+      round-trip test failed on `03-links-12` (carve-rs#441). The tree
+      `parse(x)` returns is therefore already coalesced.
+
+      POSITIONS. A merged run keeps a span only where its pieces are CONTIGUOUS
+      in the source. Where they are not -- the `<` and `>` of an autolink
+      unwrapped inside a link label, the delimiter and newline between two
+      halves of a wrapped table cell -- the merged value is not a slice of the
+      source at any offset, and §4 rates a span that selects the wrong text
+      worse than no span at all. So such a run publishes NONE.
+
+      That is a real cost and is stated rather than glossed: per-piece spans
+      that existed before the merge are gone in exactly those cases. It only
+      happens where the value was never a source slice to begin with (a
+      manufactured joiner, a dropped delimiter), so nothing that WAS placeable
+      becomes unplaceable -- but a consumer wanting to locate the pieces of such
+      a run works from the source, not from the tree.
 
       `escaped_text` is NOT `text` and does not merge with it: PART 12 §5 keeps
       the two distinct on the wire because an escape is authored form, and


### PR DESCRIPTION
Follow-up to #483, found while implementing it in carve-rs.

## The wording permits an implementation that breaks §6

§1a currently says it

> says nothing about how a producer represents runs internally - only what it publishes.

Read straight, that permits leaving the run split in the parsed tree and joining it in the encoder. I did exactly that, because the sentence reads like an invitation to. It satisfies §1a and breaks §6 on the same document:

> §6 ROUND TRIP. `parse(x)` serialized and deserialized MUST equal `parse(x)`.

What comes back holds one text node where the tree held three. `tests/ast_json.rs::corpus_round_trip` in carve-rs failed on `03-links-12` (markup-carve/carve-rs#441), which is how this surfaced rather than shipping.

Two normative rules that can only be satisfied together, with the wording pointing at the combination that fails, is worth a paragraph. The freedom that genuinely exists is about how a scanner **builds** a run while parsing; the tree `parse(x)` returns is already coalesced.

## And what the merge costs

The original text did not say. A merged run can only keep a span where its pieces are **contiguous** in the source. Where they are not - an autolink unwrapped inside a link label leaves the `<` and `>` behind, a wrapped table cell is joined across a delimiter and a newline - the merged value is not a slice of the source at any offset, and §4 rates a span that selects the wrong text worse than none.

So per-piece spans that existed before the merge are gone in those cases. Nothing that *was* placeable becomes unplaceable, since it only happens where the value was never a source slice to begin with, but a consumer locating the pieces of such a run now works from the source rather than the tree. That is a trade §1a makes, and it should be in the text rather than discovered by whoever implements it next.

Spec suite 686 tests, 0 failures. Executable spec 527/527, 0 defects. No grammar production or corpus changes - normative prose plus the matching docs page.
