### PR TITLE
tools: reach the Tier-2 corpus in the cross-engine check (2 of 33 compared -> 27)

### DIFF
--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -119,6 +119,37 @@ const rustBaseCommand = rustCarveBinary
   ? [rustCarveBinary]
   : ['cargo', 'run', '--quiet', '--']
 
+/*
+ * Tier-2 features whose only requirement is that an extension be registered.
+ *
+ * The optional corpus is 33 documents and the run reached 3 of them, because
+ * every case needed a hand-written adapter and only the option-carrying ones
+ * had been written (carve#496). Citations alone is 16 of the 33 - the single
+ * largest Tier-2 surface, and the one with no cross-engine measurement at all.
+ *
+ * These need no options, so one table serves both engines that are driven
+ * through an inline script. carve-rs is driven through its BINARY and still
+ * needs a CLI path; those cases stay unreached there and are reported as such.
+ */
+const PLAIN_EXTENSION_FEATURES = {
+  'citations-numbered': { js: 'citations', php: 'CitationsExtension' },
+  'citations-author-date': {
+    js: 'citations',
+    // Not a plain registration: the fixture pins the author-date style,
+    // and registering the extension with its default mode renders the
+    // NUMBERED style against it. Caught by the run this table enables.
+    jsOptions: "{ mode: 'author-date' }",
+    php: 'CitationsExtension',
+    phpArgs: "mode: 'author-date'",
+  },
+  'code-callouts': { js: 'codeCallouts', php: 'CodeCalloutsExtension' },
+  details: { js: 'details', php: 'DetailsExtension' },
+  spoiler: { js: 'spoiler', php: 'SpoilerExtension' },
+  tabs: { js: 'tabs', php: 'TabsExtension' },
+  'list-table': { js: 'listTable', php: 'ListTableExtension' },
+  'bare-url-autolink': { js: 'autolink', php: 'AutolinkExtension' },
+}
+
 const impls = [
   {
     name: 'rust',
@@ -205,6 +236,20 @@ const impls = [
           `,
         ]
       }
+      const plain = PLAIN_EXTENSION_FEATURES[feature]
+      if (plain) {
+        return [
+          'node',
+          '--input-type=module',
+          '-e',
+          `
+            import { readFileSync } from 'node:fs';
+            import { ${entry}, ${plain.js} } from './dist/index.js';
+            const source = readFileSync(process.argv[1], 'utf8');
+            process.stdout.write(${entry}(source, { extensions: [${plain.js}(${plain.jsOptions ?? ''})] }));
+          `,
+        ]
+      }
       return null
     },
     hooks: [
@@ -255,14 +300,15 @@ const impls = [
           `,
         ]
       }
-      if (feature === 'bare-url-autolink') {
+      const plain = PLAIN_EXTENSION_FEATURES[feature]
+      if (plain) {
         return [
           'php',
           '-r',
           `
             require 'vendor/autoload.php';
             $converter = new MarkupCarve\\Carve\\CarveConverter();
-            $converter->addExtension(new MarkupCarve\\Carve\\Extension\\AutolinkExtension());
+            $converter->addExtension(new MarkupCarve\\Carve\\Extension\\${plain.php}(${plain.phpArgs ?? ''}));
             echo $converter->convert(file_get_contents($argv[1]));
           `,
         ]


### PR DESCRIPTION
Fixes #496.

`compare:impls --corpus=optional` is the only cross-engine measurement of Tier-2 opt-in features. It ran 33 documents, compared **2**, and exited 0.

| | before | after |
| --- | --- | --- |
| optional cases compared | 2 | **27** |
| not compared | 30 | 5 |
| cross-engine diffs | 0 (of 2) | 0 (of 27) |

## Not missing functionality - missing adapters

Citations, code callouts, details, spoiler, tabs and list-table all shipped in every engine. Every case needs a hand-written adapter in this script, and only the ones carrying **options** had ever been written. Registering an extension with *no* options - which is all most of these need - had no entry at all, so 30 cases reached at most one engine and contributed no evidence.

carve-js and carve-php are both driven through an inline script here, so neither needs a CLI change. One shared `PLAIN_EXTENSION_FEATURES` table serves both.

## The first run it enabled found a bug

In this table, not in an engine: `citations-author-date` is not a plain registration. It needs `mode: 'author-date'`, and registering the extension with its default rendered the **numbered** style against an author-date fixture - `pass=26/27 mismatch=1` on the first run.

That is the argument for the change in one line. **16 of the 33 optional cases are citations** - the single largest Tier-2 surface, and none of them had ever been compared across engines.

`bare-url-autolink` moves into the shared table too, replacing a hand-written carve-php branch that carve-js had no counterpart for - the asymmetry that kept that case at one engine.

## What is still not compared

carve-rs is driven through its **binary**, so it still needs a CLI path and its cases stay unreached. The run reports that rather than passing over it, and the five remaining cases all need a renderer or parser option rather than an extension:

`smart-quotes-locale-de`, `smart-typography-off`, `markdown-typography-source`, `section-wrapper-off`, `source-line-after-generated-id`

Two of those five already have a verified carve-js path (`{ sections: false }` and the autolink extension) but no carve-php counterpart, so they still reach only one engine. #496 stays open for the carve-rs CLI half.
