### PR TITLE
fix: the sibling-overlap rule exempts every hoisted definition kind

### DIFF
--- a/scripts/spec/ast-positions.mjs
+++ b/scripts/spec/ast-positions.mjs
@@ -92,16 +92,29 @@ function checkContainment(doc, findings) {
  * Two kinds of sibling legitimately share source, for reasons that are rules
  * rather than accidents, so neither is compared:
  *
- *   HOISTED DEFINITIONS. PART 12 §7 makes a `footnote` or `abbreviation_def` a
- *   child of the DOCUMENT wherever it was written, and its `pos` still records
- *   where that was - which is inside whatever container it was authored in. So
- *   a definition written inside a div is a document-level sibling of that div
- *   whose span sits inside it. That is the hoisting rule working.
+ *   HOISTED DEFINITIONS. PART 12 §7 makes a definition a child of the DOCUMENT
+ *   wherever it was written, and its `pos` still records where that was - which
+ *   is inside whatever container it was authored in. So a definition written
+ *   inside a div is a document-level sibling of that div whose span sits inside
+ *   it. That is the hoisting rule working.
+ *
+ *   ALL THREE KINDS, and the list is checked against the schema by
+ *   tests/ast-positions.test.mjs rather than remembered. It held only the first
+ *   two for a while after §10 added `link_reference_definition` - which hoists
+ *   "exactly as §7 requires of the other two definition kinds" - so this checker
+ *   reported a §4 sibling overlap for carve-php, the one engine that implements
+ *   the node, every time a definition was authored inside a container.
  *
  *   BREAKS. A break is anchored at a line terminator, so two breaks meeting at
  *   one newline share that boundary without either being wrong.
  */
-const EXEMPT_FROM_OVERLAP = new Set(['footnote', 'abbreviation_def', 'hard_break', 'soft_break'])
+export const HOISTED_DEFINITION_TYPES = new Set([
+  'footnote',
+  'abbreviation_def',
+  'link_reference_definition',
+])
+
+const EXEMPT_FROM_OVERLAP = new Set([...HOISTED_DEFINITION_TYPES, 'hard_break', 'soft_break'])
 
 /**
  * SIBLING SPANS MUST NOT OVERLAP.

--- a/tests/ast-positions.test.mjs
+++ b/tests/ast-positions.test.mjs
@@ -16,7 +16,11 @@ import { readFileSync, readdirSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parse } from '@markup-carve/carve'
-import { checkPositions, walkNodes } from '../scripts/spec/ast-positions.mjs'
+import {
+  HOISTED_DEFINITION_TYPES,
+  checkPositions,
+  walkNodes,
+} from '../scripts/spec/ast-positions.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const repo = resolve(here, '..')
@@ -258,20 +262,45 @@ test('a first-to-last span over a sibling is a finding', () => {
   )
 })
 
-test('a hoisted definition inside a container is not an overlap', () => {
-  // PART 12 §7: the definition is a document-level sibling of the div it was
-  // written in, and its pos still points inside that div.
-  const doc = {
-    type: 'document',
-    children: [
-      { type: 'div', pos: span(0, 48), children: [] },
-      { type: 'abbreviation_def', pos: span(4, 20), children: [] },
-    ],
-  }
-  const findings = []
-  checkPositions(doc, 'x'.repeat(60), findings)
+// EVERY hoisted kind, not just one. The exemption held `footnote` and
+// `abbreviation_def` for a while after PART 12 §10 added
+// `link_reference_definition`, which hoists the same way - and this checker then
+// reported a §4 sibling overlap for carve-php, the only engine that implements
+// the node, on every definition authored inside a container. A test naming one
+// kind could not fail on that.
+for (const type of HOISTED_DEFINITION_TYPES) {
+  test(`a hoisted ${type} inside a container is not an overlap`, () => {
+    // PART 12 §7: the definition is a document-level sibling of the div it was
+    // written in, and its pos still points inside that div.
+    const doc = {
+      type: 'document',
+      children: [
+        { type: 'div', pos: span(0, 48), children: [] },
+        { type, pos: span(4, 20), children: [] },
+      ],
+    }
+    const findings = []
+    checkPositions(doc, 'x'.repeat(60), findings)
+    assert.deepEqual(
+      findings.filter((f) => f.includes('sibling spans overlap')),
+      [],
+    )
+  })
+}
+
+test('every definition kind the schema hoists is exempt from the overlap rule', () => {
+  // The rule lives in the schema's own words ("Hoisted to the document") and in
+  // PART 12 §7 and §10. Deriving the check from the schema means the next
+  // definition kind cannot ship with the exemption list left behind - which is
+  // exactly what happened to `link_reference_definition`.
+  const schema = JSON.parse(readFileSync(resolve(repo, 'resources/ast-schema.json'), 'utf8'))
+  const hoisted = Object.entries(schema.$defs)
+    .filter(([, def]) => /hoisted to the document/i.test(def.description ?? ''))
+    .map(([name]) => name)
+  const missing = hoisted.filter((type) => !HOISTED_DEFINITION_TYPES.has(type))
   assert.deepEqual(
-    findings.filter((f) => f.includes('sibling spans overlap')),
+    missing,
     [],
+    `the schema says these hoist, and the overlap rule does not exempt them: ${missing.join(', ')}`,
   )
 })


### PR DESCRIPTION
`scripts/ast-positions.mjs` was reporting a §4 violation for a correct implementation.

## What it reported

PART 12 §7 hoists a definition to the document wherever it was written, and §4 keeps its `pos` pointing at the container it was authored in - so a hoisted definition is a document-level sibling whose span sits inside its neighbour. The overlap check exempts that deliberately, and its list named two kinds: `footnote` and `abbreviation_def`.

§10 added a third. Measured against carve-php, the one engine that implements `link_reference_definition`:

Input:

```
::: note
text [a][r]

[r]: /u
:::
```

php's tree (correct - the definition is hoisted, its span still inside the div):

```
admonition                  lines 1-5  off 0-33
link_reference_definition   lines 4-4  off 22-29
```

and the checker's verdict:

```
sibling spans overlap at $.children[1]: "link_reference_definition" starts at 22,
inside "admonition" which ends at 33
```

So the report that decides what "conformant" means was telling the only conformant engine it was wrong, on every definition authored inside a container. The type's own clause says it hoists *"exactly as §7 requires of the other two definition kinds"* - the rule was stated and the enforcement list was left behind.

## Why the existing test could not catch it

`a hoisted definition inside a container is not an overlap` named `abbreviation_def` and nothing else, so it passed while the sibling kind was unexempted. That case now runs once per kind, driven by the same exported set the checker uses.

On top of that, a test derives the answer from the SCHEMA rather than from memory: every `$defs` entry whose description says it is *"Hoisted to the document"* must be in the exempt set. The next definition kind cannot ship with the list behind it.

Verified by removing the new entry: the schema-derived check fails and so do the per-kind cases. A guard nobody has watched fail is the failure mode this whole change is about.
