### PR TITLE
spec: a heading reference folds NFC, and not NFKC

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -8676,3 +8676,31 @@ see[^a] and [t][r]
 ```
 
 :::
+
+## A heading reference folds Unicode normalization, but not compatibility
+
+The heading index is matched loosely on purpose (PART 9R R1): trimmed, internal whitespace collapsed, NFC-normalized, then compared case-insensitively. NFC has to be in that list because the ID side already normalizes (§25) - without it a document publishes `id="Café"` and then declines `[Café][]` against the very heading that produced it, and the two spellings look identical on screen so the miss has no visible cause. The heading below is written `Cafe` + U+0301 and the reference is precomposed U+00E9.
+
+Compatibility folding is NOT in the list: `[file][]` does not reach `# ﬁle`. NFKC would change which text the author is quoting rather than how it is spelled. carve-rs folded NFC and the other three did not (carve#725).
+
+::: compare
+
+```carve
+# Café
+
+see [Café][] and [file][]
+
+# ﬁle
+```
+
+```html
+<section id="Café">
+  <h1>Café</h1>
+  <p>see <a href="#Café">Café</a> and [file][]</p>
+</section>
+<section id="ﬁle">
+  <h1>ﬁle</h1>
+</section>
+```
+
+:::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>609 / 609</strong>
+    <strong>610 / 610</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>609 / 609</strong>
+    <strong>610 / 610</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>609 / 609</strong>
+    <strong>610 / 610</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,9 +36,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `c3f5a12` | `609 / 609` | `0` | `0` | `2.31` |
-| JS | `bf8a695` | `609 / 609` | `0` | `0` | `56.16` |
-| PHP | `c3b630f` | `609 / 609` | `0` | `0` | `51.60` |
+| Rust | `c3f5a12` | `610 / 610` | `0` | `0` | `2.31` |
+| JS | `bf8a695` | `610 / 610` | `0` | `0` | `56.16` |
+| PHP | `c3b630f` | `610 / 610` | `0` | `0` | `51.60` |
 
 Spec commit: `b539d14`, plus the corpus case this change adds
 
@@ -324,7 +324,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=609 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=610 targets=html,markdown,plain,carve,ansi
 rust: pass=618/618 mismatch=0 error=0 skipped=0 runs=3030 avg_ms=2.31
 js: pass=618/618 mismatch=0 error=0 skipped=0 runs=3030 avg_ms=56.16
 php: pass=618/618 mismatch=0 error=0 skipped=0 runs=3030 avg_ms=51.60
@@ -332,11 +332,11 @@ cross_impl_diffs=1
   DIFF [markdown] 217-a-heading-id-keeps-a-non-ascii-space
 
 Target agreement (implementations compared against each other)
-html: compared=609 diffs=0 errors=0 fixtures=yes
-markdown: compared=609 diffs=1 errors=0 fixtures=1
-plain: compared=609 diffs=0 errors=0 fixtures=1
-carve: compared=609 diffs=0 errors=0 fixtures=10
-ansi: compared=609 diffs=0 errors=0 fixtures=none
+html: compared=610 diffs=0 errors=0 fixtures=yes
+markdown: compared=610 diffs=1 errors=0 fixtures=1
+plain: compared=610 diffs=0 errors=0 fixtures=1
+carve: compared=610 diffs=0 errors=0 fixtures=10
+ansi: compared=610 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 609 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 610 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus with no HTML divergences.
 Pre-1.0, a minor release may still change the grammar.

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,3 +24,4 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
+221-a-heading-reference-folds-unicode-normalization-but-not-compatibility  the pinned build does not NFC-normalize the heading-reference key, so the precomposed reference misses the decomposed heading; fixed by carve-js#686, drops out at the next release

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3641,11 +3641,26 @@ EOF = (* end of file *) ;
       same-named heading. Matching against the heading index is LOOSER
       than the linkDefs matching above: the label and the heading text
       are both trimmed, their internal whitespace runs collapsed to one
-      space, and then compared case-INSENSITIVELY, so `[getting
-      started][]` finds `# Getting Started`. That asymmetry is
+      space, NFC-NORMALIZED, and then compared case-INSENSITIVELY, so
+      `[getting started][]` finds `# Getting Started` and `[Café][]`
+      finds `# Cafe` + U+0301. That asymmetry is
       deliberate -- a linkDefs label is an identifier the author wrote
       twice and can keep identical, while a heading ref is prose the
-      author is quoting from elsewhere in the document. The index holds
+      author is quoting from elsewhere in the document.
+      NFC and NOT NFKC: canonical equivalence only, so `ﬁle` does not
+      match `file` and `① one` does not match `1 one` -- compatibility
+      folding would change which text an author is quoting, not just how it
+      is spelled. NFC belongs in the list for two reasons. The id side is
+      ALREADY NFC (§25), so without it a document publishes `id="Café"`
+      and then declines `[Café][]` against the heading that produced it --
+      the same alphabet on one side of the resolution and not the other.
+      And NFC is a WEAKER fold than the case fold this list already
+      admits: case folding relates codepoints Unicode calls distinct,
+      while NFC relates sequences Unicode DEFINES as the same, so
+      admitting the stronger one and refusing the weaker one is backwards.
+      The two spellings are also indistinguishable on screen, so a
+      reference that misses has no visible cause (carve#725, where
+      carve-rs folded and the other three did not). The index holds
       headings at top level and
       inside divs, admonitions, list items, and definitions, but
       DECLINES any heading with a blockquote ancestor, in either

