### PR TITLE
spec: pin §10a on the Markdown and plain targets, and gate on a fixture mismatch

### DIFF
--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -816,6 +816,14 @@ if (failOnDiff) {
   // the start and never gated on, so the check could report a formatter
   // rewriting documents and still exit 0.
   const invariantFailures = roundtrip ? semanticFailures + idempotenceFailures : 0
+  // A MISMATCH is an engine disagreeing with a FIXTURE, and it was counted,
+  // printed in the summary and never gated on: the run exited 0 while the
+  // summary said `js: pass=545/547 mismatch=2`. Cross-engine agreement was the
+  // only failing condition, so the one thing a fixture exists to catch - an
+  // engine wrong where the corpus says what right is - could not fail the job.
+  const mismatches = roundtrip
+    ? 0
+    : active.reduce((total, impl) => total + stats[impl.name].mismatch, 0)
   if (undocumentedUnreachable.length > 0) {
     console.error(
       `\n${undocumentedUnreachable.length} optional case(s) reached fewer than two engines with no ` +
@@ -826,9 +834,14 @@ if (failOnDiff) {
     )
     process.exit(1)
   }
-  if (failing > 0 || invariantFailures > 0) {
+  if (failing > 0 || invariantFailures > 0 || mismatches > 0) {
     if (failing > 0) {
       console.error(`\n${failing} ${label} difference(s) - see the DIFF lines above.`)
+    }
+    if (mismatches > 0) {
+      console.error(
+        `${mismatches} case(s) where an engine disagrees with the expected output - see the per-engine mismatch counts above.`,
+      )
     }
     if (invariantFailures > 0) {
       console.error(
@@ -837,5 +850,7 @@ if (failOnDiff) {
     }
     process.exit(1)
   }
-  console.log(`\nNo ${label} differences, and no PART 11 §1 invariant failures.`)
+  console.log(
+    `\nNo ${label} differences, no fixture mismatches, and no PART 11 §1 invariant failures.`,
+  )
 }

--- a/tests/corpus/177-two-abbreviation-definitions.md
+++ b/tests/corpus/177-two-abbreviation-definitions.md
@@ -1,0 +1,5 @@
+*[HTML]: HyperText Markup Language
+
+*[CSS]: Cascading Style Sheets
+
+<abbr title="HyperText Markup Language">HTML</abbr> and <abbr title="Cascading Style Sheets">CSS</abbr>.

--- a/tests/corpus/177-two-abbreviation-definitions.txt
+++ b/tests/corpus/177-two-abbreviation-definitions.txt
@@ -1,0 +1,5 @@
+*[HTML]: HyperText Markup Language
+
+*[CSS]: Cascading Style Sheets
+
+HTML and CSS.


### PR DESCRIPTION
Closes #589.

All three engines implement §10a now (markup-carve/carve-js#592, markup-carve/carve-rs#520, markup-carve/carve-php#710), so the rule gets the fixtures the mechanism in #590 was added to hold: `177-two-abbreviation-definitions` gains a `.md` and a `.txt` carrying the definitions §10a says survive. Byte-identical across the three.

```text
markdown: compared=548 diffs=0 errors=0 fixtures=1
plain: compared=548 diffs=0 errors=0 fixtures=1
```

## Adding them found the hole they were meant to close, one level up

A **mismatch** - an engine disagreeing with a **fixture** - was counted, printed in the summary, and never gated on. `--fail-on-diff` failed only on cross-engine differences, so:

```text
js: pass=545/547 mismatch=2 error=0 …
```

exited **0**. The one thing a fixture exists to catch - an engine wrong where the corpus says what right is - could not fail the job. That is not hypothetical: the comparison page quoted exactly those numbers for two engines last week while the nightly stayed green.

I found it by corrupting the new `.md` on purpose to check the fixture was load-bearing. It was scored, all three engines disagreed with it, and the run still exited 0.

Now gated, with the mismatch count reported separately from the diff count because they mean different things: a diff is engines disagreeing with each other, a mismatch is an engine disagreeing with the spec.

Verified both ways - exit 1 with the fixture corrupted, exit 0 restored. Every engine is at `mismatch=0` today, so this lands green.
