### PR TITLE
ci: run compare-impls, which has never run

### DIFF
--- a/.github/workflows/ast-conformance.yml
+++ b/.github/workflows/ast-conformance.yml
@@ -116,3 +116,33 @@ jobs:
           # gets muted, which is the failure this whole issue is about.
           CARVE_REQUIRE_ALL_ENGINES: '1'
         run: npm run ast:check -- --satellite-limit=520
+
+      # PART 11: the formatter must not change what a document says. The
+      # `--roundtrip` mode formats each corpus document and re-reads the result,
+      # which is the only automated check of that invariant across engines - and
+      # it had never run. It caught carve-rs#432, where `carve fmt` on a
+      # blockquote containing a comment emitted source in which the hidden text
+      # rendered as a visible paragraph: content the author hid, published by
+      # running the formatter. Green by not running, while that shipped.
+      #
+      # GATES, because a formatter that changes the document is wrong under every
+      # reading of PART 11 - there is no design question to settle first.
+      - name: PART 11 formatter round trip
+        env:
+          CARVE_JS_DIR: ${{ github.workspace }}/carve-js
+          CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
+          CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
+        run: npm run compare:impls -- --roundtrip --fail-on-diff
+
+      # The default mode compares every render target engine-against-engine.
+      # REPORTS rather than gates: its remaining differences need language
+      # decisions (carve#478, carve#481), and gating on an unresolved question
+      # teaches people to ignore the job - which is how both of these checkers
+      # came to be unwired in the first place.
+      - name: Cross-engine render comparison (report only)
+        if: always()
+        env:
+          CARVE_JS_DIR: ${{ github.workspace }}/carve-js
+          CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
+          CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
+        run: npm run compare:impls

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -92,21 +92,45 @@ const JS_ENTRY = {
   ansi: 'carveToAnsi',
 }
 