--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -624,12 +624,17 @@ function resolveRefs(html, ctx) {
 
 /*
  * R1 matches the heading index LOOSER than it matches link definitions: trim,
- * collapse internal whitespace, fold case. A definition label is an identifier
- * the author wrote twice; a heading reference is prose quoted from elsewhere in
- * the document.
+ * collapse internal whitespace, NFC-normalize, fold case. A definition label is
+ * an identifier the author wrote twice; a heading reference is prose quoted from
+ * elsewhere in the document.
+ *
+ * NFC and not NFKC. Without it the id side is normalized (§25) and this side is
+ * not, so a document publishes `id="Café"` and then declines `[Café][]` against
+ * the very heading that produced it - carve#725, where carve-rs folded and the
+ * other three did not.
  */
 function refKey(text) {
-  return stripTags(text).trim().replace(/\s+/g, ' ').toLowerCase()
+  return stripTags(text).trim().replace(/\s+/g, ' ').normalize('NFC').toLowerCase()
 }
 
 /* Register a heading in the implicit-reference index. FIRST wins. */

--- a/tests/corpus/221-a-heading-reference-folds-unicode-normalization-but-not-compatibility.crv
+++ b/tests/corpus/221-a-heading-reference-folds-unicode-normalization-but-not-compatibility.crv
@@ -1,0 +1,5 @@
+# Café
+
+see [Café][] and [file][]
+
+# ﬁle

--- a/tests/corpus/221-a-heading-reference-folds-unicode-normalization-but-not-compatibility.html
+++ b/tests/corpus/221-a-heading-reference-folds-unicode-normalization-but-not-compatibility.html
@@ -1,0 +1,7 @@
+<section id="Café">
+  <h1>Café</h1>
+  <p>see <a href="#Café">Café</a> and [file][]</p>
+</section>
+<section id="ﬁle">
+  <h1>ﬁle</h1>
+</section>

--- a/tests/spec/221-a-heading-reference-folds-unicode-normalization-but-not-compatibility.test
+++ b/tests/spec/221-a-heading-reference-folds-unicode-normalization-but-not-compatibility.test
@@ -1,0 +1,17 @@
+A heading reference folds Unicode normalization, but not compatibility
+
+```
+# Café
+
+see [Café][] and [file][]
+
+# ﬁle
+.
+<section id="Café">
+  <h1>Café</h1>
+  <p>see <a href="#Café">Café</a> and [file][]</p>
+</section>
+<section id="ﬁle">
+  <h1>ﬁle</h1>
+</section>
+```


### PR DESCRIPTION
Settles markup-carve/carve#725.

R1's implicit heading fallback matched loosely - trim, collapse internal whitespace, fold case - but did not normalize, while heading IDS have been NFC-normalized since §25. So:

Input:

```
# Cafe<U+0301>

see [Café][]
```

Output before (carve-js, carve-php, oracle):

```html
<section id="Café">
  <h1>Café</h1>
  <p>see [Café][]</p>
</section>
```

The document publishes `id="Café"` and then declines a reference spelling that exact string, against the very heading that produced it. carve-rs resolved it.

## Why NFC belongs in the list

- **The id side already normalizes.** Without this the resolution uses one alphabet on the id side and another on the lookup side.
- **NFC is a WEAKER fold than the case fold already admitted.** Case folding relates codepoints Unicode calls distinct; NFC relates sequences Unicode DEFINES as the same. Admitting the stronger and refusing the weaker was backwards.
- **The miss has no visible cause.** Both spellings render identically, and editors/filesystems hand authors either one.

## Why NFKC does not

`[file][]` must not reach `# ﬁle`; `[1 one][]` must not reach `# ① one`. Compatibility folding changes *which text* the author is quoting, not how it is spelled. Verified carve-rs is NFC-only, so this codifies what it already does rather than widening it.

Nothing here touches link-DEFINITION matching, which stays exact per §6 and #703.

## What changed

- R1's heading-fallback list gains NFC, with NFKC explicitly excluded and the id-side argument stated.
- `scripts/spec/html.mjs`: `refKey` normalizes.
- Corpus 221 pins BOTH halves in one document - the NFC reference resolves, the NFKC reference stays literal - so an engine cannot be fixed halfway. The `.crv` carries a decomposed heading (`Cafe` + U+0301) and a precomposed reference; verified the combining mark survives corpus generation.

Engine PRs: carve-js and carve-php normalize the key; carve-rs needs no behavior change and gets tests pinning NFC plus the NFKC negative, so its behavior stops being an accident.

Corpus 221 is declared drift against the pinned reference build until the release carrying the carve-js fix.