### PR TITLE
test: the executable spec reads what the engine formatted (closes the cross-read gap)

### DIFF
--- a/tests/corpus-fmt-roundtrip.test.mjs
+++ b/tests/corpus-fmt-roundtrip.test.mjs
@@ -42,6 +42,9 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { carveToCarve, carveToHtml } from '@markup-carve/carve'
+import { parse as oracleParse, Refuse } from '../scripts/spec/layout.mjs'
+import { renderDoc } from '../scripts/spec/html.mjs'
+import { REFUSED_ALLOW } from '../scripts/spec/refused-allow.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const corpusDir = resolve(here, 'corpus')
@@ -114,4 +117,113 @@ test('fmt(x) matches every .fmt fixture (PART 11 §2)', () => {
     if (actual !== expected) wrong.push(`${slug}\n    expected: ${JSON.stringify(expected)}\n      actual: ${JSON.stringify(actual)}`)
   }
   assert.deepEqual(wrong, [], `the writer disagrees with its pinned canonical form:\n  ${wrong.join('\n  ')}`)
+})
+
+/*
+ * THE CROSS-READ. Everything above asks the writing engine to read its own
+ * output, and self-consistency is all that measures: a writer that emits a form
+ * only its own parser accepts passes every one of them.
+ *
+ * That is not hypothetical. All three engines wrote a footnote body at three
+ * spaces; carve-js's parser reads blocks there, so its round trip was green,
+ * while carve-rs and carve-php broke on their own output (carve#709). And all
+ * three wrote a lone table span marker GLUED to the pipe, where `<` is also the
+ * left-alignment sigil - `|<|` is a colspan to every engine and an alignment
+ * marker to the reader below (carve#710).
+ *
+ *   oracleHtml(engineFmt(x)) == oracleHtml(x)
+ *
+ * The engine writes, the executable spec reads. Neither half can hide a defect
+ * in the other, which is the property the three sweeps above cannot have.
+ */
+const oracleHtml = (source) => {
+  try {
+    return renderDoc(oracleParse(source)).trim()
+  } catch (error) {
+    if (error instanceof Refuse) return `REFUSED ${error.message}`
+    throw error
+  }
+}
+
+// Documents the executable spec REFUSES (a security bound, PART 9 §25). The
+// refusal is the correct answer, and comparing two refusal messages says
+// nothing, so they are excluded here and covered by tests/corpus.test.mjs.
+const crossReadable = documents.filter(({ slug }) => !REFUSED_ALLOW.has(slug))
+
+test('a cross-read document set is non-empty, so a filter cannot pass as a clean run', () => {
+  assert.ok(
+    crossReadable.length > documents.length - 50,
+    `${crossReadable.length} of ${documents.length} documents are cross-read`,
+  )
+})
+
+/*
+ * Documents where the PINNED writer and this reader still disagree, each with
+ * the reason and the change that closes it. Never a silent skip: the second test
+ * below fails when a listed document starts agreeing, so the list empties itself
+ * on the pin bump instead of turning into a list of excuses. Same shape as
+ * resources/engine-pin-drift.txt.
+ */
+const KNOWN_CROSS_READ_DIVERGENCE = new Map([
+  // The writer glues a lone span marker to the opening pipe, where `<` is also
+  // the left-alignment sigil: `|<|` is a colspan to every engine and an
+  // alignment marker here. Fixed in the three writers (carve-js#686,
+  // carve-rs#628, carve-php#828); these clear when the pin moves past it.
+  ['10-tables-with-rowspan-and-colspan', 'a lone span marker is written glued to the pipe'],
+  ['52-table-alignment-with-colspan', 'a lone span marker is written glued to the pipe'],
+  ['98-table-span-marker-in-first-column', 'a lone span marker is written glued to the pipe'],
+  ['106-blocked-span-marker-renders-as-empty-cell', 'a lone span marker is written glued to the pipe'],
+  ['107-colspan-marker-scans-left-past-a-consumed-cell', 'a lone span marker is written glued to the pipe'],
+  // The writer put a footnote body at THREE spaces, one column above its own
+  // (PART 9 §16), so the body's blocks sat at a relative column above zero and
+  // did not open. Fixed for all three writers (carve#709); the pin predates it.
+  ['203-a-footnote-body-holds-blocks-and-they-render-where-they-were-written', 'a footnote body is written at three spaces'],
+  ['204-a-heading-in-a-footnote-body-takes-an-id-but-no-section-wrapper', 'a footnote body is written at three spaces'],
+  ['205-an-attribute-line-inside-a-footnote-body-attaches-inside-it', 'a footnote body is written at three spaces'],
+  ['218-a-footnote-body-s-own-column-is-two-and-a-third-column-is-its-text', 'a footnote body is written at three spaces'],
+  ['219-a-definition-below-a-footnote-body-s-column-is-the-document-s-own-text', 'a footnote body is written at three spaces'],
+  ['220-a-definition-past-a-footnote-body-s-column-is-the-body-s-own-text', 'a footnote body is written at three spaces'],
+])
+
+function crossReadDivergences() {
+  const changed = []
+  for (const { slug, source } of crossReadable) {
+    const before = oracleHtml(source)
+    if (before.startsWith('REFUSED')) continue
+    if (oracleHtml(carveToCarve(source)) !== before) changed.push(slug)
+  }
+  return changed
+}
+
+test('the executable spec reads what the engine formatted (carve#710)', () => {
+  const unexpected = crossReadDivergences().filter((slug) => !KNOWN_CROSS_READ_DIVERGENCE.has(slug))
+  assert.deepEqual(
+    unexpected,
+    [],
+    `the engine's formatter wrote a form the executable spec reads differently - ` +
+      `each of these is either a writer emitting a form only its own parser accepts, ` +
+      `or an oracle defect, and both are findings:\n  ${unexpected.join('\n  ')}`,
+  )
+})
+
+test('every known cross-read divergence is still diverging', () => {
+  const diverging = new Set(crossReadDivergences())
+  const fixed = [...KNOWN_CROSS_READ_DIVERGENCE.keys()].filter((slug) => !diverging.has(slug))
+  assert.deepEqual(
+    fixed,
+    [],
+    `these documents now survive the cross-read - delete them from ` +
+      `KNOWN_CROSS_READ_DIVERGENCE so the gate keeps watching them:\n  ${fixed.join('\n  ')}`,
+  )
+})
+
+test('every known cross-read divergence names a document that exists', () => {
+  const slugs = new Set(documents.map(({ slug }) => slug))
+  const dead = [...KNOWN_CROSS_READ_DIVERGENCE.keys()].filter((slug) => !slugs.has(slug))
+  assert.deepEqual(
+    dead,
+    [],
+    `KNOWN_CROSS_READ_DIVERGENCE names documents the corpus no longer has, so those ` +
+      `entries exempt nothing and hide nothing - renumbered or deleted:\n  ${dead.join('\n  ')}`,
+  )
 })


