### PR TITLE
spec: the ohm grammar's identStart drops the leading dash

### DIFF
--- a/resources/carve-core.ohm
+++ b/resources/carve-core.ohm
@@ -322,7 +322,15 @@ CarveCore {
   attrVal    = quoted | squoted | bareVal
   bareVal    = (~(" " | "}" | newline) any)+
   ident      = identStart identRest*
-  identStart = letter | "_" | "-"
+  // PART 7: identifier = (letter | '_'), {letter | digit | '_' | '-'}
+  // A leading "-" is NOT admitted. This file was the only artifact that
+  // allowed one: the normative EBNF does not, and carve-js, carve-rs and
+  // carve-php all render `{--flag}` and `{#-id}` as literal text. The oracle
+  // instead built `<span --flag="">`, which is not a serializable HTML
+  // attribute name (carve#722). `extName` shares this rule, and
+  // `extension_name = identifier` in the EBNF, so `:-foo[x]` stays literal
+  // too - which all three engines already do.
+  identStart = letter | "_"
   identRest  = letter | digit | "_" | "-"
 
   // A word absorbs any bare delimiter glued between two word characters -


### PR DESCRIPTION
Fixes #722.

PART 7 is `identifier = (letter | '_'), {letter | digit | '_' | '-'}`. The ohm grammar's `identStart` also admitted `-`, so the executable spec was the only artifact reading a dash-first identifier as an identifier.

## Measured, before and after

Oracle against carve-js on current mains:

| input | carve-js | oracle before | oracle after |
|---|---|---|---|
| `[x]{--flag}` | `<p>[x]{–flag}</p>` | `<p><span --flag="">x</span></p>` | agrees |
| `[x]{#-id}` | literal, `#-id` as a tag | `<p><span id="-id">x</span></p>` | agrees |
| `-{--flag} item` | `<p>-{–flag} item</p>` | `<ul><li --flag="">item</li></ul>` | agrees |
| `1.{#-id} item` | literal | `<ol><li id="-id">item</li></ol>` | agrees |

`<span --flag="">` is not a serializable HTML attribute name, so the old output was not merely divergent.

## extName shares the rule

`extName = identStart identRest*`, and the EBNF has `extension_name = identifier`, so narrowing `identStart` narrows extension names too. That is correct and now checked rather than assumed: `:-foo[x]` stays literal, which carve-js, carve-rs and carve-php all already do.

## Controls

Only `identStart` narrows, so a dash INSIDE an identifier and a leading underscore are untouched:

| input | result |
|---|---|
| `[x]{a-b=c}` | `<span a-b="c">` in both |
| `[x]{_ok}` | `<span _ok="">` in both |

## Why nothing caught it

No corpus document writes a dash-first identifier, so `formal-core-check` never reached the rule. It stays at 609 of 609 conformant, 0 defects, 0 refused.

One note for whoever writes the corpus case: my first attempt used `--` to comment the rule, which Ohm reads as an alternative's case label rather than a comment. The grammar silently stopped parsing and every shape came back as an ohm error, not as a divergence - a mistake that looks like a much bigger failure than it is.
