### PR TITLE
docs: the comparison page quoted a run from a corpus 43% smaller than today's

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -277,10 +277,10 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=302
-rust: pass=302/302 mismatch=0 error=0 skipped=0 avg_ms=23.47
-js: pass=302/302 mismatch=0 error=0 skipped=0 avg_ms=51.22
-php: pass=302/302 mismatch=0 error=0 skipped=0 avg_ms=53.20
+profile=default/no-opt-in corpus=core corpus_pairs=529 targets=html
+rust: pass=529/529 mismatch=0 error=0 skipped=0 runs=529 avg_ms=2.34
+js: pass=529/529 mismatch=0 error=0 skipped=0 runs=529 avg_ms=53.34
+php: pass=529/529 mismatch=0 error=0 skipped=0 runs=529 avg_ms=51.97
 cross_impl_diffs=0
 
 Extension capability matrix
@@ -292,29 +292,41 @@ extension_profile_note=this run compares default/no-opt-in output. Use --corpus=
 
 Optional raw output:
 
-> **Note:** the snapshot below is from 2026-06-19 (4 optional corpus pairs).
-> The optional corpus has since grown to 31 pairs (citations-numbered enrichment
-> cases 13-24 for typed locators, integral marker, and suppress-author; code
-> callouts cases 10-12; trailing-comma case 24; the Markdown-target cases 30-31).
-> The `Optional feature coverage` block also names each case's pinned target now
-> (`feature (target): engines`), and the summary line carries a `targets=` field.
-> Regenerate with `npm run compare:impls -- --corpus=optional` to get current
-> counts.
+Timings are from one machine and mean nothing across rows; the counts are the
+point. `tests/implementation-comparison-counts.test.mjs` fails if the
+`corpus_pairs` quoted here stops matching the corpus, which is how this block
+came to say 4 when the corpus held 33.
 
 ```text
 Implementation summary
-profile=optional/opt-in corpus=optional corpus_pairs=4
-rust: pass=2/2 mismatch=0 error=0 skipped=2 avg_ms=24.42
-js: pass=2/2 mismatch=0 error=0 skipped=2 avg_ms=48.94
-php: pass=3/3 mismatch=0 error=0 skipped=1 avg_ms=52.87
+profile=optional/opt-in corpus=optional corpus_pairs=33 targets=html,markdown
+rust: pass=3/3 mismatch=0 error=0 skipped=30 runs=3 avg_ms=2.38
+js: pass=3/3 mismatch=0 error=0 skipped=30 runs=3 avg_ms=62.34
+php: pass=3/3 mismatch=0 error=0 skipped=30 runs=3 avg_ms=50.95
 cross_impl_diffs=0
 
+Target agreement (implementations compared against each other)
+html: compared=2 diffs=0 errors=0 fixtures=yes
+markdown: compared=1 diffs=0 errors=0 fixtures=yes
+
 Optional feature coverage
-social-link-templates: rust, js, php
-symbol-map: rust, js
-smart-quotes-locale-de: php
-bare-url-autolink: php
+social-link-templates (html): rust, js, php
+symbol-map (html): rust, js
+smart-quotes-locale-de (html): php
+bare-url-autolink (html): php
+citations-numbered (html): none
+code-callouts (html): none
+...
+
+NOT COMPARED: 30 of 33 optional cases reached fewer than two engines, so they
+contribute no agreement evidence. This is not a pass.
 ```
