### PR TITLE
docs: the migration guide understated what a ported heading id does

### DIFF
--- a/docs/migrate-from-markdown.md
+++ b/docs/migrate-from-markdown.md
@@ -178,11 +178,40 @@ This note has an id and a class, set by the line above it.
 :::
 ```
 
-A `{...}` written at the **end of a heading line is literal text**, not an attribute (a deliberate Djot-strict choice). To give a heading a custom id, put the attribute on the preceding line:
+A `{...}` written at the **end of a heading line is not an attribute** (a deliberate Djot-strict choice). To give a heading a custom id, put the attribute on the preceding line:
 
 ```carve
 {#intro}
 ## Introduction
+```
+
+**This is the migration trap most likely to bite you, because it fails
+quietly.** `{#id}` at the end of a heading is the kramdown and Pandoc spelling,
+so it is all over existing Markdown - and left in place it does not stay inert.
+`## Introduction {#intro}` renders as:
+
+```html
+<section id="Introduction-intro">
+  <h2>Introduction {<span class="tag"><strong>#intro</strong></span>}</h2>
+</section>
+```
+
+Two things happened, neither of them an error:
+
+- `#intro` is a **tag** in Carve, so it renders as a tag chip inside the
+  heading rather than as the characters you wrote.
+- The auto-generated id is derived from the heading text, and that text now
+  includes the tag - so the anchor is `Introduction-intro`, not `Introduction`
+  and not `intro`. **Every inbound link to either breaks**, and the page still
+  renders.
+
+`carve lint` reports it, which is the cheapest way to find them all before you
+publish:
+
+```
+1:17  heading-trailing-attribute  Trailing "{#intro}" on a heading is literal
+      text in Carve, not an attribute block. Move it to a "{#intro}" line
+      directly above the heading.
 ```
 
 Without an explicit id, headings still get an auto-generated id from their text (case is preserved; a leading digit gets an `s-` prefix). Lowercasing and ASCII-folding are available as opt-in transforms.
@@ -309,7 +338,7 @@ When moving a document from Markdown to Carve:
 - [ ] Check `_underline_` occurrences - these render as `<u>` in Carve, not `<em>`
 - [ ] Convert GFM table delimiter rows to `|=` header cells
 - [ ] Replace `~~strike~~` with `~strike~` (single tilde)
-- [ ] Move any heading `{#id}` onto the line above the heading (trailing is literal)
+- [ ] Move any heading `{#id}` onto the line above the heading - `carve lint` finds them, and left in place the `#id` becomes a tag AND changes the heading's anchor
 - [ ] Check the indentation of top-level block markers: a leading-indented `#`, `>`, `-`, `` ``` ``, or `:::` is literal paragraph text in Carve, not a block. Markdown tolerates 0-3 spaces of indent; Carve requires a block marker at column 0 (or, inside a list, at the item's content column)
 - [ ] Decide on raw HTML: bare `<tags>` become literal text, so replace them with Carve constructs (or use the explicit `{=html}` passthrough for trusted content; disable it with `allowRawHtml: false` for untrusted input)
 - [ ] Audit CSS and JS for direct-child assumptions - headings now nest their content in `<section>` (see [Headings are wrapped in `<section>`](#headings-are-wrapped-in-section))

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bump-carve-pin": "node scripts/bump-carve-pin.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs tests/degradation-claims.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs tests/degradation-claims.test.mjs tests/migration-claims.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },

--- a/tests/migration-claims.test.mjs
+++ b/tests/migration-claims.test.mjs
@@ -1,0 +1,88 @@
+/*
+ * The migration guide's claims are real, and still real.
+ *
+ * docs/migrate-from-markdown.md is followed with existing documents in hand.
+ * A wrong row there does not confuse a reader in the abstract - it corrupts a
+ * file they are porting, and the page's whole value is that its "Changed" rows
+ * are trustworthy.
+ *
+ * Only the mechanical rows are pinned: the ones that say a Markdown spelling
+ * does or does not do something in Carve. Prose about workflow is left alone.
+ *
+ * The heading case gets the most attention because it is the one that fails
+ * quietly: `## H {#id}` is the kramdown/Pandoc spelling, it is everywhere in
+ * existing Markdown, and left in place it renders a tag chip AND changes the
+ * heading's anchor. Nothing about the output looks like an error.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { carveToHtml, lintCarve } from '@markup-carve/carve'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const page = readFileSync(resolve(root, 'docs/migrate-from-markdown.md'), 'utf8')
+
+const html = (source) => carveToHtml(source).replace(/\s+/g, ' ').trim()
+
+test('a Markdown + bullet is not a Carve bullet', () => {
+  assert.equal(html('+ item\n'), '<p>+ item</p>')
+  assert.match(html('- item\n'), /<ul>/)
+})
+
+test('a spaced thematic break is not a thematic break', () => {
+  // The page: "Contiguous `---`, `***`, or `___` (no spaced forms)".
+  assert.doesNotMatch(html('- - -\n'), /<hr/)
+  assert.equal(html('---\n'), '<hr>')
+})
+
+test('GFM double tilde is literal; Carve strikethrough is single', () => {
+  assert.equal(html('a ~~strike~~ b\n'), '<p>a ~~strike~~ b</p>')
+  assert.match(html('a ~strike~ b\n'), /<s>strike<\/s>/)
+})
+
+test('Markdown ** bold is literal; Carve bold is single asterisk', () => {
+  assert.equal(html('a **bold** b\n'), '<p>a **bold** b</p>')
+  assert.match(html('a *bold* b\n'), /<strong>bold<\/strong>/)
+})
+
+test('a bare HTML tag is literal', () => {
+  assert.equal(html('a <b>x</b> c\n'), '<p>a &lt;b&gt;x&lt;/b&gt; c</p>')
+})
+
+test('a trailing heading attribute becomes a tag AND moves the anchor', () => {
+  // Both halves matter. "Literal text" alone would let someone assume the
+  // characters simply survive, and the anchor change is the part that breaks
+  // inbound links without looking like a failure.
+  const out = html('## Introduction {#intro}\n')
+
+  assert.match(out, /<section id="Introduction-intro">/, 'the anchor absorbs the tag text')
+  assert.match(out, /<span class="tag">/, 'the #id is parsed as a tag, not left as characters')
+  assert.doesNotMatch(out, /<section id="Introduction">/)
+  assert.doesNotMatch(out, /<section id="intro">/)
+})
+
+test('the linter reports the trailing heading attribute', () => {
+  // The guide now points at `carve lint` as the way to find these before
+  // publishing, so the rule has to exist and fire.
+  const findings = lintCarve('## Introduction {#intro}\n')
+  const hit = findings.find((f) => f.rule === 'heading-trailing-attribute')
+
+  assert.ok(hit, `expected a heading-trailing-attribute finding, got ${JSON.stringify(findings)}`)
+  assert.match(hit.message, /directly above the heading/)
+})
+
+test('the attribute-on-the-line-above form works', () => {
+  assert.match(html('{#intro}\n## Introduction\n'), /<section id="intro">/)
+})
+
+test('each pinned claim still appears on the page', () => {
+  for (const phrase of [
+    'a Markdown `+` bullet is not a Carve bullet',
+    'no spaced forms',
+    'heading-trailing-attribute',
+  ]) {
+    assert.ok(page.includes(phrase), `docs/migrate-from-markdown.md no longer says "${phrase}"`)
+  }
+})


### PR DESCRIPTION
`## Introduction {#intro}` is the kramdown and Pandoc spelling, so it is all over existing Markdown. The guide said a trailing `{...}` on a heading "is **literal text**, not an attribute" and moved on.

Left in place it is not inert:

```html
<section id="Introduction-intro">
  <h2>Introduction {<span class="tag"><strong>#intro</strong></span>}</h2>
</section>
```

Two things happen, neither of them an error:

- `#intro` is a **tag** in Carve, so it renders as a tag chip inside the heading rather than as the characters the author wrote.
- The auto-generated id comes from the heading **text**, which now includes the tag - so the anchor is `Introduction-intro`, not `Introduction` and not `intro`. **Every inbound link to either breaks, and the page still renders.**

"Literal text" understates both halves. Someone reading it assumes the characters survive and the anchor is unaffected; neither holds.

Verified identical in carve-js, carve-rs and carve-php - a documentation gap, not a divergence.

The guide now shows the rendered output, names both consequences, and points at `carve lint`, which already has a `heading-trailing-attribute` rule naming the fix. The checklist item said "(trailing is literal)"; it now says what happens instead.

## The test

`tests/migration-claims.test.mjs` pins the mechanical rows - the ones asserting that a Markdown spelling does or does not do something in Carve. A wrong row here does not confuse a reader in the abstract, it corrupts a file they are porting.

| pinned |
| --- |
| a `+` bullet is not a bullet |
| spaced `- - -` is not a thematic break |
| `~~strike~~` is literal; `~strike~` is strikethrough |
| `**bold**` is literal; `*bold*` is bold |
| a bare HTML tag is literal |
| both halves of the heading case, and the lint rule the guide now promises |
| the attribute-on-the-line-above form works |

A final test asserts each pinned phrase still appears on the page, so a claim deleted upstream takes its test with it.

Verified it can fail: asserting the anchor is `Introduction` fails the run.
