### PR TITLE
ci: upgrade mermaid-lint to 0.36.0, make its warnings fail, run Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+# Every job here only reads the repo; nothing publishes or comments.
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,11 +19,28 @@ jobs:
   conformance:
     name: spec-corpus conformance
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22]
+        # The floor tracks @markup-carve/carve's `engines` field (">=20"),
+        # not Node's EOL calendar: 20 is past end-of-life, but it is still
+        # the oldest runtime the package promises to work on, so the
+        # reference implementation has to be shown conformant there. Raise
+        # this leg only when carve-js raises `engines`.
+        #
+        # The ceiling is this repo's own contribution. carve-js declares
+        # ">=20" but its matrix stops at 22, so 24 (Active LTS) and 26
+        # (Current) are unverified anywhere else.
+        #
+        # 26 gates like every other leg rather than running
+        # continue-on-error: these steps are the corpus, the formal Core
+        # grammar and the pinned reference build, so a red leg is a real
+        # conformance signal — and a spec repo wants to hear that loudly. If
+        # a future Node genuinely breaks a toolchain rather than the spec,
+        # demote that leg then, with the breakage on record.
+        node-version: [20, 22, 24, 26]
 
     steps:
       - uses: actions/checkout@v6
@@ -33,6 +51,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
 
       # Installs ohm-js (the executable spec) and the pinned
       # `@markup-carve/carve` reference build the conformance steps render
@@ -76,6 +95,7 @@ jobs:
   docs-build:
     name: docs build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v6
@@ -84,7 +104,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Prefer HTTPS for Git dependencies
@@ -101,13 +121,14 @@ jobs:
   mermaid-lint:
     name: mermaid diagrams valid
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Prefer HTTPS for Git dependencies
@@ -118,7 +139,7 @@ jobs:
       - run: npm ci
 
       # Validate every Mermaid diagram embedded in tracked docs, including the
-      # ```mermaid blocks inside .crv sources (via --ext crv), so a broken
-      # diagram fails the PR instead of silently rendering as an error in the
-      # browser.
+      # ```mermaid blocks inside .crv sources, so a broken diagram fails the PR
+      # instead of silently rendering as an error in the browser. Discovery and
+      # strictness are configured in mermaid-lint.config.js.
       - run: npm run lint:mermaid

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: read
   pages: write
@@ -27,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Prefer HTTPS for Git dependencies

