### PR TITLE
spec: a trailing attribute block is part of the inline node's span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **PART 12 §4: a trailing attribute block is part of the node's span**
+  (carve#521). `*x*{#i}` gives the `strong` a span of 0..7, not 0..3. This
+  follows from the existing "a span covers the markup the author wrote" rule
+  rather than adding to it - an attribute block is markup of the node's own by
+  the same reading that makes a break's backslash part of the break. carve-rs
+  already covers it; carve-js stops at the content and moves.
+
+### Changed
+
 - **PART 11 §10a is narrowed to the definition kinds that have a node**
   (carve#592). It required a link, footnote or abbreviation definition nothing
   references to survive the Markdown, plain-text and terminal renderers. The

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -4452,6 +4452,36 @@ EOF = (* end of file *) ;
       a `text` node -- the one node whose exact source text the tree carries.
       (carve#549, fixed in carve-rs#492.)
 
+      A TRAILING ATTRIBUTE BLOCK IS THE NODE'S OWN MARKUP, so the span covers
+      it. For
+
+          *x*{#i}
+
+      the `strong` span is the whole run, offsets 0..7, not 0..3. The braces
+      are where the node's `attrs` came from; a span that stops at `*x*` says
+      the node begins and ends before the markup that gave it half its
+      content.
+
+      This follows from the sentence above rather than adding to it -- an
+      attribute block is markup of the node's own by the same reading that
+      makes a break's backslash part of the break. carve-rs covers the block
+      and carve-js stops at the content, so carve-js moves (carve#521).
+
+      IT ALSO REMOVES A WORKAROUND. The `strong` > `emphasis` pair that §4's
+      combined-form rule materialises derives the inner span from the outer one
+      by trimming the two-character delimiters. With the attribute block
+      OUTSIDE the outer span that arithmetic is right; with it inside and
+      unaccounted for, the inner node would claim `x*/{#`. carve-rs omits the
+      inner span whenever the node carries attributes rather than publish a
+      wrong one -- correct, and no longer necessary once the outer span is
+      known to include the block, because the trim can then take the block off
+      the end first.
+
+      No corpus document has an attributed inline today, which is why two
+      answers coexisted. One case pins it; `*x*{#i}` is enough, and the
+      combined form `/*x*/{#i}` is worth a second because it is where the
+      derived inner span makes the difference observable.
+
       A break the parser SYNTHESIZED is a different case and keeps the bare
       newline: a line block's implied break and a hard-break fence's converted
       newlines have no backslash, because the author wrote none. The


### PR DESCRIPTION
Settles markup-carve/carve-rs#521.

```
*x*{#i}
```

| engine | `strong` span | selects |
| --- | --- | --- |
| carve-js | `[0, 3]` | `*x*` |
| carve-rs | `[0, 7]` | `*x*{#i}` |

Two answers, so a consumer cannot use an inline span to select the styled text without knowing which engine produced the tree - the thing PART 12 exists to prevent.

## Decided by a rule that was already there

§4 already says:

> **A SPAN COVERS THE MARKUP THE AUTHOR WROTE.** Where a node has markup of its own, its span covers that markup and not merely the content inside it.

An attribute block is markup of the node's own by the same reading that makes a break's backslash part of the break (#549). The braces are where the node's `attrs` came from; a span stopping at `*x*` says the node ends before the markup that gave it half its content.

So **carve-rs is right and carve-js moves.** This is written as a consequence of the existing sentence rather than as a new rule, because that is what it is.

## It also removes a workaround

The `strong` > `emphasis` pair that the combined-form rule materialises derives the inner span from the outer by trimming the two-character delimiters. With the attribute block inside the outer span and unaccounted for, the inner node would claim `x*/{#`.

carve-rs omits the inner span whenever the node carries attributes rather than publish a wrong one - correct, and unnecessary once the outer span is known to include the block, because the trim can take the block off the end first.

## Corpus

No document has an attributed inline today, which is how two answers coexisted. The clause names the two worth pinning: `*x*{#i}`, and the combined `/*x*/{#i}` because that is where the derived inner span makes the difference observable. Not added here - carve-js has to move first, or the fixture pins a shape the reference does not produce.

## Note

`npm test` shows one unrelated local failure from an untracked `tests/corpus/_fence3.mjs` dated 1 August, same as I flagged on #593. CI does not see it.