### PR TITLE
tools: php adapters for sections + source-line

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -373,13 +373,13 @@ came to say 4 when the corpus held 33.
 ```text
 Implementation summary
 profile=optional/opt-in corpus=optional corpus_pairs=33 targets=html,markdown
-rust: pass=3/3 mismatch=0 error=0 skipped=30 runs=3 avg_ms=2.91
-js: pass=31/31 mismatch=0 error=0 skipped=2 runs=31 avg_ms=78.43
-php: pass=28/28 mismatch=0 error=0 skipped=5 runs=28 avg_ms=69.21
+rust: pass=5/5 mismatch=0 error=0 skipped=28 runs=5 avg_ms=22.17
+js: pass=32/32 mismatch=0 error=0 skipped=1 runs=32 avg_ms=64.69
+php: pass=31/31 mismatch=0 error=0 skipped=2 runs=31 avg_ms=54.55
 cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=27 diffs=0 errors=0 fixtures=yes
+html: compared=30 diffs=0 errors=0 fixtures=yes
 markdown: compared=2 diffs=0 errors=0 fixtures=yes
 
 Optional feature coverage
@@ -391,12 +391,13 @@ citations-numbered (html): js, php
 code-callouts (html): js, php
 ...
 
-NOT COMPARED: 5 of 33 optional cases reached fewer than two engines, so they
+NOT COMPARED: 1 of 33 optional cases reached fewer than two engines, so they
 contribute no agreement evidence. This is not a pass.
 ```
 
-**Read the last block, not the `cross_impl_diffs=10` above it.** Five of the 33
-optional cases still reach fewer than two engines and contribute no evidence.
+**Read the last block, not the `cross_impl_diffs=10` above it.** One of the 33
+optional cases still reaches fewer than two engines and contributes no
+evidence.
 
 That was 30 until carve#521. The features were implemented everywhere all
 along; what was missing was a way for this tool to switch them on. carve-js and
@@ -406,28 +407,29 @@ the compared count from 2 to 27, and covering citations, which is 16 of the 33
 on its own.
 
 The rest need a renderer or parser OPTION rather than an extension, and an