+
+**Read the last block, not the `cross_impl_diffs=0` above it.** 30 of the 33
+optional cases reach fewer than two engines, so this run compares 2 documents
+and agrees about them. The features are implemented everywhere; there is no way
+to switch them on from a command line, which is the only interface this tool
+has (carve#496).
 
 ## Scope
 

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -6,24 +6,26 @@ same `.crv` / `.html` pairs and reports default conformance, optional Tier-2
 adapter coverage, rough CLI timing, and the extension hook surface each
 implementation exposes.
 
-## Snapshot (2026-06-19)
+## Snapshot (2026-08-03)
 
-> Run on 2026-06-19 with all three implementations built from their current
-> `main`. Regenerate any time with `npm run compare:impls`. The figures below
-> are that run; the core corpus has since grown (402 pairs at time of writing),
-> so treat the counts as a historical snapshot, not a live total.
+> Run with all three implementations built from their own `main`. Regenerate any
+> time with `npm run compare:impls`. Timings are from one machine and mean
+> nothing across rows; the counts are the point, and
+> `tests/implementation-comparison-counts.test.mjs` fails when they stop
+> matching the corpus - which is how this page came to quote 302 pairs against a
+> corpus of 529.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>302 / 302</strong>
+    <strong>529 / 529</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>302 / 302</strong>
+    <strong>529 / 529</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>302 / 302</strong>
+    <strong>529 / 529</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -34,11 +36,16 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `dd0f150` | `302 / 302` | `0` | `0` | `23.47` |
-| JS | `f54a860` | `302 / 302` | `0` | `0` | `51.22` |
-| PHP | `b8b3e58` | `302 / 302` | `0` | `0` | `53.20` |
+| Rust | `8c636c5` | `529 / 529` | `0` | `0` | `2.34` |
+| JS | `b6c126f` | `529 / 529` | `0` | `0` | `53.34` |
+| PHP | `bf0b340` | `529 / 529` | `0` | `0` | `51.97` |
 
-Spec commit: `7c41ccc`
+Spec commit: `bf06ef4`
+
+The `0` cross-implementation diffs above is the **html** target. Over every
+target the same run reports two, both on the canonical-writer (`carve`) target
+and both filed: carve#481 (the engines serialize different pipeline stages) and
+carve-php#631 (an abbreviation definition hoisted out of its container).
 
 ## Optional Tier-2 Profile
 
@@ -60,11 +67,16 @@ guard, attribute wrapper, and a `symbols` render map; carve#258), so a fresh
 
 | Implementation | Optional pass | Skipped | Mismatches | Errors | Avg CLI ms/file |
 |----------------|---------------|---------|------------|--------|-----------------|
-| Rust | `2 / 2` | `2` | `0` | `0` | `24.42` |
-| JS | `2 / 2` | `2` | `0` | `0` | `48.94` |
-| PHP | `3 / 3` | `1` | `0` | `0` | `52.87` |
+| Rust | `3 / 3` | `30` | `0` | `0` | `2.38` |
+| JS | `3 / 3` | `30` | `0` | `0` | `62.34` |
+| PHP | `3 / 3` | `30` | `0` | `0` | `50.95` |
 
 Optional cross-implementation diffs: `0`
+
+Note the `Skipped` column against a corpus of 33: each engine runs three cases
+and skips thirty, so the `0` diffs is agreement about three documents. The
+features are implemented in all three; there is no way to switch them on from a
+command line, which is the only interface this tool has (carve#496).
 
 ## CLI Timing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,9 +179,9 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 492 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 529 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
-carve-php, and carve-rs - all run the same corpus with no open divergences.
+carve-php, and carve-rs - all run the same corpus with no HTML divergences.
 Pre-1.0, a minor release may still change the grammar.
 
 Reference material covers the normative [grammar](./grammar) and

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bump-carve-pin": "node scripts/bump-carve-pin.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/corpus-fmt-roundtrip.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },

--- a/tests/implementation-comparison-counts.test.mjs
+++ b/tests/implementation-comparison-counts.test.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from 'node:url'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const page = readFileSync(resolve(root, 'docs/implementation-comparison.md'), 'utf8')
+const landing = readFileSync(resolve(root, 'docs/index.md'), 'utf8')
 
 const countPairs = (dir) =>
   readdirSync(resolve(root, dir)).filter((f) => f.endsWith('.crv')).length
@@ -54,3 +55,38 @@ for (const corpus of ['core', 'optional']) {
     )
   })
 }
+
+test('the comparison cards and table quote the real core corpus size', () => {
+  // The same run appears three times on that page: a card grid, a table, and
+  // the raw text block. Only the text block was pinned at first, so the grid
+  // and table went on saying 302 next to a corrected 529.
+  const live = countPairs('tests/corpus')
+  //
+  // Matched narrowly on purpose: the optional-profile block on the same page
+  // legitimately quotes `3 / 3`, and a loose "N / N" pattern flagged it. Only
+  // the card grid (<strong>N / N</strong>) and the core table (`N / N` in
+  // backticks) speak for the core corpus.
+  // The optional-profile section has a table of the same shape, quoting the
+  // optional corpus, so the scan stops at its heading.
+  const core = page.split('## Optional Tier-2 Profile')[0]
+  const cards = [...core.matchAll(/<strong>(\d+)\s*\/\s*(\d+)<\/strong>/g)]
+  const tableCells = [...core.matchAll(/\|\s*`(\d+)\s*\/\s*(\d+)`\s*\|/g)]
+  const quotedPairs = [...cards, ...tableCells]
+    .filter(([, a, b]) => a === b)
+    .map(([, a]) => Number(a))
+  assert.ok(quotedPairs.length >= 6, `expected the card grid and table to quote N / N; found ${quotedPairs.length}`)
+  for (const n of quotedPairs) {
+    assert.equal(n, live, `docs/implementation-comparison.md quotes ${n} / ${n} where the corpus holds ${live}`)
+  }
+})
+
+test('the landing page quotes the real corpus size', () => {
+  const live = countPairs('tests/corpus')
+  const m = landing.match(/pinned by (\d+) corpus examples/)
+  assert.ok(m, 'docs/index.md no longer states a corpus example count in the expected phrasing')
+  assert.equal(
+    Number(m[1]),
+    live,
+    `docs/index.md says "pinned by ${m[1]} corpus examples"; the corpus holds ${live}`,
+  )
+})

