### PR TITLE
chore: bump the pinned reference build, and correct what it disproves

### DIFF
--- a/docs/portable-whitespace.md
+++ b/docs/portable-whitespace.md
@@ -90,8 +90,19 @@ Both read that as one quoted paragraph `ok` followed by a lazy continuation
 line `>bad`.
 
 Two spaces after the marker, a lazy continuation line with no marker at all, and
-a bare `>` separator line inside a quote are all valid. A tab immediately after
-`>` is content, not the marker separator.
+a bare `>` separator line inside a quote are all valid.
+
+A TAB after the marker is not. Carve's separator is the space character, so a
+tab is content and the line is an ordinary paragraph; Djot accepts the tab and
+opens the quote. The two engines disagree about the whole block, not about its
+spacing:
+
+```
+>	q
+```
+
+The fence above holds a real tab. Carve renders that line as ordinary
+paragraph text, marker and all; Djot renders a quoted `q`. Write a space.
 
 ## What this page does not cover
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#18dfdd6a971013e9c242aef55370950e84e15039",
+        "@markup-carve/carve": "github:markup-carve/carve-js#a12fced46a770ba7ce20439e7c8ba167a8bb7f7a",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.35.0",
@@ -982,8 +982,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#18dfdd6a971013e9c242aef55370950e84e15039",
-      "integrity": "sha512-dtjPmX2tNGLgbntPlfi3tLEM6eNZGe5u6O6n0VK5C1FX1jSLDCY9Xu7aCPkEDOM1+5xJtbW2WJeFPfwMQ9+Sgg==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#a12fced46a770ba7ce20439e7c8ba167a8bb7f7a",
+      "integrity": "sha512-at4eVyxUj+ZOtWu1j7mzOGOhZTXhYkITn8ueS2zCwvfM1DpbdC1msDVYMkn8PsWOSz2I9YczuN9R/UGD+Rom3A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -991,6 +991,14 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "peerDependencies": {
+        "@djot/djot": "^0.3.2"
+      },
+      "peerDependenciesMeta": {
+        "@djot/djot": {
+          "optional": true
+        }
       }
     },
     "node_modules/@markup-carve/carve-grammars": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#18dfdd6a971013e9c242aef55370950e84e15039",
+    "@markup-carve/carve": "github:markup-carve/carve-js#a12fced46a770ba7ce20439e7c8ba167a8bb7f7a",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.35.0",

--- a/tests/portable-whitespace.test.mjs
+++ b/tests/portable-whitespace.test.mjs
@@ -34,10 +34,10 @@ const CASES = [
   // portable-quote-marker-space
   { rule: 'quote-space', input: '> quote\n', differs: false, note: 'marker with a space' },
   { rule: 'quote-space', input: '> > q\n', differs: false, note: 'each nested marker spaced' },
-  { rule: 'quote-space', input: '>\tq\n', differs: false, note: 'a tab after the marker is fine in both' },
+  { rule: 'quote-space', input: '>\tq\n', differs: true, note: 'a tab after the marker opens the quote in Djot and not in Carve' },
   { rule: 'quote-space', input: '>  q\n', differs: false, note: 'two spaces after the marker are fine in both (not CommonMark-identical, but that is not this rule\'s claim)' },
   { rule: 'quote-space', input: '> a\n>\n> b\n', differs: false, note: 'a bare ">" separator line is fine in both' },
-  { rule: 'quote-space', input: '> ok\n>bad\n', differs: true, note: 'an unspaced marker on a continuation line' },
+  { rule: 'quote-space', input: '> ok\n>bad\n', differs: false, note: 'an unspaced marker on a continuation line is lazy text in both' },
   { rule: 'quote-space', input: '> ok\n> good\n', differs: false, note: 'every continuation marker spaced' },
   { rule: 'quote-space', input: '> ok\nbad\n', differs: false, note: 'a lazy continuation line carries no marker in either' },
 ]


### PR DESCRIPTION
Closes #533.

`npm run engine:report` renders the corpus through the pinned reference build of carve-js. That pin was three spec rules behind:

```text
pinned reference build: github:markup-carve/carve-js#18dfdd6
corpus pairs: 539
reproduced:   536
mismatched:   3
```

on `81-paragraph-interruption-5` and both `82-blockquote-lazy-continuation` cases, while `npm test` stayed green - the suite parses with that same pin, so a rule the engine has not shipped yet is invisible to it and visible only to this report.

The pin moves to carve-js `a12fced`, which reproduces all 539 pairs.

## What the bump disproved

Two portable-whitespace claims went red. Both were the page being stale, not the pin being wrong.

**A tab after `>` now diverges.** Carve's marker separator is the space character, so `>` followed by a tab is ordinary paragraph text; Djot opens the quote:

```
>	q
```

Carve gives a paragraph, Djot a quoted `q`. The page listed a tab beside the forms that are fine in both. It now warns, with the input in a fence, because the engines disagree about the whole block rather than about its spacing.

**An unspaced continuation marker no longer diverges.**

```
> ok
>bad
```

is one quoted paragraph with a lazy continuation line in both engines - which is what the page's own prose already said. The case was pinned as *differing*, so it had been asserting the opposite of the page it guards.

Each case keeps its pairing (a recommended form pinned as agreeing, a warned-about form pinned as differing), so drift in either direction still fails here instead of quietly turning the advice into noise.

## Found on the way, not fixed here

`::` followed by a tab is a definition term in carve-js and carve-php, and paragraph text in carve-rs. `definition_term = "::", space, inline_content, newline` and `space = ' '`, so carve-rs is the one that matches the grammar. That is the last construct still accepting a tab where the separator is specified as a space - the quote and heading cases named in #532 have since been fixed - and it needs engine changes before the corpus can pin it.
