### PR TITLE
spec: check the grammar's cross-engine claims, and correct one that had rotted

### DIFF
--- a/.github/workflows/ast-conformance.yml
+++ b/.github/workflows/ast-conformance.yml
@@ -152,3 +152,22 @@ jobs:
           CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
           CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
         run: npm run compare:impls
+
+      # The grammar names engines and says what they do - "all impls support
+      # it", "carve-rs is the reference here", "carve-php additionally accepts
+      # colon-bearing keys". Those sentences are how a second implementer learns
+      # where the margins are, and nothing checked any of them. Two had already
+      # rotted: PART 12 §4's implementation status described an engine that no
+      # longer existed, and the math paragraph named a carve-php defect that was
+      # fixed. Both were found by reading.
+      #
+      # GATES, in both directions: a claim of agreement fails if an engine
+      # drifts, and a documented divergence fails if it is silently resolved -
+      # which is the direction that leaves a false sentence in the spec.
+      - name: Grammar cross-engine claims
+        if: always()
+        env:
+          CARVE_JS_DIR: ${{ github.workspace }}/carve-js
+          CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
+          CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
+        run: npm run claims:check

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "docs:preview": "vitepress preview docs",
     "corpus:build": "node scripts/generate-corpus.mjs",
     "compare:impls": "node scripts/compare-impls.mjs",
+    "claims:check": "node scripts/engine-claims.mjs",
     "combinatorial:check": "node scripts/combinatorial-check.mjs",
     "property:check": "node scripts/property-check.mjs",
     "ast:check": "node scripts/ast-conformance.mjs",

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1270,8 +1270,14 @@ math_display = "$$", code_span ;
    Canonical = carve-js / djot.js (pinned, corpus Math section). The
    `{=format}` raw form is code-span-ONLY and is NOT inherited by math:
    `$\`x\`{=html}` leaves the `{=html}` literal (both impls already agree).
-   carve-php currently DROPS valid math attributes -- to be fixed.
-   The math content is the verbatim text of the reused code_span. *)
+   The math content is the verbatim text of the reused code_span.
+
+   (This paragraph used to end "carve-php currently DROPS valid math
+   attributes -- to be fixed". It does not: an attribute block on a math
+   span renders the class in ALL THREE engines, verified over each of
+   their mains. A sentence describing one engine's defect is only true on
+   the day it is written, and nothing here re-checks it -- PART 12 section 4's
+   implementation status had rotted the same way.) *)
 
 (* --- Emphasis (left/right word-boundary rule; PART 9 §9 is normative).
    The word-boundary restriction applies to EVERY bare emphasis delimiter

--- a/scripts/engine-claims.mjs
+++ b/scripts/engine-claims.mjs
@@ -1,0 +1,136 @@
+/*
+ * The grammar's cross-engine claims are real, and still real.
+ *
+ * resources/grammar.ebnf names specific engines and says what they do: "all
+ * impls support it", "carve-rs is the reference here", "carve-php additionally
+ * accepts colon-bearing keys". Those sentences are how a second implementer
+ * learns where the margins are, and nothing checked any of them.
+ *
+ * They rot. PART 12 §4's implementation status described carve-rs as recording
+ * block positions only - "869 block nodes and 54 left" - long after it placed
+ * inline ones too, and pointed at two tracking issues that were both closed.
+ * The math paragraph ended "carve-php currently DROPS valid math attributes --
+ * to be fixed" long after carve-php stopped dropping them. Both were found by
+ * reading, not by a gate.
+ *
+ * This runs the engines and pins each claim as an OBSERVABLE relation - do they
+ * agree, or does one differ - rather than any engine's exact bytes, which the
+ * corpus already pins. A claim that says "all three agree" fails here if one
+ * drifts; a claim that documents a divergence fails here if it is silently
+ * resolved, which is the direction that leaves a false sentence behind.
+ *
+ * Needs the sibling engines, so it runs in the conformance workflow rather than
+ * in `npm test`. Without them it exits 2 rather than 0: a claim checker that
+ * reports success having run nothing is the failure it exists to prevent.
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { phpDir, rustDir } from './lib/engine-locations.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const root = resolve(here, '..')
+const jsDir = process.env.CARVE_JS_DIR ?? resolve(root, '../carve-js')
+
+/**
+ * Every claim states the SECTION it comes from, so a failure names the sentence
+ * to correct rather than leaving someone to find it.
+ *
+ * `expect` is 'agree' when the grammar says the engines behave alike, or a list
+ * of engines that must differ from the rest.
+ */
+const CLAIMS = [
+  {
+    section: 'PART 3, math attributes',
+    quote: 'an attribute block on a math span applies to the math element in every engine',
+    source: '$`x`{.c}\n',
+    expect: 'agree',
+  },
+  {
+    section: 'PART 9 §14, attribute identifiers',
+    quote: 'carve-php additionally accepts colon-bearing keys as spans, where carve-js treats those as literal',
+    source: '[x]{xml:lang="en"}\n',
+    expect: ['php'],
+  },
+  {
+    section: 'PART 9 §14, attribute identifiers',
+    quote: 'carve-php additionally accepts colon-bearing classes as spans, where carve-js treats those as literal',
+    source: '[y]{.sm:hover}\n',
+    expect: ['php'],
+  },
+]
+
+const engines = []
+if (existsSync(join(jsDir, 'dist/index.js'))) engines.push({ name: 'js', kind: 'js', dir: jsDir })
+for (const candidate of ['target/release/carve', 'target/debug/carve']) {
+  const dir = rustDir()
+  if (dir && existsSync(join(dir, candidate))) {
+    engines.push({ name: 'rs', kind: 'cli', bin: join(dir, candidate) })
+    break
+  }
+}
+if (phpDir() && existsSync(join(phpDir(), 'bin/carve'))) {
+  engines.push({ name: 'php', kind: 'cli', bin: join(phpDir(), 'bin/carve') })
+}
+
+if (engines.length < 3) {
+  console.error(
+    `engine-claims: need all three engines, found ${engines.length} (${engines.map((e) => e.name).join(', ') || 'none'}).`,
+  )
+  console.error('A claim checker that reports success having run nothing is the failure it exists to prevent.')
+  process.exit(2)
+}
+
+const lib = await import(join(jsDir, 'dist/index.js'))
+const tmp = mkdtempSync(join(tmpdir(), 'carve-claims-'))
+const normalize = (html) => html.replace(/\s+/g, ' ').trim()
+
+function render(engine, source) {
+  if (engine.kind === 'js') return normalize(lib.carveToHtml(source))
+  const file = join(tmp, 'case.crv')
+  writeFileSync(file, source)
+  return normalize(execFileSync(engine.bin, ['--html', file], { encoding: 'utf8', maxBuffer: 1 << 26 }))
+}
+
+let failures = 0
+try {
+  for (const claim of CLAIMS) {
+    const outputs = engines.map((e) => [e.name, render(e, claim.source)])
+    const distinct = new Map()
+    for (const [name, out] of outputs) {
+      if (!distinct.has(out)) distinct.set(out, [])
+      distinct.get(out).push(name)
+    }
+
+    let ok
+    if (claim.expect === 'agree') {
+      ok = distinct.size === 1
+    } else {
+      // Exactly two groups, and the odd one out is the named set.
+      const groups = [...distinct.values()].map((names) => names.slice().sort().join(','))
+      ok = distinct.size === 2 && groups.includes(claim.expect.slice().sort().join(','))
+    }
+
+    if (ok) {
+      console.log(`ok  ${claim.section}: ${claim.quote}`)
+      continue
+    }
+    failures++
+    console.log(`FAIL ${claim.section}: ${claim.quote}`)
+    console.log(`     source: ${JSON.stringify(claim.source)}`)
+    for (const [out, names] of distinct) console.log(`     ${names.join(', ')}: ${out}`)
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true })
+}
+
+console.log(`\n${CLAIMS.length - failures}/${CLAIMS.length} grammar claims hold.`)
+if (failures > 0) {
+  console.error(
+    `${failures} claim(s) in resources/grammar.ebnf no longer describe the engines. Correct the sentence, or the engine.`,
+  )
+  process.exit(1)
+}


