### PR TITLE
fix: the oracle keeps a caption inside a list item, and bump the stale engine pin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#cb644719152934d97eca037e1d9d3a5a38df315f",
+        "@markup-carve/carve": "github:markup-carve/carve-js#bf8a6958b315f7b000f253bd73c0a9946b669eb2",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.35.0",
@@ -982,8 +982,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#cb644719152934d97eca037e1d9d3a5a38df315f",
-      "integrity": "sha512-NRB71uZm9K+CEl0iQfoA+T2Fy3GW6JuTPeWk3yiAZZyfAPUmo2i3/6yCkbGZebN3wwBNIqtnjEZMxcdv9unR/w==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#bf8a6958b315f7b000f253bd73c0a9946b669eb2",
+      "integrity": "sha512-H3izPIhy332zxXf1fl1tYfGd4hGLmnM+ZCI903xVEMH6NnWdei6E+F77IkUzDjjEKhhdhbjrFP993uqUCTERJA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "bump-carve-pin": "node scripts/bump-carve-pin.mjs",
     "sync-carve-wasm": "node scripts/sync-carve-wasm.mjs",
     "lint:mermaid": "mermaid-lint --ext crv --quiet",
-    "test": "node --test tests/definition-at-column-zero.test.mjs tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/nesting-cap-degrade.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/crossref-shape.test.mjs tests/schema-fields-are-produced.test.mjs tests/ast-shape.test.mjs tests/ast-positions.test.mjs tests/ast-references.test.mjs tests/ast-json-claims.test.mjs tests/test-manifest.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/portable-whitespace.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs tests/degradation-claims.test.mjs tests/migration-claims.test.mjs tests/oracle-framing-never-leaks.test.mjs tests/engine-pin-matches-the-lock.test.mjs",
+    "test": "node --test tests/caption-inside-a-container.test.mjs tests/definition-at-column-zero.test.mjs tests/corpus.test.mjs tests/reference-build.test.mjs tests/optional-corpus.test.mjs tests/corpus-targets.test.mjs tests/normativity.test.mjs tests/nesting-cap-degrade.test.mjs tests/examples.test.mjs tests/playground-extensions.test.mjs tests/node-vocabulary.test.mjs tests/ast-schema.test.mjs tests/crossref-shape.test.mjs tests/schema-fields-are-produced.test.mjs tests/ast-shape.test.mjs tests/ast-positions.test.mjs tests/ast-references.test.mjs tests/ast-json-claims.test.mjs tests/test-manifest.test.mjs tests/fixture-bytes.test.mjs tests/roundtrip.test.mjs tests/share-link.test.mjs tests/divergence-claims.test.mjs tests/portable-whitespace.test.mjs tests/corpus-fmt-roundtrip.test.mjs tests/implementation-comparison-counts.test.mjs tests/degradation-claims.test.mjs tests/migration-claims.test.mjs tests/oracle-framing-never-leaks.test.mjs tests/engine-pin-matches-the-lock.test.mjs",
     "test:conformance": "npm run corpus:build && npm test",
     "examples:snapshot": "UPDATE_EXAMPLES=1 node --test tests/examples.test.mjs"
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#cb644719152934d97eca037e1d9d3a5a38df315f",
+    "@markup-carve/carve": "github:markup-carve/carve-js#bf8a6958b315f7b000f253bd73c0a9946b669eb2",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.35.0",

