### PR TITLE
ci: measure the whole corpus in the scheduled AST job, not the first 520

### DIFF
--- a/.github/workflows/ast-conformance.yml
+++ b/.github/workflows/ast-conformance.yml
@@ -115,7 +115,14 @@ jobs:
           # make the run permanently red, and a permanently red scheduled job
           # gets muted, which is the failure this whole issue is about.
           CARVE_REQUIRE_ALL_ENGINES: '1'
-        run: npm run ast:check -- --satellite-limit=520
+        # NO --satellite-limit here. The cap exists for a quick local pass;
+        # this job provisions every engine precisely so it can measure all of
+        # them over everything. It was pinned at 520 when the corpus was that
+        # size, and the corpus has grown to 542 (545 samples with the synthetic
+        # astral cases), so the last 25 were being skipped - a number that goes
+        # further out of date with every fixture added, and the newest fixtures
+        # are the ones most likely to catch drift.
+        run: npm run ast:check
 
       # PART 11: the formatter must not change what a document says. The
       # `--roundtrip` mode formats each corpus document and re-reads the result,


### PR DESCRIPTION
The PART 12 conformance step passed `--satellite-limit=520`. That number was the corpus size when it was written; the corpus is now **542 documents (545 samples** with the synthetic astral cases), so the satellite engines were checked over the first 520 and the last 25 were skipped.

The cap exists for a quick local pass - `scripts/ast-conformance.mjs` says so in as many words. This job is the opposite of that: it checks out and builds every engine, and sets `CARVE_REQUIRE_ALL_ENGINES=1` specifically so a missing engine is a broken job rather than a quiet skip. Capping the sample there hands back the property that flag was added to remove.

The skipped tail is also the worst one to skip. Fixtures are appended, so the last 25 are the newest - where drift shows up first - and the gap widens with every fixture added, silently, because nothing recomputes the number.

Cost is negligible: the satellites already run over 520 documents, so this is about 5% more work on a scheduled job.

## On the other finding for this file

Codex also flagged that `npm ci` here should be preceded by the `git config url."https://github.com/".insteadOf` rewrite the docs jobs use, since `package-lock.json` resolves the `@markup-carve/*` git dependencies as `git+ssh://`. **Not reproduced** - this workflow has run and succeeded three times today. Left alone rather than fixed on speculation.