### PR TITLE
docs: the comparison page contradicted itself three ways

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -36,16 +36,20 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `3b2d034` | `548 / 548` | `0` | `0` | `3.18` |
-| JS | `191b6c3` | `548 / 548` | `0` | `0` | `76.81` |
-| PHP | `8da0258` | `546 / 548` | `2` | `0` | `69.90` |
+| Rust | `3b2d034` | `548 / 548` | `0` | `0` | `5.32` |
+| JS | `191b6c3` | `548 / 548` | `0` | `0` | `144.80` |
+| PHP | `e091e99` | `548 / 548` | `0` | `0` | `132.06` |
 
 Spec commit: `78979fa`
 
-The `0` cross-implementation diffs above is the **html** target. Over every
-target the same run reports two, both on the canonical-writer (`carve`) target
-and both filed: carve#481 (the engines serialize different pipeline stages) and
-carve-php#631 (an abbreviation definition hoisted out of its container).
+The `0` cross-implementation diffs above holds on EVERY target, not only
+**html**: `markdown`, `plain`, `carve` and `ansi` each compare 548 documents
+with no difference. The two the previous run reported were on the
+canonical-writer (`carve`) target and are gone with the engine changes below.
+
+> This run shared a loaded machine (load average ~35), so its per-file times are
+> several times the usual and mean nothing against the previous snapshot's. The
+> counts are what this table is for.
 
 ## Optional Tier-2 Profile
 
@@ -290,17 +294,17 @@ Default raw output:
 ```text
 Implementation summary
 profile=default/no-opt-in corpus=core corpus_pairs=548 targets=html,markdown,plain,carve,ansi
-rust: pass=548/548 mismatch=0 error=0 skipped=0 runs=2740 avg_ms=3.18
-js: pass=548/548 mismatch=0 error=0 skipped=0 runs=2740 avg_ms=76.81
-php: pass=546/548 mismatch=2 error=0 skipped=0 runs=2740 avg_ms=69.90
-cross_impl_diffs=8
+rust: pass=548/548 mismatch=0 error=0 skipped=0 runs=2740 avg_ms=5.32
+js: pass=548/548 mismatch=0 error=0 skipped=0 runs=2740 avg_ms=144.80
+php: pass=548/548 mismatch=0 error=0 skipped=0 runs=2740 avg_ms=132.06
+cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=548 diffs=2 errors=0 fixtures=yes
-markdown: compared=548 diffs=2 errors=0 fixtures=none
+html: compared=548 diffs=0 errors=0 fixtures=yes
+markdown: compared=548 diffs=0 errors=0 fixtures=none
 plain: compared=548 diffs=0 errors=0 fixtures=none
-carve: compared=548 diffs=2 errors=0 fixtures=none
-ansi: compared=548 diffs=2 errors=0 fixtures=none
+carve: compared=548 diffs=0 errors=0 fixtures=none
+ansi: compared=548 diffs=0 errors=0 fixtures=none
 target_agreement_note=only html has expected-output fixtures; the other targets assert that the implementations agree with each other.
 
 Extension capability matrix
@@ -339,14 +343,14 @@ came to say 4 when the corpus held 33.
 ```text
 Implementation summary
 profile=optional/opt-in corpus=optional corpus_pairs=33 targets=html,markdown
-rust: pass=3/3 mismatch=0 error=0 skipped=30 runs=3 avg_ms=2.45
-js: pass=28/28 mismatch=0 error=0 skipped=5 runs=28 avg_ms=58.71
-php: pass=27/27 mismatch=0 error=0 skipped=6 runs=27 avg_ms=51.01
-cross_impl_diffs=10
+rust: pass=3/3 mismatch=0 error=0 skipped=30 runs=3 avg_ms=2.91
+js: pass=31/31 mismatch=0 error=0 skipped=2 runs=31 avg_ms=78.43
+php: pass=28/28 mismatch=0 error=0 skipped=5 runs=28 avg_ms=69.21
+cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=547 diffs=3 errors=0 fixtures=yes
-markdown: compared=547 diffs=2 errors=0 fixtures=yes
+html: compared=27 diffs=0 errors=0 fixtures=yes
+markdown: compared=2 diffs=0 errors=0 fixtures=yes
 
 Optional feature coverage
 social-link-templates (html): rust, js, php

--- a/tests/implementation-comparison-counts.test.mjs
+++ b/tests/implementation-comparison-counts.test.mjs
@@ -136,6 +136,28 @@ test('a quoted run never compares more documents than it ran', () => {
   assert.ok(checked.length >= 5, `expected target-agreement rows in the quoted output; found ${checked.length}`)
 })
 
