### PR TITLE
spec: narrow §10a to the definition kinds that have a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **PART 11 §10a is narrowed to the definition kinds that have a node**
+  (carve#592). It required a link, footnote or abbreviation definition nothing
+  references to survive the Markdown, plain-text and terminal renderers. The
+  link half is unimplementable in any engine: a link reference definition leaves
+  NO node in the tree, so a renderer walking blocks has nothing to walk - and
+  PART 12 §3a had already considered adding that node and declined it. One
+  section was requiring what another's recorded decision made unreachable. The
+  gap the narrowing leaves is stated rather than hidden: an unused link
+  definition survives nothing today, so `carve --markdown` loses the URL.
+
 ### Fixed
 
 - **The executable spec follows NO OPEN PARAGRAPH, NO LAZY LINE** (carve#582).

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -4014,10 +4014,40 @@ EOF = (* end of file *) ;
       manufacture a layout whose only merit is dodging an escape.
 
   10a. AN UNUSED DEFINITION SURVIVES THE NON-HTML TARGETS -- NORMATIVE. A
-      link, footnote or abbreviation definition that NOTHING references is
-      still emitted by the Markdown, plain-text and terminal renderers. HTML
-      drops it, because HTML has nowhere to put a definition nobody used; the
-      other three do not get to drop content the author wrote.
+      FOOTNOTE or ABBREVIATION definition that NOTHING references is still
+      emitted by the Markdown, plain-text and terminal renderers. HTML drops
+      it, because HTML has nowhere to put a definition nobody used; the other
+      three do not get to drop content the author wrote.
+
+      A LINK REFERENCE DEFINITION IS NOT COVERED, and not because it deserves
+      less. It is the one definition kind with NO NODE IN THE TREE: `[lbl]: /u`
+      alone parses to a document with empty `children` in all three engines,
+      and §7 fixes the root at `type`, `children` and `srcByteLength`, so the
+      collected map cannot ride there either. A renderer walking blocks has
+      nothing to walk, so requiring the output would require an output no
+      engine can produce (carve#592).
+
+      This clause first said "link, footnote or abbreviation" and was wrong to.
+      PART 12 §3a had already considered the missing node and declined it --
+      "a bigger change than this clause is worth ... a new node type, a new
+      hoisting rule, three engines to move" -- so one section was requiring
+      what another section's recorded decision made unreachable. Narrowed here
+      rather than left contradictory: a spec that demands the impossible is
+      worse than one that admits a gap.
+
+      THE GAP IS REAL AND IS NOT CLOSED BY NARROWING. An unused link reference
+      definition currently survives nothing: not the tree, not a round trip
+      through the AST, and now explicitly not the non-HTML targets. So
+      `carve --markdown` on a document that is only `[lbl]: /u` emits nothing,
+      and the URL the author wrote is gone. That is the same content loss §10a
+      exists to prevent, reached by a different route.
+
+      Whether to add `link_reference_definition` to the vocabulary is therefore
+      open on TWO independent grounds now, where §3a weighed only one: making
+      a resolved reference's destination recoverable (§3a), and making an
+      unused one survive at all (this clause). §3a's cost list is unchanged and
+      still the estimate; what has changed is that the same node would pay for
+      two things rather than one.
 
           [^n]: %         ->  markdown  [^n]: %
                               plain     [^n]: %


### PR DESCRIPTION
Closes #592.

§10a required a link, footnote **or abbreviation** definition that nothing references to survive the Markdown, plain-text and terminal renderers. The link half cannot be implemented by any engine.

## Why

A link reference definition leaves **no node in the tree**. `[lbl]: /u` alone parses to a document with empty `children` in all three engines, and §7 fixes the root at `type`, `children` and `srcByteLength`, so the collected map cannot ride there either. A renderer walking blocks has nothing to walk.

That put two sections in contradiction. PART 12 §3a had already considered this exact node and declined it:

> a bigger change than this clause is worth … a new node type, a new hoisting rule, three engines to move

So §10a was requiring output that §3a's recorded decision made unreachable. I wrote §10a and did not check that; #592 found it.

## Narrowed rather than left contradictory

A spec that demands the impossible is worse than one that admits a gap. The two implementable halves are worth keeping - carve-js already ships both in carve-js#588.

## The gap is stated, not hidden

An unused link reference definition survives **nothing** today: not the tree, not a round trip through the AST, and now explicitly not the non-HTML targets. So `carve --markdown` on a document that is only `[lbl]: /u` emits nothing and the URL the author wrote is gone.

That is the same content loss §10a exists to prevent, reached by another route - so the clause says so instead of quietly dropping the case.

## What this does to the node question

Whether to add `link_reference_definition` to the vocabulary is now open on **two independent grounds**, where §3a weighed only one:

1. making a resolved reference's destination recoverable (§3a), and
2. making an unused one survive at all (this clause).

§3a's cost list is unchanged and still the estimate. What changed is that the same node would pay for two things rather than one - which is a different trade than the one §3a declined, and worth re-weighing deliberately rather than by accident.

## Note

`npm test` shows one unrelated local failure - an untracked `tests/corpus/_fence3.mjs` from 1 August trips `corpus-targets.test.mjs`. It is untracked, so CI does not see it; worth deleting from the working copy.