### PR TITLE
ci: the PART 11 gate runs even when PART 12 fails

### DIFF
--- a/.github/workflows/ast-conformance.yml
+++ b/.github/workflows/ast-conformance.yml
@@ -128,6 +128,12 @@ jobs:
       # GATES, because a formatter that changes the document is wrong under every
       # reading of PART 11 - there is no design question to settle first.
       - name: PART 11 formatter round trip
+        # ALWAYS, because this gate is independent of the one above it. The
+        # first run of this workflow had PART 12 fail, which SKIPPED this step -
+        # so a formatter that changed what a document says would have gone
+        # unmeasured because of an unrelated AST finding, and the job would have
+        # reported one failure while silently not performing the other check.
+        if: always()
         env:
           CARVE_JS_DIR: ${{ github.workspace }}/carve-js
           CARVE_RS_DIR: ${{ github.workspace }}/carve-rs


### PR DESCRIPTION
The first execution of this workflow - it had never run before today - reported:

```
PART 12 conformance            failure
PART 11 formatter round trip   SKIPPED
Cross-engine render comparison (report only)   ran
```

The two gates check unrelated properties: one the serialized AST, the other that a formatter does not change what a document says. Neither depends on the other. Chaining them means an AST finding silently cancels the formatter gate, so the job reports one failure while not performing the other check at all.

A gate that stops running because something else went wrong is the same defect as a gate that never ran - which is the defect this whole workflow exists to fix. The report step below already carried `if: always()` for exactly this reason; the gate above it did not.

One line. No behavior change when everything passes.
