### PR TITLE
spec: apply a block-attribute line to a paragraph inside a list item

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -2577,6 +2577,30 @@ A **sibling item after it** is a different question, and there the list is loose
 
 :::
 
+A paragraph inside an item carries block attributes like any other, and the attribute line sits above it exactly as it does at document level.
+
+::: compare
+
+```carve
+- a
+
+  first
+
+  {.c}
+  second
+```
+
+```html
+<ul>
+  <li><p>a</p>
+    <p>first</p>
+    <p class="c">second</p>
+  </li>
+</ul>
+```
+
+:::
+
 ## List continuation marker
 
 A lone `+` at the list marker column attaches the following flush-left block to the current item, with no blank line, keeping the list tight — useful for code blocks or tables you would rather not indent.

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,28 +17,28 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>554 / 559</strong>
+    <strong>560 / 560</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>558 / 559</strong>
+    <strong>560 / 560</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>557 / 559</strong>
+    <strong>560 / 560</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>15</strong>
+    <strong>3</strong>
     <span>cross-implementation diffs</span>
   </div>
 </div>
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `eb0e181` | `554 / 559` | `5` | `0` | `9.91` |
-| JS | `953046f` | `558 / 559` | `1` | `0` | `245.89` |
-| PHP | `7738356` | `557 / 559` | `2` | `0` | `202.06` |
+| Rust | `2d5d050` | `560 / 560` | `0` | `0` | `33.33` |
+| JS | `addf7aa` | `560 / 560` | `0` | `0` | `92.51` |
+| PHP | `22fa88b` | `560 / 560` | `0` | `0` | `82.98` |
 
 Spec commit: `00a54d6`
 
@@ -294,18 +294,18 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=559 targets=html,markdown,plain,carve,ansi
-rust: pass=561/566 mismatch=5 error=0 skipped=0 runs=2795 avg_ms=9.91
-js: pass=565/566 mismatch=1 error=0 skipped=0 runs=2795 avg_ms=245.89
-php: pass=564/566 mismatch=2 error=0 skipped=0 runs=2795 avg_ms=202.06
-cross_impl_diffs=15
+profile=default/no-opt-in corpus=core corpus_pairs=560 targets=html,markdown,plain,carve,ansi
+rust: pass=567/567 mismatch=0 error=0 skipped=0 runs=2800 avg_ms=33.33
+js: pass=567/567 mismatch=0 error=0 skipped=0 runs=2800 avg_ms=92.51
+php: pass=567/567 mismatch=0 error=0 skipped=0 runs=2800 avg_ms=82.98
+cross_impl_diffs=3
 
 Target agreement (implementations compared against each other)
-html: compared=559 diffs=2 errors=0 fixtures=yes
-markdown: compared=559 diffs=1 errors=0 fixtures=1
-plain: compared=559 diffs=1 errors=0 fixtures=1
-carve: compared=559 diffs=10 errors=0 fixtures=5
-ansi: compared=559 diffs=1 errors=0 fixtures=none
+html: compared=560 diffs=0 errors=0 fixtures=yes
+markdown: compared=560 diffs=0 errors=0 fixtures=1
+plain: compared=560 diffs=0 errors=0 fixtures=1
+carve: compared=560 diffs=3 errors=0 fixtures=5
+ansi: compared=560 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 559 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 560 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus with no HTML divergences.
 Pre-1.0, a minor release may still change the grammar.

--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -346,7 +346,18 @@ function renderItem(item, list, depth, ctx) {
       // multi-line `` ``` ``-run folded in as lazy text -- is one span, not one
       // per line. Matches the top-level para path in renderBlock.
       const html = renderInline(b.lines.join('\n'))
-      parts.push({ inlineable: true, html: list.tight ? html : `<p>${html}</p>` })
+      // A paragraph inside an item carries its block attributes like any other
+      // (PART 9 §15). This path built the `<p>` by hand and never consulted
+      // `battrs`, so `- a` + blank + `  {.c}` + `  text` parsed the attribute
+      // correctly and then dropped it on the way out - the one paragraph site
+      // in this renderer that did (carve#626).
+      //
+      // A TIGHT item renders its paragraph without a `<p>`, and there is
+      // nowhere to hang the attributes; that shape cannot occur, because an
+      // attribute line arrives after a blank and a blank plus a visible
+      // paragraph is what makes the item loose.
+      const pattrs = b.battrs ? renderBlockAttrs(b.battrs) : ''
+      parts.push({ inlineable: true, html: list.tight ? html : `<p${pattrs}>${html}</p>` })
     } else {
       parts.push({ inlineable: false, html: renderBlock(b, depth + 1, ctx) })
     }

--- a/tests/corpus/87-compact-list-blocks-7.crv
+++ b/tests/corpus/87-compact-list-blocks-7.crv
@@ -1,0 +1,6 @@
+- a
+
+  first
+
+  {.c}
+  second

--- a/tests/corpus/87-compact-list-blocks-7.html
+++ b/tests/corpus/87-compact-list-blocks-7.html
@@ -1,0 +1,6 @@
+<ul>
+  <li><p>a</p>
+    <p>first</p>
+    <p class="c">second</p>
+  </li>
+</ul>

--- a/tests/spec/87-compact-list-blocks.test
+++ b/tests/spec/87-compact-list-blocks.test
@@ -75,3 +75,19 @@ Compact list blocks
   <li><p>b</p></li>
 </ul>
 ```
+
+```
+- a
+
+  first
+
+  {.c}
+  second
+.
+<ul>
+  <li><p>a</p>
+    <p>first</p>
+    <p class="c">second</p>
+  </li>
+</ul>
+```


### PR DESCRIPTION
Closes markup-carve/carve#626.

```
- a

  first

  {.c}
  second
```

The executable spec rendered `<p>second</p>`; all three engines render `<p class="c">second</p>`.

## The parse was never wrong

The node carried the attributes the whole time:

```json
{"t":"para","lines":["second"],"battrs":[[["class","c"]]]}
```

`renderListItem` built the item's paragraph by hand -

```js
parts.push({ inlineable: true, html: list.tight ? html : `<p>${html}</p>` })
```

\- the one paragraph site in `html.mjs` that never consulted `battrs`. The attribute survived the parse, survived the tree, and was discarded on the way out. (My original diagnosis on the issue blamed the parser; corrected there.)

A tight item renders its paragraph without a `<p>` at all, so there is nowhere to hang attributes - and that shape cannot arise, because an attribute line arrives after a blank, and a blank plus a visible paragraph is what makes the item loose.

## What the corpus case pins, and what it deliberately does not

The case uses an item that is unambiguously loose - two visible paragraphs, the attribute on the second - so it pins the **attribute** and nothing else. All three engines produce it byte-identically.

The neighbouring shape `- a` + blank + `%% n` + `text` looks similar and is **not** pinned here: the engines split two-to-one on whether that item is loose, and §17 L1 does not settle it. That is markup-carve/carve#627. I had a change making the reference follow carve-js on it, measured against a stale carve-php checkout, and reverted it rather than pinning a minority answer.

## Comparison page

Refreshed from a single `npm run compare:impls` against checkouts of all three engines created immediately before the run:

```
html/markdown/plain/ansi   0 diffs
carve                     12 diffs
```

Every remaining cross-engine disagreement is in the canonical writer, and most are the marker over-escaping fixed in markup-carve/carve-rs#567.