### PR TITLE
docs: the smartTypography switch is implemented; measure it instead of asserting it

### DIFF
--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -484,23 +484,46 @@ carveToHtml(source, { smartTypography: false })
 ```
 
 ```php [carve-php]
-$converter = CarveConverter::create(smartTypography: false);
+$renderer = (new HtmlRenderer())->setSmartTypography(SmartTypographyMode::Source);
+$converter = CarveConverter::create(renderer: $renderer);
 ```
 
 ```rust [carve-rs]
-let options = Options::default().with_smart_typography(false);
+let options = Options { smart_typography: SmartTypographyMode::Source, ..Options::default() };
 ```
 
 :::
 
-**Implementation status.** None of the three calls above works today: carve-php
-raises `Unknown named parameter $smartTypography`, carve-rs has no
-`with_smart_typography`, and carve-js accepts the option and **ignores** it, so a
-host wiring it up gets a page that looks configured and is not. That last one is
-the only non-conformant state - the spec lets a host omit the switch, but not
-accept it silently. The parse side is already done everywhere: smart typography
-is an AST node carrying both the resolved glyph and the author's source run, so
-what remains is renderer plumbing rather than a parser change.
+**Implementation status.** All three engines honor the switch on HTML and on
+Markdown, each with its own spelling - it is host API, not syntax, so the
+spelling is the engine's to choose:
+
+| | carve-js | carve-php | carve-rs |
+|---|---|---|---|
+| HTML | `carveToHtml(src, { smartTypography: false })` | `(new HtmlRenderer())->setSmartTypography(SmartTypographyMode::Source)` | `Options { smart_typography: SmartTypographyMode::Source, .. }` |
+| Markdown | `carveToMarkdown(src, { smartTypography: 'source' })` | `(new MarkdownRenderer())->setSmartTypography(...)` | same `Options` field |
+
+Both also expose it on the command line, where machine-facing output is most
+often produced: `carve --html --smart-typography source` in carve-php and
+carve-rs. An unknown mode is rejected rather than ignored.
+
+Two spellings this page used to show do not exist: carve-php has no
+`CarveConverter::create(smartTypography: ...)` named parameter (the mode is set
+on the renderer), and carve-rs has no `with_smart_typography` builder (the field
+is set on `Options`). The code group above shows the real ones.
+
+Plain text and ANSI still emit the glyph in all three, which the sentence above
+- "the presentation renderers emit each node's source run" - reads as covering.
+That gap is open ([carve#560][st-issue]); the two targets a host reaches for
+machine-facing output are the two that are done.
+
+This section's claim is now measured rather than asserted: the optional corpus
+case `29-smart-typography-off` is rendered by all three engines through the
+comparison harness, so a regression fails there instead of leaving this
+paragraph quietly wrong - which is the state it was in for as long as it named
+three calls that no longer matched any engine.
+
+[st-issue]: https://github.com/markup-carve/carve/issues/560
 
 The switch is document-global on purpose. Defaulting it per target - on for
 HTML, off for Markdown and plain text - was considered and rejected: one source

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -183,18 +183,16 @@ const PLAIN_EXTENSION_FEATURES = {
  * option nobody implemented - carve#560).
  */
 const UNREACHABLE_REASONS = {
-  'smart-typography-off':
-    'no engine implements the documented smartTypography switch (carve#560)',
   'smart-quotes-locale-de':
     'carve-js has no quote-locale option; carve-php has the extension (carve#560)',
   'section-wrapper-off':
     'carve-php has no sections switch; carve-js has the option (carve#560)',
   'source-line-after-generated-id':
     'the fixture needs sections off, which carve-php cannot do (carve#560)',
-  'markdown-typography-source': 'carve-rs exposes no CLI flag for it',
 }
 
 const JS_OPTION_FEATURES = {
+  'smart-typography-off': '{ smartTypography: false }',
   'markdown-typography-source': "{ smartTypography: 'source' }",
   'section-wrapper-off': '{ sections: false }',
   'source-line-after-generated-id': '{ sourceLine: true, sections: false }',
@@ -225,6 +223,9 @@ const impls = [
           '--symbol', 'rocket=🚀', '--symbol', 'tada=🎉', '--symbol', '+1=👍', '--symbol', 'UPPER=⬆️',
           ...flags,
         ]
+      }
+      if (feature === 'smart-typography-off' || feature === 'markdown-typography-source') {
+        return [...rustBaseCommand, '--smart-typography', 'source', ...flags]
       }
       return null
     },
@@ -352,6 +353,19 @@ const impls = [
         ]
       }
       if (target !== 'html') return null
+      if (feature === 'smart-typography-off') {
+        return [
+          'php',
+          '-r',
+          `
+            require 'vendor/autoload.php';
+            $renderer = new MarkupCarve\\Carve\\Renderer\\HtmlRenderer();
+            $renderer->setSmartTypography(MarkupCarve\\Carve\\Renderer\\SmartTypographyMode::Source);
+            $converter = MarkupCarve\\Carve\\CarveConverter::create(renderer: $renderer);
+            echo $converter->convert(file_get_contents($argv[1]));
+          `,
+        ]
+      }
       if (feature === 'social-link-templates') {
         return [
           'php',


### PR DESCRIPTION
Refs markup-carve/carve#560.

The **Implementation status** paragraph in `docs/divergence-from-djot.md` said none of the three calls it showed worked: carve-php raised `Unknown named parameter $smartTypography`, carve-rs had no `with_smart_typography`, carve-js accepted the option and ignored it.

All three statements are false today, and two were false about the *spelling* rather than the feature - carve-php sets the mode on the renderer, carve-rs on `Options`, and the page showed neither.

## Measured

| | carve-js | carve-php | carve-rs |
|---|---|---|---|
| HTML | on main | markup-carve/carve-php#729 | markup-carve/carve-rs#535 |
| Markdown | already | already | already |
| CLI | - | markup-carve/carve-php#732 | markup-carve/carve-rs#538 |

Plain text and ANSI still emit the glyph everywhere, which the section's own sentence - "the presentation renderers emit each node's source run" - reads as covering. That remains the open half of carve#560, and the page now says so.

## The claim is checked now

`29-smart-typography-off` was recorded in `compare:impls` as reaching no engine at all: the fixture existed, nothing could render it, and the reason line pointed at carve#560. With the option and the CLI flags in place, all three engines render it and agree:

```
smart-typography-off (html): rust, js, php
html: compared=28 diffs=0 errors=0 fixtures=yes
```

So it moves out of the unreachable table into the compared set. `markdown-typography-source` loses its reason line too - it named carve-rs's missing CLI flag, which now exists.

That is the difference this PR is really about. The old paragraph was accurate when written and wrong within weeks, and nothing failed. The fixture fails.

## Ordering

The harness adapters for the two CLI-driven engines need markup-carve/carve-rs#538 and markup-carve/carve-php#732 merged; the library-side changes are already on main in all three. Until then `compare:impls --corpus=optional` reports those engines as skipped for the case rather than failing.