### PR DESCRIPTION
Closes the gate markup-carve/carve#710 asks for.

## What was missing

`tests/corpus-fmt-roundtrip.test.mjs` already asserts `toHtml(fmt(x)) == toHtml(x)`, `fmt(fmt(x)) == fmt(x)` and the `.fmt` bytes over the whole corpus. All three ask the WRITING engine to read its own output, so self-consistency is all they measure: a writer that emits a form only its own parser accepts passes every one of them.

Two defects lived in that gap:

- all three engines wrote a footnote body at THREE spaces, one column above its own (PART 9 §16). carve-js reads blocks there, so its round trip was green while carve-rs and carve-php broke on their own output (markup-carve/carve#709);
- all three wrote a lone table span marker GLUED to the opening pipe, where `<` is also the left-alignment sigil - `|<|` is a colspan to every engine and an alignment marker to the reader in this repo (markup-carve/carve#710).

## The property

```
oracleHtml(engineFmt(x)) == oracleHtml(x)
```

The engine writes, the executable spec reads. Neither half can hide a defect in the other, which is exactly what the existing sweeps cannot do.

## Landing it honestly

It cannot go in green against the PINNED engine, which predates both writer fixes. The eleven documents it finds are listed in `KNOWN_CROSS_READ_DIVERGENCE` with the reason and the change that closes each - five the span marker (fixed in markup-carve/carve-js#686, markup-carve/carve-rs#628, markup-carve/carve-php#828), six the footnote body column (markup-carve/carve#709, already merged in the engines).

Two guards keep that list from becoming a list of excuses:

- **a listed document that starts agreeing fails the run.** Verified by pointing the test at a build that carries both writer fixes: all eleven clear, so the list empties itself on the next pin bump rather than needing someone to remember it.
- **an entry naming a document the corpus no longer has fails too.** Corpus numbers shift when an example is inserted, and an entry that matches nothing exempts nothing and hides nothing - it just sits there looking like knowledge.

Both guards were checked by breaking them on purpose (adding a passing slug, then a nonexistent one) rather than by reading the code, since a guard that cannot fail is the thing this whole change is about.

Documents the executable spec REFUSES are excluded - comparing two refusal messages says nothing, and `tests/corpus.test.mjs` covers them - and the exclusion is bounded by a count assertion so a filter bug cannot pass as a clean run.
