### PR TITLE
spec: the AST's no-break-space sentinel is published, so say what it means

### DIFF
--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -2748,7 +2748,8 @@
           "const": "text"
         },
         "value": {
-          "type": "string"
+          "type": "string",
+          "description": "May contain U+E000, which stands for a NO-BREAK SPACE the parser resolved from an escaped space (`\\ `) or from preserved line-block indentation (PART 9 section 23). It is distinct from a literal U+00A0 in the source, which is published as itself. A consumer MUST map U+E000 to its target's no-break space, or to an ordinary space where the target has none, and MUST NOT emit it."
         },
         "escapedLeadingCaret": {
           "type": "boolean",

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -4424,7 +4424,21 @@ EOF = (* end of file *) ;
                    reference link
         image      `src`, `alt`, `title`
         code       `value`
-        text       `value`
+        text       `value`. It may contain U+E000, which STANDS FOR a
+                   no-break space the parser resolved from an escaped space
+                   (`\ `) or from preserved line-block indentation (§23).
+                   That is not the same node content as a literal U+00A0 the
+                   author typed, which is published as itself, and the
+                   renderers already treat the two differently. A consumer
+                   MUST map U+E000 to its target's no-break space, or to an
+                   ordinary space where the target has none, and MUST NOT
+                   emit it. Stated because all three engines publish it and
+                   nothing said so: two consumers in this org passed it
+                   straight through, one into Pandoc JSON and one back into
+                   Carve source in place of the `\ ` it came from
+                   (carve#721). Private-use codepoints ABOVE U+E000 are
+                   writer-internal staging and never reach a published value
+                   (carve-rs#404)
         heading    `level`, `children`
         list       `ordered`, `tight`, `start`, `items`, and the AUTHOR-CHOICE
                    fields `bulletChar`, `delim` and `bareMarker` (PART 11 §6)


### PR DESCRIPTION
Documents the sentinel. Does not change any engine's behavior.

Takes the wording proposed in #721, with two additions noted below. Re-measured first rather than taking the issue's table on trust - carve-rs `7aaab40`, carve-js `1a901e5`, carve-php `224d70e`, each rebuilt after the fetch:

```
a\ b
```

| engine | text node value |
|---|---|
| carve-rs | `U+0061 U+E000 U+0062` |
| carve-js | `U+0061 U+E000 U+0062` |
| carve-php | `U+0061 U+E000 U+0062` |

And a literally typed no-break space is published as itself: `U+0061 U+00A0 U+0062`. So the distinction the sentinel carries is real, and a consumer that passes it through loses it.

## Where it lands

- `resources/grammar.ebnf`, PART 12's field-names section, on the `text  value` row - which is where a consumer looking up what `value` holds actually arrives.
- `resources/ast-schema.json`, as a `description` on `text.value`. Non-validating, so nothing that validated before stops validating; `ast:check` still reports the same pre-existing position findings and no schema failures.

## Two additions to the proposed wording

- It names line-block indentation (§23) as the second source, not just the escaped space, since that is where a value can hold a RUN of them.
- It records that private-use codepoints above U+E000 are writer-internal staging and never reach a published value. carve-rs moved its writer's markers to U+E010 and up for exactly this reason (carve-rs#404) and no text said so, which is what let the collision class in markup-carve/carve#678 go unnoticed for as long as it did.

## Deliberately not here

The two questions the issue flags for decision:

- whether the schema should carry the codepoint as a named constant rather than leaving consumers to hard-code it;
- whether `scripts/ast-conformance.mjs` should assert that no other private-use codepoint reaches a published value.

Both are worth doing and neither is a wording question, so they should not ride along with one.

Gates: 990 tests pass, `core:check` 609 of 609 conformant with 0 defects.
