### PR TITLE
fix(ast:check): compare the resolved stage, which is the one engines publish

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -476,7 +476,15 @@ for (const { name, source } of samples) {
     // implementation whose internals differ. Checking the runtime tree measured
     // a shape no consumer ever receives, and so could not see the wire form
     // every other engine here is measured against.
-    doc = lib.toAstJson(lib.parse(source))
+    // RESOLVED, not parse-only. `resolve()` is where a reference link becomes a
+    // link or degrades to text, and every other engine here resolves inside its
+    // own parse - so serializing carve-js's parse-only tree compared a stage no
+    // other engine exposes and reported the difference as the satellite's.
+    //
+    // `ref` is the tell: the schema calls it "present only between parse and
+    // resolve", so a reference surviving into the reference AST means the
+    // reference AST was taken before resolve (carve#486).
+    doc = lib.toAstJson(typeof lib.resolve === 'function' ? lib.resolve(lib.parse(source)) : lib.parse(source))
   } catch (error) {
     jsFindings.push(`${name}: parse threw - ${error.message}`)
     continue


### PR DESCRIPTION
The reference AST was built with `toAstJson(parse(source))` - **no `resolve`**. Every
satellite is measured against carve-js, whose own `--json` CLI resolves, as do carve-rs and
carve-php inside their parse. So the baseline was a stage carve-js never publishes, and any
document with a reference link or crossref was compared apples-to-oranges - with the
difference reported as the *satellite's*.

```
carve-js parse only      ["text","link","text"]
carve-js parse+resolve   ["text","text","text"]
carve-rs / carve-php     ["text","text","text"]
carve-js CLI --json      ["text","text","text"]
```

**`ref` was the tell, and the schema already said it:** *"present only between parse and
resolve"*. A reference surviving into the reference AST meant the AST was taken too early.
I read that field as evidence of a cross-engine disagreement instead, and filed #486 about
a difference that does not exist. That issue is now closed as my measurement error; this is
the part of it that was real.

Guarded with a `typeof` check so a build predating the `resolve` export still runs.

## The numbers move, and upward

| | before | after |
|---|---|---|
| carve-js (reference) | 10 findings | **57** |
| carve-rs | 37 findings | 42 |

The reference's own count quintuples once it is measured at the stage it publishes:
13 links with no position, and **three §1a adjacent-text-run violations that `resolve()`
leaves behind**:

```
see [a][] here              2 adjacent text pairs
[pre <http://h> post](/u)   2 adjacent text pairs
```

carve#488 says the coalesced tree is what `parse(x)` returns, so a later stage that
re-splits a run has to re-merge it. That is a defect in the reference rather than in this
script, so it is filed separately (markup-carve/carve-js#549) rather than fixed here.

A checker that reports more after a correctness fix is the point: those findings existed
the whole time and the wrong comparison stage hid them.

Spec suite: 711 tests, 0 failures.