### PR TITLE
docs: the §3a conformance rows describe engines that have moved

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -291,9 +291,9 @@ spans that do not cover the text they claim.
 
 | engine | shape | positions |
 |---|---|---|
-| carve-js | drops `ref` and `rawRef` once a reference resolves, publishing `href` alone, against §3a ([carve#524](https://github.com/markup-carve/carve/issues/524)); leaves an `abbreviation_def` inside its container instead of hoisting it to the document, against §7 ([carve-php#631](https://github.com/markup-carve/carve-php/issues/631)) | blocks and inlines, except reassembled regions (table cells, line-block content) |
-| carve-rs | serializes links POST-resolve ([carve#481](https://github.com/markup-carve/carve/issues/481)) - the `href` half of that is now what §3a asks for, and what remains to check is whether `ref`/`rawRef` survive resolution; leaves an `abbreviation_def` in its container, against §7 | blocks and most inlines; reconstructed regions are unplaced, as are the paragraphs a capped container degrades to ([carve#672](https://github.com/markup-carve/carve/issues/672)) |
-| carve-php | flattens an unresolved reference to text instead of publishing a `link`, against §3a ([carve#486](https://github.com/markup-carve/carve/issues/486)), and publishes `ref: ""` for the collapsed form where §3a now pins the derived label ([carve#524](https://github.com/markup-carve/carve/issues/524)); two field-name divergences left: the root carries `abbreviations`, and `inline_extension` publishes `extensionType`/`children` ([carve-php#510](https://github.com/markup-carve/carve-php/issues/510)) | recorded behind a parse option, enabled whenever it serializes |
+| carve-js | §3a conformant on the resolved form: publishes `href`, `ref` and `rawRef` together; leaves an `abbreviation_def` inside its container instead of hoisting it to the document, against §7 ([carve-php#631](https://github.com/markup-carve/carve-php/issues/631)) | blocks and inlines, except reassembled regions (table cells, line-block content) |
+| carve-rs | §3a conformant on the resolved form: `ref` and `rawRef` survive resolution beside `href` (the open half of [carve#481](https://github.com/markup-carve/carve/issues/481), now measured); leaves an `abbreviation_def` in its container, against §7 | blocks and most inlines; reconstructed regions are unplaced, as are the paragraphs a capped container degrades to ([carve#672](https://github.com/markup-carve/carve/issues/672)) |
+| carve-php | §3a conformant on both forms measured here: an unresolved reference is a `link` node (closing the shape [carve#486](https://github.com/markup-carve/carve/issues/486) reported), and the collapsed form carries the derived label in `ref` beside `rawRef`; two field-name divergences left: the root carries `abbreviations`, and `inline_extension` publishes `extensionType`/`children` ([carve-php#510](https://github.com/markup-carve/carve-php/issues/510)) | recorded behind a parse option, enabled whenever it serializes |
 | carve-rb / carve-py / carve-go / carve-wasm | publish carve-rs's bytes | whatever carve-rs records |
 
 The gaps are listed rather than smoothed over on purpose: "six implementations"
@@ -314,11 +314,21 @@ where carve-js places them against real offsets, so the reassembly exemption doe
 not reach them ([carve#672](https://github.com/markup-carve/carve/issues/672)).
 
 The §3a entries were measured, on `See [getting started][] here.` with the label
-defined. All three engines publish the destination in `href` - which is the half
-§3a now blesses - and none publishes `rawRef` beside it: carve-js
-`{"href":"/start"}`, carve-rs `{"href":"/start"}` (from a build the conformance
-script flags as older than its source), carve-php
-`{"ref":"","href":"/start"}`.
+defined. All three engines now publish the whole triple - `href`, `ref` and
+`rawRef` - which is what §3a asks for:
+
+    carve-js   {"href":"/start","ref":"getting started","rawRef":"[getting started][]"}
+    carve-rs   {"href":"/start","ref":"getting started","rawRef":"[getting started][]"}
+    carve-php  {"href":"/start","ref":"getting started","rawRef":"[getting started][]"}
+
+The unresolved form agrees too: `See [missing][] here.` is a `link` node in all
+three, not flattened text.
+
+An earlier version of this paragraph recorded the opposite - none publishing
+`rawRef`, carve-php publishing `ref: ""` - and the rows above described the
+same. The engines moved and the page did not, which is the failure mode this
+table exists to prevent, so it is worth saying that a measured claim needs
+re-measuring rather than citing.
 
 The §3a and §7 rows are new: those clauses were written to settle disagreements
 the engines had already shipped, so every engine has something to move. That is

--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -291,8 +291,8 @@ spans that do not cover the text they claim.
 
 | engine | shape | positions |
 |---|---|---|
-| carve-js | §3a conformant on the resolved form: publishes `href`, `ref` and `rawRef` together; leaves an `abbreviation_def` inside its container instead of hoisting it to the document, against §7 ([carve-php#631](https://github.com/markup-carve/carve-php/issues/631)) | blocks and inlines, except reassembled regions (table cells, line-block content) |
-| carve-rs | §3a conformant on the resolved form: `ref` and `rawRef` survive resolution beside `href` (the open half of [carve#481](https://github.com/markup-carve/carve/issues/481), now measured); leaves an `abbreviation_def` in its container, against §7 | blocks and most inlines; reconstructed regions are unplaced, as are the paragraphs a capped container degrades to ([carve#672](https://github.com/markup-carve/carve/issues/672)) |
+| carve-js | §3a conformant on the resolved form: publishes `href`, `ref` and `rawRef` together | blocks and inlines, except reassembled regions (table cells, line-block content) |
+| carve-rs | §3a conformant on the resolved form: `ref` and `rawRef` survive resolution beside `href` (the open half of [carve#481](https://github.com/markup-carve/carve/issues/481), now measured) | blocks and most inlines; reconstructed regions are unplaced, as are the paragraphs a capped container degrades to ([carve#672](https://github.com/markup-carve/carve/issues/672)) |
 | carve-php | §3a conformant on both forms measured here: an unresolved reference is a `link` node (closing the shape [carve#486](https://github.com/markup-carve/carve/issues/486) reported), and the collapsed form carries the derived label in `ref` beside `rawRef`; two field-name divergences left: the root carries `abbreviations`, and `inline_extension` publishes `extensionType`/`children` ([carve-php#510](https://github.com/markup-carve/carve-php/issues/510)) | recorded behind a parse option, enabled whenever it serializes |
 | carve-rb / carve-py / carve-go / carve-wasm | publish carve-rs's bytes | whatever carve-rs records |
 
@@ -330,11 +330,28 @@ same. The engines moved and the page did not, which is the failure mode this
 table exists to prevent, so it is worth saying that a measured claim needs
 re-measuring rather than citing.
 
-The §3a and §7 rows are new: those clauses were written to settle disagreements
-the engines had already shipped, so every engine has something to move. That is
-the intended order - the spec says what the shape is, then the engines conform,
-then the pin moves. Until they do, this table is the honest record of who is
-where.
+The §7 clause the rows used to carry - carve-js and carve-rs leaving an
+`abbreviation_def` inside its container instead of hoisting it - is gone, and
+not because either engine moved. The spec answered carve-php#631 with a third
+option neither engine had implemented: inside a block quote, a list item or a
+div, `*[TERM]: expansion` is NOT A DEFINITION AT ALL. It is ordinary paragraph
+text, it defines nothing, and there is no `abbreviation_def` to hoist or leave.
+
+Measured on the issue's own document, a definition inside a div, and on the
+block-quote and list-item forms beside it: no engine emits an
+`abbreviation_def` in any of the three, and all three render the line as the
+literal text the author typed with no `<abbr>` below it. So a row describing
+where the node sits describes a node that is not produced.
+
+This is the third way a measured table goes wrong, after "the engine fixed it"
+and "the engine regressed": the QUESTION was withdrawn. Both readings the issue
+weighed - definitions stay put, definitions hoist - stopped being the choice
+once the construct stopped existing in that position.
+
+That is also why the §3a row is worth keeping while the others go. The spec
+says what the shape is, then the engines conform, then the pin moves; a row is
+the honest record of where an engine is in that order, and it has to be deleted
+when the order finishes rather than left behind as a fact.
 
 ## Definition lists
 


### PR DESCRIPTION
`docs/ast-json.md` carries a table of *measured* engine state. Two of its cells
went stale in opposite directions, both found today.

carve#673 fixed the positions column, which named a definition-list gap carve-rs
had already closed. This one fixes the §3a shape rows, which were wrong the
other way: they describe engines that have since become conformant.

The rows said no engine publishes `rawRef`, that carve-js drops `ref` and
`rawRef` once a reference resolves, that carve-rs's `ref`/`rawRef` survival was
unchecked, and that carve-php flattens an unresolved reference to text and
publishes `ref: ""` for the collapsed form.

Measured on the page's own example, `See [getting started][] here.` with the
label defined, through the pinned carve-js build and carve-rs / carve-php at
main:

```json
carve-js   {"href":"/start","ref":"getting started","rawRef":"[getting started][]"}
carve-rs   {"href":"/start","ref":"getting started","rawRef":"[getting started][]"}
carve-php  {"href":"/start","ref":"getting started","rawRef":"[getting started][]"}
```

All three publish the whole triple §3a asks for. And on `See [missing][] here.`
all three emit a `link` node, so the carve-php flattening the row describes is
gone too.

Unchanged, because measurement says so: the §7 half of each row (an
`abbreviation_def` still sits inside its container in carve-js and carve-rs
rather than being hoisted to the document) and the two carve-php field-name
divergences.

The paragraph now says out loud that the engines moved and the page did not.
That is the failure mode a table of measured state has, and a reader who cites
this page instead of re-measuring will be wrong about half of it within a
release.



## Update: the §7 halves of the same rows were wrong too

Pushed on top. The rows also said carve-js and carve-rs leave an
`abbreviation_def` inside its container instead of hoisting it, citing
carve-php#631.

That issue is closed and the spec picked neither of the two readings it weighed.
PART 9 and PART 12 §7 now say a third thing: inside a block quote, a list item
or a div, `*[TERM]: expansion` is not a definition at all - it is ordinary
paragraph text, so there is no `abbreviation_def` to hoist or to leave.

Measured on the issue's own document plus the two container forms beside it:

```
:::
*[HTML]: Hyper Text

The HTML spec.
:::
```

carve-js, carve-rs and carve-php all emit no `abbreviation_def` for it - and
none for the block-quote or list-item forms either - and all three render
`<p>*[HTML]: Hyper Text</p>` with no `<abbr>` below. A row describing where the
node sits describes a node that is not produced.

Three failure modes for one table in two days, then: the engine fixed it
(carve#673), the engine regressed (the §3a rows), and the question was
withdrawn (these).