### PR TITLE
spec: a reassembled node may omit pos, so §1a and §4 can both hold

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -82,6 +82,14 @@ document into invalid text.
 An implementation that cannot place a node **omits `pos` rather than inventing
 one**, and says so. Absent is a fact a consumer can act on; a wrong span is not.
 
+A **reassembled** node - one the producer joined from pieces the source
+separates, or synthesized outright - **may omit `pos` and is conformant doing
+so**. A table cell continued on a `+` line, the hard break a line block makes
+from a soft one, line-block content rebuilt around an indentation sentinel, and
+a `text` run coalesced across such a gap all have values that are not a slice of
+the source at any offset, so no honest span exists. The exemption is narrow: it
+covers nodes that *cannot* be placed, not nodes that have not been placed yet.
+
 ## Adjacent text runs are coalesced
 
 A node's children hold **no two adjacent `text` nodes**. Where parsing produced
@@ -115,7 +123,8 @@ A merged run keeps a `pos` only where its pieces are **contiguous** in the
 source. Where they are not - the `<` and `>` of an autolink unwrapped inside a
 link label, the delimiter between two halves of a wrapped table cell - the
 merged value is not a slice of the source at any offset, so the node carries no
-position rather than one that selects the wrong text.
+position rather than one that selects the wrong text. §4 names that a permitted
+category rather than a gap, so a merged run without a position is conformant.
 
 The schema cannot express this - JSON Schema has no way to forbid two adjacent
 array entries of the same shape - so it is checked by the shape comparison in
@@ -266,6 +275,12 @@ spans that do not cover the text they claim.
 
 The gaps are listed rather than smoothed over on purpose: "six implementations"
 is only a claim worth making if the disagreements are visible.
+
+The **reassembled** regions in the positions column are not among them - §4 names
+that category permitted, so a table cell or line-block region without a position
+is conformant rather than owed. What is still a gap is anything else in that
+column: a `definition_term` is a slice of the source like any other node, so
+carve-rs leaving a definition list's own parts unplaced is a real one.
 
 The §3a and §7 rows are new: those clauses were written to settle disagreements
 the engines had already shipped, so every engine has something to move. That is

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3968,6 +3968,50 @@ EOF = (* end of file *) ;
       The contract a consumer relies on is unchanged: JSON it is handed carries
       positions. How the producer arranged that is the producer's business.
 
