### PR TITLE
tools: the fuzzer says which builds it compared

### DIFF
--- a/scripts/fuzz-impls.mjs
+++ b/scripts/fuzz-impls.mjs
@@ -48,7 +48,7 @@
  * no fuzzer.
  */
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, writeFileSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -128,6 +128,37 @@ if (missing.length) {
   console.error('A fuzzer that reports success having rendered nothing is worse than no fuzzer.')
   process.exit(2)
 }
+
+/*
+ * Say WHICH build each engine is, before rendering anything.
+ *
+ * Missing was already fatal. STALE was silent, and stale is the worse failure:
+ * the run completes, the divergences look real, and they are two days old. A
+ * seed-101 run reported four `>`-marker divergences that had been fixed the day
+ * before - the carve-rs binary was from a sibling checkout the fallback path
+ * found, built before that fix landed. Four of eight findings were fiction, and
+ * nothing in the output said so.
+ *
+ * The paths are printed because the fallback is a bare `../carve-rs` relative to
+ * this repo: whoever sets CARVE_RS_DIR and typos it gets a different engine
+ * without being told. The mtime is printed because a checkout at the right
+ * revision can still hold a binary built before the last commit.
+ */
+const provenance = (label, file) => {
+  let built = 'unknown'
+  try {
+    built = statSync(file).mtime.toISOString().replace('T', ' ').slice(0, 16)
+  } catch {
+    /* reported as unknown; the existence checks above already passed */
+  }
+  return `  ${label.padEnd(10)} ${built}  ${file}`
+}
+
+console.log('fuzz-impls: comparing these builds')
+console.log(provenance('carve-js', jsEntry))
+console.log(provenance('carve-rs', rustBinary))
+console.log(provenance('carve-php', phpBinary))
+console.log('')
 
 const lib = await import(jsEntry)
 // A wrong entry-point NAME must fail loudly. While `plain` was mapped to a


### PR DESCRIPTION
A missing engine was already fatal - `A fuzzer that reports success having rendered nothing is worse than no fuzzer`. A **stale** one was silent, and stale is the worse failure: the run completes, the divergences look real, and they are two days old.

## What happened today

A `--seed=101` run reported four `>`-marker divergences that had been fixed the day before:

```
>t    js: <p>&gt;t</p>    rs: <blockquote><p>t</p></blockquote>
>]    >>    >%            (same shape)
```

The carve-rs binary came from a sibling checkout the fallback path found - `../carve-rs` relative to this repo - built before carve-rs#467 landed. **Four of the eight findings were fiction**, and nothing in the output said so. It was caught only because one of them contradicted a merged PR's own comparison table.

## The change

Paths and build times, printed before anything is rendered:

```
fuzz-impls: comparing these builds
  carve-js   2026-08-03 19:08  /tmp/carve-js/dist/index.js
  carve-rs   2026-08-01 13:30  /media/mark/data/work/git/carve-rs/target/release/carve
  carve-php  2026-08-03 02:32  /tmp/carve-php/bin/carve
```

The date is the point. One build two days older than the others is visible at a glance; a wrong path is not, because the fallback is a bare relative directory - anyone who sets `CARVE_RS_DIR` and typos it silently gets a different engine.

**mtime rather than revision**, deliberately: a checkout at the right commit can still hold a binary built before it, and that is exactly the case here. `git rev-parse` in the engine directory would have reported the right commit and told me nothing.

## Not a gate

Unchanged - this stays a tool you run and shrink from. The banner costs one `statSync` per engine and is printed on every run including the ones that find nothing, because that is when you are least likely to check.

Re-running seed 101 against correctly-built engines gives 8 real minimal reproducers, two of which are the same defect and are now filed as markup-carve/carve-rs#491 and #557.