--- a/docs/.vitepress/examples/demo.crv
+++ b/docs/.vitepress/examples/demo.crv
@@ -248,7 +248,7 @@ yarn add @markup-carve/carve
 %% renderer enables the Mermaid extension; otherwise it shows as a code block.
 
 ```mermaid
-graph TD
+flowchart TD
     A[Write Carve] --> B{LSP diagnostics}
     B -->|clean| C[Preview]
     B -->|warnings| D[Quick fix]

--- a/mermaid-lint.config.js
+++ b/mermaid-lint.config.js
@@ -1,0 +1,34 @@
+/**
+ * Mermaid diagram linting for the Carve docs.
+ *
+ * Carve renders Mermaid through a Tier-3 extension but treats the diagram body
+ * as an opaque code fence — it never parses Mermaid grammar. Without this lint a
+ * broken diagram sails through CI and only fails later, in the reader's browser.
+ *
+ * Config lives here rather than in the `lint:mermaid` flags so editor and
+ * toolchain adapters (VS Code, remark, markdownlint) apply the same settings.
+ */
+export default {
+  // Carve's own diagrams live inside .crv documents (the playground demo), not
+  // just Markdown, so discovery has to look past the default md/mdx/mmd set.
+  extensions: ['crv'],
+
+  // Fail on warnings, not just parse errors. Only `duplicate-ids` defaults to
+  // "error"; the other ~56 semantic rules report at "warn", so without this
+  // they would report into a log nobody reads and never gate a PR.
+  //
+  // `quiet` has no config key, so `lint:mermaid` passes --quiet on the command
+  // line: it drops one "scanning" line per tracked file (706 lines -> 3 here)
+  // while still printing warnings. That combination needs mermaid-lint >= 0.35.2
+  // — before that fix, --quiet + strict exited 1 while printing "all valid"
+  // (jasonworden/mermaid-lint#120).
+  //
+  // A diagram that genuinely has to break a rule suppresses it in place rather
+  // than forcing the rule off repo-wide, and the directive must carry a reason:
+  //
+  //   %% mermaid-lint-disable-next-line prefer-flowchart: pinned to legacy syntax
+  //
+  // Also -disable (rest of diagram), -disable-diagram, -disable-file, -enable.
+  // Requires mermaid-lint >= 0.36.0.
+  strict: true,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@markup-carve/carve": "github:markup-carve/carve-js#bf8a6958b315f7b000f253bd73c0a9946b669eb2",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
-        "@mermaid-lint/cli": "^0.35.0",
+        "@mermaid-lint/cli": "^0.36.0",
         "ajv": "^8.20.0",
         "markdown-it-container": "^4.0.0",
         "ohm-js": "^17.5.0",
@@ -1057,12 +1057,12 @@
       }
     },
     "node_modules/@mermaid-lint/cli": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-lint/cli/-/cli-0.35.0.tgz",
-      "integrity": "sha512-G/XyPbqtPmXLI3KwyrHeWLadPbOCOV20bPatfRnO2hqwuIHBkkXvNF0wBSURLQ5whN39cCwOs62apRSzSLWK1Q==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-lint/cli/-/cli-0.36.0.tgz",
+      "integrity": "sha512-TJqln/YWPxTxgX8CuAowIojoq98r7FHydGnS52NO5NaDIhLqoj6DXHOLa98ZDmZAqsGmqBbVy8s9v4EkBj7u/A==",
       "dev": true,
       "dependencies": {
-        "@mermaid-lint/core": "0.35.0",
+        "@mermaid-lint/core": "0.36.0",
         "chalk": "^5.4.1",
         "fast-glob": "^3.3.3"
       },
@@ -1074,13 +1074,13 @@
       }
     },
     "node_modules/@mermaid-lint/core": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-lint/core/-/core-0.35.0.tgz",
-      "integrity": "sha512-vPd1fIDYaCVlTIDe/yLEglnI0fiQkWicJcqlhL2qWpse3OcMwvxO3hkfopc7DkNafsmRXw0NBPth6xHPd0cR6w==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-lint/core/-/core-0.36.0.tgz",
+      "integrity": "sha512-KiNMcRTKCnCYpHXDFXJbc0xN/vQEp+ENChfiXnlbO9WVThBK2ZMGhkheRLhhwPpkqg29LaDNcIZNreTg6l9UcQ==",
       "dev": true,
       "dependencies": {
         "@mermanjs/web": "^0.7.0",
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.12",
         "jsdom": "^26.1.0",
         "lilconfig": "^3.0.0",
         "mermaid": "^11.8.1",
@@ -4551,9 +4551,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "engine:report": "node scripts/engine-report.mjs",
     "bump-carve-pin": "node scripts/bump-carve-pin.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
-    "lint:mermaid": "mermaid-lint --ext crv --quiet",
+    "lint:mermaid": "mermaid-lint --quiet",
     "test": "node --test tests/caption-inside-a-container.test.mjs tests/definition-at-column-zero.test.mjs tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/nesting-cap-degrade.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/crossref-shape.test.mjs tests/schema-fields-are-produced.test.mjs tests/ast-shape.test.mjs tests/ast-positions.test.mjs tests/ast-references.test.mjs tests/ast-json-claims.test.mjs tests/test-manifest.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/portable-whitespace.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs tests/degradation-claims.test.mjs tests/migration-claims.test.mjs tests/oracle-framing-never-leaks.test.mjs tests/engine-pin-matches-the-lock.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
@@ -29,7 +29,7 @@
     "@markup-carve/carve": "github:markup-carve/carve-js#bf8a6958b315f7b000f253bd73c0a9946b669eb2",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
-    "@mermaid-lint/cli": "^0.35.0",
+    "@mermaid-lint/cli": "^0.36.0",
     "ajv": "^8.20.0",
     "markdown-it-container": "^4.0.0",
     "ohm-js": "^17.5.0",

--- a/tests/examples/demo.html
+++ b/tests/examples/demo.html
@@ -218,7 +218,7 @@ Arrows and comparisons: → ← ↔ ⇒ , ≠ ≤ ≥ , © ® ™.</p>
   </section>
   <section id="Mermaid-Tier-3-extension">
     <h2>Mermaid (Tier-3 extension)</h2>
-    <pre><code class="language-mermaid">graph TD
+    <pre><code class="language-mermaid">flowchart TD
     A[Write Carve] --&gt; B{LSP diagnostics}
     B --&gt;|clean| C[Preview]
     B --&gt;|warnings| D[Quick fix]


### PR DESCRIPTION
Follow-up to #165, which wired mermaid-lint into CI. That job is under-configured in a way that hides a live finding in this repo's own docs, and CI still builds the docs on an end-of-life Node.

Addresses jasonworden/mermaid-lint#99.

## 1. `--quiet` is hiding a real warning

`--quiet` suppresses warn-severity findings, and `demo.crv` has one — `prefer-flowchart` on its `graph TD` block:

```
docs/.vitepress/examples/demo.crv:251:1: warning: prefer-flowchart:
  use `flowchart` instead of `graph`