+/**
+ * How to invoke carve-rs: a BUILT binary when one is there, `cargo run` if not.
+ *
+ * `cargo run` compiles into whatever CARGO_TARGET_DIR points at, and a machine
+ * with a shared target directory has more than one checkout of the same package
+ * pointing at it. Two of them take turns rebuilding, so a run can measure a
+ * binary compiled from a DIFFERENT source tree than the one it names - which is
+ * how a clean carve-rs was reported as breaking a PART 11 invariant here, and
+ * the finding evaporated when the same document was checked by hand.
+ *
+ * scripts/ast-conformance.mjs already prefers the built binary and even reports
+ * a stale one. This brings the two checkers into line, and makes a CI run use
+ * the release build the workflow just produced instead of recompiling in debug.
+ */
+const rustCarveBinary = (() => {
+  const dir = rustDir()
+  if (!dir) return null
+  for (const candidate of ['target/release/carve', 'target/debug/carve']) {
+    if (existsSync(join(dir, candidate))) return `./${candidate}`
+  }
+  return null
+})()
+
+const rustBaseCommand = rustCarveBinary
+  ? [rustCarveBinary]
+  : ['cargo', 'run', '--quiet', '--']
+
 const impls = [
   {
     name: 'rust',
     cwd: rustDir(),
     prepare: null,
-    defaultCommand: (target = 'html') => ['cargo', 'run', '--quiet', '--', ...CLI_FLAGS[target]],
+    defaultCommand: (target = 'html') => [...rustBaseCommand, ...CLI_FLAGS[target]],
     optionalCommand(feature, target = DEFAULT_TARGET) {
       const flags = CLI_FLAGS[target]
       if (!flags) return null
       if (feature === 'social-link-templates') {
         return [
-          'cargo',
-          'run',
-          '--quiet',
-          '--',
+          ...rustBaseCommand,
           '--mention-url',
           '/users/{name}',
           '--tag-url',
@@ -116,7 +140,7 @@ const impls = [
       }
       if (feature === 'symbol-map') {
         return [
-          'cargo', 'run', '--quiet', '--',
+          ...rustBaseCommand,
           '--symbol', 'rocket=🚀', '--symbol', 'tada=🎉', '--symbol', '+1=👍', '--symbol', 'UPPER=⬆️',
           ...flags,
         ]
@@ -581,9 +605,24 @@ if (bench) {
 if (failOnDiff) {
   const failing = roundtrip ? roundtripDiffs : crossImplDiffs
   const label = roundtrip ? 'round-trip' : 'cross-implementation'
-  if (failing > 0) {
-    console.error(`\n${failing} ${label} difference(s) - see the DIFF lines above.`)
+  // PART 11 §1's own invariants gate too, and separately from cross-engine
+  // agreement. `to_html(fmt(x)) != to_html(x)` means ONE engine's formatter
+  // changed what the document says - a corruption whether or not the others
+  // agree with it, and the engines agreeing on a wrong answer is the case this
+  // catches that a diff count cannot. They were counted and printed here from
+  // the start and never gated on, so the check could report a formatter
+  // rewriting documents and still exit 0.
+  const invariantFailures = roundtrip ? semanticFailures + idempotenceFailures : 0
+  if (failing > 0 || invariantFailures > 0) {
+    if (failing > 0) {
+      console.error(`\n${failing} ${label} difference(s) - see the DIFF lines above.`)
+    }
+    if (invariantFailures > 0) {
+      console.error(
+        `${invariantFailures} PART 11 §1 invariant failure(s) - see the INVARIANT lines above.`,
+      )
+    }
     process.exit(1)
   }
-  console.log(`\nNo ${label} differences.`)
+  console.log(`\nNo ${label} differences, and no PART 11 §1 invariant failures.`)
 }

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -15,6 +15,10 @@ const bench = args.has('--bench')
 // indentation, inserted blank lines, escape runs - so its output is exactly
 // where the engines are least likely to have been compared (carve#353).
 const roundtrip = args.has('--roundtrip')
+// Opt-in, so a local run stays informational and CI can be strict. Without it
+// this script reports divergences and exits 0, which is why two engines
+// disagreeing about a document's canonical form went unnoticed (carve#478).
+const failOnDiff = args.has('--fail-on-diff')
 const limitArg = process.argv.find((a) => a.startsWith('--limit='))
 const limit = limitArg ? Number(limitArg.slice('--limit='.length)) : Infinity
 const corpusArg = process.argv.find((a) => a.startsWith('--corpus='))
@@ -567,4 +571,19 @@ console.log(
 
 if (bench) {
   console.log('\nBenchmark note: timings include process startup and are useful for CLI-level smoke comparison only.')
+}
+
+// The gate. In roundtrip mode a diff means an engine's formatter changed what a
+// document says, which is wrong under any reading of PART 11 - there is no
+// design question behind it. In the default mode a diff means the engines
+// disagree about a target's output; whether every one of those is a defect is
+// still open (carve#474), so gate that mode only once they are resolved.
+if (failOnDiff) {
+  const failing = roundtrip ? roundtripDiffs : crossImplDiffs
+  const label = roundtrip ? 'round-trip' : 'cross-implementation'
+  if (failing > 0) {
+    console.error(`\n${failing} ${label} difference(s) - see the DIFF lines above.`)
+    process.exit(1)
+  }
+  console.log(`\nNo ${label} differences.`)
 }


### PR DESCRIPTION
`compare:impls` is the only automated comparison of the engines' **rendered** output - every target, engine against engine - and it is wired into no job. It exists as an npm script somebody has to remember to run.

That is not theoretical. Running it by hand found carve-rs#436 last week (nested links unwrapped in the HTML renderer but not in Markdown or ANSI, so `carve fmt` output was not valid Markdown), and its `--roundtrip` mode found carve-rs#432, where `carve fmt` on a blockquote containing a comment emitted source in which the hidden text rendered as a visible paragraph - content the author hid, published by running the formatter.

## The wiring was written once and lost

PR #476 was titled "run the cross-engine checkers". Its merge commit touched only `scripts/ast-conformance.mjs`. The workflow half never landed, and #482 later added `ast-conformance.yml` for the `ast:check` half alone. So the nightly job that checks out and builds all four engines has been running one of the two checkers it was built for.

This adds `--fail-on-diff` and two steps to that existing job:

- **`--roundtrip --fail-on-diff` gates.** A formatter that changes what a document says is wrong under every reading of PART 11; there is no design question to settle first.
- **The default mode reports** (`if: always()`, so a gate failure does not hide it). Its remaining differences need language decisions (#478, #481), and gating on an unresolved question teaches people to ignore the job - which is how both checkers came to be unwired.

## Two defects in the checker itself, found while producing a number from it

**PART 11 §1's own invariants were printed and never gated.** The script emits `INVARIANT to_html(fmt(x)) != to_html(x)` and `INVARIANT fmt(fmt(x)) != fmt(x)`, counts them, and `--fail-on-diff` looked only at the cross-engine diff count. A run could name a formatter that corrupts documents and exit 0. They gate now, separately - one engine corrupting a document is a defect whether or not the others agree, and "the engines agree on a wrong answer" is precisely what a diff count cannot see.

**The rust engine was invoked with `cargo run`.** That compiles into whatever `CARGO_TARGET_DIR` points at, and this machine has one shared target directory with several carve-rs checkouts pointing at it. They take turns rebuilding, so a run can measure a binary built from a *different* source tree than the one it names. It reported carve-rs at main breaking `to_html(fmt(x)) == to_html(x)`; the same document checked by hand against that worktree's own release binary produced identical HTML. `ast-conformance.mjs` has always preferred the built binary and even reports a stale one - the two checkers now agree, and CI uses the release build the workflow just produced instead of recompiling in debug.

## Verification

All three engines in fresh worktrees at their own `main`, carve-php built from a clean checkout:

```
all three at main, FULL corpus (527 docs)   exit 0
                                            "No round-trip differences, and no
                                             PART 11 section 1 invariant failures."

carve-rs at 2dd075c (pre-#433), 420 docs    exit 1
                                            3 round-trip diffs
                                            2 invariant failures, naming
                                            70-blocks-that-render-to-nothing
```

So the gating step is **green on main today** - it is not being merged red.

The report step surfaces two cross-engine differences on the `carve` target, both filed rather than gated: markup-carve/carve#481 (the engines serialize different pipeline stages) and markup-carve/carve-php#631 (an abbreviation definition inside a container is hoisted to the document, so `fmt` moves the author's line). The second was found by this run.

Worth recording how nearly this went wrong: the first attempt used the **shared** carve-php checkout, which carries uncommitted changes and trails main. It reported 14 round-trip differences. Every one was the checkout, not the engines. A gate is only as good as the provenance of what it measures, which is the same lesson the `cargo run` fix encodes.