### PR TITLE
ci: gate the three non-HTML targets the engines already agree on

### DIFF
--- a/.github/workflows/ast-conformance.yml
+++ b/.github/workflows/ast-conformance.yml
@@ -140,7 +140,34 @@ jobs:
           CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
         run: npm run compare:impls -- --roundtrip --fail-on-diff
 
-      # The default mode compares every render target engine-against-engine.
+      # The three non-HTML targets the engines already AGREE on, gated.
+      #
+      # The report-only step below is right about the targets that still carry
+      # open language questions - all of which live on `carve`, the canonical
+      # writer (carve#478, carve#481). It is not right about the rest: markdown,
+      # plain and ansi compare clean across all three engines on every corpus
+      # document, and leaving them in a job that cannot fail means agreement,
+      # once reached, is observed rather than defended.
+      #
+      # That is not hypothetical. carve#516 was a Markdown divergence on a line
+      # block whose input the corpus already contained: the fixture existed, the
+      # target was compared, and nothing was allowed to go red. A corpus fixture
+      # carries an HTML expectation only, so for every other target this
+      # engine-against-engine comparison is the whole check.
+      #
+      # If one of these three starts diverging for a reason that turns out to
+      # need a language decision, move that target back to the reporting step
+      # rather than deleting the gate.
+      - name: Cross-engine render comparison (markdown, plain, ansi)
+        if: always()
+        env:
+          CARVE_JS_DIR: ${{ github.workspace }}/carve-js
+          CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
+          CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
+        run: npm run compare:impls -- --targets=markdown,plain,ansi --fail-on-diff
+
+      # The default mode compares every render target engine-against-engine,
+      # including `carve`.
       # REPORTS rather than gates: its remaining differences need language
       # decisions (carve#478, carve#481), and gating on an unresolved question
       # teaches people to ignore the job - which is how both of these checkers


### PR DESCRIPTION
The report-only cross-engine comparison is right about the targets that still carry open language questions - all of which live on `carve`, the canonical writer (#478, #481). It is not right about the rest.

```
markdown: compared=536 diffs=0 errors=0
plain:    compared=536 diffs=0 errors=0
ansi:     compared=536 diffs=0 errors=0
```

Leaving those in a job that **cannot fail** means the agreement is observed rather than defended.

## Not hypothetical

#516 was a Markdown divergence on a line block whose input the corpus **already contained** - two engines dropped the first line's indent while keeping it on every later line of the same block. The fixture existed, the target was compared, and nothing was allowed to go red. It stayed open until someone read the report by hand.

A corpus fixture carries an **HTML** expectation only, so for every other target this engine-against-engine comparison *is* the check. Three of the four can now fail.

## If one of them diverges later

Move that target back to the reporting step rather than deleting the gate - the reason the report-only step exists is sound, it was just applied more widely than the evidence warranted.