### PR TITLE
spec: a repeated class collapses, as every engine already does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **PART 9 §15 A3: a repeated class collapses** (carve#615). The merge said
+  "ALL classes accumulate in source order, NO de-duplication ... class='a b b
+  c', matching djot and carve-php", and no implementation did that. Measured on
+  `{.a .b}` / `{.b .c}` / `text`: carve-js, carve-rs and carve-php all emit
+  `class="a b c"`, and the INLINE path in `scripts/spec` deduplicates too - so
+  the clause named as its witness the engine that contradicts it. Accumulating
+  is about the LISTS: a later block adds its classes rather than replacing the
+  earlier block's, and a class already present is not added twice.
+
+  The worked example in the clause has no repeated class, which is why it read
+  the same either way and why nothing caught this. `scripts/spec` implemented
+  the sentence rather than the engines and was the only implementation emitting
+  the duplicate - on a block attribute line, and on a reference definition's
+  attributes once §16 gained the slot.
+
 - **PART 12 §7: hoisting the node is not the same as defining the abbreviation**
   (carve#708). An `abbreviation_def` written inside a container is a document
   child wherever it was written, and it expands occurrences only when it was

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2721,12 +2721,31 @@ EOF = (* end of file *) ;
       A3 MERGE (over all pending blocks, source order):
          * id -> last one wins;
          * key=value -> last value for a given key wins;
-         * class -> ALL classes accumulate in source order, NO
-           de-duplication ({.a .b} then {.b .c} -> class="a b b c",
-           matching djot and carve-php).
+         * class -> ALL classes accumulate in source order, DE-DUPLICATED
+           ({.a .b} then {.b .c} -> class="a b c"). Accumulating is about
+           the LISTS: a later block adds its classes rather than replacing
+           the earlier block's, which is what makes stacking work. A class
+           already present is not added twice, in one block or across
+           several.
          Worked djot-canonical example: {#id} {key=val} {.foo .bar}
          {key=val2} {.baz} {#id2} then "Okay" ->
          <p id="id2" key="val2" class="foo bar baz">Okay</p>.
+
+         THIS SAID "NO de-duplication ... class='a b b c', matching djot and
+         carve-php", and no implementation did that. Measured on
+         `{.a .b}` / `{.b .c}` / `text`: carve-js, carve-rs and carve-php all
+         emit `class="a b c"`, and the INLINE path in this repository's own
+         executable spec deduplicates too. The clause named carve-php as the
+         engine following it, which was the reverse of what carve-php does.
+
+         The worked example above hid it: it has no repeated class, so it
+         reads the same under either rule. `scripts/spec` implemented the
+         sentence rather than the engines and was the only implementation
+         emitting `a b b c` - on a block attribute line and, once §16 gained
+         the definition slot, on a reference definition's attributes as well.
+         A repeated class in one HTML `class` attribute is also a no-op for
+         every consumer, so nothing downstream wanted the duplicate.
+         (carve#615)
       A4 DROP IF DANGLING. pending with no following block element (end of
          document) produces no output.
       A5 MULTI-LINE BLOCK. One block may wrap across lines ({#id\n .foo} is

--- a/scripts/spec/render.mjs
+++ b/scripts/spec/render.mjs
@@ -707,7 +707,11 @@ export function parseAttrList(text) {
 }
 
 // PART 9 SS15 A3 merge for BLOCK attribute lines: first-appearance position,
-// last value wins for id/key, classes ACCUMULATE in source order (no dedup)
+// last value wins for id/key, classes ACCUMULATE in source order and
+// DEDUPLICATE - a later list adds its classes rather than replacing the
+// earlier one's, and a class already present is not added twice. This used to
+// keep the duplicate, following a clause sentence no engine implemented
+// (carve#615).
 export function renderBlockAttrs(lists) {
   const parts = []
   const classes = []
@@ -720,7 +724,7 @@ export function renderBlockAttrs(lists) {
           classAt = parts.length
           parts.push(null)
         }
-        classes.push(a[1])
+        if (!classes.includes(a[1])) classes.push(a[1])
       } else if (a[0] === 'id') {
         if (seen.has('#id')) parts[seen.get('#id')] = ` id="${escapeAttr(a[1])}"`
         else {


### PR DESCRIPTION
Fixes #615.

§15 A3 said:

> class -> ALL classes accumulate in source order, NO de-duplication (`{.a .b}` then `{.b .c}` -> `class="a b b c"`, matching djot and carve-php).

Measured on that exact input:

| engine | `{.a .b}` / `{.b .c}` / `text` |
|---|---|
| carve-js | `class="a b c"` |
| carve-rs | `class="a b c"` |
| carve-php | `class="a b c"` |
| `scripts/spec` (before) | `class="a b b c"` |

So the clause named as its witness the one engine it describes least, and the executable spec was the only implementation following it. The INLINE path in `scripts/spec` already deduplicates — same repository, one function away.

## What changed, and what did not

**Not changed:** classes still ACCUMULATE across lists. A later block adds its classes rather than replacing the earlier block's, which is what makes stacking attribute lines work, and is what §16's definition-attribute merge relies on (`[ex]: /u {.external}` + `[E][ex]{.internal}` is still `class="external internal"`).

**Changed:** a class already present is not added twice — in one block or across several.

## Why it lasted

The clause's worked example is `{#id} {key=val} {.foo .bar}` / `{key=val2} {.baz} {#id2}`, which has no repeated class. It reads identically under either rule, so the corpus case pinned by it could not discriminate, and no corpus document has a repeated class in one block.

It surfaced because #612 gave a reference definition an attribute slot that routes through this same merge: carve-php implemented the collapse (matching the other two engines), the executable spec kept the duplicate, and the difference showed up on `[ex]: /u {.a .a}` — reported in markup-carve/carve-php#719's verification.

## Verified

`npm test`: 777 tests, 0 failures, with the pinned reference build.

One note for whoever runs this locally: with a `node_modules` copied from another checkout rather than `npm ci`, `tests/crossref-shape.test.mjs` fails five tests against the wrong reference build. That is the copied dependency, not this branch — `npm ci` restores the pin and they pass.
