### PR TITLE
spec: pin a definition below and past a footnote body's column

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -8620,3 +8620,59 @@ see[^a]
 ```
 
 :::
+
+## A definition below a footnote body's column is the document's own text
+
+One space is not a continuation - §16 wants two - so the line leaves the note and is the document's next block. It is not a definition either: the production starts at the opening bracket and allows no leading indent, so the reference below stays literal. The line is VISIBLE and INERT, and those two halves have to be pinned together: carve-js and carve-php rendered it AND defined from it, so a reader saw the definition as prose while a reference silently resolved through the same line (carve#701, carve-js#681, carve-php#825).
+
+::: compare
+
+```carve
+[^a]: note
+ [r]: /u
+
+see[^a] and [t][r]
+```
+
+```html
+<p>[r]: /u</p>
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and [t][r]</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+:::
+
+## A definition past a footnote body's column is the body's own text
+
+Three spaces IS a continuation, so the line belongs to the note - but the body's column is two and the third column is residual indent its blocks read, so the definition never reaches an opener position and stays paragraph text inside the note. Visible and inert again, and for the opposite reason to the case above: there the line was outside the body, here it is inside it. Beside "A footnote body's own column is two", this is what makes the column load-bearing in both directions.
+
+::: compare
+
+```carve
+[^a]: note
+   [r]: /u
+
+see[^a] and [t][r]
+```
+
+```html
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and [t][r]</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note
+[r]: /u<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+:::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>607 / 607</strong>
+    <strong>609 / 609</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>607 / 607</strong>
+    <strong>609 / 609</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>607 / 607</strong>
+    <strong>609 / 609</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,9 +36,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `c3f5a12` | `607 / 607` | `0` | `0` | `2.31` |
-| JS | `bf8a695` | `607 / 607` | `0` | `0` | `56.16` |
-| PHP | `c3b630f` | `607 / 607` | `0` | `0` | `51.60` |
+| Rust | `c3f5a12` | `609 / 609` | `0` | `0` | `2.31` |
+| JS | `bf8a695` | `609 / 609` | `0` | `0` | `56.16` |
+| PHP | `c3b630f` | `609 / 609` | `0` | `0` | `51.60` |
 
 Spec commit: `b539d14`, plus the corpus case this change adds
 
@@ -324,7 +324,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=607 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=609 targets=html,markdown,plain,carve,ansi
 rust: pass=618/618 mismatch=0 error=0 skipped=0 runs=3030 avg_ms=2.31
 js: pass=618/618 mismatch=0 error=0 skipped=0 runs=3030 avg_ms=56.16
 php: pass=618/618 mismatch=0 error=0 skipped=0 runs=3030 avg_ms=51.60
@@ -332,11 +332,11 @@ cross_impl_diffs=1
   DIFF [markdown] 217-a-heading-id-keeps-a-non-ascii-space
 
 Target agreement (implementations compared against each other)
-html: compared=607 diffs=0 errors=0 fixtures=yes
-markdown: compared=607 diffs=1 errors=0 fixtures=1
-plain: compared=607 diffs=0 errors=0 fixtures=1
-carve: compared=607 diffs=0 errors=0 fixtures=10
-ansi: compared=607 diffs=0 errors=0 fixtures=none
+html: compared=609 diffs=0 errors=0 fixtures=yes
+markdown: compared=609 diffs=1 errors=0 fixtures=1
+plain: compared=609 diffs=0 errors=0 fixtures=1
+carve: compared=609 diffs=0 errors=0 fixtures=10
+ansi: compared=609 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 607 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 609 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus with no HTML divergences.
 Pre-1.0, a minor release may still change the grammar.

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -25,3 +25,5 @@
 #
 # Format: <slug><space><space><reason>
 218-a-footnote-body-s-own-column-is-two-and-a-third-column-is-its-text  the pinned build takes the body column from the first continuation line, so the rows at three land at relative zero and open a table; fixed by carve-js#679, drops out at the next release
+219-a-definition-below-a-footnote-body-s-column-is-the-document-s-own-text  the pinned build collects a definition anywhere in a note body, so this line renders AND defines; fixed by carve-js#681, drops out at the next release
+220-a-definition-past-a-footnote-body-s-column-is-the-body-s-own-text  same pinned leniency one column further in - the line renders inside the note AND defines; fixed by carve-js#681, drops out at the next release

--- a/tests/corpus/219-a-definition-below-a-footnote-body-s-column-is-the-document-s-own-text.crv
+++ b/tests/corpus/219-a-definition-below-a-footnote-body-s-column-is-the-document-s-own-text.crv
@@ -1,0 +1,4 @@
+[^a]: note
+ [r]: /u
+
+see[^a] and [t][r]

--- a/tests/corpus/219-a-definition-below-a-footnote-body-s-column-is-the-document-s-own-text.html
+++ b/tests/corpus/219-a-definition-below-a-footnote-body-s-column-is-the-document-s-own-text.html
@@ -1,0 +1,10 @@
+<p>[r]: /u</p>
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and [t][r]</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>

--- a/tests/corpus/220-a-definition-past-a-footnote-body-s-column-is-the-body-s-own-text.crv
+++ b/tests/corpus/220-a-definition-past-a-footnote-body-s-column-is-the-body-s-own-text.crv
@@ -1,0 +1,4 @@
+[^a]: note
+   [r]: /u
+
+see[^a] and [t][r]

--- a/tests/corpus/220-a-definition-past-a-footnote-body-s-column-is-the-body-s-own-text.html
+++ b/tests/corpus/220-a-definition-past-a-footnote-body-s-column-is-the-body-s-own-text.html
@@ -1,0 +1,10 @@
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and [t][r]</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note
+[r]: /u<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>

--- a/tests/spec/219-a-definition-below-a-footnote-body-s-column-is-the-document-s-own-text.test
+++ b/tests/spec/219-a-definition-below-a-footnote-body-s-column-is-the-document-s-own-text.test
@@ -1,0 +1,19 @@
+A definition below a footnote body's column is the document's own text
+
+```
+[^a]: note
+ [r]: /u
+
+see[^a] and [t][r]
+.
+<p>[r]: /u</p>
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and [t][r]</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```

--- a/tests/spec/220-a-definition-past-a-footnote-body-s-column-is-the-body-s-own-text.test
+++ b/tests/spec/220-a-definition-past-a-footnote-body-s-column-is-the-body-s-own-text.test
@@ -1,0 +1,19 @@
+A definition past a footnote body's column is the body's own text
+
+```
+[^a]: note
+   [r]: /u
+
+see[^a] and [t][r]
+.
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and [t][r]</p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note
+[r]: /u<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```


### PR DESCRIPTION
Corpus half of markup-carve/carve#701 and markup-carve/carve#669. #717 fixed the column; this pins what sits on either side of it.

Neither side holds a definition, for opposite reasons:

- **one space in** - not a continuation (§16 wants two), so the line has left the note and is the document's next block. Not a definition either: `reference_definition` starts at the opening bracket and allows no leading indent.
- **three spaces in** - a continuation, so the line belongs to the note, but the body's column is two and the third column is residual indent the body's blocks read. The definition never reaches an opener position and stays paragraph text inside the note.

Both cases render the line and resolve nothing. Each document pins BOTH halves, so an engine that gets one right and the other wrong still fails - which matters here, because the failure mode was getting them in the wrong combination:

| indent | carve-rs | carve-js before | carve-php before | oracle |
| --- | --- | --- | --- | --- |
| 1 | `V-` | `VA` | `VA` | `V-` |
| 3 | `V-` | `-A` | `VA` | `V-` |

`V` = the line renders, `A` = a reference to it resolves. `VA` is the combination no reading produces: the reader saw `[r]: /u` as prose while `[t][r]` silently resolved through the same line. carve#669 named it the part with no defensible answer, and nothing in the corpus covered these indents, which is why it survived.

Engine fixes: markup-carve/carve-js#681 (merged), markup-carve/carve-php#825. carve-rs already reads both this way.

Both documents are declared drift against the pinned reference build, which still has the leniency; the lines drop out with the pin bump after the release carrying carve-js#681.