### PR TITLE
fix: the fixture rule must not ask for a `carve` filename

### DIFF
--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -4,7 +4,12 @@ import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSy
 import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { DEFAULT_TARGET, expectedFileFor, targetOf } from './lib/corpus-targets.mjs'
+import {
+  DEFAULT_TARGET,
+  TARGET_EXTENSIONS,
+  expectedFileFor,
+  targetOf,
+} from './lib/corpus-targets.mjs'
 import { phpDir, rustDir } from './lib/engine-locations.mjs'
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)))
@@ -509,6 +514,13 @@ const activeTargets = ALL_TARGETS.filter((target) =>
  * it would quietly downgrade a scored case to an engines-agree check.
  */
 function expectedFor(pair, target) {
+  // `carve` has no expected-output extension on purpose: Carve-source
+  // expectations live in tests/corpus-roundtrip/, and a second home would put
+  // two files named `NN-slug.crv` in one directory. Asking for a filename here
+  // threw `unknown target 'carve'` on the FIRST case of every default run - the
+  // early return this replaced never reached the lookup, so extending the
+  // fixture rule to the core corpus had to skip it explicitly.
+  if (!TARGET_EXTENSIONS[target]) return null
   const optionalPath = join(corpusDir, expectedFileFor(pair.slug, target))
   if (!isOptional && target !== DEFAULT_TARGET) {
     return existsSync(optionalPath) ? readFileSync(optionalPath, 'utf8').trim() : null

--- a/tests/corpus-targets.test.mjs
+++ b/tests/corpus-targets.test.mjs
@@ -66,6 +66,16 @@ test('a target maps to the extension the corpus README documents', () => {
   })
 })
 
+test('a target with no expected-output extension is not asked for a filename', () => {
+  // `carve` is deliberately absent from TARGET_EXTENSIONS, and expectedFileFor
+  // throws on it by design. Every caller therefore has to check FIRST: the
+  // fixture rule for core cases did not, and `compare:impls` died on the first
+  // document of every default run with `unknown target 'carve'` - a crash on
+  // the happy path, shipped because the run I checked passed --targets=.
+  assert.throws(() => expectedFileFor('01-emphasis', 'carve'), /unknown target 'carve'/)
+  assert.equal(TARGET_EXTENSIONS.carve, undefined)
+})
+
 test('carve is not an expected-output target', () => {
   // Carve-source expectations live in tests/corpus-roundtrip/. A second home
   // would put two files named `NN-slug.crv` in one directory, one the input.


### PR DESCRIPTION
**main is red.** The nightly AST-conformance run has failed since #594:

```text
Error: unknown target 'carve' for '01-emphasis-10' - expected one of html, markdown, plain, ansi
```

`carve` is deliberately absent from `TARGET_EXTENSIONS` - Carve-source expectations live in `tests/corpus-roundtrip/`, and a second home would put two files named `NN-slug.crv` in one directory - so `expectedFileFor` throws on it by design and every caller has to check first.

The early return I replaced never reached the lookup. Extending the fixture rule to the core corpus had to skip it explicitly, and did not, so the default run died on its FIRST document.

## Why I did not see it

Every run I checked passed `--targets=`, and none of the target lists I used included `carve`. The default target set is the one the nightly uses, and the one that matters.

A test now pins the contract - `expectedFileFor` throws on `carve`, so a caller must consult `TARGET_EXTENSIONS` first - because the same mistake is available to the next caller of that helper.

Verified with the default target set and with `--targets=html,carve`: 548 compared per target, no diffs, no errors.