### PR DESCRIPTION
The grammar names engines and says what they do - *"all impls support it"*, *"carve-rs is the reference here"*, *"carve-php additionally accepts colon-bearing keys"*. Those sentences are how a second implementer learns where the margins are, and nothing checked any of them.

## Two had already rotted, both found by reading

- **PART 12 §4's implementation status** described carve-rs as recording block positions only - "869 block nodes and 54 left" - long after it placed inline ones too, and pointed at carve-js#441 and carve-rs#333, *both closed*. Fixed separately in #498.
- **The math paragraph** ended *"carve-php currently DROPS valid math attributes -- to be fixed"*. It does not, and has not for some time: `$` + backtick-x + backtick + `{.c}` renders `<span class="math inline c">` in all three engines. Corrected here, with a note saying why the sentence was wrong rather than deleting it silently.

## The checker

`scripts/engine-claims.mjs` runs the engines and pins each claim as an **observable relation** - do they agree, or does one differ - rather than any engine's exact bytes, which the corpus already pins.

It gates **in both directions**: a claim of agreement fails if an engine drifts, and a documented divergence fails if it is silently *resolved* - which is the direction that leaves a false sentence in the spec.

| claim | relation |
| --- | --- |
| math attributes apply in every engine | agreement |
| carve-php accepts colon-bearing attribute **keys** as spans | divergence |
| carve-php accepts colon-bearing attribute **classes** as spans | divergence |

The last two are worth a gate on their own account. They produce **different HTML across engines**:

```
[x]{xml:lang="en"}

js, rs   <p>[x]{xml:lang=“en”}</p>
php      <p><span xml:lang="en">x</span></p>
```

No corpus document exercises them, so `compare:impls` reports zero html differences. The spec names the margin exactly and nothing measured it.

## Verified in both directions

Inverting one claim's expected relation fails the run and names the sentence to fix:

```
FAIL PART 9 §14, attribute identifiers: carve-php additionally accepts colon-bearing keys …
     js, rs: <p>[x]{xml:lang=“en”}</p>
     php: <p><span xml:lang="en">x</span></p>
1 claim(s) in resources/grammar.ebnf no longer describe the engines. Correct the sentence, or the engine.
```

Running with an engine missing exits **2**, not 0 - a claim checker that reports success having run nothing is the failure it exists to prevent.

Runs in the conformance workflow, which already builds every engine, with `if: always()` so an earlier gate's failure cannot cancel it. Spec suite 684 tests, 0 failures.
