### PR TITLE
ci: check the profile battery still matches the engine that generates it

### DIFF
--- a/.github/workflows/ast-conformance.yml
+++ b/.github/workflows/ast-conformance.yml
@@ -171,3 +171,21 @@ jobs:
           CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
           CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
         run: npm run claims:check
+      # tests/profile-fixtures.json is the shared profile battery: carve-js and
+      # carve-rs assert their profile output against it, and it is GENERATED
+      # from carve-php by a command documented in a comment at the top of
+      # gen-profile-fixtures.php. Nothing ran that command again.
+      #
+      # So if carve-php's profile output changed, the file would keep the old
+      # answer and the other two engines would go on agreeing with it - three
+      # engines in consensus about a reference none of them produces. The
+      # battery is the only cross-engine check of what a profile PERMITS, which
+      # is a security surface: `comment` and `minimal` exist to strip things.
+      - name: Profile battery is still what carve-php produces
+        if: always()
+        env:
+          CARVE_PHP_AUTOLOAD: ${{ github.workspace }}/carve-php/vendor/autoload.php
+        run: |
+          php tests/gen-profile-fixtures.php > /tmp/profile-fixtures.regenerated.json
+          diff -u tests/profile-fixtures.json /tmp/profile-fixtures.regenerated.json \
+            || { echo "::error::tests/profile-fixtures.json no longer matches carve-php. Regenerate it (see the header of tests/gen-profile-fixtures.php) and re-check carve-js and carve-rs against the new file."; exit 1; }


### PR DESCRIPTION
`tests/profile-fixtures.json` is the shared profile battery. carve-js and carve-rs both assert their profile output against it - and it is **generated from carve-php** by a command documented in a comment at the top of `gen-profile-fixtures.php`:

```
// Run from a carve-php checkout: `php tests/gen-profile-fixtures.php > tests/profile-fixtures.json`
```

Nothing ever ran that command again.

So if carve-php's profile output changed, the file would keep the old answer and the other two engines would go on agreeing with it - **three engines in consensus about a reference none of them produces**.

That matters more here than in most places. The battery is the only cross-engine check of what a profile *permits*, and `comment` / `minimal` exist to strip things: a silently stale reference is a security surface going unmeasured, not a formatting detail.

## Not fixing a drift

Regenerating against carve-php `main` today produces a **byte-identical** file. This closes the reason a drift would not be noticed, rather than a drift.

## Verified in both directions

- Perturbing one string in the checked-in file makes the diff fail, with the regeneration instructions in the error.
- Unmodified, it passes.

Runs in the conformance workflow, which already checks out and `composer install`s carve-php, with `if: always()` so an earlier gate cannot cancel it. Spec suite 684 tests, 0 failures.
