### PR TITLE
spec: the serialized AST is pre-resolve, and every definition hoists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **PART 12 §3a: the serialized AST is PRE-RESOLVE** (carve#481, carve#486,
+  carve-php#624). The tree records what the author wrote, not what the document
+  resolves to. `[getting started][]` publishes a `link` carrying `ref`, an empty
+  `href` and the `rawRef` source - resolved or not, and even when nothing
+  defines the label, where flattening it to text discarded the fact that a
+  reference was written at all. Both stages validated against the schema, which
+  is how three engines came to disagree without any of them being wrong; the tie
+  goes to the stage that keeps `rawRef`'s stated purpose reachable and keeps
+  `[x][]` alive through a format cycle. It also removes the need for a
+  `raw_text` document node: nothing reverts to literal source, so nothing has to
+  carry text that must not be escaped again.
+
+### Changed
+
+- **PART 12 §7 now covers every definition kind, not only footnotes**
+  (carve-php#631). An `abbreviation_def` authored inside a div, list item or
+  block quote is a child of the DOCUMENT, exactly as a `footnote` is. The clause
+  was written against PART 9 §16 and read as footnote-specific, so the engines
+  split - carve-php hoisted both, carve-js and carve-rs hoisted only the
+  footnote - while all three rendered identical HTML, because an abbreviation is
+  document-global wherever it is written. The formatter consequence is accepted
+  rather than overlooked: it already ships for footnotes, where `> [^a]: body`
+  formats to the definition after an emptied `>`.
+
 - **An optional `sections` switch on the HTML renderer** (carve#427). Setting it
   to `false` renders headings flat, with the id back on the `<h*>` and the blocks
   that would have been section children left as siblings. The default is

--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -42,16 +42,25 @@ The encoding turns an N×M integration problem into N+M.
 }
 ```
 
-Four rules carry most of the weight:
+Five rules carry most of the weight:
 
 **The root carries exactly three fields** - `type`, `children`, `srcByteLength`
-(PART 12 §7). Frontmatter and footnote definitions are **block nodes in the
-tree**, not root fields, because a root field cannot carry a position and both
-are source an editor navigates to.
+(PART 12 §7). Frontmatter and definitions are **block nodes in the tree**, not
+root fields, because a root field cannot carry a position and both are source an
+editor navigates to. A definition is a child of the **document** even when it was
+authored inside a container - footnote and abbreviation alike - because its scope
+is the document wherever it was written. Its `pos` still says where that was.
 
 **Field names are spec surface** (§3). `href`, `src`, `value`, `level`,
 `children`. An implementation whose internals differ maps on the way out; it does
 not export its internals, and it does not invent a synonym.
+
+**The tree is pre-resolve** (§3a). It records what the author wrote, not what the
+document resolves to. `[getting started][]` publishes a `link` with `ref`, an
+empty `href` and the `rawRef` source - resolved or not, and even when nothing
+defines the label. Both stages validate against the schema, which is how three
+engines came to disagree; the tie goes to the stage that keeps `[x][]` alive
+through a format cycle and keeps `[a][]` distinguishable from `[a](#a)`.
 
 **Type identifiers come from the [profiles vocabulary](/profiles)** (§1-2), and
 are `snake_case` always. The AST carries a few types a profile cannot deny -
@@ -231,11 +240,16 @@ payload instead of rejecting it.
 ## What is not in it
 
 Formatter-internal nodes (PART 11, and the `raw_text` case the profiles
-vocabulary excludes) are not part of the document and are not serialized.
+vocabulary excludes) are not part of the document and are not serialized. Under
+§3a nothing on the document side needs `raw_text` either: an unresolved
+reference stays a `link` rather than reverting to literal source, so no node has
+to carry text that must not be escaped again.
 
 Resolution results a consumer could recompute - footnote numbering, caption
 numbers - **are** serialized, because recomputing them means reimplementing the
-resolution rules.
+resolution rules. Those are **added alongside** the authored construct, not
+substituted for it: a resolved footnote reference keeps its label and gains its
+number.
 
 ## Conformance status
 
@@ -245,13 +259,19 @@ spans that do not cover the text they claim.
 
 | engine | shape | positions |
 |---|---|---|
-| carve-js | conformant | blocks and inlines, except reassembled regions (table cells, line-block content) |
-| carve-rs | conformant | blocks and most inlines; reconstructed regions and a definition list's own parts are unplaced ([carve-rs#333](https://github.com/markup-carve/carve-rs/issues/333)) |
-| carve-php | two field-name divergences left: the root carries `abbreviations`, and `inline_extension` publishes `extensionType`/`children` ([carve-php#510](https://github.com/markup-carve/carve-php/issues/510)) | recorded behind a parse option, enabled whenever it serializes |
+| carve-js | leaves an `abbreviation_def` inside its container instead of hoisting it to the document, against §7 ([carve-php#631](https://github.com/markup-carve/carve-php/issues/631)) | blocks and inlines, except reassembled regions (table cells, line-block content) |
+| carve-rs | serializes links POST-resolve, against §3a, and leaves an `abbreviation_def` in its container, against §7 ([carve#481](https://github.com/markup-carve/carve/issues/481)) | blocks and most inlines; reconstructed regions and a definition list's own parts are unplaced ([carve-rs#333](https://github.com/markup-carve/carve-rs/issues/333)) |
+| carve-php | flattens an unresolved reference to text instead of publishing a `link`, against §3a ([carve#486](https://github.com/markup-carve/carve/issues/486)); two field-name divergences left: the root carries `abbreviations`, and `inline_extension` publishes `extensionType`/`children` ([carve-php#510](https://github.com/markup-carve/carve-php/issues/510)) | recorded behind a parse option, enabled whenever it serializes |
 | carve-rb / carve-py / carve-go / carve-wasm | publish carve-rs's bytes | whatever carve-rs records |
 
 The gaps are listed rather than smoothed over on purpose: "six implementations"
 is only a claim worth making if the disagreements are visible.
+
+The §3a and §7 rows are new: those clauses were written to settle disagreements
+the engines had already shipped, so every engine has something to move. That is
+the intended order - the spec says what the shape is, then the engines conform,
+then the pin moves. Until they do, this table is the honest record of who is
+where.
 
 ## Definition lists
 

--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -945,7 +945,7 @@
     "document": {
       "type": "object",
       "title": "document (root)",
-      "description": "The root carries EXACTLY three fields (PART 12 section 7). Frontmatter and footnote definitions are block nodes in `children`, not root fields, because a root field cannot carry the `pos` section 4 requires of everything else - and both are source an editor navigates to.\n\nThe root is the one node with no `pos`: it spans the whole source by definition.",
+      "description": "The root carries EXACTLY three fields (PART 12 section 7). Frontmatter and definitions - footnote AND abbreviation alike (PART 12 section 7) - are block nodes in `children`, not root fields, because a root field cannot carry the `pos` section 4 requires of everything else - and both are source an editor navigates to.\n\nThe root is the one node with no `pos`: it spans the whole source by definition.",
       "required": [
         "type",
         "children",
@@ -2015,11 +2015,11 @@
         },
         "ref": {
           "type": "string",
-          "description": "Unresolved reference label of `[text][ref]`. Present only between parse and resolve."
+          "description": "Reference label of `[text][ref]`, as the author wrote it. Present whenever the author wrote a reference link - resolved or not - because the serialized tree is PRE-RESOLVE (PART 12 section 3a). It is not a transient between parse and resolve."
         },
         "rawRef": {
           "type": "string",
-          "description": "Verbatim source of an unresolved reference, so it can be restored as literal text."
+          "description": "Verbatim source of the reference as written, so the construct can be restored. Reachable because the tree is PRE-RESOLVE (PART 12 section 3a); under a post-resolve tree this field would describe something already discarded."
         },
         "fromCrossref": {
           "type": "boolean",

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3807,6 +3807,67 @@ EOF = (* end of file *) ;
       internal field the reference does not have. A consumer reading `href`
       must not have to know which engine produced the document.
 
+   3a. THE SERIALIZED TREE IS PRE-RESOLVE -- NORMATIVE. It records what the
+      AUTHOR WROTE, not what the document resolves to. Reference resolution,
+      like rendering, happens after; a producer MUST NOT fold its results into
+      the tree in place of the authored construct.
+
+      Concretely, for `[getting started][]` against a heading that defines it:
+
+        {"type":"link","href":"","ref":"getting started",
+         "rawRef":"[getting started][]"}
+
+      `ref` is present because the author wrote a reference link (§3), `href`
+      is empty because nothing has resolved it yet, and `rawRef` carries the
+      source so the construct can be restored. A tree publishing
+      `{"type":"link","href":"#Getting-Started"}` for that source has serialized
+      a LATER STAGE: the reference is gone, and no consumer can tell it from a
+      document whose author typed the destination out.
+
+      AN UNRESOLVED REFERENCE IS STILL A LINK NODE. Where nothing defines
+      `[a]`, `see [a][] here` publishes `text`, `link`, `text` -- the link
+      carrying `ref` and no `href` -- NOT one text node holding `see [a][]
+      here`. Flattening it to text discards the fact that the author wrote a
+      reference at all, and it makes the same document have two node counts
+      depending on which engine produced it, which is exactly what §1 and §1a
+      exist to prevent. (carve#486)
+
+      SO THERE IS NO `raw_text`. An engine that reverts an unresolved reference
+      to literal source needs a node type to carry text that must not be
+      escaped again, and no such type is in the vocabulary. Under this clause
+      the reversion does not happen, so the need does not arise: what the
+      author wrote is a link, and it stays one. §5 already excludes the
+      formatter-internal `raw_text` from the wire; this says why nothing on the
+      document side has to reach for it. (carve-php#624)
+
+      WHY PRE-RESOLVE. Both stages are defensible and both validate against the
+      schema, which is how three engines came to disagree without any of them
+      being wrong (carve#481). The tie is broken by what each one COSTS.
+
+      Post-resolve makes `rawRef`'s stated purpose -- "so it can be restored as
+      literal text" -- unreachable, because the field it would be restored from
+      is gone by the time anyone could use it. It also means `[x][]` cannot
+      survive a format cycle in ANY implementation: the writer cannot reproduce
+      a construct the tree no longer carries, so PART 11's canonical writer
+      silently rewrites one construct into another. That is not a writer bug
+      and cannot be fixed in the writer.
+
+      Pre-resolve keeps both. It also keeps the distinction a linter, a
+      refactoring tool, or an editor round-tripping a file needs: `[a][]` and
+      `[a](#a)` are different things the author chose between, and a format
+      that preserves authored form one layer down (PART 11 §6: bullet
+      characters, delimiters, the bare marker) has no reason to discard this
+      one.
+
+      WHAT IS STILL SERIALIZED. §5's rule is unchanged and is not in tension
+      with this one: resolution RESULTS a consumer would otherwise have to
+      recompute -- footnote numbering, caption numbers -- are serialized,
+      because recomputing them means reimplementing PART 9R. The difference is
+      that those are ADDED alongside the authored construct; they do not
+      REPLACE it. A resolved footnote reference keeps its label and gains its
+      number. A resolved link keeps its `ref` and gains nothing: `href` is the
+      author's field, empty when the author did not write a destination.
+
    4. POSITIONS ARE REQUIRED. Every node EXCEPT the document root carries
       `pos`:
 
@@ -3967,6 +4028,41 @@ EOF = (* end of file *) ;
       that container empty; the serialized tree follows the same rule rather
       than inventing a second one. Its `pos` still records where it was
       WRITTEN, so nothing about navigation is lost by the move.
+
+      THIS COVERS EVERY DEFINITION KIND, NOT ONLY FOOTNOTES -- NORMATIVE. An
+      `abbreviation_def` authored inside a div, a list item or a block quote is
+      a child of the DOCUMENT, exactly as a `footnote` is. The clause above was
+      written against PART 9 §16 and read as footnote-specific, so the engines
+      split: carve-php hoisted both kinds, carve-js and carve-rs hoisted the
+      footnote and left the abbreviation in its container, and all three
+      rendered identical HTML -- because an abbreviation is document-global
+      wherever it is written, which is the same property that makes a footnote
+      definition document-level metadata. A rule that applies to one and not
+      the other needed a reason, and there is none. (carve-php#631)
+
+      THE FORMATTER CONSEQUENCE IS ACCEPTED, NOT OVERLOOKED. Hoisting means
+      PART 11's writer emits the definition after the container the author
+      wrote it in, which reads like a violation of PART 11 §6 ("fmt does not
+      reorder ... those are the author's choices and the AST records them").
+      It is not, because §6 governs what the writer may do with what the tree
+      HOLDS, and this clause is what the tree holds. The consequence is already
+      shipping and corpus-pinned for footnotes:
+
+        See [^a].
+
+        > [^a]: note body
+
+      formats to the definition after an emptied `>`, and corpus
+      `115-footnote-definition-inside-a-container-is-collected` pins the
+      collection it follows from. Extending the rule to abbreviations extends
+      that consequence; it does not introduce it.
+
+      THE ALTERNATIVE WAS TO NARROW THE RULE instead -- keep definitions where
+      they were written, for both kinds. It was rejected because it reverses a
+      pinned rule that ships today, and because the argument for hoisting is
+      not about convenience: a definition is metadata whose SCOPE is the
+      document, and a tree that nests document-scoped metadata inside a
+      container invites a consumer to treat it as container-scoped.
 
       Definitions appear in DOCUMENT ORDER by source position. Numbering is a
       resolution result and stays on the reference (§5).


### PR DESCRIPTION
Closes #481. Closes #486. Answers markup-carve/carve-php#624 and markup-carve/carve-php#631.

Four issues, one question in different clothes: **does the serialized tree record what the author wrote, or what the document means?** Two clauses settle all four.

## PART 12 §3a (new) — pre-resolve

`[getting started][]` publishes a `link` carrying `ref`, an empty `href`, and the `rawRef` source — resolved or not, and even where nothing defines the label. An unresolved reference is still a link node, not one flattened text run.

Both stages validate against the schema, which is how three engines came to disagree without any of them being wrong. The tie is broken on **cost**:

- Post-resolve makes `rawRef`'s stated purpose — "so it can be restored as literal text" — unreachable, because the field it would restore from is gone by the time anyone could use it.
- And `[x][]` then cannot survive a format cycle in **any** engine: a writer cannot reproduce a construct the tree no longer carries. That is not a writer bug and cannot be fixed in the writer.
- Pre-resolve keeps both, and keeps `[a][]` distinguishable from `[a](#a)` for a linter or an editor round-tripping a file — the same authored-form argument PART 11 §6 already makes for bullet characters and delimiters.

It also removes the need for a `raw_text` **document** node (carve-php#624). That type existed to carry source that must not be escaped again, produced when an unresolved reference reverted to literal text. Under §3a the reversion does not happen, so the need does not arise.

§5 is untouched and not in tension: resolution *results* a consumer would have to recompute (footnote numbering, caption numbers) are still serialized. They are **added alongside** the authored construct, not substituted for it.

## PART 12 §7 (extended) — every definition kind, not only footnotes

An `abbreviation_def` authored inside a container is a child of the **document**, exactly as a `footnote` is.

The clause was written against PART 9 §16 and read as footnote-specific, so the engines split — and I checked each against its **serializer** rather than its parse tree, since carve-js's `parse()` returns a legacy shape:

| | footnote def in a container | abbreviation def in a container |
|---|---|---|
| carve-js | hoisted to document | left in the container |
| carve-rs | hoisted to document | left in the container |
| carve-php | hoisted | hoisted |

All three render identical HTML, because an abbreviation is document-global wherever it is written — the same property that makes a footnote definition document-level metadata. A rule that applies to one kind and not the other needed a reason, and there was none.

**The formatter consequence is accepted, not overlooked.** Hoisting means the writer emits the definition after the container the author wrote it in, which reads like a PART 11 §6 violation. It is not: §6 governs what the writer may do with what the tree *holds*, and this clause is what the tree holds. It already ships for footnotes —

```
See [^a].

> [^a]: note body
```

formats in carve-rs to the definition after an emptied `>`, and corpus `115-footnote-definition-inside-a-container-is-collected` pins the collection it follows from. Extending the rule extends that consequence; it does not introduce it.

The alternative — narrow the rule and keep every definition where written — was rejected in the clause text: it reverses a pinned rule that ships today, and a tree that nests document-scoped metadata inside a container invites a consumer to treat it as container-scoped.

## Schema

`ref`'s description said *"Present only between parse and resolve"*, which §3a contradicts — it is on the wire whenever the author wrote a reference. Same for `rawRef`, whose purpose is only reachable pre-resolve, and the document root's description, which named only footnote definitions.

**Descriptions only. No constraint moved**, so no engine has to conform before this lands — which keeps the usual engine-before-pin ordering available for the code changes that follow.

## Every engine has something to move

These clauses were written to settle disagreements the engines had already shipped, so `docs/ast-json.md`'s conformance table now records who is where rather than smoothing it over: carve-rs serializes links post-resolve, carve-php flattens an unresolved reference to text, and carve-js and carve-rs both leave `abbreviation_def` in its container.

Spec suite: 707 passing.