### PR TITLE
test: three optional cases were skipped for want of a runner, not support

### DIFF
--- a/tests/optional-corpus.test.mjs
+++ b/tests/optional-corpus.test.mjs
@@ -19,6 +19,7 @@ import { basename, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { expectedFileFor, targetOf } from '../scripts/lib/corpus-targets.mjs'
 import {
+  autolink,
   carveToAnsi,
   carveToHtml,
   carveToMarkdown,
@@ -86,6 +87,20 @@ const featureRunners = {
   'section-wrapper-off': (source, render) => render(source, { sections: false }),
   'source-line-after-generated-id': (source, render) =>
     render(source, { sections: false, sourceLine: true }),
+  /*
+   * Three features that had NO RUNNER and so read as unsupported. The reference
+   * engine does all three, and each case matches its committed fixture on the
+   * first try - so the skip was describing the harness, not the engine, and
+   * three expected files were being verified by nothing (carve#645 is the same
+   * shape: a guard whose inputs are a fixed list only guards that list).
+   *
+   * `smart-quotes-locale-de` stays skipped and is the reason a skip is worth
+   * having: the engine has no locale-quote option at all, so that pair really
+   * is describing something unimplemented.
+   */
+  'bare-url-autolink': (source, render) => render(source, { extensions: [autolink()] }),
+  'smart-typography-off': (source, render) => render(source, { smartTypography: false }),
+  'markdown-typography-source': (source, render) => render(source, { smartTypography: 'source' }),
   'code-callouts': (source, render) => render(source, { extensions: [codeCallouts()] }),
   details: (source, render) => render(source, { extensions: [details()] }),
   'list-table': (source, render) => render(source, { extensions: [listTable()] }),


### PR DESCRIPTION
`tests/optional-corpus.test.mjs` skips a Tier-2 case when its feature has no entry in `featureRunners`, and its header says why: "unsupported Tier-2 features stay visible as skipped tests instead of being silently ignored."

Four cases were skipped. Three are features the reference engine supports:

| case | what it needed |
| --- | --- |
| `04-bare-url-autolink` | `extensions: [autolink()]` |
| `29-smart-typography-off` | `smartTypography: false` |
| `31-markdown-typography-source` | `smartTypography: 'source'` |

Each matches its committed fixture on the first run. Nothing was wrong with the engine or the pairs - three expected files were being verified by nothing, while the report read as "this implementation does not do that yet".

Mutation-checked rather than assumed live: changing one byte of `29-smart-typography-off.html` turns that case red.

`03-smart-quotes-locale-de` stays skipped, and is the reason the mechanism is worth having - carve-js has no locale-quote option at all (`{ locale: 'de' }`, `{ smartQuotes: 'de' }` and `{ quotes: 'de' }` all render the English glyphs), so that pair really does describe something unimplemented.

Skipped: 4 before, 1 after. Passing optional cases: 29 before, 32 after.
