### PR TITLE
test: pin a footnote body that holds blocks

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -8204,3 +8204,42 @@ see[^a] and [t][r]
 
 :::
 
+
+## A footnote body holds blocks, and they render where they were written
+
+A note body is a container: it holds blocks, not just inline content, and each renders at the body's own indentation. The body here ends in a PARAGRAPH deliberately - where a note ends in a table, a code block or a list instead, the engines disagree about where the backlink goes (carve#688), and pinning that shape would pin one answer by accident.
+
+::: compare
+
+```carve
+[^a]: intro
+
+  | a |
+  | - |
+  | b |
+
+  closing line.
+
+see[^a]
+```
+
+```html
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>intro</p>
+      <table>
+        <thead><tr><th>a</th></tr></thead>
+        <tbody>
+          <tr><td>b</td></tr>
+        </tbody>
+      </table>
+      <p>closing line.<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+:::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>590 / 590</strong>
+    <strong>591 / 591</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>590 / 590</strong>
+    <strong>591 / 591</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>590 / 590</strong>
+    <strong>591 / 591</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,9 +36,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `dd73999` | `590 / 590` | `0` | `0` | `2.48` |
-| JS | `d1699f3` | `590 / 590` | `0` | `0` | `61.39` |
-| PHP | `a9008b3` | `590 / 590` | `0` | `0` | `56.48` |
+| Rust | `dd73999` | `591 / 591` | `0` | `0` | `2.64` |
+| JS | `bf8a695` | `591 / 591` | `0` | `0` | `65.95` |
+| PHP | `c3b630f` | `591 / 591` | `0` | `0` | `60.69` |
 
 Spec commit: `b539d14`, plus the corpus case this change adds
 
@@ -317,18 +317,18 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=590 targets=html,markdown,plain,carve,ansi
-rust: pass=602/602 mismatch=0 error=0 skipped=0 runs=2950 avg_ms=2.48
-js: pass=602/602 mismatch=0 error=0 skipped=0 runs=2950 avg_ms=61.39
-php: pass=602/602 mismatch=0 error=0 skipped=0 runs=2950 avg_ms=56.48
+profile=default/no-opt-in corpus=core corpus_pairs=591 targets=html,markdown,plain,carve,ansi
+rust: pass=603/603 mismatch=0 error=0 skipped=0 runs=2955 avg_ms=2.64
+js: pass=603/603 mismatch=0 error=0 skipped=0 runs=2955 avg_ms=65.95
+php: pass=603/603 mismatch=0 error=0 skipped=0 runs=2955 avg_ms=60.69
 cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=590 diffs=0 errors=0 fixtures=yes
-markdown: compared=590 diffs=0 errors=0 fixtures=1
-plain: compared=590 diffs=0 errors=0 fixtures=1
-carve: compared=590 diffs=0 errors=0 fixtures=10
-ansi: compared=590 diffs=0 errors=0 fixtures=none
+html: compared=591 diffs=0 errors=0 fixtures=yes
+markdown: compared=591 diffs=0 errors=0 fixtures=1
+plain: compared=591 diffs=0 errors=0 fixtures=1
+carve: compared=591 diffs=0 errors=0 fixtures=10
+ansi: compared=591 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 590 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 591 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus with no HTML divergences.
 Pre-1.0, a minor release may still change the grammar.

--- a/tests/corpus/203-a-footnote-body-holds-blocks-and-they-render-where-they-were-written.crv
+++ b/tests/corpus/203-a-footnote-body-holds-blocks-and-they-render-where-they-were-written.crv
@@ -1,0 +1,9 @@
+[^a]: intro
+
+  | a |
+  | - |
+  | b |
+
+  closing line.
+
+see[^a]

--- a/tests/corpus/203-a-footnote-body-holds-blocks-and-they-render-where-they-were-written.html
+++ b/tests/corpus/203-a-footnote-body-holds-blocks-and-they-render-where-they-were-written.html
@@ -1,0 +1,16 @@
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>intro</p>
+      <table>
+        <thead><tr><th>a</th></tr></thead>
+        <tbody>
+          <tr><td>b</td></tr>
+        </tbody>
+      </table>
+      <p>closing line.<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>

--- a/tests/spec/203-a-footnote-body-holds-blocks-and-they-render-where-they-were-written.test
+++ b/tests/spec/203-a-footnote-body-holds-blocks-and-they-render-where-they-were-written.test
@@ -1,0 +1,30 @@
+A footnote body holds blocks, and they render where they were written
+
+```
+[^a]: intro
+
+  | a |
+  | - |
+  | b |
+
+  closing line.
+
+see[^a]
+.
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>intro</p>
+      <table>
+        <thead><tr><th>a</th></tr></thead>
+        <tbody>
+          <tr><td>b</td></tr>
+        </tbody>
+      </table>
+      <p>closing line.<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```


### PR DESCRIPTION
A note body is a container: it holds blocks, not just inline content. Nothing in the corpus said so - every footnote body in 590 documents was a single paragraph, so how a table, a list or a code block renders inside one was decided by three engines independently with nothing comparing them.

They did not decide it the same way. Everything below was measured while writing this one case, and all four is fixed now:

| defect | engine |
| --- | --- |
| closing `</code></pre>` indented, six spaces of content INSIDE the `<pre>` | carve-php#815 |
| nested table/list at 2 columns where the others use 8 | carve-php#819 |
| heading in a note body gets no generated id, unlike in a quote/div/item | carve-js#669 |
| dangling attribute at the body's end attaches to the next DOCUMENT block | carve-php#816 |

```
[^a]: intro

  | a |
  | - |
  | b |

  closing line.

see[^a]
```

```html
<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a></p>
<section role="doc-endnotes">
  <hr>
  <ol>
    <li id="fn1">
      <p>intro</p>
      <table>
        <thead><tr><th>a</th></tr></thead>
        <tbody>
          <tr><td>b</td></tr>
        </tbody>
      </table>
      <p>closing line.<a href="#fnref1" role="doc-backlink">↩</a></p>
    </li>
  </ol>
</section>
```

## The body ends in a paragraph on purpose

Where a note ends in a table, a code block or a list instead, the engines disagree about where the backlink goes: carve-js and carve-php synthesize a paragraph for it, carve-rs appends it bare after the block - and for a block-quote body puts it inside the quoted paragraph. That is carve#688, with the matrix. Pinning such a shape now would settle it by accident.

591 pairs, 603 of 603 in every engine, zero cross-implementation differences (carve-rs `dd73999`, carve-js `bf8a695`, carve-php `c3b630f`).
