### PR TITLE
ci: gate the pinned reference build on its declared drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,21 @@ jobs:
       - name: Executable-spec gate (formal Core grammar vs corpus)
         run: npm run core:check
 
+      # The pinned reference build vs the corpus. NOT a gate on drift -- the
+      # corpus is deliberately allowed to run ahead of the engine, and gating
+      # on the mismatch itself would reinstate exactly the deadlock
+      # scripts/engine-report.mjs exists to document.
+      #
+      # This gates on the drift being DECLARED. resources/engine-pin-drift.txt
+      # names the slugs the pin is knowingly behind on and why; a spec PR that
+      # puts the corpus ahead adds a line there and stays green. Undeclared
+      # drift, and lines the pin has caught up on, both go red.
+      #
+      # It ran in no job at all until now, which is how carve#533 found the
+      # pinned build three documents behind with nothing reporting it.
+      - name: Pinned reference build matches its declared drift
+        run: npm run engine:report -- --check
+
   docs-build:
     name: docs build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The pinned reference build is now checked against the corpus in CI**
+  (carve#533). `engine:report` existed as an npm script that no workflow ran,
+  so the pin drifted three documents behind the corpus with nothing reporting
+  it. It is not gated on drift itself - the corpus is deliberately allowed to
+  run ahead of the engine, and gating on the mismatch would reinstate the
+  deadlock the script's own header warns about. It gates on the drift being
+  DECLARED: `resources/engine-pin-drift.txt` names the slugs the pin is
+  knowingly behind on and why, and `npm run engine:report -- --check` fails
+  when the real set differs in either direction - undeclared drift, or a line
+  the pin has since caught up on.
+
 ### Changed
 
 - **PART 12 §3a: a RESOLVED reference keeps its destination** (carve#524). The

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -1,0 +1,27 @@
+# Corpus documents the PINNED reference build does not reproduce.
+#
+# `npm run engine:report` renders every corpus document through the
+# `@markup-carve/carve` build package.json pins, and compares against the
+# committed HTML. A mismatch is not automatically wrong: when a spec rule
+# lands here, the engine has not shipped it yet, and the corpus is ahead of
+# the pin until someone moves it. That window is normal and the report exists
+# to describe it.
+#
+# What is NOT normal is not knowing which window you are in. carve#533 found
+# the pinned build three documents behind with nothing reporting it, because
+# `engine:report` was an npm script that no CI job ran.
+#
+# So the window is DECLARED rather than tolerated. This file lists the slugs
+# the pin is knowingly behind on, one per line, each with the reason.
+# `npm run engine:report -- --check` fails when the real set differs in
+# EITHER direction:
+#
+#   - a slug mismatches and is not listed  -> new drift, or a corpus fixture
+#     that does not match any engine. Red immediately, which is the point.
+#   - a slug is listed and now reproduces  -> the pin moved past it. Delete
+#     the line in the same commit that moves the pin.
+#
+# Emptying this file is the normal end state after `npm run bump-carve-pin`.
+#
+# Format: <slug><space><space><reason>
+176-a-marker-separator-is-a-space-never-a-tab  carve#559 landed the rule; carve-js has not shipped it

--- a/scripts/engine-report.mjs
+++ b/scripts/engine-report.mjs
@@ -14,7 +14,16 @@
  * wire it into the blocking gates, or the deadlock it exists to document comes
  * straight back.
  *
- * Usage: node scripts/engine-report.mjs [--diff]
+ * --check turns it into a gate on the DECLARED window rather than on drift
+ * itself, which is the distinction that keeps the deadlock above from coming
+ * back. resources/engine-pin-drift.txt names the slugs the pin is knowingly
+ * behind on; --check fails only when the real set differs from that file, in
+ * either direction. A spec PR that puts the corpus ahead of the engine adds a
+ * line there and stays green; drift nobody declared goes red the same day.
+ * That is what carve#533 asked for - it found the pin three documents behind
+ * with nothing reporting it, because this script ran in no CI job at all.
+ *
+ * Usage: node scripts/engine-report.mjs [--diff] [--check]
  */
 
 import { readdirSync, readFileSync } from 'node:fs'
@@ -25,6 +34,7 @@ import { carveToHtml } from '@markup-carve/carve'
 const here = dirname(fileURLToPath(import.meta.url))
 const corpusDir = resolve(here, '..', 'tests/corpus')
 const diffMode = process.argv.includes('--diff')
+const checkMode = process.argv.includes('--check')
 
 const slugs = readdirSync(corpusDir)
   .filter((f) => f.endsWith('.crv'))
@@ -73,4 +83,51 @@ if (mismatches.length || threw.length) {
   )
 }
 
-process.exit(mismatches.length || threw.length ? 1 : 0)
+if (!checkMode) process.exit(mismatches.length || threw.length ? 1 : 0)
+
+/*
+ * --check: compare the real drift against the DECLARED drift.
+ *
+ * Reported in both directions on purpose. "Undeclared" is the carve#533 case,
+ * drift nobody wrote down. "Stale" is the one that rots quietly the other way:
+ * the pin moves, the engine catches up, and the file goes on excusing a
+ * document that reproduces fine - so the next real drift on that slug is
+ * pre-excused and never reported.
+ */
+const driftPath = resolve(here, '..', 'resources/engine-pin-drift.txt')
+const declared = new Map(
+  readFileSync(driftPath, 'utf8')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#'))
+    .map((l) => {
+      const at = l.search(/\s{2,}/)
+      if (at === -1) throw new Error(`engine-pin-drift.txt: no reason on line: ${l}`)
+      return [l.slice(0, at), l.slice(at).trim()]
+    }),
+)
+
+const actual = new Set([...mismatches.map((m) => m.slug), ...threw.map((t) => t.slug)])
+const undeclared = [...actual].filter((s) => !declared.has(s)).sort()
+const stale = [...declared.keys()].filter((s) => !actual.has(s)).sort()
+
+console.log(`\ndeclared drift:          ${declared.size} (resources/engine-pin-drift.txt)`)
+
+for (const slug of undeclared) {
+  console.log(`  UNDECLARED  ${slug} - the pin does not reproduce this and nothing says why`)
+}
+for (const slug of stale) {
+  console.log(`  STALE       ${slug} - reproduces now; drop the line (reason was: ${declared.get(slug)})`)
+}
+
+if (undeclared.length || stale.length) {
+  console.log(
+    `\nresources/engine-pin-drift.txt does not describe this build.\n` +
+      `Add a line (with the reason) for drift a spec rule just created, or delete\n` +
+      `lines the pin has caught up on - in the commit that causes either.`,
+  )
+  process.exit(1)
+}
+
+console.log('\nDrift matches what is declared.')
+process.exit(0)


### PR DESCRIPTION
Closes #533.

`engine:report` renders every corpus document through the carve-js build `package.json` pins and compares against the committed HTML. It existed as an npm script **that no workflow ran** - which is how the pin got three documents behind the corpus with nothing reporting it. It is down to one today, but only because someone looked.

```
pinned reference build:  github:markup-carve/carve-js#a12fced4…
corpus pairs:            542
reproduced:              541
mismatched:              1
--- 176-a-marker-separator-is-a-space-never-a-tab
```

## Not gated on drift

The corpus is deliberately allowed to run ahead of the engine - that is how a spec rule lands here before any engine ships it. Gating on the mismatch would reinstate exactly the deadlock `scripts/engine-report.mjs` warns about in its own header:

> Exits non-zero when anything mismatches, so it is usable on demand or in a non-blocking job - just do not wire it into the blocking gates, or the deadlock it exists to document comes straight back.

## Gated on the drift being declared

`resources/engine-pin-drift.txt` names the slugs the pin is knowingly behind on, each with a reason. `npm run engine:report -- --check` fails when the real set differs **in either direction**:

- **UNDECLARED** - the pin does not reproduce a document and nothing says why. The #533 case.
- **STALE** - a listed slug reproduces now. This is the one that rots the other way: the engine catches up, the line goes on excusing a document that is fine, and the next real drift on that slug is pre-excused and never reported.

A spec PR that puts the corpus ahead adds a line and stays green, where a reviewer sees the window being opened next to the rule that opened it. Emptying the file is the normal end state after `npm run bump-carve-pin`.

This is the same shape as the normative-clause inventory from #539, for the same reason: removing a check stays allowed, removing it *silently* does not.

## Both directions checked, not assumed

- Emptying the file → `UNDECLARED 176-a-marker-separator-is-a-space-never-a-tab`, exit 1.
- Adding a slug that reproduces → `STALE 05-lists`, exit 1.
- Restoring → exit 0.

The single declared entry is `176-a-marker-separator-is-a-space-never-a-tab`, whose rule landed in #559 hours ago and which carve-js has not shipped - the expected window, now written down instead of inferred.