+test('a quoted run\'s diff total matches its own per-target rows', () => {
+  // `cross_impl_diffs` is the sum over every target in that run, so a block
+  // saying `cross_impl_diffs=10` above rows that all read `diffs=0` is quoting
+  // two different runs at once - which the optional block did, with a total
+  // from the core run and rows from its own.
+  const blocks = [...page.matchAll(/```text\n([\s\S]*?)```/g)].map((m) => m[1])
+  let checked = 0
+  for (const block of blocks) {
+    const total = block.match(/cross_impl_diffs=(\d+)/)
+    const rows = [...block.matchAll(/^\w+: compared=\d+ diffs=(\d+)/gm)]
+    if (!total || rows.length === 0) continue
+    const summed = rows.reduce((n, m) => n + Number(m[1]), 0)
+    assert.equal(
+      summed,
+      Number(total[1]),
+      `a quoted run says cross_impl_diffs=${total[1]} over per-target rows summing to ${summed}`,
+    )
+    checked++
+  }
+  assert.ok(checked >= 2, `expected both quoted runs to carry a diff total; checked ${checked}`)
+})
+
 test('the landing page quotes the real corpus size', () => {
   const live = countPairs('tests/corpus')
   const m = landing.match(/pinned by (\d+) corpus examples/)

--- a/tests/implementation-comparison-counts.test.mjs
+++ b/tests/implementation-comparison-counts.test.mjs
@@ -92,6 +92,50 @@ test('the comparison cards and table quote the real core corpus size', () => {
   }
 })
 
+test('the cards and the table agree about what each engine passed', () => {
+  // Both speak for the SAME run, and the denominator check above passes when
+  // they disagree about the NUMERATOR: the page shipped cards reading
+  // `547 / 547` for all three engines directly above a table reading
+  // `545 / 547` and `544 / 547`, because the snapshot was taken while two of
+  // them were mid-fix and only one half was updated afterwards.
+  const core = page.split('## Optional Tier-2 Profile')[0]
+  const cards = [...core.matchAll(/<strong>(\d+)\s*\/\s*(\d+)<\/strong>/g)].map((m) => m[1])
+  const rows = [...core.matchAll(/\|\s*`(\d+)\s*\/\s*(\d+)`\s*\|/g)].map((m) => m[1])
+  assert.equal(
+    cards.length,
+    rows.length,
+    `the card grid quotes ${cards.length} engine results and the table ${rows.length}; one of them changed shape`,
+  )
+  assert.deepEqual(
+    cards,
+    rows,
+    'the comparison cards and the table quote different pass counts for the same run',
+  )
+})
+
+test('a quoted run never compares more documents than it ran', () => {
+  // `compared=N` in a block's target-agreement section counts documents from
+  // THAT run, so it cannot exceed the run's own `corpus_pairs`. The optional
+  // block quoted `compared=547` under `corpus_pairs=33` - the core run's rows,
+  // pasted into the optional block, claiming coverage sixteen times the size of
+  // the corpus that run uses.
+  const blocks = [...page.matchAll(/```text\n([\s\S]*?)```/g)].map((m) => m[1])
+  const checked = []
+  for (const block of blocks) {
+    const pairs = block.match(/corpus_pairs=(\d+)/)
+    if (!pairs) continue
+    const limit = Number(pairs[1])
+    for (const [, target, compared] of block.matchAll(/^(\w+): compared=(\d+)/gm)) {
+      checked.push(`${target}=${compared}`)
+      assert.ok(
+        Number(compared) <= limit,
+        `a quoted run says ${target}: compared=${compared} where its own corpus_pairs=${limit}`,
+      )
+    }
+  }
+  assert.ok(checked.length >= 5, `expected target-agreement rows in the quoted output; found ${checked.length}`)
+})
+
 test('the landing page quotes the real corpus size', () => {
   const live = countPairs('tests/corpus')
   const m = landing.match(/pinned by (\d+) corpus examples/)


### PR DESCRIPTION
Every defect here is the page disagreeing with the page, which is why the corpus-size gate beside it saw none of them.

**The cards and the table disagreed.** The cards read `548 / 548` for all three engines directly above a table reading `546 / 548` for carve-php. The table was measured before markup-carve/carve-php#703 landed; the cards were not re-measured at all.

**The optional block quoted the core run's rows.**

```text
html: compared=547 diffs=3 errors=0 fixtures=yes
markdown: compared=547 diffs=2 errors=0 fixtures=yes
```

in a run whose own `corpus_pairs=33`. The real output is `compared=27` and `compared=2`.

**Its diff total came from a third run.** `cross_impl_diffs=10` sat above per-target rows that all read `diffs=0`.

## Re-measured

548/548 in all three engines, and `diffs=0` on **every** target - `html`, `markdown`, `plain`, `carve`, `ansi` - not only html. The two differences the page attributed to the canonical-writer target are gone with the engine fixes that landed since.

Timings are from a loaded machine (load average ~35) and the page now says so, rather than quoting them as if comparable with the previous snapshot's. The counts are what the table is for.

## The checks

Three, none needing an engine:

- the cards and the table must agree about what each engine passed
- no quoted run may compare more documents than it ran (`compared=N` ≤ that block's `corpus_pairs`)
- a run's `cross_impl_diffs` must equal the sum of its own per-target rows

All three fail against the page as it stands on main, which is how I know they would have caught this. The existing gate pins the corpus SIZE, so the pair counts were right in all three blocks while everything else drifted.