### PR TITLE
chore: bump the carve-js pin, and drop the drift it caught up on

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#0297e5205287491045232ae78384f543148129c6",
+    "@markup-carve/carve": "github:markup-carve/carve-js#43a298057ace4ae27e1c6f14a611a99f82d1a6a0",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.35.0",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,5 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-184-a-caret-is-a-reference-label-not-an-empty-footnote  the pinned build reads `[^]: /u` as an empty-label footnote definition and drops it, so the reference stays literal; `reference_label` admits `^` and `footnote_label` is one-or-more, which makes it a link reference definition (carve-js#597 family, carve-rs#511 item 6)
-186-a-comment-fence-is-a-comment-at-any-column-too  carve-js drops both comment-fence delimiters but renders the enclosed BODY, so a comment shows its own contents (carve-js#630)


### PR DESCRIPTION
carve-js landed both rules the corpus was ahead of it on:

- `184-a-caret-is-a-reference-label-not-an-empty-footnote` (markup-carve/carve-js#631)
- `186-a-comment-fence-is-a-comment-at-any-column-too` (markup-carve/carve-js#630)

so the pin moves and both declared drift lines go with it, in the commit that makes them stale.

**Zero declared drift**: the pinned build now reproduces every one of the 569 corpus documents.

The gate did exactly its job here, in both directions. It refused the bump until the now-stale declarations were removed - a declaration that has quietly become false is the same hazard as undeclared drift, and only a two-way check catches it.

Gates: 795 tests, `core:check` clean (569 conformant, 0 defects, 0 sentinel leaks), verified after a clean `npm ci` rather than against a `node_modules` newer than the pin.