+      A REASSEMBLED NODE MAY OMIT `pos` -- NORMATIVE. A node whose value is not
+      a contiguous slice of the source, because the producer joined it from
+      pieces the source separates or synthesized it outright, MAY omit `pos`
+      rather than invent one, and is CONFORMANT doing so. This is a permitted
+      category, not a shortfall to be tracked.
+
+      It covers the hard break a line block synthesizes from a soft one,
+      line-block content rebuilt around an indentation sentinel, a table row or
+      cell put back together from continuation lines, and -- because §1a merges
+      them -- a `text` run whose pieces are not adjacent in the source:
+
+          | x | A long description |
+          +     | that continues     |
+
+      The cell's text is `A long description that continues`, joined across a
+      newline, a `+` and an indent the value does not contain. §1a requires ONE
+      text node; no offset pair covers that value. Without this clause the two
+      rules left a producer no conformant answer at all: coalesce and carry a
+      span over characters the value drops, or coalesce and omit the span the
+      paragraph below appears to demand. §1a's own POSITIONS note already chose
+      the second; this is where §4 agrees to it. (carve#490)
+
+      Stated in the spec rather than left to each engine because §1a is
+      normative: any implementation following it faithfully arrives at the same
+      fork, so an answer chosen per engine would be three answers. That the
+      three engines' residues already converged -- same three documents, same
+      kind of content -- is the evidence that this is a property of the rules
+      and not of anyone's parser.
+
+      THE EXEMPTION IS NARROW. The test is whether a true span EXISTS, not
+      whether one was computed. A node the producer has simply not placed yet
+      is still a gap, and a text run lifted whole out of the source has a span
+      whether or not anyone wrote it down. Nor does it license reassembling
+      more than the language requires, to manufacture the exemption: a producer
+      that joins where the source did not is publishing its bookkeeping, which
+      is what §1a exists to stop.
+
+      The conformance checker still REPORTS an absent `pos`, because it cannot
+      tell a reassembled node from an unplaced one from the tree alone. That is
+      why the position half of that check is a report and the §1a half is a
+      gate. A report is the right instrument here: the distinction needs a human
+      reading the document, and the numbers below are what such a reading
+      produced.
+
       IMPLEMENTATION STATUS. All three engines record positions behind a parse
       option and enable them whenever they serialize, which is the arrangement
       the paragraph above permits. Measured over the corpus:
@@ -3991,10 +4035,13 @@ EOF = (* end of file *) ;
       `<` and `>` between the pieces are not in the value.
 
       This state is convergent rather than accidental, and it is the evidence
-      behind carve#490, which asks whether a reassembled node should be a NAMED
-      permitted category under this section rather than a conformance shortfall
-      each engine reports separately. Until that is decided the rule below
-      stands as written.
+      that settled carve#490: THAT residue -- the reassembled content named
+      above -- is the permitted category, not a shortfall each engine reports
+      separately. The exemption is scoped to it and does not launder anything
+      else. docs/ast-json.md's table additionally records carve-rs leaving a
+      definition list's OWN parts unplaced; a `definition_term` is a slice of
+      the source like any other node, so if that is still true it is a gap, and
+      the numbers above were taken without separating it out.
 
       The earlier text here named per-engine gaps that no longer exist -- it
       described carve-rs as placing block nodes only, "869 block nodes and 54
@@ -4012,7 +4059,9 @@ EOF = (* end of file *) ;
 
       An implementation that cannot yet produce positions MUST NOT emit `pos`
       with invented values, and MUST NOT omit it silently: it does not yet
-      serialize conformantly, and should say so.
+      serialize conformantly, and should say so. A reassembled node under the
+      clause above is not that case -- there the absence IS the conformant
+      answer, and nothing needs saying.
 
    5. WHAT IS NOT IN THE SERIALIZED FORM. Formatter-internal nodes (PART 11,
       and the `raw_text` case profiles.md excludes) are not part of the

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -104,12 +104,23 @@
         content_column -> sublist (PART 9 §24 C3); otherwise paragraph /
         lazy item text.
      S4 PARTIAL MATCH. The unmatched containers are candidates to close.
-        LAZY CONTINUATION: if the innermost MATCHED context holds an OPEN
+        LAZY CONTINUATION: if ANY container in the open stack holds an OPEN
         PARAGRAPH and the residue is NOT an interrupting line (PART 9 §10 --
         list markers and plain text fold; visible openers interrupt), L
-        folds into that paragraph and NOTHING closes. Otherwise close the
-        unmatched containers and re-classify the residue in the surviving
-        context (S3).
+        folds into the INNERMOST such paragraph and NOTHING closes --
+        regardless of how many containers the line failed to match.
+        Otherwise close the unmatched containers and re-classify the residue
+        in the surviving context (S3).
+
+        This said "the innermost MATCHED context holds an OPEN PARAGRAPH",
+        which describes something no implementation does. A lazy line carries
+        no markers, so it matches ZERO containers and the innermost matched
+        context is the document root, which holds no open paragraph -- under
+        that wording `> a` / `b` would close the quote at depth 1. Every engine
+        folds there, and corpus 82-blockquote-lazy-continuation pins it. What
+        the wording did produce was a split at depth 2: carve-rs closed both
+        quotes where carve-js and carve-php folded into the nested one
+        (carve#506, carve-rs#452). Depth is not a parameter of this rule.
      S5 OPENERS. When S3/S4 classify the residue as a container opener (a
         quote marker; a list marker at an admissible column; a `+`
         continuation marker at the marker column, PART 9 §17 L3/L4; a fence
@@ -374,7 +385,8 @@ blockquote_line = '>', (newline | (space, inline_content, newline)) ;
 
 (* LAZY CONTINUATION -- NORMATIVE (CommonMark-compatible). After one or more
    blockquote_lines, a line that does NOT carry the '>' marker still continues
-   the blockquote -- exactly as if it carried '>' -- provided it is:
+   the blockquote -- folding into the INNERMOST open paragraph, at whatever
+   depth that paragraph sits -- provided it is:
      - not blank (a blank line ends the blockquote), and
      - not a block-opener: a heading, table, fenced code, `:::` div, thematic
        break, OR an "invisible" reference / footnote / abbreviation definition
@@ -1310,8 +1322,14 @@ math_display = "$$", code_span ;
    Canonical = carve-js / djot.js (pinned, corpus Math section). The
    `{=format}` raw form is code-span-ONLY and is NOT inherited by math:
    `$\`x\`{=html}` leaves the `{=html}` literal (both impls already agree).
-   carve-php currently DROPS valid math attributes -- to be fixed.
-   The math content is the verbatim text of the reused code_span. *)
+   The math content is the verbatim text of the reused code_span.
+
+   (This paragraph used to end "carve-php currently DROPS valid math
+   attributes -- to be fixed". It does not: an attribute block on a math
+   span renders the class in ALL THREE engines, verified over each of
+   their mains. A sentence describing one engine's defect is only true on
+   the day it is written, and nothing here re-checks it -- PART 12 section 4's
+   implementation status had rotted the same way.) *)
 
 (* --- Emphasis (left/right word-boundary rule; PART 9 §9 is normative).
    The word-boundary restriction applies to EVERY bare emphasis delimiter
@@ -2227,7 +2245,7 @@ EOF = (* end of file *) ;
          - a valid table row (valid_row(L), §5 T2; a stray `|` in prose,
            and a line-initial `|` with no closing `|`, are NOT ones);
          - a fenced code opener WITH a matching closer ahead (I4);
-         - a `:::` opener WITH a matching closer ahead (I4).
+         - a `:::` opener, closer or not (I4).
          So "intro \n # H" is <p>intro</p> + <h1>; "intro \n --- \n more"
          is <p>intro</p> + <hr> + <p>more</p> (corpus
          76-paragraph-interruption).
@@ -2247,13 +2265,24 @@ EOF = (* end of file *) ;
       I3 IMAGE EXCLUDED. A line that is only a bare image ("![alt](url)")
          does not interrupt: an image is not a block of its own in Carve;
          it stays an inline image inside the paragraph.
-      I4 CLOSER LOOKAHEAD -- the same &(...) guards the fence / div /
-         frontmatter productions carry. An UNTERMINATED ``` or `:::` opener
-         does not interrupt; the line stays paragraph text (a stray ``` in
-         prose then opens an unclosed inline verbatim run rendering as
-         <code> to the end of the block -- the code_span maximal-run rule).
-         Pinned by corpus 76-paragraph-interruption (unterminated-fence and
-         unterminated-`:::` pairs).
+      I4 CLOSER LOOKAHEAD -- the same &(...) the VERBATIM fence productions
+         carry. An UNTERMINATED ``` or ~~~ opener does not interrupt; the line
+         stays paragraph text, and a stray ``` in prose then opens an unclosed
+         inline verbatim run rendering as <code> to the end of the block (the
+         code_span maximal-run rule). Pinned by corpus
+         81-paragraph-interruption-19.
+
+         A `:::` OPENER IS NOT GUARDED. It interrupts whether or not a closer
+         follows, and an unterminated one closes at EOF (PART 9 §25). Pinned by
+         corpus 81-paragraph-interruption-20: `Text` / `:::` / `stuff` is a
+         paragraph followed by a div holding `stuff`.
+
+         This clause used to guard both, and cited a corpus that pins the
+         opposite for `:::`. All three engines follow the corpus. The `:::`
+         half was superseded when unclosed containers changed from degrading
+         to closing at EOF (carve#439) and was not updated with it; the stale
+         citation to "corpus 76" is the same paragraph renumbering that
+         accompanied that change.
       I5 INVISIBLE CONSTRUCTS interrupt AND are consumed: a reference
          definition (link `[r]: url`, footnote `[^r]: …`, abbreviation
          `*[A]: …`), a comment (`%%` line, `%%%` block), and a
@@ -2839,11 +2868,23 @@ EOF = (* end of file *) ;
       - STANZAS. A blank line ends a stanza; each stanza is its own `<p>` inside
         the single `<div class="line-block">`.
       - LEADING WHITESPACE. Each body line's leading whitespace is PRESERVED
-        (unlike ordinary paragraph content, which is trimmed). In HTML each
-        leading space serializes as a NBSP (`&nbsp;`, U+00A0), so indentation is
-        visible with no external CSS (matching Pandoc). Plain-text / ANSI
-        renderers emit the literal spaces. A tab in the leading run follows the
-        tab-stop rule (PART 9 §24).
+        (unlike ordinary paragraph content, which is trimmed), down to a single
+        column. In HTML each leading space serializes as a NBSP (`&nbsp;`,
+        U+00A0), so indentation is visible with no external CSS (matching
+        Pandoc). Plain-text / ANSI renderers emit the literal spaces. A tab in
+        the leading run follows the tab-stop rule (PART 9 §24).
+      - MEDIAL GAPS. An INNER or TRAILING run of TWO OR MORE columns is
+        preserved the same way and serializes as the same NBSPs. This is the
+        inline alignment verse and address blocks are made of -- the caesura of
+        Old English verse, a column of aligned text -- and collapsing it loses
+        the per-line layout the block exists to keep (matching Pandoc, where
+        every space the author writes is significant). A LONE inner space is NOT
+        preserved: it stays an ordinary, collapsible space so a long line can
+        still wrap between words. Tab arithmetic is the leading run's, counted
+        from the column the run starts at -- so the SAME tab is a gap or a lone
+        space depending on the column it lands in, which is what makes it worth
+        pinning: corpus 41-line-blocks-9 holds a tab that crosses one column
+        (collapses) beside two that cross two stops (kept), and a leading one.
       - REFERENCE COLUMN. Leading whitespace is measured RELATIVE TO THE FENCE
         indent, not absolute column 0: a `line-block` nested in a list has the
         container's structural indent stripped first (the list dedents to its
@@ -3734,8 +3775,33 @@ EOF = (* end of file *) ;
 
       SCOPE. The rule is about `text` nodes only, and only about ADJACENCY
       within one parent's child list. It does not merge across an intervening
-      node, it does not merge other types, and it says nothing about how a
-      producer represents runs internally -- only what it publishes.
+      node, and it does not merge other types. It says nothing about how a
+      producer builds a run while parsing -- an inline scanner that accumulates
+      pieces and joins them at the end of the parse is exactly as conformant as
+      one that never split.
+
+      BUT THE MERGE IS PART OF `parse(x)`, NOT OF SERIALIZATION -- NORMATIVE.
+      §6 requires `parse(x)` serialized and deserialized to equal `parse(x)`.
+      An implementation that leaves the run split in the parsed tree and joins
+      it in the encoder satisfies §1a and BREAKS §6 on the same document: what
+      comes back holds one node where the tree held three, so the round trip is
+      not an identity. carve-rs was written that way first and its corpus
+      round-trip test failed on `03-links-12` (carve-rs#441). The tree
+      `parse(x)` returns is therefore already coalesced.
+
+      POSITIONS. A merged run keeps a span only where its pieces are CONTIGUOUS
+      in the source. Where they are not -- the `<` and `>` of an autolink
+      unwrapped inside a link label, the delimiter and newline between two
+      halves of a wrapped table cell -- the merged value is not a slice of the
+      source at any offset, and §4 rates a span that selects the wrong text
+      worse than no span at all. So such a run publishes NONE.
+
+      That is a real cost and is stated rather than glossed: per-piece spans
+      that existed before the merge are gone in exactly those cases. It only
+      happens where the value was never a source slice to begin with (a
+      manufactured joiner, a dropped delimiter), so nothing that WAS placeable
+      becomes unplaceable -- but a consumer wanting to locate the pieces of such
+      a run works from the source, not from the tree.
 
       `escaped_text` is NOT `text` and does not merge with it: PART 12 §5 keeps
       the two distinct on the wire because an escape is authored form, and
@@ -3781,6 +3847,67 @@ EOF = (* end of file *) ;
       An implementation MUST NOT invent a synonym, and MUST NOT expose an
       internal field the reference does not have. A consumer reading `href`
       must not have to know which engine produced the document.
+
+   3a. THE SERIALIZED TREE IS PRE-RESOLVE -- NORMATIVE. It records what the
+      AUTHOR WROTE, not what the document resolves to. Reference resolution,
+      like rendering, happens after; a producer MUST NOT fold its results into
+      the tree in place of the authored construct.
+
+      Concretely, for `[getting started][]` against a heading that defines it:
+
+        {"type":"link","href":"","ref":"getting started",
+         "rawRef":"[getting started][]"}
+
+      `ref` is present because the author wrote a reference link (§3), `href`
+      is empty because nothing has resolved it yet, and `rawRef` carries the
+      source so the construct can be restored. A tree publishing
+      `{"type":"link","href":"#Getting-Started"}` for that source has serialized
+      a LATER STAGE: the reference is gone, and no consumer can tell it from a
+      document whose author typed the destination out.
+
+      AN UNRESOLVED REFERENCE IS STILL A LINK NODE. Where nothing defines
+      `[a]`, `see [a][] here` publishes `text`, `link`, `text` -- the link
+      carrying `ref` and no `href` -- NOT one text node holding `see [a][]
+      here`. Flattening it to text discards the fact that the author wrote a
+      reference at all, and it makes the same document have two node counts
+      depending on which engine produced it, which is exactly what §1 and §1a
+      exist to prevent. (carve#486)
+
+      SO THERE IS NO `raw_text`. An engine that reverts an unresolved reference
+      to literal source needs a node type to carry text that must not be
+      escaped again, and no such type is in the vocabulary. Under this clause
+      the reversion does not happen, so the need does not arise: what the
+      author wrote is a link, and it stays one. §5 already excludes the
+      formatter-internal `raw_text` from the wire; this says why nothing on the
+      document side has to reach for it. (carve-php#624)
+
+      WHY PRE-RESOLVE. Both stages are defensible and both validate against the
+      schema, which is how three engines came to disagree without any of them
+      being wrong (carve#481). The tie is broken by what each one COSTS.
+
+      Post-resolve makes `rawRef`'s stated purpose -- "so it can be restored as
+      literal text" -- unreachable, because the field it would be restored from
+      is gone by the time anyone could use it. It also means `[x][]` cannot
+      survive a format cycle in ANY implementation: the writer cannot reproduce
+      a construct the tree no longer carries, so PART 11's canonical writer
+      silently rewrites one construct into another. That is not a writer bug
+      and cannot be fixed in the writer.
+
+      Pre-resolve keeps both. It also keeps the distinction a linter, a
+      refactoring tool, or an editor round-tripping a file needs: `[a][]` and
+      `[a](#a)` are different things the author chose between, and a format
+      that preserves authored form one layer down (PART 11 §6: bullet
+      characters, delimiters, the bare marker) has no reason to discard this
+      one.
+
+      WHAT IS STILL SERIALIZED. §5's rule is unchanged and is not in tension
+      with this one: resolution RESULTS a consumer would otherwise have to
+      recompute -- footnote numbering, caption numbers -- are serialized,
+      because recomputing them means reimplementing PART 9R. The difference is
+      that those are ADDED alongside the authored construct; they do not
+      REPLACE it. A resolved footnote reference keeps its label and gains its
+      number. A resolved link keeps its `ref` and gains nothing: `href` is the
+      author's field, empty when the author did not write a destination.
 
    4. POSITIONS ARE REQUIRED. Every node EXCEPT the document root carries
       `pos`:
@@ -3841,30 +3968,47 @@ EOF = (* end of file *) ;
       The contract a consumer relies on is unchanged: JSON it is handed carries
       positions. How the producer arranged that is the producer's business.
 
-      IMPLEMENTATION STATUS. carve-php serializes conformantly: it records
-      positions behind a parse option and enables them whenever it serializes,
-      which is the arrangement the paragraph above permits.
+      IMPLEMENTATION STATUS. All three engines record positions behind a parse
+      option and enable them whenever they serialize, which is the arrangement
+      the paragraph above permits. Measured over the corpus:
 
-      carve-js records positions but not on every node. The types that come out
-      without one are all REASSEMBLED rather than sliced from the source -- the
-      hard break a line block synthesizes from a soft one, and table rows and
-      cells put back together from several lines. They are absent rather than
-      wrong, which is the half of the rule below that matters, and they are
-      tracked in carve-js#441.
+        carve-js    3414 placed,  10 unplaced   (0.29%)
+        carve-rs    3389 placed,   9 unplaced   (0.26%)
+        carve-php   3405 placed,   5 unplaced   (0.15%)
 
-      carve-rs records positions on BLOCK nodes and none on inline ones. Over
-      the corpus that places 869 block nodes and leaves 54, and the ones left
-      are refusals rather than gaps: line-block content is reassembled around
-      an indentation sentinel, so it is not a slice of the source and cannot
-      honestly be placed. Its inline variants are tuple-shaped, so there is
-      nowhere to put a position without changing the variant itself, which is
-      why the inline half has not started. Tracked in carve-rs#333, which also
-      records the six trap classes carve-js hit, in the order they bit.
+      What is left is not a backlog. Every engine independently arrived at
+      nearly the same residue, on the same THREE documents -- a line block
+      (41-line-blocks-9) and two table cells continued across lines
+      (63-table-multi-line-cell-continuation,
+      64-table-rowspan-with-multi-line-content). All of it is REASSEMBLED
+      content: a hard break a line block synthesizes from a soft one, line-block
+      content rebuilt around an indentation sentinel, a cell joined from several
+      source lines by a space the source does not contain. None of it is a slice
+      of the source at any offset, so no span selects it.
+
+      carve-rs additionally leaves the merged text of an unwrapped autolink
+      unplaced (03-links-12), for the same reason once §1a joins the run: the
+      `<` and `>` between the pieces are not in the value.
+
+      This state is convergent rather than accidental, and it is the evidence
+      behind carve#490, which asks whether a reassembled node should be a NAMED
+      permitted category under this section rather than a conformance shortfall
+      each engine reports separately. Until that is decided the rule below
+      stands as written.
+
+      The earlier text here named per-engine gaps that no longer exist -- it
+      described carve-rs as placing block nodes only, "869 block nodes and 54
+      left", and pointed at carve-js#441 and carve-rs#333 for tracking. Both
+      issues are closed and both engines have moved. A status section that
+      states numbers has to be re-measured when it is read; these were taken
+      from the corpus on the day this paragraph was written.
 
       carve-rb serializes carve-rs's tree, so it publishes exactly what that
-      engine records - the block positions and not the inline ones. It is the
-      route by which the conformance checker reaches carve-rs at all, since
-      carve-rs has no JSON serializer of its own.
+      engine records. It is the route by which the conformance checker reaches
+      carve-rs at all, since carve-rs has no JSON serializer of its own -- and
+      therefore also the route by which a stale carve-rs PIN in carve-rb shows
+      up as a conformance failure that carve-rs itself does not have
+      (carve-rb#41).
 
       An implementation that cannot yet produce positions MUST NOT emit `pos`
       with invented values, and MUST NOT omit it silently: it does not yet
@@ -3925,6 +4069,41 @@ EOF = (* end of file *) ;
       that container empty; the serialized tree follows the same rule rather
       than inventing a second one. Its `pos` still records where it was
       WRITTEN, so nothing about navigation is lost by the move.
+
+      THIS COVERS EVERY DEFINITION KIND, NOT ONLY FOOTNOTES -- NORMATIVE. An
+      `abbreviation_def` authored inside a div, a list item or a block quote is
+      a child of the DOCUMENT, exactly as a `footnote` is. The clause above was
+      written against PART 9 §16 and read as footnote-specific, so the engines
+      split: carve-php hoisted both kinds, carve-js and carve-rs hoisted the
+      footnote and left the abbreviation in its container, and all three
+      rendered identical HTML -- because an abbreviation is document-global
+      wherever it is written, which is the same property that makes a footnote
+      definition document-level metadata. A rule that applies to one and not
+      the other needed a reason, and there is none. (carve-php#631)
+
+      THE FORMATTER CONSEQUENCE IS ACCEPTED, NOT OVERLOOKED. Hoisting means
+      PART 11's writer emits the definition after the container the author
+      wrote it in, which reads like a violation of PART 11 §6 ("fmt does not
+      reorder ... those are the author's choices and the AST records them").
+      It is not, because §6 governs what the writer may do with what the tree
+      HOLDS, and this clause is what the tree holds. The consequence is already
+      shipping and corpus-pinned for footnotes:
+
+        See [^a].
+
+        > [^a]: note body
+
+      formats to the definition after an emptied `>`, and corpus
+      `115-footnote-definition-inside-a-container-is-collected` pins the
+      collection it follows from. Extending the rule to abbreviations extends
+      that consequence; it does not introduce it.
+
+      THE ALTERNATIVE WAS TO NARROW THE RULE instead -- keep definitions where
+      they were written, for both kinds. It was rejected because it reverses a
+      pinned rule that ships today, and because the argument for hoisting is
+      not about convenience: a definition is metadata whose SCOPE is the
+      document, and a tree that nests document-scoped metadata inside a
+      container invites a consumer to treat it as container-scoped.
 
       Definitions appear in DOCUMENT ORDER by source position. Numbering is a
       resolution result and stays on the reference (§5).

--- a/tests/normativity.test.mjs
+++ b/tests/normativity.test.mjs
@@ -34,6 +34,20 @@ const part9Sections = new Set(
   [...part9.matchAll(/^ {3}(\d+)\. {1,3}[A-Z]/gm)].map((m) => Number(m[1])),
 )
 
+// The same collection for PART 12, whose clause numbers carry an optional
+// LETTER suffix (`1a.`, `3a.`). The docs cite them both as "PART 12 §3a" and,
+// once the part is established on the page, as a bare "(§3a)" - so the bare
+// form has to be checked too, which is only safe on the pages that are ABOUT
+// PART 12 (listed below).
+const part12Start = grammar.indexOf('PART 12:')
+const part12 = grammar.slice(part12Start)
+const part12Sections = new Set(
+  [...part12.matchAll(/^ {3}(\d+[a-z]?)\. {1,3}[A-Z]/gm)].map((m) => m[1]),
+)
+
+// Pages whose bare "§N" citations mean PART 12.
+const part12Pages = ['docs/ast-json.md']
+
 const docFiles = [
   ...readdirSync(resolve(repo, 'docs'))
     .filter((f) => f.endsWith('.md'))
@@ -71,6 +85,56 @@ test('every "PART 9 §N" reference resolves to a real section', () => {
     dangling,
     [],
     `dangling normative references (valid: §${[...part9Sections].sort((a, b) => a - b).join(', §')}):\n${dangling.join('\n')}`,
+  )
+})
+
+// This is the check that was missing when PR #525 landed from a branch cut
+// before PR #518 and silently removed PART 12 §3a - along with §1a's merge
+// clauses, §4's implementation status and §7's every-definition-kind rule -
+// from the normative text. The whole suite stayed green, because nothing
+// asserted that a section the docs describe still exists. docs/ast-json.md
+// went on citing "(§3a)" against a grammar that no longer had one.
+test('every PART 12 section reference resolves to a real clause', () => {
+  assert.ok(
+    part12Sections.size >= 6,
+    `PART 12 clause scan found only: ${[...part12Sections]}`,
+  )
+  const dangling = []
+  const check = (file, id) => {
+    if (!part12Sections.has(id)) dangling.push(`${file}: §${id}`)
+  }
+  // A citation GROUP, so shorthand reaches every clause it names and not only
+  // the first: "§1-2", "§3a and §4", "PART 12 §1, §1a, §6". Without this a
+  // renumbering that orphaned the far end of a range would leave this green,
+  // which is the same shape of dead check the regression below slipped past.
+  const CLAUSE = String.raw`\d+[a-z]?`
+  const group = (lead) =>
+    new RegExp(
+      `${lead}(${CLAUSE})((?:\\s*(?:,|&|and|or|to|–|-)\\s*§?${CLAUSE})*)`,
+      'g',
+    )
+  const scan = (file, text, lead) => {
+    for (const m of text.matchAll(group(lead))) {
+      check(file, m[1])
+      for (const tail of m[2].matchAll(new RegExp(`§?(${CLAUSE})`, 'g'))) {
+        check(file, tail[1])
+      }
+    }
+  }
+  for (const file of docFiles) {
+    const text = readFileSync(file, 'utf8')
+    // Qualified: "PART 12 §3a", "PART 12 section 3a".
+    scan(file, text, String.raw`PART 12 (?:§|section )`)
+    // Bare "(§3a)" on the pages that are about PART 12.
+    if (part12Pages.some((p) => file.endsWith(p))) scan(file, text, '§')
+  }
+  // The schema descriptions cite PART 12 too, and they are published.
+  const schema = readFileSync(resolve(repo, 'resources/ast-schema.json'), 'utf8')
+  scan('resources/ast-schema.json', schema, String.raw`PART 12 (?:§|section )`)
+  assert.deepEqual(
+    dangling,
+    [],
+    `references to PART 12 clauses that do not exist (valid: ${[...part12Sections].join(', ')}):\n${dangling.join('\n')}`,
   )
 })
 


### PR DESCRIPTION
Closes #490. **Stacked on #540** - review that one first; this branch contains it.

PART 12 §1a coalesces adjacent text runs; §4 requires a position on every node but the root. Where a merge crosses a gap in the source, the two rules leave a producer no conformant answer.

Input:

```
| x | A long description |
+     | that continues     |
```

The cell's text is `A long description that continues`, joined across a newline, a `+` and an indent the value does not contain. §1a requires one text node; no offset pair covers that value. So the producer either carries a span over characters the value drops, or omits the span §4 appears to demand.

## What changed

§1a's POSITIONS note already chose the second. §4 is where that had to be agreed to, and it was not: its implementation status described the same residue in all three engines and then asked, in this issue, whether such a node should be a **named permitted category** rather than a shortfall each engine reports separately.

It is now named. A node whose value is not a contiguous slice of the source - joined from pieces the source separates, or synthesized outright - **may omit `pos` and is conformant doing so**.

Stated in the spec rather than per engine because §1a is normative: any implementation following it faithfully arrives at the same fork, so an answer chosen per engine would be three answers. That the three engines' residues had already converged - same three documents, same kind of content - is the evidence that this is a property of the rules and not of anyone's parser.

## The exemption is scoped, and launders nothing else

The test is whether a true span *exists*, not whether one was computed. A node the producer has not placed yet is still a gap, and a producer that joins where the source did not is publishing its bookkeeping - which is what §1a exists to stop.

One concrete case is called out rather than swept in: `docs/ast-json.md`'s conformance table records carve-rs leaving a **definition list's own parts** unplaced. A `definition_term` is a slice of the source like any other node, so if that is still true it is a gap, not reassembly. Both the clause and the table now say so. I did not re-measure carve-rs here, so the table's claim is carried forward as written rather than confirmed.

## Not changed

`scripts/ast-conformance.mjs` still reports an absent `pos`. It cannot tell a reassembled node from an unplaced one from the tree alone, which is why the position half of that check is a report and the §1a half is a gate. The spec now records that reasoning instead of leaving the report looking like a backlog.