### PR TITLE
spec: I4 guards the verbatim fence only; a `:::` opener interrupts either way

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2206,7 +2206,7 @@ EOF = (* end of file *) ;
          - a valid table row (valid_row(L), §5 T2; a stray `|` in prose,
            and a line-initial `|` with no closing `|`, are NOT ones);
          - a fenced code opener WITH a matching closer ahead (I4);
-         - a `:::` opener WITH a matching closer ahead (I4).
+         - a `:::` opener, closer or not (I4).
          So "intro \n # H" is <p>intro</p> + <h1>; "intro \n --- \n more"
          is <p>intro</p> + <hr> + <p>more</p> (corpus
          76-paragraph-interruption).
@@ -2226,13 +2226,24 @@ EOF = (* end of file *) ;
       I3 IMAGE EXCLUDED. A line that is only a bare image ("![alt](url)")
          does not interrupt: an image is not a block of its own in Carve;
          it stays an inline image inside the paragraph.
-      I4 CLOSER LOOKAHEAD -- the same &(...) guards the fence / div /
-         frontmatter productions carry. An UNTERMINATED ``` or `:::` opener
-         does not interrupt; the line stays paragraph text (a stray ``` in
-         prose then opens an unclosed inline verbatim run rendering as
-         <code> to the end of the block -- the code_span maximal-run rule).
-         Pinned by corpus 76-paragraph-interruption (unterminated-fence and
-         unterminated-`:::` pairs).
+      I4 CLOSER LOOKAHEAD -- the same &(...) the VERBATIM fence productions
+         carry. An UNTERMINATED ``` or ~~~ opener does not interrupt; the line
+         stays paragraph text, and a stray ``` in prose then opens an unclosed
+         inline verbatim run rendering as <code> to the end of the block (the
+         code_span maximal-run rule). Pinned by corpus
+         81-paragraph-interruption-18.
+
+         A `:::` OPENER IS NOT GUARDED. It interrupts whether or not a closer
+         follows, and an unterminated one closes at EOF (PART 9 §25). Pinned by
+         corpus 81-paragraph-interruption-19: `Text` / `:::` / `stuff` is a
+         paragraph followed by a div holding `stuff`.
+
+         This clause used to guard both, and cited a corpus that pins the
+         opposite for `:::`. All three engines follow the corpus. The `:::`
+         half was superseded when unclosed containers changed from degrading
+         to closing at EOF (carve#439) and was not updated with it; the stale
+         citation to "corpus 76" is the same paragraph renumbering that
+         accompanied that change.
       I5 INVISIBLE CONSTRUCTS interrupt AND are consumed: a reference
          definition (link `[r]: url`, footnote `[^r]: …`, abbreviation
          `*[A]: …`), a comment (`%%` line, `%%%` block), and a


### PR DESCRIPTION
I4 said an unterminated ``` **or** `:::` opener does not interrupt, and cited the corpus as pinning both. **The corpus pins the opposite for `:::`.**

`81-paragraph-interruption-19`:

```
Text
:::
stuff
```

```html
<p>Text</p>
<div>
  <p>stuff</p>
</div>
```

All three engines follow the corpus, so the clause described behaviour no implementation has.

The fence half **is** right, and is pinned by `81-paragraph-interruption-18` - an unterminated ``` stays paragraph text and opens an unclosed inline verbatim run:

```
Text
```
code
```

```html
<p>Text
<code>
code</code></p>
```

## Why it went stale

The `:::` half was superseded when unclosed containers changed from degrading to closing at EOF (#439). The behaviour changed, the corpus was regenerated, I4 was not - and its citation still names "corpus 76", the number that category carried before the same change renumbered it to **81**.

A clause that states a rule *and* cites its fixture can go stale in both halves at once, and did. That is the third stale-by-renumbering pointer this sweep has hit; the first two were carve-grammars#73 and #74.

I1's bullet list is corrected to match: a `:::` opener interrupts, closer or not.

## How it surfaced

Chasing a carve-rs divergence - rs keeps `- :::` literal where carve-js and carve-php open a div. That is a **separate** engine question, since I4 governs interruption and there is no paragraph to interrupt on a marker line, but reading I4 to settle it turned up the contradiction.

Spec suite 707 passing, executable spec 531/531 with 0 defects. No corpus or grammar-production change - this is prose catching up to fixtures that were already correct.