### PR TITLE
fix(compare-impls): the carve target is compared, not looked up

### DIFF
--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -4,7 +4,13 @@ import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSy
 import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { DEFAULT_TARGET, expectedFileFor, targetOf } from './lib/corpus-targets.mjs'
+import {
+  COMPARISON_TARGETS,
+  DEFAULT_TARGET,
+  TARGET_EXTENSIONS,
+  expectedFileFor,
+  targetOf,
+} from './lib/corpus-targets.mjs'
 import { phpDir, rustDir } from './lib/engine-locations.mjs'
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)))
@@ -47,7 +53,7 @@ const isOptional = corpusName === 'optional'
 // committing four more expected files per corpus case would not add to it. In
 // the optional corpus each case pins its own target and carries the matching
 // expected file (tests/corpus-optional/README.md).
-const ALL_TARGETS = ['html', 'markdown', 'plain', 'carve', 'ansi']
+const ALL_TARGETS = COMPARISON_TARGETS
 const targetsArg = process.argv.find((a) => a.startsWith('--targets='))
 const targetsRequest = targetsArg ? targetsArg.slice('--targets='.length) : 'all'
 let targets =
@@ -509,6 +515,20 @@ const activeTargets = ALL_TARGETS.filter((target) =>
  * it would quietly downgrade a scored case to an engines-agree check.
  */
 function expectedFor(pair, target) {
+  // The `carve` target has no expected file in EITHER corpus by design:
+  // Carve-source expectations live in tests/corpus-roundtrip/, because a
+  // second home would put two files named `NN-slug.crv` in one directory, one
+  // of them the input (scripts/lib/corpus-targets.mjs says so at the top of
+  // TARGET_EXTENSIONS). So it is an engines-agree check and there is nothing
+  // to look up.
+  //
+  // Asking the pairing rule for its filename THROWS, which is the right answer
+  // for a manifest typo and the wrong one for the target deliberately left
+  // out. #590 moved that call to the first line of this function, ahead of the
+  // `target !== DEFAULT_TARGET` check that used to shield it, so every run
+  // died on the first document with `unknown target 'carve'` - including the
+  // scheduled AST conformance job, which is where it surfaced.
+  if (!TARGET_EXTENSIONS[target]) return null
   const optionalPath = join(corpusDir, expectedFileFor(pair.slug, target))
   if (!isOptional && target !== DEFAULT_TARGET) {
     return existsSync(optionalPath) ? readFileSync(optionalPath, 'utf8').trim() : null

--- a/scripts/lib/corpus-targets.mjs
+++ b/scripts/lib/corpus-targets.mjs
@@ -27,6 +27,26 @@ export const TARGET_EXTENSIONS = {
 
 export const DEFAULT_TARGET = 'html'
 
+/*
+ * Every target the engines are compared on.
+ *
+ * A SUPERSET of `TARGET_EXTENSIONS`: `carve` is compared engine-against-engine
+ * but has no expected file here, so the two lists are not interchangeable and
+ * a runner that treats them as one asks the pairing rule for a filename that
+ * does not exist. carve#590 did exactly that and every `compare:impls` run
+ * died on the first document.
+ *
+ * It lives beside the extensions map so the difference between "compared" and
+ * "has a fixture" is visible in one place, and tests/corpus-targets.test.mjs
+ * pins what the difference is allowed to be.
+ */
+export const COMPARISON_TARGETS = ['html', 'markdown', 'plain', 'carve', 'ansi']
+
+/** Targets compared without an expected file - `carve` lives in corpus-roundtrip/. */
+export function fixturelessTargets() {
+  return COMPARISON_TARGETS.filter((t) => !Object.hasOwn(TARGET_EXTENSIONS, t))
+}
+
 export function targetNames() {
   return Object.keys(TARGET_EXTENSIONS)
 }

--- a/tests/corpus-targets.test.mjs
+++ b/tests/corpus-targets.test.mjs
@@ -15,9 +15,11 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { basename, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
+  COMPARISON_TARGETS,
   DEFAULT_TARGET,
   TARGET_EXTENSIONS,
   expectedFileFor,
+  fixturelessTargets,
   targetNames,
   targetOf,
 } from '../scripts/lib/corpus-targets.mjs'
@@ -115,5 +117,36 @@ test('a non-html case does not also carry an html fixture', () => {
       !existsSync(resolve(corpusDir, `${slug}.html`)),
       `${slug} pins target '${target}' but also has an html fixture`,
     )
+  }
+})
+
+test('every compared target either has a fixture rule or is named as having none', () => {
+  // The two lists are NOT interchangeable. `COMPARISON_TARGETS` is what the
+  // engines are compared on; `TARGET_EXTENSIONS` is what has an expected file
+  // here. Treating one as the other means asking `expectedFileFor` for a name
+  // it is designed to refuse, and it refuses by throwing - correctly, because
+  // for a manifest entry an unknown target is a typo.
+  //
+  // carve#590 moved that call ahead of the check that used to shield it, and
+  // `unknown target 'carve' for '01-emphasis-10'` killed every compare:impls
+  // run, main included, until the nightly conformance job reported it.
+  for (const target of targetNames()) {
+    assert.ok(
+      COMPARISON_TARGETS.includes(target),
+      `${target} has an expected-file rule but is never compared`,
+    )
+  }
+  // Exactly one target is compared without a fixture, and it is `carve`:
+  // Carve-source expectations live in tests/corpus-roundtrip/, because a
+  // second home would put two `NN-slug.crv` files in one directory.
+  assert.deepEqual(fixturelessTargets(), ['carve'])
+})
+
+test('asking for a fixtureless target\'s filename is still an error', () => {
+  // The throw is load-bearing for manifest typos - it must not be softened
+  // into an html fallback, which would silently pair a case with the wrong
+  // file. Callers that compare a fixtureless target skip the lookup instead.
+  for (const target of fixturelessTargets()) {
+    assert.throws(() => expectedFileFor('01-example', target), /unknown target/)
   }
 })


### PR DESCRIPTION
**main is red.** Every `compare:impls` run dies on the first document:

```
Error: unknown target 'carve' for '01-emphasis-10' - expected one of html, markdown, plain, ansi
```

All three invocations in CI - plain, `--roundtrip` and `--corpus=optional` - so the entire cross-implementation gate has been off since it landed. The **scheduled** AST conformance job is what reported it, which is a decent argument for having scheduled jobs at all.

## Two lists that look alike and are not

| list | means | has `carve`? |
|---|---|---|
| `COMPARISON_TARGETS` | the engines are compared on it | yes |
| `TARGET_EXTENSIONS` | it has an expected file in this corpus | **no**, deliberately |

Carve-source expectations live in `tests/corpus-roundtrip/`, because a second home would put two files named `NN-slug.crv` in one directory, one of them the input. `corpus-targets.mjs` already said so in a comment above the map.

#590 moved `expectedFileFor` to the first line of `expectedFor`, ahead of the `target !== DEFAULT_TARGET` check that had been shielding it. That function throws on an unknown target **on purpose**: for a manifest entry an unknown target is a typo, and an html fallback would silently pair the case with the wrong file. So the throw stays; the lookup is skipped for a target that is compared without a fixture.

## The distinction is a test now, not a comment

The target list moved next to the extensions map, and `tests/corpus-targets.test.mjs` pins what the difference between them is allowed to be: every target with a fixture rule is compared, exactly one compared target has no fixture rule, and it is `carve`. Removing the guard reproduces the error above.

759 tests pass; all three invocations report no differences, no fixture mismatches and no PART 11 §1 invariant failures.
