### PR TITLE
chore(deps): upgrade mermaid-lint 0.36.0 -> 0.40.0

### DIFF
--- a/mermaid-lint.config.js
+++ b/mermaid-lint.config.js
@@ -24,11 +24,17 @@ export default {
   // (jasonworden/mermaid-lint#120).
   //
   // A diagram that genuinely has to break a rule suppresses it in place rather
-  // than forcing the rule off repo-wide, and the directive must carry a reason:
+  // than forcing the rule off repo-wide, and the directive must carry a reason
+  // (a bare one is itself reported, as `suppression-malformed`):
   //
   //   %% mermaid-lint-disable-next-line prefer-flowchart: pinned to legacy syntax
   //
-  // Also -disable (rest of diagram), -disable-diagram, -disable-file, -enable.
+  // Also -disable (rest of diagram), -disable-diagram and -enable, all as `%%`
+  // comments inside the diagram. -disable-file is the exception: it is only
+  // honoured as a Markdown HTML comment above the fence, not as `%%`.
+  //
+  //   <!-- mermaid-lint-disable-file prefer-flowchart: legacy doc examples -->
+  //
   // Requires mermaid-lint >= 0.36.0.
   strict: true,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@markup-carve/carve": "github:markup-carve/carve-js#bf8a6958b315f7b000f253bd73c0a9946b669eb2",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
-        "@mermaid-lint/cli": "^0.36.0",
+        "@mermaid-lint/cli": "^0.40.0",
         "ajv": "^8.20.0",
         "markdown-it-container": "^4.0.0",
         "ohm-js": "^17.5.0",
@@ -1057,12 +1057,12 @@
       }
     },
     "node_modules/@mermaid-lint/cli": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-lint/cli/-/cli-0.36.0.tgz",
-      "integrity": "sha512-TJqln/YWPxTxgX8CuAowIojoq98r7FHydGnS52NO5NaDIhLqoj6DXHOLa98ZDmZAqsGmqBbVy8s9v4EkBj7u/A==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-lint/cli/-/cli-0.40.0.tgz",
+      "integrity": "sha512-5HoSaWmJDnWCnSd+NesRprnLyuKbEYO8CR65Lu1eErp3IHc4AXRVZoXcvhuqQ3wrpiapO2vi3d0XJWJQhpLHeA==",
       "dev": true,
       "dependencies": {
-        "@mermaid-lint/core": "0.36.0",
+        "@mermaid-lint/core": "0.40.0",
         "chalk": "^5.4.1",
         "fast-glob": "^3.3.3"
       },
@@ -1074,16 +1074,16 @@
       }
     },
     "node_modules/@mermaid-lint/core": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-lint/core/-/core-0.36.0.tgz",
-      "integrity": "sha512-KiNMcRTKCnCYpHXDFXJbc0xN/vQEp+ENChfiXnlbO9WVThBK2ZMGhkheRLhhwPpkqg29LaDNcIZNreTg6l9UcQ==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-lint/core/-/core-0.40.0.tgz",
+      "integrity": "sha512-NxEKqwToVFjvt6WgUXolYkmd7OzTApmtiQ3RsnPA62rgvSkaaMJC0v+Dg9sSQTjEiIGrzE6jT0ZM7FgDepNZYg==",
       "dev": true,
       "dependencies": {
         "@mermanjs/web": "^0.7.0",
         "dompurify": "^3.4.12",
         "jsdom": "^26.1.0",
         "lilconfig": "^3.0.0",
-        "mermaid": "^11.8.1",
+        "mermaid": "11.15.0",
         "micromatch": "^4.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@markup-carve/carve": "github:markup-carve/carve-js#bf8a6958b315f7b000f253bd73c0a9946b669eb2",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
-    "@mermaid-lint/cli": "^0.36.0",
+    "@mermaid-lint/cli": "^0.40.0",
     "ajv": "^8.20.0",
     "markdown-it-container": "^4.0.0",
     "ohm-js": "^17.5.0",


### PR DESCRIPTION
Follow-up to #694. Four mermaid-lint releases landed the same day that one did — all additive, and nothing in this repo needed changing to absorb them.

| release | change |
|---|---|
| 0.37.0 | docs for the 8 diagram types mermaid 11.15 added |
| 0.38.0 | skip leading YAML frontmatter when detecting diagram type, plus a `frontmatter-must-be-first` rule |
| 0.39.0 | `radar-beta` semantic rules |
| 0.40.0 | report a stale `-disable-file` as `suppression-unused` |

## Why the new rules were worth checking rather than assuming

0.38 and 0.39 each add rules, and #694 turned on `strict: true` — so a new warn-severity rule now **fails the build** instead of printing into a log nobody reads. A minor-version dependency bump can now break CI in a way it couldn't before that change.

Both new rule sets were run against the corpus before this bump. The two diagrams in `demo.crv` are a `flowchart` and a `sequenceDiagram`, so neither the radar nor the frontmatter rules apply, and `lint:mermaid` stays green:

```console
$ npm run lint:mermaid
checked 2 diagrams in 703 files — all valid
  flowchart        1
  sequenceDiagram  1
```

`engines` is unchanged at `>=20`, so the Node floor doesn't move.

## A correction to the config comment

#694's `mermaid-lint.config.js` listed `-disable-file` alongside the `%%` directive forms. That's wrong — it's only honoured as a Markdown HTML comment above the fence:

```
<!-- mermaid-lint-disable-file prefer-flowchart: legacy doc examples -->
```

Written as `%%` inside the diagram it does *not* apply as a file-level suppression; the linter reports `suppression-malformed` instead. Good diagnostic, but the comment as merged would have sent someone down the wrong path. Both spellings verified against 0.40.0.

## Verification

| gate | result |
|---|---|
| `npm test` | 934 tests, **933 pass, 0 fail** |
| `npm run core:check` | passes |
| `npm run engine:report -- --check` | passes |
| corpus in sync | `git diff --exit-code` clean after `corpus:build` |
| `npm run docs:build` | builds |
| `npm run lint:mermaid` | 2 diagrams valid, exit 0 |

One thing I did **not** manage to reproduce: I couldn't get `suppression-unused` (the 0.40 headline) to fire on a deliberately stale `-disable-file`. It may need a condition I didn't hit. Nothing in this repo uses suppressions, so it doesn't affect the bump — flagging it rather than implying I verified it.
