### PR TITLE
spec: the render ceiling must sit above the parse cap, not equal it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#50bddaf9161daba542a0befbe6fe22f0e49cb52e",
+        "@markup-carve/carve": "github:markup-carve/carve-js#18dfdd6a971013e9c242aef55370950e84e15039",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.35.0",
@@ -982,8 +982,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#50bddaf9161daba542a0befbe6fe22f0e49cb52e",
-      "integrity": "sha512-IW664CtAYI+hBPANpeEA/1Thxy1qSPr/Dl3mPKJBhvKsGtz7+WG4tGpPdZ6O7Hkzw0yPzUxczoU7RjOyMIfbMg==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#18dfdd6a971013e9c242aef55370950e84e15039",
+      "integrity": "sha512-dtjPmX2tNGLgbntPlfi3tLEM6eNZGe5u6O6n0VK5C1FX1jSLDCY9Xu7aCPkEDOM1+5xJtbW2WJeFPfwMQ9+Sgg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#50bddaf9161daba542a0befbe6fe22f0e49cb52e",
+    "@markup-carve/carve": "github:markup-carve/carve-js#18dfdd6a971013e9c242aef55370950e84e15039",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.35.0",

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3043,10 +3043,22 @@ EOF = (* end of file *) ;
         conformant implementation SHOULD use the same value (it MAY choose a
         larger fixed cap, but never an unbounded one). Past the cap every
         container kind FLATTENS the same way -- the opener becomes literal
-        paragraph text -- rather than crashing. The same ceiling MUST apply
-        to recursive RENDER / RESOLVE / FILTER passes over a
-        programmatically constructed tree, not only the parse path. It MUST
-        bound abbreviation, reference,
+        paragraph text -- rather than crashing. Recursive RENDER / RESOLVE /
+        FILTER passes over a programmatically constructed tree MUST be
+        bounded too, not only the parse path -- but their ceiling MUST NOT
+        be reachable by a tree the SAME implementation's parser produces. A
+        parsed tree is deeper than the containers that produced it (the
+        paragraph inside the innermost container is one level further down),
+        so a render ceiling EQUAL to MAX_NESTING_DEPTH truncates a document
+        the parser has just accepted, and truncation on the render path
+        deletes content silently instead of degrading it to literal text.
+        The render ceiling MUST therefore EXCEED MAX_NESTING_DEPTH by enough
+        to cover the blocks a container subtree adds; the reference uses
+        MAX_NESTING_DEPTH + 32. This sentence previously required the SAME
+        ceiling on both paths, and all three engines complied: at exactly
+        MAX_NESTING_DEPTH the canonical writer dropped the innermost
+        paragraph and the Markdown / plain-text / ANSI renderers dropped the
+        whole document. It MUST bound abbreviation, reference,
         footnote, and crossref expansion so total work stays O(n): in
         particular an empty abbreviation term is rejected, a reference is not
         resolved by rescanning the whole output per occurrence, and a crossref


### PR DESCRIPTION
Fixes markup-carve/carve#517 at the source. The engine PRs (carve-js#543, carve-js#551, carve-rs#462, and one pending for carve-php) make the implementations stop deleting content; this makes the spec stop requiring it.

## The sentence

Section 25's resource-bounds rule said:

> Past the cap every container kind FLATTENS the same way [...] **The same ceiling MUST apply to recursive RENDER / RESOLVE / FILTER passes** over a programmatically constructed tree, not only the parse path.

All three engines complied. Complying deletes content.

## Why "the same ceiling" is the wrong ceiling

A parsed tree is deeper than the containers that produced it - the paragraph inside the innermost container is one level further down. So a render ceiling equal to `MAX_NESTING_DEPTH` fires on a tree the parser has just accepted.

And the two paths fail differently. Past the cap the *parser* degrades: the opener becomes literal text, and the content is still there. Past its ceiling a *renderer* emits nothing. The rule reused a number without reusing the behavior that made the number safe.

Measured at exactly 200 levels, before the engine fixes:

```
depth 199  html=1 markdown=1 plain=1 ansi=1 carve=1
depth 200  html=1 markdown=0 plain=0 ansi=0 carve=0
```

The canonical writer emitted 200 openers, an empty line, and 200 closers, so PART 11's semantic invariant broke. The Markdown, plain-text and ANSI renderers were worse: the empty string propagates up through each parent's non-empty filter, so the **whole document** rendered to nothing.

Eight of the twelve renderer bounds across the three engines sat at or below the parse cap. The two that did not are the two whose constants were written with an explicit reason for the number.

## What the rule says now

Render, resolve and filter passes stay bounded - that requirement is unchanged and is the actual DoS defense. What changes is that their ceiling must not be reachable by a tree the same implementation's parser produces, so it must exceed `MAX_NESTING_DEPTH` by enough to cover the blocks a container subtree adds. The reference uses `MAX_NESTING_DEPTH + 32`.

## Pin bump

Second commit bumps the reference engine to the build that has this. Without it the rule would claim behavior the pinned version does not have, which is the failure mode this repo already guards against elsewhere. Verified against the pinned package rather than a local checkout:

```
pinned engine, depth 200  html=1 markdown=1 plain=1 ansi=1 carve=1
```

## Note

Three independent implementations landed on the same defect. That is what an instruction to reuse the wrong number looks like from the outside, and it is the argument for fixing the sentence rather than only the engines.
