### PR TITLE
spec: enforce the crossref shape, and drop the field it replaced

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#cb6add2af97bea2c124bef250a55a9de00a68145",
+        "@markup-carve/carve": "github:markup-carve/carve-js#51b2fc4fb4925bb89d2e0f7d455b949608153861",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.35.0",
@@ -982,8 +982,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#cb6add2af97bea2c124bef250a55a9de00a68145",
-      "integrity": "sha512-5m7RAZqRcrqcN5O62AKWDdLIMK6WBznXgeJ30NwIiFCPrbXxQaYS3iTDyNWiAaayS1rg6DrZ9hJdtg2UjZuzzw==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#51b2fc4fb4925bb89d2e0f7d455b949608153861",
+      "integrity": "sha512-zQGRcXnce0OP0HApXhp7JF6B9lXEWmcSLSxlUAHGnQomp//lHDNB9aezZpAgG6bO8DT9y80a3ArbveyrInVL/Q==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "bump-carve-pin": "node scripts/bump-carve-pin.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/schema-fields-are-produced.test.mjs tests/ast-shape.test.mjs tests/ast-positions.test.mjs tests/test-manifest.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/portable-whitespace.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs tests/degradation-claims.test.mjs tests/migration-claims.test.mjs",
+    "test": "node --test tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/crossref-shape.test.mjs tests/schema-fields-are-produced.test.mjs tests/ast-shape.test.mjs tests/ast-positions.test.mjs tests/test-manifest.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/portable-whitespace.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs tests/degradation-claims.test.mjs tests/migration-claims.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#cb6add2af97bea2c124bef250a55a9de00a68145",
+    "@markup-carve/carve": "github:markup-carve/carve-js#51b2fc4fb4925bb89d2e0f7d455b949608153861",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.35.0",

--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -2021,10 +2021,6 @@
           "type": "string",
           "description": "Verbatim source of the reference as written, so the construct can be restored. Reachable because the tree is PRE-RESOLVE (PART 12 section 3a); under a post-resolve tree this field would describe something already discarded."
         },
-        "fromCrossref": {
-          "type": "boolean",
-          "description": "Set when the link was produced from a `</#id>` cross-reference."
-        },
         "attrs": {
           "$ref": "#/$defs/attrs"
         },

--- a/tests/crossref-shape.test.mjs
+++ b/tests/crossref-shape.test.mjs
@@ -1,0 +1,72 @@
+/*
+ * A crossref publishes the authored construct and its resolution (PART 12 §3a).
+ *
+ * The rule was written into the grammar with nothing enforcing it (carve#614),
+ * because the reference build was one of the engines that had it wrong: a
+ * resolved crossref was a `link`, an unresolved one was not a node at all.
+ * carve-js#605 fixed that, and this is the check that keeps it fixed - the
+ * clause and the pin now say the same thing, and a regression in either fails
+ * here rather than being noticed by someone reading both.
+ *
+ * The OTHER two engines are checked by `npm run ast:check`, which diffs their
+ * trees against this build. What that cannot catch is this build drifting,
+ * which is what this file is for.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { carveToAstJson } from '@markup-carve/carve'
+
+const inlines = (source) => {
+  const paragraphs = carveToAstJson(source).children.filter((n) => n.type === 'paragraph')
+  return paragraphs.at(-1)?.children ?? []
+}
+
+test('a resolved crossref keeps the authored id and publishes the destination', () => {
+  const [, ref] = inlines('# Intro\n\nSee </#intro>.\n')
+  assert.equal(ref.type, 'heading_ref')
+  assert.equal(ref.target, 'intro')
+  assert.equal(ref.href, '#Intro')
+})
+
+test('the authored id is the spelling written, not the id resolved to', () => {
+  // Ids resolve case-insensitively, so `href` cannot carry this distinction
+  // and a tree without `target` cannot be written back as authored.
+  const [, lower] = inlines('# Intro\n\nSee </#intro>.\n')
+  const [, upper] = inlines('# Intro\n\nSee </#Intro>.\n')
+  assert.equal(lower.href, upper.href)
+  assert.notEqual(lower.target, upper.target)
+})
+
+test('an unresolved crossref is still a node', () => {
+  // Flattening it to text discards the fact that the author wrote a reference,
+  // and gives the same document two node counts across engines - §3a's reason
+  // for the same rule on `[a][]`.
+  const kids = inlines('See </#Nope>.\n')
+  assert.deepEqual(
+    kids.map((n) => n.type),
+    ['text', 'heading_ref', 'text'],
+  )
+  assert.equal(kids[1].href, undefined)
+})
+
+test('the display text is not on the wire', () => {
+  // §3a: the heading is in the same document. Copying its inline content into
+  // every reference is unbounded where `href` is fixed-size.
+  const [, ref] = inlines('# Intro\n\nSee </#intro>.\n')
+  assert.equal(ref.children, undefined)
+  assert.equal(ref.resolvedText, undefined)
+})
+
+test('a crossref inside a link label stays in the tree', () => {
+  // "Links never nest" is a rendering rule and must not be paid for out of the
+  // tree: dropping the node here would publish `[see H](/outer)` for
+  // `[see </#H>](/outer)`.
+  const [link] = inlines('# H\n\n[see </#H>](/outer)\n')
+  assert.equal(link.type, 'link')
+  assert.deepEqual(
+    link.children.map((c) => c.type),
+    ['text', 'heading_ref'],
+  )
+  assert.equal(link.children[1].href, '#H')
+})


### PR DESCRIPTION
Closes markup-carve/carve#610. Follow-up to markup-carve/carve#614, which wrote the rule and said the check had to wait for the reference build.

markup-carve/carve-js#608 landed the shape, so the pin moves and the check lands with it.

## The check

`tests/crossref-shape.test.mjs` pins what the clause says, one test per sentence:

- a resolved crossref publishes the authored `target` **and** the resolved `href`;
- the authored id is the spelling written, not the id resolved to (ids resolve case-insensitively, so `href` alone cannot carry it);
- an unresolved crossref is still a node, not text;
- the display text is not on the wire;
- a crossref inside a link label survives in the tree, even though the renderers suppress the nested anchor.

Every one of those was unfalsifiable before: the grammar said it, the reference build did something else, and nothing compared them.

## `fromCrossref` leaves the schema

It marked a `link` the resolver had built from `</#id>`. With the crossref keeping its own node type there is nothing to mark - the type says it.

What found it is worth noting: the schema-field check from markup-carve/carve#602 failed on this branch, because the field was still declared and no corpus document produced it any more. That is the exact state that check exists to report, on the first change that created one.