--- a/tests/implementation-comparison-counts.test.mjs
+++ b/tests/implementation-comparison-counts.test.mjs
@@ -1,0 +1,56 @@
+/*
+ * The comparison page quotes a run, and a quoted run goes stale.
+ *
+ * docs/implementation-comparison.md embeds the raw output of
+ * `npm run compare:impls` so a reader can see what the tool reports without
+ * running four engines. That output carries `corpus_pairs=N`, and N is a fact
+ * about this repository that anyone can check - so nobody did. The page said
+ * 302 core pairs when there were 529, and its own hand-written correction note
+ * ("has since grown to 31 pairs") was itself out of date at 33.
+ *
+ * This pins only the counts, not the whole block. The timings and the pass
+ * lines are properties of the machine that ran it and are meant to be a
+ * snapshot; the corpus size is not, and a page claiming the tool covers 302
+ * documents when it covers 529 understates it by 43%.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const page = readFileSync(resolve(root, 'docs/implementation-comparison.md'), 'utf8')
+
+const countPairs = (dir) =>
+  readdirSync(resolve(root, dir)).filter((f) => f.endsWith('.crv')).length
+
+const quoted = [...page.matchAll(/corpus=(core|optional) corpus_pairs=(\d+)/g)].map((m) => ({
+  corpus: m[1],
+  pairs: Number(m[2]),
+}))
+
+test('the page quotes a run for both corpora', () => {
+  assert.deepEqual(
+    quoted.map((q) => q.corpus).sort(),
+    ['core', 'optional'],
+    'expected one quoted summary line per corpus; the page shape changed',
+  )
+})
+
+for (const corpus of ['core', 'optional']) {
+  test(`the quoted ${corpus} corpus size is the real one`, () => {
+    const entry = quoted.find((q) => q.corpus === corpus)
+    assert.ok(entry, `no quoted summary line for the ${corpus} corpus`)
+    const live = countPairs(corpus === 'core' ? 'tests/corpus' : 'tests/corpus-optional')
+    const rerun =
+      corpus === 'optional'
+        ? 'npm run compare:impls -- --corpus=optional'
+        : 'npm run compare:impls'
+    assert.equal(
+      entry.pairs,
+      live,
+      `docs/implementation-comparison.md quotes corpus_pairs=${entry.pairs} for the ${corpus} corpus, which now holds ${live}. Re-run "${rerun}" and paste the current output.`,
+    )
+  })
+}


### PR DESCRIPTION
`docs/implementation-comparison.md` embeds the raw output of `compare:impls` so a reader can see what the tool reports without building four engines. The quoted run said:

```
profile=default/no-opt-in corpus=core corpus_pairs=302
```

The core corpus holds **529**.

The optional block was worse. It quoted **4** pairs and carried a hand-written note saying the corpus *"has since grown to 31 pairs"* - which was itself stale at **33**. A correction that needs its own correction is the shape of a number nobody re-measures.

Both blocks are regenerated from a real run against all three engines built from their own mains.

## The optional block now leads with the part that matters

It used to end at `cross_impl_diffs=0`, which reads as agreement. The run compares **two** of the 33 cases: 30 reach fewer than two engines and contribute no evidence at all (#496, surfaced by #497). The block now carries that roll-up and a sentence saying which number to believe.

## The gate

`tests/implementation-comparison-counts.test.mjs` pins the counts - **only** the counts. Timings are a property of the machine that ran them and are meant to be a snapshot; a corpus size is not, and a page claiming the tool covers 302 documents when it covers 529 understates it by 43%.

It fails with the command to fix it:

```
docs/implementation-comparison.md quotes corpus_pairs=302 for the core corpus,
which now holds 529. Re-run "npm run compare:impls" and paste the current output.
```

Verified failing on the page as it stood and passing on the regenerated one.

Wired into `npm test`, whose file list is explicit - a new test file there is not picked up by a glob, which is worth stating because adding one and assuming it runs is the same class of mistake this PR is about.


---

## Update: the page said 302 in three places, not one

The first commit fixed the two raw-output blocks and left a card grid, a summary table, and a note explaining the corpus "has since grown (402 pairs at time of writing)". Three renderings of one run, one corrected - worse than none corrected, because a reader cannot tell which is current.

All of it now reads 529, from the same run, with the engine commits it came from. The optional table was stale the same way (`2 / 2`, skipped=2) and now shows `3 / 3` with **skipped=30** against a corpus of 33 - the number that says what the run actually compared.

`docs/index.md` said conformance is "pinned by **492** corpus examples" and that the engines run the corpus "with no open divergences". The count is 529, and the divergence claim is true of HTML but not of every target: `compare:impls` reports two on the canonical-writer target, both filed (#481, carve-php#631). The sentence now says HTML, which is what the corpus pins.

The gate grew to match - card grid, core table, and landing-page phrasing. **The first version pinned one of the three places the same number appears, which is how the other two stayed wrong through a commit specifically about that number.** Scoped narrowly: the optional section quotes `3 / 3` legitimately, so the core scan stops at its heading.

Verified failing on a perturbed card and a perturbed landing-page count, passing as committed.