### PR TITLE
ci: bump every repo that carries the spec, and check that list against the org

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -12,10 +12,16 @@ name: Bump downstream corpora
 # DRAFT — "implement me", not ready to merge. If it passes, the PR is opened
 # ready. Re-runs keep an existing PR's draft state in sync with conformance.
 #
-# Setup: create a fine-grained PAT with access to markup-carve/carve-js,
-# markup-carve/carve-php and markup-carve/carve-rs (Contents: read & write,
-# Pull requests: read & write) and store it as the BUMP_TOKEN secret on this
-# repo.
+# Setup: create a fine-grained PAT with access to every repo in the matrix
+# below (Contents: read & write, Pull requests: read & write) and store it as
+# the BUMP_TOKEN secret on this repo.
+#
+# The matrix is not only the three engines. Every repo that carries the spec as
+# a submodule goes stale the same way, and the grammar satellites had no bump at
+# all: carve-grammars and tree-sitter-carve both reported a green suite against a
+# submodule weeks behind main (carve-grammars#83, tree-sitter-carve#46). A green
+# run against a stale corpus is the failure mode this workflow exists to prevent,
+# and which repo the corpus belongs to makes no difference to it.
 
 on:
   push:
@@ -53,6 +59,35 @@ jobs:
             lang: rust
             test: cargo test --test corpus
             allowlist: the `IMPLEMENTED` slice in `tests/corpus.rs`
+          # The grammar satellites. They do not render, so "conformance" for
+          # them is their coverage matrix: a new corpus category has to be
+          # classified as covered or skipped, and an unclassified one fails.
+          # That is the same draft signal as an allowlist entry.
+          - repo: markup-carve/carve-grammars
+            submodule: spec
+            lang: node
+            test: npm ci && npm test
+            allowlist: the `COVERAGE` matrix in `tests/lib/coverage.js` (per grammar, `covered` or `skip` with a reason)
+          - repo: markup-carve/tree-sitter-carve
+            submodule: spec
+            lang: node
+            test: npm ci && npx tree-sitter generate && npm run test:corpus
+            allowlist: the `covered` / `skip` lists in `test/coverage.json`
+          - repo: markup-carve/vscode-carve
+            submodule: spec
+            lang: node
+            test: npm ci && npm run build && npm run test:grammar
+            allowlist: the `covered` / `skip` lists in `tests/categories.json`
+          - repo: markup-carve/carve-skill
+            submodule: spec
+            lang: node
+            test: npm ci && npm test
+            allowlist: the drift guard in `test/` (the skill text has to state what the spec now says)
+          # NOT here: markup-carve/intellij-carve, which also carries the spec
+          # submodule. Its corpus snapshots run through Gradle with an IDE SDK
+          # download, which does not fit this workflow's node/rust/php shape.
+          # The matrix-coverage job below names it as a known exception rather
+          # than letting it fall out of sight.
     steps:
       # Toolchain to run the impl's corpus conformance (mirrors each repo's
       # own CI), so the bump can decide draft-vs-ready.
@@ -197,7 +232,11 @@ jobs:
             # allowlist, then drop the `-<n>` sub-pair suffix exactly as each
             # impl's own matcher does (carve-php reports per-pair, js/rs report
             # base categories).
-            cats="$(grep -iE 'IMPLEMENTED' "$CONF_LOG" 2>/dev/null \
+            # The engines name their allowlist in the failure ("missing from
+            # IMPLEMENTED"); the grammar satellites say "unclassified
+            # categories" instead. Both forms name the categories, so match
+            # either rather than reporting no categories for half the matrix.
+            cats="$(grep -iE 'IMPLEMENTED|unclassified|covered or skip' "$CONF_LOG" 2>/dev/null \
               | grep -oE '[0-9]{2,}-[a-z0-9]+(-[a-z0-9]+)*' \
               | sed -E 's/-[0-9]+$//' | sort -u || true)"
             # A rendering difference is a DIFFERENT failure: the category may
@@ -317,3 +356,66 @@ jobs:
               echo "Could not enable auto-merge on $REPO PR #$existing (check 'Allow auto-merge' + branch protection)."
             fi
           fi