-option is per-engine API, so there is no shared table for them. Four of the five
-are now driven through one: `markdown-typography-source` reaches carve-js and
-carve-php, and the other three reach carve-js.
+option is per-engine API, so there is no shared table for them.
+`smart-typography-off` and `markdown-typography-source` reach all three
+engines - carve-rs's `--smart-typography source` flag serves both.
+`section-wrapper-off` and `source-line-after-generated-id` reach carve-js and
+carve-php: carve-php#537 added the `HtmlRenderer::setSectionWrapping()`
+opt-out those two adapters drive, and carve-php#679 fixed the id/stamp
+ordering the second case pins (carve#535).
 
-Reaching an engine is not the same as being compared. These four remain
-single-engine, and the run now says why rather than reporting a uniform "no CLI
+Reaching an engine is not the same as being compared. One case remains
+single-engine, and the run says why rather than reporting a uniform "no CLI
 path":
 
 | case | why |
 | --- | --- |
-| `smart-typography-off` | no engine implements the documented switch (carve#560) |
-| `smart-quotes-locale-de` | carve-js has no quote-locale option |
-| `section-wrapper-off` | carve-php has no `sections` switch |
-| `source-line-after-generated-id` | its fixture needs sections off, which carve-php cannot do |
+| `smart-quotes-locale-de` | carve-js has no quote-locale option (carve#560) |
 
 That distinction is the point. A missing adapter is this repo's backlog; a
-missing option is the engine's, and the difference decides who fixes it. Three
-of these four are capability gaps, which is why no amount of harness work would
-have moved them.
+missing option is the engine's, and the difference decides who fixes it. This
+one is a capability gap, which is why no amount of harness work would move it.
 
-carve-rs is driven through its binary and exposes no flag for any of these, so
-its cases still need a CLI path (carve#496).
+carve-rs is driven through its binary and exposes no flag for the sections
+switch or the source-line stamp, so `section-wrapper-off` and
+`source-line-after-generated-id` still need a CLI path there (carve#496).
 
 ## Scope
 

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -183,18 +183,20 @@ const PLAIN_EXTENSION_FEATURES = {
  * CAPABILITY rather than a missing adapter.
  *
  * Left out of the reporting entirely, "not compared" reads as a harness
- * backlog. Three of these are not: the option does not exist in the engines
- * that would have to run them, so writing an adapter is impossible rather than
+ * backlog. This one is not: the option does not exist in either engine that
+ * would have to run it, so writing an adapter is impossible rather than
  * pending, and the fix is in the engine (or in the page that documents an
  * option nobody implemented - carve#560).
+ *
+ * `section-wrapper-off` and `source-line-after-generated-id` used to live here
+ * too, on the strength of "carve-php has no sections switch". carve-php#537
+ * added `HtmlRenderer::setSectionWrapping()` and carve-php#679 fixed the id/
+ * stamp ordering the second case turns on, so both are wired below instead
+ * (carve#535).
  */
 const UNREACHABLE_REASONS = {
   'smart-quotes-locale-de':
     'carve-js has no quote-locale option; carve-php has the extension (carve#560)',
-  'section-wrapper-off':
-    'carve-php has no sections switch; carve-js has the option (carve#560)',
-  'source-line-after-generated-id':
-    'the fixture needs sections off, which carve-php cannot do (carve#560)',
 }
 
 const JS_OPTION_FEATURES = {
@@ -368,6 +370,40 @@ const impls = [
             $renderer = new MarkupCarve\\Carve\\Renderer\\HtmlRenderer();
             $renderer->setSmartTypography(MarkupCarve\\Carve\\Renderer\\SmartTypographyMode::Source);
             $converter = MarkupCarve\\Carve\\CarveConverter::create(renderer: $renderer);
+            echo $converter->convert(file_get_contents($argv[1]));
+          `,
+        ]
+      }
+      // carve-php#537 added the opt-out; before it this case had no php
+      // adapter to write at all (carve#535).
+      if (feature === 'section-wrapper-off') {
+        return [
+          'php',
+          '-r',
+          `
+            require 'vendor/autoload.php';
+            $renderer = new MarkupCarve\\Carve\\Renderer\\HtmlRenderer();
+            $renderer->setSectionWrapping(false);
+            $converter = MarkupCarve\\Carve\\CarveConverter::create(renderer: $renderer);
+            echo $converter->convert(file_get_contents($argv[1]));
+          `,
+        ]
+      }
+      // Needs BOTH: the sections opt-out above, and sourceLines - which is a
+      // BlockParser constructor argument, not a renderer setting, so this is
+      // the one adapter here that builds a custom parser instead of taking
+      // CarveConverter::create()'s default. Only correct since carve-php#679
+      // fixed the id/stamp ordering the fixture pins (carve#535).
+      if (feature === 'source-line-after-generated-id') {
+        return [
+          'php',
+          '-r',
+          `
+            require 'vendor/autoload.php';
+            $parser = new MarkupCarve\\Carve\\Parser\\BlockParser(trackSourceLines: true);
+            $renderer = new MarkupCarve\\Carve\\Renderer\\HtmlRenderer();
+            $renderer->setSectionWrapping(false);
+            $converter = MarkupCarve\\Carve\\CarveConverter::create(parser: $parser, renderer: $renderer);
             echo $converter->convert(file_get_contents($argv[1]));
           `,
         ]


### PR DESCRIPTION
Closes #535

`npm run compare:impls -- --corpus=optional --fail-on-diff` still named three
optional cases reaching fewer than two engines: `smart-quotes-locale-de`,
`section-wrapper-off`, `source-line-after-generated-id`. Only the first is
still an engine capability gap (carve-js has no quote-locale option, tracked
by #560). The other two are not, any more:

- markup-carve/carve-php#537 added `HtmlRenderer::setSectionWrapping(false)`, the opt-out
  `section-wrapper-off`'s fixture needs.
- markup-carve/carve-php#679 fixed the `data-source-line`/generated-id ordering
  `source-line-after-generated-id` pins, so once sections are off (same
  switch) the fixture is reachable there too - it needs both `setSectionWrapping(false)`
  and a `BlockParser(trackSourceLines: true)`.

This wires both as php adapters in `scripts/compare-impls.mjs`, drops their
now-stale entries from `UNREACHABLE_REASONS` (the script's own stale-reason
check under `--fail-on-diff` fails the run if a resolved reason is left in
place), and updates the quoted run in `docs/implementation-comparison.md` to
match.

**Before** (real carve-js/carve-php/carve-rs checkouts, HEAD of each main):

```text
NOT COMPARED: 3 of 33 optional cases reached fewer than two engines, so they contribute no agreement evidence. This is not a pass.
  fewer than two engines: smart-quotes-locale-de (1), section-wrapper-off (1), source-line-after-generated-id (1)
```

**After:**

```text
Implementation summary
profile=optional/opt-in corpus=optional corpus_pairs=33 targets=html,markdown
rust: pass=5/5 mismatch=0 error=0 skipped=28 runs=5 avg_ms=22.17
js: pass=32/32 mismatch=0 error=0 skipped=1 runs=32 avg_ms=64.69
php: pass=31/31 mismatch=0 error=0 skipped=2 runs=31 avg_ms=54.55
cross_impl_diffs=0

Target agreement (implementations compared against each other)
html: compared=30 diffs=0 errors=0 fixtures=yes
markdown: compared=2 diffs=0 errors=0 fixtures=yes

NOT COMPARED: 1 of 33 optional cases reached fewer than two engines, so they contribute no agreement evidence. This is not a pass.
  fewer than two engines: smart-quotes-locale-de (1)
    smart-quotes-locale-de: carve-js has no quote-locale option; carve-php has the extension (carve#560)
```

`npm run compare:impls -- --corpus=optional --fail-on-diff` exits 0 (no cross-
impl diffs, no undocumented-unreachable case, no stale `UNREACHABLE_REASONS`
entry).

`smart-quotes-locale-de` stays documented and out of this PR's scope - it is a
genuine capability gap (verified against carve-js's current source: no
locale-quote option exists), tracked by #560.

Verification notes, run against fresh clones of carve-js/carve-php/carve-rs
(HEAD of each main), since `ast:check`/`claims:check`/`compare:impls` are not
part of `ci.yml` and need those checkouts provisioned by hand locally:

- `npm run compare:impls -- --corpus=optional --fail-on-diff`: exit 0, output
  above.
- `npm test` (no engine-checkout env vars, matching what `ci.yml` actually
  runs): 1007 pass, 0 fail, 1 skipped - unchanged from before this change.
- `npm run core:check`, `npm run engine:report -- --check`,
  `npm run corpus:build` + `git diff --exit-code -- tests/corpus tests/spec`:
  all clean, matching `ci.yml`'s conformance job.
- `npm run docs:build` and `npm run lint:mermaid`: clean.
- `codex review --uncommitted` on the staged diff: "No discrete, actionable
  correctness issues were found in the staged changes."

Two `UNREACHABLE_REASONS` fixes fell out of reading the current carve-php
source rather than trusting the issue's own capability table, which had gone
stale in the days since it was written: `setSectionWrapping()` already existed
(markup-carve/carve-php#537, Aug 1) and the ordering fix already shipped (markup-carve/carve-php#679).
Verified both against a built carve-php checkout before wiring the adapters,
not just against the class existing.
