### PR TITLE
test: pin a tab in a line-block gap, the one shape the engines disagreed on

### DIFF
--- a/docs/examples/core.md
+++ b/docs/examples/core.md
@@ -3749,3 +3749,28 @@ b</p>
 
 :::::
 
+A gap written with TABS measures in columns, not characters: each tab advances
+to the next four-column stop, counted from where the run starts. So a tab is a
+medial gap or a lone space depending on where it lands - below, `tab` sits at
+column 3 so its tab crosses one column and collapses, while the two after `wide`
+cross two full stops and are kept. A LEADING tab follows the same arithmetic.
+
+:::: compare
+
+```carve
+::: |
+tab	gap
+wide		gap
+	lead
+:::
+```
+
+```html
+<div class="line-block">
+  <p>tab gap<br>
+wide&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;gap<br>
+&nbsp;&nbsp;&nbsp;&nbsp;lead</p>
+</div>
+```
+
+::::

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2813,7 +2813,10 @@ EOF = (* end of file *) ;
         every space the author writes is significant). A LONE inner space is NOT
         preserved: it stays an ordinary, collapsible space so a long line can
         still wrap between words. Tab arithmetic is the leading run's, counted
-        from the column the run starts at.
+        from the column the run starts at -- so the SAME tab is a gap or a lone
+        space depending on the column it lands in, which is what makes it worth
+        pinning: corpus 41-line-blocks-9 holds a tab that crosses one column
+        (collapses) beside two that cross two stops (kept), and a leading one.
       - REFERENCE COLUMN. Leading whitespace is measured RELATIVE TO THE FENCE
         indent, not absolute column 0: a `line-block` nested in a list has the
         container's structural indent stripped first (the list dedents to its

--- a/tests/corpus/41-line-blocks-9.crv
+++ b/tests/corpus/41-line-blocks-9.crv
@@ -1,0 +1,5 @@
+::: |
+tab	gap
+wide		gap
+	lead
+:::

--- a/tests/corpus/41-line-blocks-9.html
+++ b/tests/corpus/41-line-blocks-9.html
@@ -1,0 +1,5 @@
+<div class="line-block">
+  <p>tab gap<br>
+wide&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;gap<br>
+&nbsp;&nbsp;&nbsp;&nbsp;lead</p>
+</div>

--- a/tests/spec/41-line-blocks.test
+++ b/tests/spec/41-line-blocks.test
@@ -107,3 +107,17 @@ b</p>
   </aside>
 </div>
 ```
+
+```
+::: |
+tab	gap
+wide		gap
+	lead
+:::
+.
+<div class="line-block">
+  <p>tab gap<br>
+wide&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;gap<br>
+&nbsp;&nbsp;&nbsp;&nbsp;lead</p>
+</div>
+```


### PR DESCRIPTION
§23 says tab arithmetic is the leading run's, counted from the column the run
starts at — so the **same tab** is a medial gap or a lone collapsible space
depending on where it lands. No fixture held one, and the engines drifted on it:

| | carve-js | carve-php | carve-rs |
|---|---|---|---|
| `tab⇥gap` (crosses 1 column) | `tab gap` | `tab gap` | **`tab⇥gap`** |

carve-rs emitted the raw tab where the other two emitted a space, and nothing
could show either wrong. That is the same shape of gap #487 existed to close,
one level down — it was caught by hand-comparing the three engines, which is not
a method that scales.

## The fixture

All three cases in one block:

```
::: |
tab⇥gap          ← tab at column 3, crosses ONE column → collapses
wide⇥⇥gap        ← two tabs from column 4, two full stops → kept, 8 NBSPs
⇥lead            ← leading tab, the existing rule, now written down
:::
```

`resources/grammar.ebnf` §23 cites it, the way the other normative notes cite
theirs.

## Placement

**Appended** to the Line blocks section rather than filed beside the medial-gap
example it belongs with. Inserting mid-section renumbers examples 4-8 of the
same category — `41-line-blocks-4` becomes `-5` and so on — and the numbering is
the cross-impl contract inside a category too, not only across them. The
category number is untouched either way, so #489's guard passes on both; this
just keeps the diff to what changed.

## Verified before pinning

The fixture records what all three engines **already** do, not what one of them
does. Byte-identical output from carve-js `main`, carve-php `main` and carve-rs
`main` (which has this right via markup-carve/carve-rs#442), and from the
executable-spec oracle.

`npm test` 684/684. `core:check`: 529 inputs, 529 conformant, 0 refused, 0
defects. Docs build clean.
