### PR TITLE
fix(ast:check): the shape comparison died on every definition list

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bump-carve-pin": "node scripts/bump-carve-pin.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/portable-whitespace.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs tests/degradation-claims.test.mjs tests/migration-claims.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/ast-shape.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/portable-whitespace.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs tests/degradation-claims.test.mjs tests/migration-claims.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -41,6 +41,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Ajv2020 } from 'ajv/dist/2020.js'
+import { POS_KEYS, shapeOf, shapePaths } from './spec/ast-shape.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
@@ -195,7 +196,6 @@ function skip(label, reason) {
   console.log(`${label}: NOT MEASURED - ${reason}\n`)
 }
 
-const POS_KEYS = ['startLine', 'endLine', 'startColumn', 'endColumn', 'startOffset', 'endOffset']
 
 function* walk(node, path = '$') {
   if (Array.isArray(node)) {
@@ -250,51 +250,6 @@ function checkFrontmatterSurvives(doc, source, findings) {
   }
 }
 
-
-/**
- * A document's structural signature: the tree of node TYPES, with values,
- * attributes and positions removed.
- *
- * The schema says whether a tree is well formed; it cannot say whether two
- * engines produced the SAME tree. Both can be valid and structurally
- * different - which is what PART 12 §1 actually forbids, because "a consumer
- * written against one implementation MUST be able to read another's output"
- * is a statement about shape, not about validity.
- *
- * That gap let carve-php ship a table cell split into three text nodes where
- * the reference emits one (carve-php#612), and carve-rs the same cell as five
- * (carve-rs#413). Every span in both was correct and every document validated,
- * so nothing here reported anything.
- */
-function shapeOf(node) {
-  if (Array.isArray(node)) return node.map(shapeOf)
-  if (!node || typeof node !== 'object') return null
-  const children = []
-  // Sorted by key: engines serialize their fields in different orders, and a
-  // signature that inherited that order would report every one of them as a
-  // shape difference.
-  for (const [key, value] of Object.entries(node).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
-    if (POS_KEYS.includes(key) || key === 'pos' || key === 'srcByteLength') continue
-    if (Array.isArray(value)) {
-      const sub = value.map(shapeOf).filter((s) => s !== null)
-      if (sub.length) children.push([key, sub])
-    } else if (value && typeof value === 'object') {
-      const sub = shapeOf(value)
-      if (sub !== null) children.push([key, [sub]])
-    }
-  }
-  return typeof node.type === 'string' || children.length ? { type: node.type ?? '?', children } : null
-}
-
-/** Render a shape as a compact path list, so a mismatch names where it is. */
-function shapePaths(shape, path = '$') {
-  if (!shape) return []
-  const out = [`${path}:${shape.type}`]
-  for (const [key, subs] of shape.children) {
-    subs.forEach((s, i) => out.push(...shapePaths(s, `${path}.${key}[${i}]`)))
-  }
-  return out
-}
 
 /**
  * Compare an engine's tree against the reference's and report the FIRST place

--- a/scripts/spec/ast-shape.mjs
+++ b/scripts/spec/ast-shape.mjs
@@ -1,0 +1,77 @@
+/*
+ * A document's STRUCTURAL SIGNATURE: the tree of node types, with values,
+ * attributes and positions removed, plus a flat rendering of it.
+ *
+ * Extracted from scripts/ast-conformance.mjs so both halves can be tested
+ * without running the whole conformance report, which needs sibling engine
+ * checkouts and exits the process.
+ */
+
+/** Position fields, stripped from a signature: shape is not placement. */
+export const POS_KEYS = [
+  'startLine',
+  'endLine',
+  'startColumn',
+  'endColumn',
+  'startOffset',
+  'endOffset',
+]
+
+/**
+ * The schema says whether a tree is well formed; it cannot say whether two
+ * engines produced the SAME tree. Both can be valid and structurally
+ * different - which is what PART 12 §1 actually forbids, because "a consumer
+ * written against one implementation MUST be able to read another's output"
+ * is a statement about shape, not about validity.
+ *
+ * That gap let carve-php ship a table cell split into three text nodes where
+ * the reference emits one (carve-php#612), and carve-rs the same cell as five
+ * (carve-rs#413). Every span in both was correct and every document validated,
+ * so nothing reported anything.
+ */
+export function shapeOf(node) {
+  if (Array.isArray(node)) return node.map(shapeOf)
+  if (!node || typeof node !== 'object') return null
+  const children = []
+  // Sorted by key: engines serialize their fields in different orders, and a
+  // signature that inherited that order would report every one of them as a
+  // shape difference.
+  for (const [key, value] of Object.entries(node).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
+    if (POS_KEYS.includes(key) || key === 'pos' || key === 'srcByteLength') continue
+    if (Array.isArray(value)) {
+      const sub = value.map(shapeOf).filter((s) => s !== null)
+      if (sub.length) children.push([key, sub])
+    } else if (value && typeof value === 'object') {
+      const sub = shapeOf(value)
+      if (sub !== null) children.push([key, [sub]])
+    }
+  }
+  return typeof node.type === 'string' || children.length ? { type: node.type ?? '?', children } : null
+}
+
+/**
+ * Render a shape as a compact path list, so a mismatch names where it is.
+ *
+ * A shape can be an ARRAY, because shapeOf maps an array to an array of shapes
+ * and a node field may hold an array OF arrays. `definition_list.items` is the
+ * one the corpus reaches: each entry is itself a list of nodes, so that field's
+ * shape nests one level deeper than a plain `children` array does.
+ *
+ * Without the array branch that value reached the `shape.children` loop and
+ * threw `shape.children is not iterable`, killing the run partway through --
+ * after the position findings had already printed, so it read like a report
+ * that had finished rather than one that had died. Every definition-list
+ * document reached it, which means the shape comparison had never once run for
+ * them. Pinned by tests/ast-shape.test.mjs.
+ */
+export function shapePaths(shape, path = '$') {
+  if (!shape) return []
+  if (Array.isArray(shape)) {
+    return shape.flatMap((s, i) => shapePaths(s, `${path}[${i}]`))
+  }
+  const out = [`${path}:${shape.type}`]
+  for (const [key, subs] of shape.children) {
+    subs.forEach((s, i) => out.push(...shapePaths(s, `${path}.${key}[${i}]`)))
+  }
+  return out
+}

--- a/tests/ast-shape.test.mjs
+++ b/tests/ast-shape.test.mjs
@@ -1,0 +1,64 @@
+/*
+ * The structural-signature helpers behind scripts/ast-conformance.mjs.
+ *
+ * Extracted and tested because the shape comparison had a branch it could not
+ * survive: `definition_list.items` holds an array OF arrays, shapeOf maps that
+ * to an array of shapes, and shapePaths assumed every shape was an object. It
+ * threw `shape.children is not iterable` and killed the run - AFTER the
+ * position findings had printed, so the output read like a report that had
+ * finished rather than one that had died. Every definition-list document in the
+ * corpus reached it, so the comparison had never once run for any of them.
+ *
+ * The report only reaches that code with a sibling engine checkout present, so
+ * CI without one never hit it. These tests need no engines.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse } from '@markup-carve/carve'
+import { shapeOf, shapePaths } from '../scripts/spec/ast-shape.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repo = resolve(here, '..')
+
+test('shapePaths walks a nested array without throwing', () => {
+  // The exact value shape that used to throw: a field holding an array whose
+  // entries are themselves arrays of nodes.
+  const shape = shapeOf({
+    type: 'definition_list',
+    items: [[{ type: 'definition_term' }, { type: 'definition_description' }]],
+  })
+  const paths = shapePaths(shape)
+  assert.deepEqual(paths, [
+    '$:definition_list',
+    '$.items[0][0]:definition_term',
+    '$.items[0][1]:definition_description',
+  ])
+})
+
+test('every corpus definition list produces a walkable signature', () => {
+  // A synthetic node proves the branch; the corpus proves the branch is the one
+  // real documents take. Both matter - the crash was found by a real document.
+  const source = readFileSync(
+    resolve(repo, 'tests/corpus/25-definition-lists.crv'),
+    'utf8',
+  )
+  const paths = shapePaths(shapeOf(parse(source)))
+  assert.ok(paths.length > 0, 'signature is empty')
+  assert.ok(
+    paths.some((p) => p.endsWith(':definition_list')),
+    `no definition_list in the signature: ${paths.join(' ')}`,
+  )
+})
+
+test('a signature drops positions and values, and keeps types', () => {
+  const shape = shapeOf({
+    type: 'paragraph',
+    pos: { startLine: 1, endLine: 1, startColumn: 1, endColumn: 4, startOffset: 0, endOffset: 3 },
+    children: [{ type: 'text', value: 'abc' }],
+  })
+  assert.deepEqual(shapePaths(shape), ['$:paragraph', '$.children[0]:text'])
+})


### PR DESCRIPTION
Found while working #534. With a sibling engine checkout present, `npm run ast:check` throws partway through:

```
TypeError: shape.children is not iterable
    at shapePaths (scripts/ast-conformance.mjs:293:35)
```

## Cause

`shapeOf` maps an array to an array of shapes, and a node field can hold an array **of** arrays - `definition_list.items`, where each entry is itself a list of nodes. `shapePaths` assumed every shape was an object, so that value reached its `shape.children` loop and threw.

## Why it matters more than a crash

The throw came **after** the position findings had printed, so the output read like a report that had finished rather than one that had died.

The real consequence is that the shape comparison had never once run for a definition-list document. 17 corpus documents reach it - `25-definition-lists*`, `145-*`, `154-*`, `156-*`, `70-blocks-that-render-to-nothing-2`, `82-blockquote-lazy-continuation-5` - and the check that exists to catch two engines publishing different trees was silently absent for all of them.

CI never saw it: the comparison only runs against a sibling engine checkout, and the reference-side signature build does not call `shapePaths`.

## The fix

`shapePaths` walks an array shape. The two helpers move to `scripts/spec/ast-shape.mjs` so they can be tested without running the report, which needs sibling checkouts and calls `process.exit`.

`tests/ast-shape.test.mjs` pins the branch three ways: the synthetic node shape that threw, a real corpus definition list, and the position/value stripping the signature exists for. Removing the array branch again fails two of the three - checked, not assumed.

After the fix the report runs to completion and the shape comparison reports on definition lists for the first time. I am not quoting the resulting numbers here: my local carve-rs build is flagged STALE by the script's own build check, so they would not be a measurement of anyone's `main`.
