### PR TITLE
tools: give a Tier-1 rule about a non-HTML target somewhere to live

### DIFF
--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -474,6 +474,13 @@ function loadPairs() {
 
 const pairs = loadPairs()
 
+/**
+ * Per-target count of cases scored against a FILE, filled as the run walks the
+ * corpus. Reported instead of `fixtures=yes/none`, which could not express "some
+ * of them".
+ */
+const fixtureCounts = {}
+
 // In the optional corpus a case runs on the one target its manifest entry pins,
 // and `--targets` filters which cases that leaves. In the core corpus every case
 // runs on every requested target.
@@ -488,15 +495,25 @@ const activeTargets = ALL_TARGETS.filter((target) =>
 
 /**
  * The expected output for a pair on a target, or null when the pair has no
- * fixture on it (every core-corpus target but html - those are compared
- * engine-against-engine only).
+ * fixture on it - those are compared engine-against-engine only.
+ *
+ * A CORE case may pin a non-HTML target by adding the file the pairing rule
+ * names (`NN-slug.md`, `.txt`, `.ansi`); absent, that target stays an
+ * engines-agree check. This is what gives a Tier-1 rule about the Markdown,
+ * plain or terminal output somewhere to live: engine-against-engine agreement
+ * is a necessary invariant, not a sufficient one, and it cannot tell "all three
+ * are right" from "all three are wrong" - which is the state PART 10 §10a is in
+ * (carve#589).
  *
  * A fixture that should exist and does not is a hard error: continuing without
  * it would quietly downgrade a scored case to an engines-agree check.
  */
 function expectedFor(pair, target) {
-  if (!isOptional && target !== DEFAULT_TARGET) return null
-  const path = join(corpusDir, expectedFileFor(pair.slug, target))
+  const optionalPath = join(corpusDir, expectedFileFor(pair.slug, target))
+  if (!isOptional && target !== DEFAULT_TARGET) {
+    return existsSync(optionalPath) ? readFileSync(optionalPath, 'utf8').trim() : null
+  }
+  const path = optionalPath
   if (!existsSync(path)) {
     console.error(
       `Missing expected output ${basename(path)} for ${pair.slug} (target ${target}).`,
@@ -530,6 +547,9 @@ for (const pair of pairs) {
   const pairTargets = targetsFor(pair)
   for (const target of pairTargets) {
     const expected = expectedFor(pair, target)
+    if (expected !== null && !isOptional && target !== DEFAULT_TARGET) {
+      fixtureCounts[target] = (fixtureCounts[target] ?? 0) + 1
+    }
     const outputs = []
     const ran = []
 
@@ -681,13 +701,23 @@ if (roundtrip) {
 console.log('\nTarget agreement (implementations compared against each other)')
 for (const target of activeTargets) {
   const t = targetStats[target]
-  const fixtures = isOptional || target === DEFAULT_TARGET ? ' fixtures=yes' : ' fixtures=none'
+  // How many of this target's cases were scored against a FILE rather than
+  // against the other engines. `yes` and `none` were the only two answers while
+  // html was the only core target with fixtures; a core case may now add one
+  // per target, so the honest report is the count.
+  const scored = fixtureCounts[target] ?? 0
+  const fixtures =
+    isOptional || target === DEFAULT_TARGET
+      ? ' fixtures=yes'
+      : scored > 0
+        ? ` fixtures=${scored}`
+        : ' fixtures=none'
   console.log(`${target}: compared=${t.compared} diffs=${t.diffs} errors=${t.errors}${fixtures}`)
 }
 console.log(
   isOptional
     ? 'target_agreement_note=every optional case has an expected-output fixture on the target it pins; the counts here also assert that the implementations agree with each other.'
-    : 'target_agreement_note=only html has expected-output fixtures; the other targets assert that the implementations agree with each other.',
+    : 'target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.',
 )
 
 if (isOptional) {

--- a/tests/corpus-targets.test.mjs
+++ b/tests/corpus-targets.test.mjs
@@ -11,7 +11,7 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { basename, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
@@ -25,6 +25,37 @@ import {
 const here = dirname(fileURLToPath(import.meta.url))
 const corpusDir = resolve(here, 'corpus-optional')
 const manifest = JSON.parse(readFileSync(resolve(corpusDir, 'manifest.json'), 'utf8'))
+
+test('a core case may pin a non-HTML target by adding the file', () => {
+  // Engine-against-engine agreement is a NECESSARY invariant, not a sufficient
+  // one: it cannot tell "all three are right" from "all three are wrong", which
+  // is the state PART 10 §10a is in (carve#589). A Tier-1 rule about the
+  // Markdown, plain or terminal output needs somewhere to be written down, and
+  // that somewhere is a file beside the case, named by the same pairing rule
+  // the optional corpus uses.
+  //
+  // This checks the rule holds for whatever core cases have taken it up: every
+  // non-HTML expected file names a case that exists, and no stray extension
+  // sneaks in beside the inputs.
+  const core = resolve(here, 'corpus')
+  const known = new Set(Object.values(TARGET_EXTENSIONS))
+  const stray = []
+  const orphaned = []
+  for (const name of readdirSync(core)) {
+    // The directory's own README is prose, not an expectation.
+    if (name === 'README.md') continue
+    const ext = name.slice(name.lastIndexOf('.') + 1)
+    if (ext === 'crv') continue
+    if (!known.has(ext)) {
+      stray.push(name)
+      continue
+    }
+    const slug = name.slice(0, name.lastIndexOf('.'))
+    if (!existsSync(resolve(core, `${slug}.crv`))) orphaned.push(name)
+  }
+  assert.deepEqual(stray, [], `unknown expected-output extension in tests/corpus: ${stray.join(', ')}`)
+  assert.deepEqual(orphaned, [], `expected output with no input beside it: ${orphaned.join(', ')}`)
+})
 
 test('a target maps to the extension the corpus README documents', () => {
   assert.deepEqual(TARGET_EXTENSIONS, {

--- a/tests/corpus/README.md
+++ b/tests/corpus/README.md
@@ -4,6 +4,33 @@ This directory contains paired `(input.crv, expected.html)` files that form the 
 
 Any implementation — the TypeScript reference at [`markup-carve/carve-js`](https://github.com/markup-carve/carve-js) or future ports — is expected to read each `.crv`, render it, and produce byte-identical output to the matching `.html` (after trimming).
 
+## Pinning a non-HTML target
+
+A case may carry an expectation for another render target by adding the file the
+pairing rule names, beside its `.crv`:
+
+| target | file |
+| --- | --- |
+| markdown | `NN-slug.md` |
+| plain | `NN-slug.txt` |
+| ansi | `NN-slug.ansi` |
+
+`npm run compare:impls` scores that target against the file for that case, and
+keeps comparing the engines against each other everywhere else. The summary line
+says which: `markdown: compared=548 diffs=0 fixtures=3`.
+
+This exists because engine-against-engine agreement is a **necessary** invariant
+and not a sufficient one - it cannot tell "all three are right" from "all three
+are wrong". PART 10 §10a is normative, is about the Markdown, plain and terminal
+targets, and every engine currently violates it identically, so nothing failed
+(carve#589). A Tier-1 rule about those targets needs a file to be written down
+in, and this is it.
+
+Add one only where the rule is settled and the expected output is the spec's
+answer rather than a transcript of what the engines happen to print. The `.crv`
+inputs and `.html` outputs are regenerated from `docs/examples/`; a target file
+added here is kept as written.
+
 ## Regenerating
 
 The corpus is generated from the example pages in [`../../docs/examples/`](../../docs/examples/) (`core.md`, `extensions.md`, `edge-cases.md`):


### PR DESCRIPTION
Answers the "which way to close it" half of #589, and adds nothing red.

#589's finding is that PART 10 §10a is normative, is about the Markdown, plain and terminal targets, and **every engine violates it identically** - so nothing fails. Engine-against-engine agreement is a necessary invariant and not a sufficient one: it cannot tell "all three are right" from "all three are wrong".

The issue asks where the expectation should live before the engine fixes are filed, because today there is nowhere:

| corpus | pins | why §10a does not fit |
| --- | --- | --- |
| `tests/corpus` | HTML only | wrong target |
| `tests/corpus-roundtrip` | Carve source in, Carve source out | wrong target |
| `tests/corpus-optional` | any target, keyed on an **opt-in feature id** | §10a is Tier-1, not a feature |

## The answer

A core case may carry an expectation for another target by adding the file the pairing rule already names:

| target | file |
| --- | --- |
| markdown | `NN-slug.md` |
| plain | `NN-slug.txt` |
| ansi | `NN-slug.ansi` |

`compare:impls` scores that target against the file for that case and keeps comparing the engines to each other everywhere else. The summary line reports which, because `fixtures=yes/none` could not express "some of them":

```text
markdown: compared=548 diffs=0 errors=0 fixtures=3
plain: compared=548 diffs=0 errors=0 fixtures=none
```

This reuses `scripts/lib/corpus-targets.mjs` rather than inventing a second convention - the same rule the optional corpus uses, extended to the core one.

## No fixture in this PR

All three engines fail §10a today, so any fixture added here would land red. The engine fixes come first; this is what they land against. Filed alongside: markup-carve/carve-js#588, markup-carve/carve-rs#508, markup-carve/carve-php#706.

## Two details

The corpus generator rewrites only `.crv` and `.html`, so a target file added beside them survives `npm run corpus:build` - verified, and now stated in the corpus README.

A test pins that every non-HTML expected file in `tests/corpus` names a case that exists and carries an extension the pairing rule knows, so a stray `.markdown` or a leftover after a rename fails rather than sitting there being ignored.
