### PR TITLE
ci: say how much of the Tier-2 corpus was actually compared

### DIFF
--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -573,12 +573,39 @@ console.log(
 
 if (isOptional) {
   console.log('\nOptional feature coverage')
+  const unreachable = new Map()
   for (const pair of pairs) {
     const supported = active
       .filter((impl) => commandFor(impl, pair, pair.target))
       .map((impl) => impl.name)
-      .join(', ')
-    console.log(`${pair.feature} (${pair.target}): ${supported || 'none'}`)
+    console.log(`${pair.feature} (${pair.target}): ${supported.join(', ') || 'none'}`)
+    // Fewer than two engines means there is nothing to compare AGAINST, so the
+    // case contributes no agreement evidence even when it renders.
+    if (supported.length < 2) {
+      unreachable.set(pair.feature, (unreachable.get(pair.feature) ?? 0) + 1)
+    }
+  }
+
+  // A "0 differences" line under a run that compared 2 of 33 documents reads
+  // exactly like one that compared all of them. It is the same shape as the
+  // NOT MEASURED roll-up in ast-conformance.mjs, and for the same reason: the
+  // number that matters is how much was checked, not how much disagreed.
+  //
+  // The Tier-2 features are IMPLEMENTED in all three engines - citations, code
+  // callouts and the rest all shipped engine by engine. What is missing is a
+  // way to turn them on from the command line, which is the only interface
+  // this checker has (markup-carve/carve#496).
+  const skippedCases = [...unreachable.values()].reduce((n, x) => n + x, 0)
+  if (skippedCases > 0) {
+    const worst = [...unreachable.entries()].sort((a, b) => b[1] - a[1])
+    console.log(
+      `\nNOT COMPARED: ${skippedCases} of ${pairs.length} optional cases reached fewer than two engines, so they contribute no agreement evidence. This is not a pass.`,
+    )
+    console.log(
+      `  no CLI path in two or more engines: ${worst.map(([f, n]) => `${f} (${n})`).join(', ')}`,
+    )
+  } else {
+    console.log('\nAll optional cases reached at least two engines.')
   }
 }
 


### PR DESCRIPTION
Closes part of #496.

`compare:impls --corpus=optional` reports:

```
Target agreement
html: compared=2 diffs=0
markdown: compared=1 diffs=0
cross_impl_diffs=0
```

on a corpus of **33** documents, and exits 0. Two of thirty-three, presented exactly like thirty-three of thirty-three.

## What is actually missing

Not functionality. Citations, code callouts and the rest are implemented in all three engines - they shipped engine by engine. What is missing is a way to turn them on **from the command line**, which is the only interface this checker has. So 30 cases reach fewer than two engines and contribute no agreement evidence:

```
NOT COMPARED: 30 of 33 optional cases reached fewer than two engines, so they
contribute no agreement evidence. This is not a pass.
  no CLI path in two or more engines: citations-numbered (16), code-callouts (3),
  smart-quotes-locale-de (1), bare-url-autolink (1), citations-author-date (1),
  details (1), list-table (1), spoiler (1), tabs (1), smart-typography-off (1),
  markdown-typography-source (1), section-wrapper-off (1),
  source-line-after-generated-id (1)
```

Same shape as the `NOT MEASURED` roll-up `ast-conformance.mjs` prints for an unmeasured satellite, and for the same reason: the number that matters is how much was checked, not how much disagreed.

## Reported, not gated

The fix is in three other repos (#496 has the detail: carve-rs's `--extensions` covers the bundled interactive set but not citations; carve-php auto-registers that same set; carve-js exposes none of it from its CLI). A permanently red job gets muted, which is how the checkers this workflow runs came to be unwired in the first place.

Prints nothing on the default corpus, where every case reaches every engine. Spec suite 684 tests, 0 failures.

## Why this corpus in particular

Tier-2 is where the engines are most likely to drift - every one of those features landed one engine at a time. Core-corpus HTML agreement is the thing that has been reliably green all along; it is the Tier-2 surface that has had no cross-engine measurement at all.