+
+  # Which repos SHOULD be in the matrix above? Every repo in the org that
+  # carries this repo as a submodule. That list has moved without the matrix
+  # moving with it, and the symptom each time was a satellite reporting a green
+  # suite against a corpus weeks out of date (carve-grammars#83,
+  # tree-sitter-carve#46) - a check that cannot fail, because nothing compared
+  # the two lists.
+  matrix-coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Every repo with a spec submodule is bumped by this workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Repos deliberately outside the matrix, each with the reason it
+          # cannot be bumped here. An entry that no longer carries the
+          # submodule is reported too, so this list cannot rot either.
+          declare -A EXCEPT=(
+            ["markup-carve/intellij-carve"]="Gradle + IDE SDK build does not fit this workflow toolchains"
+          )
+
+          # The matrix, read from this file rather than restated.
+          matrix="$(grep -oE '^ +- repo: markup-carve/[a-z0-9-]+' .github/workflows/bump-downstream.yml | awk '{print $3}' | sort -u)"
+
+          carrying=""
+          for repo in $(gh repo list markup-carve --limit 200 --json nameWithOwner --jq '.[].nameWithOwner' | sort); do
+            [ "$repo" = "${{ github.repository }}" ] && continue
+            mods="$(gh api "repos/$repo/contents/.gitmodules" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)"
+            case "$mods" in
+              *markup-carve/carve*) carrying="$carrying$repo"$'\n' ;;
+            esac
+          done
+
+          missing=""
+          while IFS= read -r repo; do
+            [ -z "$repo" ] && continue
+            if ! grep -qx "$repo" <<< "$matrix" && [ -z "${EXCEPT[$repo]:-}" ]; then
+              missing="$missing- `\$repo` carries the spec submodule and nothing bumps it"$'\n'
+            fi
+          done <<< "$carrying"
+
+          stale_except=""
+          for repo in "${!EXCEPT[@]}"; do
+            if ! grep -qx "$repo" <<< "$carrying"; then
+              stale_except="$stale_except- `\$repo` is listed as an exception but no longer carries the submodule"$'\n'
+            fi
+          done
+
+          if [ -n "$missing$stale_except" ]; then
+            {
+              echo "## Bump matrix is out of date"
+              echo ""
+              printf '%s' "$missing$stale_except"
+            } >> "$GITHUB_STEP_SUMMARY"
+            printf '%s' "$missing$stale_except"
+            exit 1
+          fi
+          echo "Bump matrix covers every repo carrying the spec submodule."


### PR DESCRIPTION
Closes markup-carve/carve-grammars#83. Closes markup-carve/tree-sitter-carve#46.

The bump workflow moved the spec submodule in the three engines. Four other repos carry the same submodule and had nothing bumping them, so each one's suite went green against a corpus weeks behind main:

```
carve-grammars spec submodule: a11e6e7
current carve main:            0766705
```

Same for tree-sitter-carve. A green run against a stale corpus is the exact failure this workflow exists to prevent, and which repo the corpus sits in makes no difference to it.

## Matrix

`carve-grammars`, `tree-sitter-carve`, `vscode-carve` and `carve-skill` join it. They do not render, so their conformance is their coverage matrix: an unclassified corpus category fails, which is the same draft signal an allowlist entry gives for an engine.

The failure-mining grep learns their wording too. The engines say "missing from IMPLEMENTED"; these say "unclassified categories", and the grep only knew the first - so half the matrix would have reported no categories at all in its draft body.

`intellij-carve` carries the submodule and is deliberately NOT in the matrix: its corpus snapshots run through Gradle with an IDE SDK download, which does not fit this workflow's toolchains. It is named as an exception rather than left out of sight.

## The list itself is now checked

A second job asks the org which repos carry this repo as a submodule and compares that against the matrix. Exceptions are named, and an exception that stops carrying the submodule fails too, so that list cannot rot either.

Nothing compared those two lists before, which is how the matrix stayed at three repos while the org grew to eight. Running the check while writing it turned up `carve-skill`, which I had not thought to look for - so it is in the matrix rather than in this PR's "we should look at that some time" paragraph.

## One action outside this repo

Whoever holds `BUMP_TOKEN` needs the four new repos added to the PAT (Contents: read & write, Pull requests: read & write), or their matrix legs fail at the clone.