```

To be precise about what the current job does and doesn't catch: `duplicate-ids` defaults to **error** severity and *does* fail the build, so the lint isn't toothless. But that's 1 rule out of 62 — the other ~56 warn-severity rules are invisible and non-fatal.

The demo now uses `flowchart TD` (the current Mermaid keyword; `graph` is legacy), and `tests/examples/demo.html` is regenerated via `npm run examples:snapshot`.

## 2. Config moved out of the npm script

Discovery (`extensions: ['crv']`) and `strict: true` now live in `mermaid-lint.config.js` rather than in the `lint:mermaid` flags, so editor and toolchain adapters (VS Code, remark, markdownlint) apply the same settings as CI. `strict` is what makes the warn-default rules gate a PR.

`--quiet` stays on the command line — it has no config key — purely to drop the per-file progress lines: **706 lines of output down to 3**, with warnings still printed and counted.

That combination is only safe as of **0.35.2**. Before it, `--quiet` with `strict` exited 1 while printing `all valid`:

```console
$ npx mermaid-lint@0.35.1 --quiet --strict repro.md
checked 1 diagram in 1 file — all valid
$ echo $?
1
```

A red build with no diagnostics. Reported as jasonworden/mermaid-lint#120, fixed in mermaid-lint#121, released in 0.35.2. Its `--help` now states the contract this config depends on outright: *"With `--strict`, warnings fail the run and are still shown."*

### An escape hatch, since `strict` turns on ~56 rules

Without one, the first diagram that legitimately breaks a rule gets that rule switched off repo-wide. 0.36.0 adds eslint-style suppression directives (mermaid-lint#119) scoped to a diagram, and they must carry a reason — a bare directive is itself a warning (`suppression-malformed`):

```
%% mermaid-lint-disable-next-line prefer-flowchart: pinned to legacy syntax for a doc example
graph TD
```

Also `-disable` (rest of diagram), `-disable-diagram`, `-disable-file`, `-enable`. Nothing in the repo needs one today; it's there so `strict` doesn't become a reason to weaken the config later.

## 3. mermaid-lint 0.35.0 → 0.36.0

Also along the way: CVE bumps for `fast-uri` and `dompurify`. In fairness, 0.35.1's only functional change was a quadratic-backtracking fix in core's sequence missing-colon matcher, reachable only through `--fix`, which we don't run — so that part is hygiene, not a fix for exposure we had. `engines` stays `>=20`, so this doesn't move any floor.

## 4. Node

`actions/checkout@v6`, `setup-node@v6`, `configure-pages@v6` and `deploy-pages@v5` all already declare `using: node24`, so both `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` blocks are no-ops and are removed. The substantive change is the runtime we build on:

- `docs-build`, `mermaid-lint`, Pages deploy: **20 → 24** (Active LTS). Node 20 went EOL 2026-04-30, so the deployed site was being built on an unsupported runtime.
- conformance matrix: **[20, 22] → [20, 22, 24, 26]**.

**The floor stays at 20 deliberately.** Not because 20 is current — it isn't — but because `>=20` is `@markup-carve/carve`'s declared `engines` floor. The range the package promises is the range the reference implementation should be shown conformant across, so that leg should track the `engines` field rather than Node's release calendar.

**The ceiling is the part nothing else covers.** carve-js declares `>=20` but its own matrix stops at 22, so 24 and 26 were unverified anywhere. Note this isn't duplicated coverage either way: carve-js tests its own source, while this job tests the vendored snapshot that `sync-carve-lib` keeps in step.

Node 26 gates like every other leg rather than `continue-on-error` — these steps are the corpus, the formal Core grammar and the pinned reference build, so a red leg is a real conformance signal. If a future Node breaks a toolchain rather than the spec, that leg can be demoted then, with the breakage on record. The full suite was run on 26.5.0 before adding it.

## 5. Also

- `permissions: contents: read` on CI — it had none, so it inherited the repo default. All jobs only read.
- `timeout-minutes: 10` per job, replacing the 360-minute default.
- `cache: npm` on the conformance job, which omitted it despite running `npm ci`.

## Verification

Run locally on **Node 24.18.0 and 26.5.0**, rebased onto current `main` (7eb4202):

| gate | result |
|---|---|
| `npm test` | 918 tests, **917 pass, 0 fail** |
| `npm run core:check` | passes |
| `npm run engine:report -- --check` | passes |
| corpus in sync | `git diff --exit-code` clean after `corpus:build` |
| `npm run docs:build` | builds |
| `npm run lint:mermaid` | 2 diagrams valid, exit 0 |
| `actionlint` | clean on the changed workflows |

Also confirmed the lint fails on a regression: reintroducing `graph TD` gives exit 1 with the warning printed, under `--quiet`.

The same commit was run through this repo's own workflows on a fork PR, since checks here are held pending approval — all six green (conformance 20/22/24/26, docs build, mermaid lint).

## Out of scope

`bump-downstream.yml` pins `dtolnay/rust-toolchain@stable`, which is a mutable **branch** (`refs/heads/stable`; there is no tag by that name), in the job whose env carries `BUMP_TOKEN`. That branch moved from `4cda84d5` to `4360b525` while this PR was being written. Happy to send that separately if you'd like it.
