### PR TITLE
spec: correct which gate blocks the over-cap corpus case

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3091,14 +3091,19 @@ EOF = (* end of file *) ;
         to the block parser, and it is why the reference does not settle this
         one by being the reference.
 
-        NOT YET CORPUS-PINNED, deliberately. No corpus document reaches the
-        cap, which is why this went unnoticed: every gate compares HTML over
-        the corpus, so a path with no corpus case is a path with no
-        comparison. A case cannot be added until the reference engine emits
-        the shape above, since the corpus is checked against it -- the usual
-        order, spec first and then the engines, with the pin moving last.
-        Whoever moves carve-js adds the fixture in the same change, or this
-        reopens the moment someone touches a degrade path.
+        NOT YET CORPUS-PINNED, and the reason is worth stating exactly. No
+        corpus document reaches the cap, which is why this went unnoticed:
+        every gate compares HTML over the corpus, so a path with no corpus
+        case is a path with no comparison.
+
+        What blocks the fixture is the EXECUTABLE SPEC, not the engines. The
+        corpus is rendered by scripts/spec, and it REFUSES past
+        MAX_NESTING_DEPTH rather than degrading -- so a case added today would
+        have to go in the refusal allowlist, where it is skipped and pins
+        nothing, which is worse than no case at all. Pinning this needs the
+        degrade path implemented in scripts/spec first. Engine drift is a
+        separate matter and has its own ledger now
+        (resources/engine-pin-drift.txt, carve#533).
 
         Recursive RENDER / RESOLVE /
         FILTER passes over a programmatically constructed tree MUST be


### PR DESCRIPTION
Follow-up to #547, correcting a claim I made in it.

The §25 grouping clause says the fixture "cannot be added until the reference engine emits the shape above, **since the corpus is checked against it**".

The corpus is not checked against the reference engine. `tests/corpus.test.mjs` imports `scripts/spec/layout.mjs` and `scripts/spec/html.mjs` - the **executable spec**. That is the whole reason a spec rule can land here before any engine ships it, and `ci.yml` says so in as many words.

So the stated blocker was wrong in the direction that matters: it told a reader the fixture was waiting on carve-js, when it is waiting on this repo.

## The real blocker, measured

`scripts/spec` refuses past the cap rather than degrading:

```
Refuse: block nesting exceeds MAX_NESTING_DEPTH
```

A case added today would have to go into `scripts/spec/refused-allow.mjs`, where `tests/corpus.test.mjs` skips it and `formal-core-check.mjs` only asserts *that* it refuses. It would pin nothing about the grouping - worse than having no case, because the file would look like coverage.

Pinning #494 therefore needs the degrade path implemented in the executable spec first. The clause now says that.

Engine drift is a separate matter and has its own ledger since #566 (`resources/engine-pin-drift.txt`), so the clause no longer has to gesture at pin order to explain itself.