### PR TITLE
fix: the bump PR body actually updates

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -328,7 +328,24 @@ jobs:
             else
               gh pr ready "$existing" --repo "$REPO" 2>/dev/null || true
             fi
-            gh pr edit "$existing" --repo "$REPO" --body "$body" 2>/dev/null || true
+            # Via the REST API, NOT `gh pr edit --body`. That command goes
+            # through GraphQL and fails in this org with
+            #
+            #   GraphQL: Projects (classic) is being deprecated ...
+            #     (repository.pullRequest.projectCards)
+            #
+            # exit 1 - and `2>/dev/null || true` swallowed it, so every re-run
+            # left the body written by the FIRST run. Both open bump PRs said
+            # "Conforms to the bumped corpus - ready to merge" while their own
+            # CI failed on unclassified categories, and the list of those
+            # categories - the actionable half this job builds - never appeared
+            # on the PR that needed it.
+            #
+            # Failure is reported now rather than hidden: a body that did not
+            # update is exactly the state that was invisible before.
+            if ! gh api "repos/$REPO/pulls/$existing" -X PATCH -f body="$body" >/dev/null; then
+              echo "::warning::could not update the body of $REPO#$existing - it may describe an earlier run"
+            fi
             echo "Updated existing PR #$existing on $REPO (draft=${draft:+yes})."
           fi
 


### PR DESCRIPTION
Every open bump PR describes its FIRST run and nothing since.

`markup-carve/vscode-carve#70` and `markup-carve/tree-sitter-carve#72` both say

> Conforms to the bumped corpus — ready to merge.

while their own CI fails on unclassified corpus categories, and both are (correctly) drafts. The bump job judged them right - the logs say `does NOT conform to carve 3f347c0 -> draft PR (needs impl)` - and the **list of unclassified categories, the actionable half this job assembles, never reached the PR that needed it.**

## One line

```sh
gh pr edit "$existing" --repo "$REPO" --body "$body" 2>/dev/null || true
```

`gh pr edit` goes through GraphQL, and in this org it fails:

```
GraphQL: Projects (classic) is being deprecated in favor of the new Projects
experience, see: https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/.
(repository.pullRequest.projectCards)
```

exit 1. The `2>/dev/null || true` hides it, so this has been silent since the workflow was written. Draft state kept tracking conformance correctly because it is set by a *different* command (`gh pr ready`), which is what made the result look like a workflow that could not make up its mind rather than one whose edit was failing.

## The fix

Body updates go through the REST API, which has no `projectCards` in its response:

```sh
gh api "repos/$REPO/pulls/$existing" -X PATCH -f body="$body"
```

Verified against an open bump PR: `gh pr edit --body` exits 1 with the error above, the API PATCH returns 200 with the same content.

A failure is now reported as a `::warning::` rather than swallowed. A body that did not update is exactly the state that was invisible before - and the reason two PRs have been sitting with a body that contradicts their own CI.

## What this does not fix

The three open bump PRs keep their stale bodies until the next corpus change triggers a re-run, which will rewrite them. They are drafts and their CI is red, so nothing merges on the strength of the wrong text in the meantime.
