### PR TITLE
test: pin a definition on a footnote body's continuation line

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -8176,3 +8176,31 @@ With no matching definition the image renders as the text the author typed, exac
 ```
 
 :::
+
+## A definition on a footnote body's continuation line is collected
+
+A footnote body is a container like any other, and §16 collects a definition out of a container. On the body's own continuation column the line defines, renders nothing, and the reference below the note resolves. carve-rs rendered it as note text until carve-rs#599; nothing in the corpus held the other two to it.
+
+::: compare
+
+```carve
+[^a]: note
+  [r]: /u
+
+see[^a] and [t][r]
+```
+
+```html
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and <a href="/u">t</a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+:::
+

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>589 / 589</strong>
+    <strong>590 / 590</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>589 / 589</strong>
+    <strong>590 / 590</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>589 / 589</strong>
+    <strong>590 / 590</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,9 +36,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `0c3e043` | `589 / 589` | `0` | `0` | `3.04` |
-| JS | `cb64471` | `589 / 589` | `0` | `0` | `79.65` |
-| PHP | `4900d5c` | `589 / 589` | `0` | `0` | `72.56` |
+| Rust | `dd73999` | `590 / 590` | `0` | `0` | `2.48` |
+| JS | `d1699f3` | `590 / 590` | `0` | `0` | `61.39` |
+| PHP | `a9008b3` | `590 / 590` | `0` | `0` | `56.48` |
 
 Spec commit: `b539d14`, plus the corpus case this change adds
 
@@ -317,18 +317,18 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=589 targets=html,markdown,plain,carve,ansi
-rust: pass=601/601 mismatch=0 error=0 skipped=0 runs=2945 avg_ms=3.04
-js: pass=601/601 mismatch=0 error=0 skipped=0 runs=2945 avg_ms=79.65
-php: pass=601/601 mismatch=0 error=0 skipped=0 runs=2945 avg_ms=72.56
+profile=default/no-opt-in corpus=core corpus_pairs=590 targets=html,markdown,plain,carve,ansi
+rust: pass=602/602 mismatch=0 error=0 skipped=0 runs=2950 avg_ms=2.48
+js: pass=602/602 mismatch=0 error=0 skipped=0 runs=2950 avg_ms=61.39
+php: pass=602/602 mismatch=0 error=0 skipped=0 runs=2950 avg_ms=56.48
 cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=589 diffs=0 errors=0 fixtures=yes
-markdown: compared=589 diffs=0 errors=0 fixtures=1
-plain: compared=589 diffs=0 errors=0 fixtures=1
-carve: compared=589 diffs=0 errors=0 fixtures=10
-ansi: compared=589 diffs=0 errors=0 fixtures=none
+html: compared=590 diffs=0 errors=0 fixtures=yes
+markdown: compared=590 diffs=0 errors=0 fixtures=1
+plain: compared=590 diffs=0 errors=0 fixtures=1
+carve: compared=590 diffs=0 errors=0 fixtures=10
+ansi: compared=590 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 589 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 590 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus with no HTML divergences.
 Pre-1.0, a minor release may still change the grammar.

--- a/tests/corpus/202-a-definition-on-a-footnote-body-s-continuation-line-is-collected.crv
+++ b/tests/corpus/202-a-definition-on-a-footnote-body-s-continuation-line-is-collected.crv
@@ -1,0 +1,4 @@
+[^a]: note
+  [r]: /u
+
+see[^a] and [t][r]

--- a/tests/corpus/202-a-definition-on-a-footnote-body-s-continuation-line-is-collected.html
+++ b/tests/corpus/202-a-definition-on-a-footnote-body-s-continuation-line-is-collected.html
@@ -1,0 +1,9 @@
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and <a href="/u">t</a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>

--- a/tests/spec/202-a-definition-on-a-footnote-body-s-continuation-line-is-collected.test
+++ b/tests/spec/202-a-definition-on-a-footnote-body-s-continuation-line-is-collected.test
@@ -1,0 +1,18 @@
+A definition on a footnote body's continuation line is collected
+
+```
+[^a]: note
+  [r]: /u
+
+see[^a] and [t][r]
+.
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and <a href="/u">t</a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```


### PR DESCRIPTION
A footnote body is a container, and §16 collects a definition out of a container. Nothing in the corpus said so for the note body - no document pairs a footnote definition with an indented definition line:

```
[^a]: note
  [r]: /u

see[^a] and [t][r]
```

```html
<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and <a href="/u">t</a></p>
<section role="doc-endnotes">
  <hr>
  <ol>
    <li id="fn1">
      <p>note<a href="#fnref1" role="doc-backlink">↩</a></p>
    </li>
  </ol>
</section>
```

That absence is how carve-rs could render the line as note text and leave `[t][r]` unresolved until markup-carve/carve-rs#599 - with the corpus green throughout.

Measured on all three engines before writing the case, and again through a full sweep: 602 of 602, zero cross-implementation differences over 590 pairs (carve-rs `dd73999`, carve-js `d1699f3`, carve-php `a9008b3`).

## What is deliberately not here

The companion case - a definition inside a CODE FENCE in a note body, where the fence is opaque and the line stays content - was written, measured, and withdrawn. All three engines agree on the definition question there, but they disagree about where the note's BACKLINK goes when the body ends in a code block, so its fixture cannot be authored yet:

- carve-js and carve-php synthesize `<p><a …>↩</a></p>` after the block;
- carve-rs appends the anchor bare after `</pre>`, and for a block-quote body puts it *inside the quoted paragraph*.

That is carve#688, filed with the full matrix across five body shapes. This case ends in a paragraph, so it is unaffected either way.
