### PR TITLE
spec: MARKER REQUIRES CONTENT covers the definition-term marker too

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -429,7 +429,17 @@ bullet_marker = '-' | '*' ;  (* `+` is NOT a bullet in Carve -- it is the list
    change the meaning). Carve is stricter than CommonMark, which treats a bare
    `-` as an empty item; requiring content keeps a lone dash (a prose dash /
    placeholder) from silently becoming a list. Pinned by corpus
-   content-less-marker-is-not-a-list. *)
+   content-less-marker-is-not-a-list.
+
+   THE SAME HOLDS FOR THE DEFINITION-TERM MARKER `::`. The rule was written
+   naming bullets and ordered markers, and its rationale -- an editor stripping
+   a trailing space must not change the meaning -- is a property of every
+   marker that takes a separator space, not of those two. Left unstated, the
+   engines split three ways on `::` followed by the separator and one more
+   space: carve-js made it a `<dt>` holding a space, carve-php a `<dt>` holding
+   nothing, carve-rs a paragraph. Two of them therefore turned `:: ` (a
+   paragraph) into a definition list when a trailing space survived a save
+   (carve#512). A content-less `::` line is paragraph text. *)
 
 ordered_list = ordered_item+ ;
 ordered_item = ordered_marker, [item_attributes], space, list_item_content ;


### PR DESCRIPTION
Refs #512.

The rule is normative and gives its own reason:

> A content-less marker line -- bare (`-`) or with trailing whitespace only (`- `, `-   `) -- is NOT a list: it is paragraph text. **The rule ignores trailing whitespace**, so `-` and `- ` behave identically (an editor stripping the trailing space cannot change the meaning).

It names bullets and ordered markers. `::` is the sibling nobody extended it to, and the engines split **three ways** on a `::` line carrying the separator space and one more:

| engine | output |
| --- | --- |
| carve-js | `<dl><dt> </dt></dl>` - a term holding a space |
| carve-php | `<dl><dt></dt></dl>` - a term holding nothing |
| carve-rs | `<p>::</p>` - a paragraph |

Everything either side agrees: `::`, `:: `, `::`+TAB and `:: t` render identically in all three, as do `-`, `- `, `-   `, `1.` and `1.  `. The disagreement is exactly at marker + separator + one more space.

## carve-rs is right, and the rule's own rationale is the argument

Under the other two, `:: ` is a paragraph and `::  ` is a definition list - so **stripping one trailing space changes the document's structure**, the precise thing the rule exists to prevent. Editors strip trailing whitespace on save; so does `git apply --whitespace=fix`.

The rationale was already marker-neutral; only the enumeration was narrow. Now stated as covering `::`, with the three-way split recorded so the omission is not re-derived as intentional.

## No corpus document yet, deliberately

`tests/corpus.test.mjs` runs against the **pinned** carve-js, so a fixture pinning the corrected behaviour would fail this repo's own CI until carve-js and carve-php ship the fix. It follows once they have; #512 tracks the sequence.

Found by `npm run fuzz:impls --seed=2027`, shrunk to the one-line reproducer.