### PR TITLE
test: pin the promises docs/graceful-degradation.md makes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bump-carve-pin": "node scripts/bump-carve-pin.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs tests/degradation-claims.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },

--- a/tests/degradation-claims.test.mjs
+++ b/tests/degradation-claims.test.mjs
@@ -1,0 +1,75 @@
+/*
+ * The promises in docs/graceful-degradation.md are real, and still real.
+ *
+ * That page tells an author what survives when a document leaves interactive
+ * HTML - what a spoiler looks like in print, whether a disclosure block is
+ * flattened, whether a diagram's source is still there in Markdown. It is the
+ * page someone reads before committing to a construct, and nothing checked any
+ * of it.
+ *
+ * Only the falsifiable rows are pinned. "clickable tabs" and "blurred until
+ * revealed" describe an appearance and are left alone; "kept, not flattened"
+ * and "source preserved" name an output, and those are asserted here.
+ *
+ * Same argument as tests/divergence-claims.test.mjs, one page over: a stale
+ * entry is worse than a missing one, because every reader believes it.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { carveToHtml, carveToMarkdown, details, spoiler } from '@markup-carve/carve'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const page = readFileSync(resolve(root, 'docs/graceful-degradation.md'), 'utf8')
+
+const squash = (html) => html.replace(/\s+/g, ' ').trim()
+
+test('a spoiler is revealed, not hidden, outside interactive HTML', () => {
+  // The page: "blurred until revealed | revealed | degrades natively (hiding is
+  // meaningless offline)".
+  const source = '::: spoiler\nhidden text\n:::\n'
+  const interactive = squash(carveToHtml(source, { extensions: [spoiler()], mode: 'interactive' }))
+  const staticHtml = squash(carveToHtml(source, { extensions: [spoiler()], mode: 'static' }))
+
+  assert.match(interactive, /<details class="spoiler">/)
+  assert.match(staticHtml, /spoiler-revealed/)
+  assert.doesNotMatch(staticHtml, /<details/, 'static output must not still hide the content')
+  assert.match(staticHtml, /hidden text/, 'the content itself survives either way')
+})
+
+test('a disclosure block is kept open, not flattened', () => {
+  // The page calls this out as the special case: "native `<details open>` -
+  // kept, not flattened". A future change that unwrapped it into a plain
+  // section would still render the text, so only this asserts the difference.
+  const source = '::: details "T"\nbody\n:::\n'
+  const staticHtml = squash(carveToHtml(source, { extensions: [details()], mode: 'static' }))
+
+  assert.match(staticHtml, /<details open>/)
+  assert.match(staticHtml, /<summary>T<\/summary>/)
+})
+
+test('a diagram keeps its source in Markdown', () => {
+  // The page: "diagram source preserved (a ```mermaid fence in Markdown)".
+  const source = '```mermaid\ngraph TD;\nA-->B;\n```\n'
+  assert.equal(carveToMarkdown(source), '```mermaid\ngraph TD;\nA-->B;\n```\n')
+})
+
+test('math keeps its source in Markdown', () => {
+  // The page: "source preserved (`$...$` in Markdown)".
+  assert.equal(carveToMarkdown('x $`a^2` y\n'), 'x $a^2$ y\n')
+  assert.equal(carveToMarkdown('$$`E=mc^2`\n'), '$$E=mc^2$$\n')
+})
+
+test('each pinned claim still appears on the page', () => {
+  // A claim that is deleted upstream should take its test with it, rather than
+  // leaving an assertion here defending a promise the page no longer makes.
+  for (const phrase of [
+    'kept, not flattened',
+    'source preserved',
+    'degrades natively',
+  ]) {
+    assert.ok(page.includes(phrase), `docs/graceful-degradation.md no longer says "${phrase}"`)
+  }
+})


### PR DESCRIPTION
`docs/graceful-degradation.md` tells an author what survives when a document leaves interactive HTML - what a spoiler looks like in print, whether a disclosure block is flattened, whether a diagram's source is still there in Markdown. It is the page someone reads *before* committing to a construct, and nothing checked any of it.

Same argument as `tests/divergence-claims.test.mjs`, one page over: a stale entry there is worse than a missing one, because every reader believes it.

## Only the falsifiable rows

"clickable tabs" and "blurred until revealed" describe an appearance and are left alone. These name an output:

| row | pinned |
| --- | --- |
| spoiler | static mode reveals it and stops emitting `<details>` - the page's reasoning is that hiding is meaningless offline |
| details | static mode emits `<details open>`, **not** a flattened section |
| mermaid | the ```` ```mermaid ```` fence survives into Markdown verbatim |
| math | `` $`x` `` becomes `$x$`, `` $$`x` `` becomes `$$x$$` |

The `details` row is the one worth having. The page calls it out as the special case, and a change that unwrapped it into a plain section would still render the text - nothing else in the suite would notice.

All four hold today. **This is not fixing a drift, it is closing the reason a drift would not be noticed.**

A fifth test asserts each pinned phrase still appears on the page, so a claim deleted upstream takes its test with it rather than leaving an assertion defending a promise the page no longer makes.

## Verified it can fail

Asserting the flattened form for `details` fails the run.

## One near-miss

The first probe of the math row used `` x $`a^2`$ y `` and read the output `x $a^2$$ y` as a stray delimiter. The input was wrong - inline math is `` $`...` ``, so the trailing `$` was literal text and the engine was right. Checked before filing anything.