--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -352,7 +352,18 @@ function renderItem(item, list, depth, ctx) {
   const parts = []
   for (let i = 0; i < blocks.length; i++) {
     const b = blocks[i]
-    if (b.t === 'para') {
+    // A CAPTIONED paragraph goes through renderBlock, which owns the figure
+    // shape. This hand-built path never consulted `caption`, so a captioned
+    // image paragraph inside an item lost its caption entirely - the line was
+    // parsed correctly (the node carries `caption`) and then dropped on the way
+    // out (carve#693). The oracle promoted the same caption at the top level and
+    // inside a div, so a list item was the only container that discarded it.
+    //
+    // This is the SECOND field this site has dropped for the same reason: it
+    // duplicates the top-level paragraph logic instead of delegating, and
+    // carve#626 was `battrs` going the same way. Delegating is the fix in both
+    // cases; the inline path stays only for the plain shape it exists for.
+    if (b.t === 'para' && b.caption === undefined) {
       // render the whole paragraph in one inline pass (lines joined by soft
       // breaks) so an inline construct spanning a soft break -- e.g. a
       // multi-line `` ``` ``-run folded in as lazy text -- is one span, not one

--- a/tests/caption-inside-a-container.test.mjs
+++ b/tests/caption-inside-a-container.test.mjs
@@ -1,0 +1,74 @@
+/*
+ * A `^ ` caption attaches to the block above it wherever that block sits.
+ *
+ * The oracle promoted a captioned image paragraph at the top level and inside a
+ * `:::` div, and DELETED the caption inside a list item - not promoted, not
+ * rendered as text, absent (carve#693). The parse was never wrong: the paragraph
+ * node carried `caption`. The item renderer built its `<p>` by hand and never
+ * consulted it.
+ *
+ * That is the SECOND field this site has dropped for the same reason. carve#626
+ * was `battrs` going the same way, and the fix there was the same: delegate to
+ * renderBlock instead of duplicating the top-level paragraph logic. A hand-built
+ * path that reads some of a node's fields will keep losing the ones added later,
+ * so these assertions are written per CONTAINER rather than per field.
+ *
+ * carve-js and carve-php both promote in all three positions; carve-rs renders the
+ * line as literal text, which is carve-rs#610.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parse } from '../scripts/spec/layout.mjs'
+import { renderDoc } from '../scripts/spec/html.mjs'
+
+const html = (src) => renderDoc(parse(src))
+
+const IMAGE_WITH_CAPTION = '![alt](/i.png)\n^ Figure 1: caption\n'
+
+test('a captioned image paragraph promotes at the top level', () => {
+  const out = html(IMAGE_WITH_CAPTION)
+  assert.match(out, /<figure>/)
+  assert.match(out, /<figcaption>Figure 1: caption<\/figcaption>/)
+})
+
+test('and inside a div', () => {
+  const out = html(`:::\n${IMAGE_WITH_CAPTION}:::\n`)
+  assert.match(out, /<figcaption>Figure 1: caption<\/figcaption>/)
+})
+
+test('and inside a list item', () => {
+  // The shape that lost it. Indented to the item's content column.
+  const out = html('- ![alt](/i.png)\n  ^ Figure 1: caption\n')
+  assert.match(out, /<figcaption>Figure 1: caption<\/figcaption>/, out)
+  // The caption text must not ALSO appear as literal item text.
+  assert.ok(!out.includes('^ Figure 1: caption'), out)
+})
+
+test('and inside a block quote', () => {
+  // Not in the report; checked because "which containers" was the whole bug.
+  const out = html('> ![alt](/i.png)\n> ^ Figure 1: caption\n')
+  assert.match(out, /<figcaption>Figure 1: caption<\/figcaption>/, out)
+})
+
+test('a paragraph attribute inside an item still survives too', () => {
+  // carve#626's field, re-asserted here because both losses came from the same
+  // hand-built path: if someone reverts the delegation, this goes with it.
+  const out = html('- a\n\n  {.c}\n  text\n')
+  assert.match(out, /class="c"/, out)
+})
+
+test('an uncaptioned paragraph in an item is unchanged', () => {
+  // The boundary: the plain shape must keep taking the inline path, so a TIGHT
+  // item still renders its paragraph without a `<p>`.
+  const out = html('- plain\n')
+  assert.match(out, /<li>plain<\/li>/, out)
+})
+
+test('an orphan caption line with nothing captionable above it stays text', () => {
+  // §4: a `^ ` line anywhere else is ordinary content. Delegating must not start
+  // promoting these.
+  const out = html('- text\n  ^ not a caption\n')
+  assert.ok(!out.includes('<figcaption>'), out)
+  assert.match(out, /\^ not a caption/, out)
+})


### PR DESCRIPTION
Fixes markup-carve/carve#693. Also unblocks CI, which is red on `main` right now - hence two things in one PR.

## The caption

A `^ ` line attaches to the block above it. The oracle did that at the top level and inside a `:::` div, but inside a list ITEM it **deleted** the caption - not promoted, not rendered as text, absent:

```
- ![alt](/i.png)
  ^ Figure 1: caption
```

gave `<li><img src="/i.png" alt="alt"></li>`.

The parse was never wrong - the paragraph node carried `caption` all along. The item renderer builds its `<p>` by hand and never consulted it.

**This is the second field that site has dropped for the same reason.** markup-carve/carve#626 was `battrs` going the same way, and the comment recording it is still there. The fix is the same: delegate a captioned paragraph to `renderBlock`, which owns the figure shape, rather than duplicating the top-level logic. The inline path stays for the plain shape it exists for.

Output now matches carve-js and carve-php byte for byte. carve-rs renders the line as literal text and is tracked separately (markup-carve/carve-rs#610) - with the oracle fixed, a corpus case can finally pin the right answer, which was impossible while the oracle produced a third one.

## The pin, and why it is here

`tests/roundtrip.test.mjs` formats through the PINNED `@markup-carve/carve`, and the pin predated markup-carve/carve-js#653, the nested-list writer fix. So the `.fmt` fixtures added in markup-carve/carve#675 expected the corrected two-space form while the pinned engine still emitted the inflated four-space form:

```
+ actual   '- fruit\n    - apples\n- vegetables\n'
- expected '- fruit\n  - apples\n- vegetables\n'
```

`main` has been failing those two tests since. markup-carve/carve#662 predicted exactly this. Bumped to carve-js `bf8a695`.

I verified those failures reproduce on unmodified `main` before touching anything, so they are not fallout from the caption change - and a caption-only PR could not have been green.

## Verification

One of the seven new assertions fails on the parent commit. The others cover CONTAINERS rather than fields - top level, div, block quote, a plain uncaptioned item, and an orphan `^ ` line that must stay text - because a hand-built path that reads some of a node's fields will keep losing the ones added later. carve#626's `battrs` is re-asserted in the same file for that reason: if the delegation is reverted, both losses return together.

Full suite 917 pass, drift gate clean, `core:check` clean.