### PR TITLE
docs: Carve's blockquote marker does not need a space, and Djot's does

### DIFF
--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -200,6 +200,27 @@ punctuation (`typo ,oops, happens` must not become a subscript).
 technical writing especially, biasing toward the literal reading avoids
 surprise lists.
 
+## 5b. The blockquote marker does not require a space
+
+**Djot:** `>` must be followed by a space (or end the line). `>quoted` is a
+paragraph, and `>> quoted` is a paragraph too - nesting is spelled `> > quoted`.
+
+**Carve:** the space is optional, so `>quoted`, `>> quoted` and `>>quoted` are
+all blockquotes, the last two nested. `> > quoted` also works and means the same
+thing.
+
+```carve
+>quoted
+>>nested
+```
+
+**Why.** This follows CommonMark, where the space after `>` is optional and
+`>>text` nests. It is the spelling in every Markdown document being ported, and
+a marker that silently produced a paragraph instead of a quote would be a
+migration trap of exactly the kind
+[the migration guide](./migrate-from-markdown) exists to remove. The grammar
+states it directly: `blockquote_line = '>', [' '], inline_content, newline`.
+
 ## 6. Plain-text comments
 
 **Djot:** `{% comment %}`.

--- a/tests/divergence-claims.test.mjs
+++ b/tests/divergence-claims.test.mjs
@@ -43,11 +43,18 @@ const normalize = (html) => html.replace(/\s+/g, ' ').trim()
  *   12 (smart punctuation)  explicitly an AST-shape claim - one leaf node
  *                           against three container types - and both render
  *                           identical HTML. Nothing to see at this layer.
+ *
+ * Section 5b's "> > quoted" case is absent for a duller reason: both engines
+ * nest it, which is the claim, but they pretty-print the nesting differently
+ * (`<blockquote><p>` against `<blockquote> <p>`), and this file compares
+ * whitespace-squashed HTML. The two `differs: true` cases carry the section.
  */
 const CLAIMS = [
   { section: '1', input: '# Getting Started\n', differs: false, note: 'the emitted id is deliberately Djot-shaped - the divergence is in RESOLUTION, not the slug' },
   { section: '1b', input: '# a; b: c\n', differs: true, note: 'Carve keeps alphanumerics only, so a-b-c against Djot a;-b:-c' },
   { section: '1c', input: '{a=b .c #x}\n# abc\n', differs: true, note: 'with an explicit id, Carve keeps non-id attributes on the heading; Djot moves them to the section' },
+  { section: '5b', input: '>quoted\n', differs: true, note: 'Djot needs a space after >; Carve does not, following CommonMark' },
+  { section: '5b', input: '>> quoted\n', differs: true, note: 'Djot reads >> as text; Carve nests' },
   { section: '6', input: '%% a comment\n', differs: true, note: 'Carve has plain-text comments; Djot renders the line' },
   { section: '7', input: 'text\n# Heading\n', differs: true, note: 'a block opener interrupts a paragraph in Carve' },
   { section: '11', input: '1. one\n\n  > quoted\n', differs: true, note: 'below the content column the block detaches in Carve, attaches in Djot' },


### PR DESCRIPTION
`divergence-from-djot.md` had no row for the blockquote marker, so the page reads as if blockquotes behave the same in both. They do not, in the spelling that matters most:

| input | Carve | Djot |
| --- | --- | --- |
| `>quoted` | `<blockquote><p>quoted</p></blockquote>` | `<p>&gt;quoted</p>` |
| `>> quoted` | nested blockquotes | `<p>&gt;&gt; quoted</p>` |
| `> > quoted` | nested blockquotes | nested blockquotes |

Djot requires a space after `>` and spells nesting `> > `. Carve makes the space optional - CommonMark's rule, and the grammar says so directly:

```ebnf
blockquote_line = '>', [' '], inline_content, newline ;
```

That is the spelling in every Markdown document being ported. A marker that silently produced a paragraph instead of a quote is exactly the kind of migration trap [the migration guide](https://github.com/markup-carve/carve/blob/main/docs/migrate-from-markdown.md) exists to remove - and the page that lists the differences did not list this one.

## How it surfaced

While investigating #506 (PART 1's S4 and PART 9's lazy-continuation clause disagree about a lazy line under nested quotes). That clause claims CommonMark compatibility, so I asked Djot to arbitrate - and Djot parses the test document completely differently, because it does not nest on `>>` at all. The arbitration failed; the finding was the reason it failed.

## Tests

Two cases added to `tests/divergence-claims.test.mjs`, which is what keeps that page honest.

`> > quoted` is deliberately **not** asserted, and the file's absent-sections note now says why: both engines nest it - that is the claim - but they pretty-print the nesting differently (`<blockquote><p>` against `<blockquote> <p>`), and that file compares whitespace-squashed HTML. Asserting it would pin a formatting detail while claiming to pin a semantic one.

Spec suite 705 passing, executable spec clean.
