### PR TITLE
test: compare the engines to each other, not to the reference

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -41,7 +41,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Ajv2020 } from 'ajv/dist/2020.js'
-import { shapeOf, shapePaths } from './spec/ast-shape.mjs'
+import { classifyShapeDisagreement, shapeOf, shapePaths } from './spec/ast-shape.mjs'
 import { checkPositions } from './spec/ast-positions.mjs'
 import { checkReferenceFields } from './spec/ast-references.mjs'
 
@@ -110,6 +110,19 @@ const phpDir = process.env.CARVE_PHP_DIR ?? resolve(root, '../carve-php')
  * position fixes dropped the finding count below 40 and the document came back
  * into view.
  */
+/*
+ * How much output a per-document subprocess may produce.
+ *
+ * execFileSync defaults to 1 MB and REJECTS past it, so the runner used to
+ * report `spawnSync php ENOBUFS` as a carve-php finding on
+ * 182-openers-past-the-nesting-cap-are-one-paragraph - a document whose
+ * serialized tree is larger than that. The engine was fine; the buffer was the
+ * runner's. Worse, the document then dropped out of the three-way comparison
+ * with two votes left, so the run counted a harness limit as an engine defect
+ * AND quietly stopped comparing the one document most likely to expose one.
+ */
+const MAX_SUBPROCESS_OUTPUT = 256 * 1024 * 1024
+
 const DISPLAY_LIMIT = Number(process.env.CARVE_DISPLAY_LIMIT ?? 8)
 
 /**
@@ -260,6 +273,113 @@ function checkShapeParity(name, doc, findings) {
 }
 
 const referenceShapes = new Map()
+
+/**
+ * Every independent engine's tree signature, kept so the run can compare the
+ * engines to EACH OTHER and not only to the one that was chosen as reference.
+ *
+ * `checkShapeParity` above measures agreement with carve-js, which means a
+ * carve-js defect is unfalsifiable here: when the reference is the odd one out,
+ * the run reports it as two engines failing (carve#747). Two were found by hand
+ * that this could not surface - a reference image with a caption serialized as a
+ * paragraph while the same engine's HTML said figure (carve-js#680), and the
+ * generated heading id carried in the tree against §3a, which differed on 41 of
+ * 610 documents (carve-js#697).
+ *
+ * carve-rb is deliberately NOT in the panel: it serializes carve-rs's tree, so
+ * counting it would give that engine two votes and make a real carve-rs
+ * divergence look like a majority.
+ */
+const INDEPENDENT_ENGINES = ['carve-js', 'carve-rs', 'carve-php']
+let panelRan = false
+const enginePaths = new Map()
+
+function recordShape(engine, name, doc) {
+  let perDoc = enginePaths.get(engine)
+  if (!perDoc) {
+    perDoc = new Map()
+    enginePaths.set(engine, perDoc)
+  }
+  perDoc.set(name, shapePaths(shapeOf(doc)).join('\n'))
+}
+
+/**
+ * Name the engine that stands alone on a document, whichever engine it is.
+ *
+ * WHAT THIS CAN SEE: `shapeOf` keeps node types and nested structure, so an
+ * extra object field (`attrs` where the source has no `{`), a different node
+ * type, or a different number of children all show up. WHAT IT CANNOT: a scalar
+ * field, because shapeOf drops scalars - a missing `number` or a different `id`
+ * is invisible here and belongs to the schema and the field-level checks. Said
+ * out loud because a panel that looks broader than it is would be worse than no
+ * panel: the run would read as "the engines agree" when it only means "the
+ * engines agree about shape".
+ *
+ * Returns the number of documents on which the REFERENCE stood alone, which is
+ * the class this whole panel exists for.
+ */
+function reportEngineDisagreement() {
+  const present = INDEPENDENT_ENGINES.filter((engine) => enginePaths.has(engine))
+  if (present.length < INDEPENDENT_ENGINES.length) {
+    const missing = INDEPENDENT_ENGINES.filter((engine) => !enginePaths.has(engine))
+    console.log(`THREE-WAY COMPARISON NOT RUN: ${missing.join(', ')} contributed no trees.`)
+    console.log('  A majority needs three independent engines. This is not a pass.\n')
+
+    return 0
+  }
+
+  panelRan = true
+  const alone = new Map(present.map((engine) => [engine, []]))
+  const threeWay = []
+  let unanimous = 0
+  let compared = 0
+  let skipped = 0
+  for (const name of enginePaths.get(INDEPENDENT_ENGINES[0]).keys()) {
+    const verdict = classifyShapeDisagreement(
+      present.map((engine) => [engine, enginePaths.get(engine).get(name)]),
+    )
+    if (verdict.kind === 'skipped') {
+      skipped += 1
+      continue
+    }
+    compared += 1
+    if (verdict.kind === 'unanimous') unanimous += 1
+    else if (verdict.kind === 'alone') alone.get(verdict.engine).push(name)
+    else threeWay.push(name)
+  }
+
+  console.log(`THREE-WAY SHAPE COMPARISON (${compared} documents, ${unanimous} unanimous)`)
+  for (const engine of present) {
+    const docs = alone.get(engine)
+    if (docs.length === 0) continue
+    console.log(`  ${engine} stood alone on ${docs.length}: ${examples(docs)}`)
+  }
+  if (threeWay.length > 0) {
+    console.log(`  all three differed on ${threeWay.length}: ${examples(threeWay)}`)
+  }
+  if (compared === unanimous) console.log('  no engine stood alone.')
+  // A document one engine could not serialize leaves the panel with two votes,
+  // so it is not compared. Say how many, or a run where half the corpus dropped
+  // out reads the same as one where none did.
+  if (skipped > 0) {
+    console.log(`  ${skipped} document(s) not compared - an engine produced no tree for them.`)
+  }
+  console.log('')
+
+  return alone.get('carve-js').length
+}
+
+/**
+ * Up to three names, and a count for the rest. A single example is enough to
+ * reproduce one finding and not enough to see a pattern, which matters most
+ * here: three documents that share a cause are one defect, and three that do
+ * not are three.
+ */
+function examples(names) {
+  const shown = names.slice(0, 3).join(', ')
+
+  return names.length > 3 ? `${shown} (+${names.length - 3} more)` : shown
+}
 
 /**
  * PART 12 §1a: a node's children hold no two adjacent `text` nodes.
@@ -451,6 +571,7 @@ for (const { name, source } of samples) {
   }
   checkDocument(name, doc, source, jsFindings)
   referenceShapes.set(name, shapeOf(doc))
+  recordShape('carve-js', name, doc)
 
   // PART 12 §6: serialize then DESERIALIZE must equal the parse. Through the
   // engine's own reader - `fromAstJson` - which is the half the clause is about.
@@ -499,6 +620,7 @@ if (rsBinary) {
           // refuses every document would otherwise print 500 identical lines
           // over the report instead of one counted finding.
           stdio: ['pipe', 'pipe', 'pipe'],
+          maxBuffer: MAX_SUBPROCESS_OUTPUT,
         }),
       )
     } catch (error) {
@@ -515,9 +637,11 @@ if (rsBinary) {
         input: payload,
         encoding: 'utf8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        maxBuffer: MAX_SUBPROCESS_OUTPUT,
       }),
     )
     checkShapeParity(name, doc, rsFindings)
+    recordShape('carve-rs', name, doc)
   }
   const rsBuild = buildStatus(rsBinary, resolve(rsDir, 'src'), ['.rs'])
   if (rsBuild.stale) staleBuilds.push('carve-rs')
@@ -546,6 +670,7 @@ if (existsSync(resolve(rbDir, 'lib/carve'))) {
           encoding: 'utf8',
           env: { ...process.env },
           stdio: ['pipe', 'pipe', 'pipe'],
+          maxBuffer: MAX_SUBPROCESS_OUTPUT,
         },
       )
       doc = JSON.parse(out)
@@ -592,6 +717,7 @@ if (existsSync(resolve(phpDir, 'bin/carve'))) {
         encoding: 'utf8',
         env: { ...process.env },
         stdio: ['pipe', 'pipe', 'pipe'],
+        maxBuffer: MAX_SUBPROCESS_OUTPUT,
       })
       doc = JSON.parse(out)
     } catch (error) {
@@ -600,6 +726,7 @@ if (existsSync(resolve(phpDir, 'bin/carve'))) {
     }
     checkDocument(name, doc, source, phpFindings)
     checkShapeParity(name, doc, phpFindings)
+    recordShape('carve-php', name, doc)
     checkIngestIdentity(name, doc, phpFindings, (payload) =>
       // No '-' argument: this CLI reads stdin when no file is given and
       // rejects a dash as an unknown option.
@@ -609,6 +736,7 @@ if (existsSync(resolve(phpDir, 'bin/carve'))) {
         encoding: 'utf8',
         env: { ...process.env },
         stdio: ['pipe', 'pipe', 'pipe'],
+        maxBuffer: MAX_SUBPROCESS_OUTPUT,
       }),
     )
   }
@@ -700,6 +828,38 @@ if (notMeasured.length > 0) {
   }
 } else {
   console.log('All satellites measured.\n')
+}
+
+// The panel carve#747 asks for, run after every engine has contributed. Placed
+// BEFORE the gates below so it prints even on a run that exits on §1a: a
+// disagreement the run cannot attribute is exactly what someone reading a failed
+// run needs to see.
+const referenceStoodAlone = reportEngineDisagreement()
+
+// NOT A GATE, deliberately. In this fleet a fix lands in one engine first and is
+// ported over the following days, so the engine that is RIGHT is routinely the
+// odd one out for a while. Failing on that would put this repo red after every
+// correct carve-js change, and the fix for a red build would be to wait.
+//
+// A ratchet against recorded counts was the other option and is worse: it makes
+// a rule that is currently violated read as a rule that is currently enforced,
+// which is the failure this whole panel exists to undo, one level up.
+//
+// So: attribute it loudly and let the issue tracker carry it. What IS gated is
+// the panel having RUN - see below - because "no engine stood alone" printed
+// over two engines is the vacuous pass that started all of this.
+if (referenceStoodAlone > 0) {
+  console.log(`REFERENCE STOOD ALONE on ${referenceStoodAlone} document(s).`)
+  console.log('  Every "tree differs from the reference" line above for those documents')
+  console.log('  is attributed to the wrong engine: the other two agreed with each other.\n')
+}
+
+// The panel is the only check here that can be vacuous while printing a clean
+// line, because it needs three engines to have a majority at all. Under the flag
+// CI sets, a panel that did not run is a failure rather than a sentence.
+if (process.env.CARVE_REQUIRE_ALL_ENGINES === '1' && !panelRan) {
+  console.error('CARVE_REQUIRE_ALL_ENGINES=1 and the three-way comparison did not run.')
+  process.exit(1)
 }
 
 // §1a GATES. Every other finding class here is reported and counted; this one

--- a/scripts/spec/ast-shape.mjs
+++ b/scripts/spec/ast-shape.mjs
@@ -75,3 +75,34 @@ export function shapePaths(shape, path = '$') {
   }
   return out
 }
+
+/**
+ * Which engine, if any, stands ALONE on one document.
+ *
+ * Kept here as a pure function rather than inline in the runner so it can be
+ * tested directly. The runner's version of this could not fail on purpose: the
+ * only way to see it classify a three-way split was to find a document that
+ * produced one, which is the same reason the gap it closes went unnoticed
+ * (carve#747).
+ *
+ * `signatures` is an array of [engine, signature] in a stable order, one entry
+ * per independent engine. A signature of `undefined` means that engine produced
+ * no tree for the document, which is a finding of its own and not a
+ * disagreement about shape - so the document is skipped rather than counted as a
+ * split.
+ */
+export function classifyShapeDisagreement(signatures) {
+  if (signatures.length < 3) return { kind: 'skipped', reason: 'fewer than three engines' }
+  if (signatures.some(([, signature]) => signature === undefined)) {
+    return { kind: 'skipped', reason: 'an engine produced no tree' }
+  }
+  const [[, a], [, b], [, c]] = signatures
+  if (a === b && b === c) return { kind: 'unanimous' }
+  // Two agree and one does not: name the one that does not, WHICHEVER it is.
+  // Naming it only when it is not the reference is the defect this replaces.
+  if (a === b) return { kind: 'alone', engine: signatures[2][0] }
+  if (b === c) return { kind: 'alone', engine: signatures[0][0] }
+  if (a === c) return { kind: 'alone', engine: signatures[1][0] }
+
+  return { kind: 'three-way' }
+}

--- a/tests/ast-shape.test.mjs
+++ b/tests/ast-shape.test.mjs
@@ -19,7 +19,7 @@ import { readFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parse } from '@markup-carve/carve'
-import { shapeOf, shapePaths } from '../scripts/spec/ast-shape.mjs'
+import { classifyShapeDisagreement, shapeOf, shapePaths } from '../scripts/spec/ast-shape.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const repo = resolve(here, '..')
@@ -61,4 +61,76 @@ test('a signature drops positions and values, and keeps types', () => {
     children: [{ type: 'text', value: 'abc' }],
   })
   assert.deepEqual(shapePaths(shape), ['$:paragraph', '$.children[0]:text'])
+})
+
+/*
+ * The three-way panel (carve#747). These exist because the runner's own version
+ * of this classification could not be made to fail on purpose: seeing it handle
+ * a three-way split meant finding a corpus document that produced one, and the
+ * whole point of the panel is the cases nobody has found yet.
+ */
+test('a unanimous document names no engine', () => {
+  assert.deepEqual(
+    classifyShapeDisagreement([
+      ['carve-js', 'A'],
+      ['carve-rs', 'A'],
+      ['carve-php', 'A'],
+    ]),
+    { kind: 'unanimous' },
+  )
+})
+
+test('the engine that stands alone is named wherever it sits', () => {
+  const signatures = (js, rs, php) => [
+    ['carve-js', js],
+    ['carve-rs', rs],
+    ['carve-php', php],
+  ]
+
+  // THE CASE THE OLD CHECK COULD NOT REPORT: the reference is the odd one out,
+  // and the other two agree with each other (carve-js#697 was 41 documents of
+  // exactly this, reported as two engines failing).
+  assert.deepEqual(classifyShapeDisagreement(signatures('X', 'A', 'A')), {
+    kind: 'alone',
+    engine: 'carve-js',
+  })
+  assert.deepEqual(classifyShapeDisagreement(signatures('A', 'X', 'A')), {
+    kind: 'alone',
+    engine: 'carve-rs',
+  })
+  assert.deepEqual(classifyShapeDisagreement(signatures('A', 'A', 'X')), {
+    kind: 'alone',
+    engine: 'carve-php',
+  })
+})
+
+test('three engines that all differ are not attributed to one of them', () => {
+  assert.deepEqual(
+    classifyShapeDisagreement([
+      ['carve-js', 'A'],
+      ['carve-rs', 'B'],
+      ['carve-php', 'C'],
+    ]),
+    { kind: 'three-way' },
+  )
+})
+
+test('a document one engine could not serialize is skipped, not counted as a split', () => {
+  // Otherwise the engine with a crash also gets a shape finding for the same
+  // document, and a harness limit (the runner's own output buffer, once) reads
+  // as a disagreement about the tree.
+  const verdict = classifyShapeDisagreement([
+    ['carve-js', 'A'],
+    ['carve-rs', 'A'],
+    ['carve-php', undefined],
+  ])
+  assert.equal(verdict.kind, 'skipped')
+})
+
+test('two engines cannot form a majority', () => {
+  const verdict = classifyShapeDisagreement([
+    ['carve-js', 'A'],
+    ['carve-rs', 'B'],
+  ])
+  assert.equal(verdict.kind, 'skipped')
 })


### PR DESCRIPTION
Closes #747.

`ast:check` compared every engine against carve-js, which made the reference's own output unfalsifiable: when carve-js was the odd one out, the run reported it as the other two engines failing. #747 lists the two defects found by hand that this could not surface, one of which differed on 41 of 610 documents.

## The panel

After every engine has contributed, the run compares the three independent engines to each other and names the one that stands alone, whichever it is:

```
THREE-WAY SHAPE COMPARISON (613 documents, 610 unanimous)
  carve-php stood alone on 3: 03-links-11.crv, 03-links-12.crv, 202-a-definition-on-a-footnote-body-s-continuation-line-is-collected.crv
```

carve-rb is excluded on purpose: it serializes carve-rs's tree, so counting it would give that engine two votes and turn a real carve-rs divergence into a majority.

What the panel can see is stated in the code, because a check that looks broader than it is would be worse than none: `shapeOf` keeps node types and nested structure, so an extra object field or a different node type shows up, while a scalar field does not. "The engines agree" here means "the engines agree about shape".

## Why it does not fail the build

In this fleet a fix lands in one engine first and is ported over the following days, so the engine that is RIGHT is routinely the odd one out for a while. Gating on that would put this repo red after every correct carve-js change, and the remedy for the red build would be to wait.

A ratchet against recorded counts was the other option and is worse: it makes a rule that is currently violated read as a rule that is currently enforced, which is the failure this panel exists to undo, one level up.

What IS gated is the panel having run. `no engine stood alone` printed over two engines is the vacuous pass that started all of this, so under `CARVE_REQUIRE_ALL_ENGINES=1` a panel that could not form a majority fails the run.

## The classification is testable, and was tested by breaking it

`classifyShapeDisagreement` is a pure function in `scripts/spec/ast-shape.mjs`. The runner's inline version could not be made to fail on purpose - seeing it classify a three-way split meant finding a corpus document that produced one, and the cases nobody has found yet are exactly the point. The tests cover each position including the one the old check could not report, and I verified they fail by reverting the function to the old reference-privileged behavior:

```
not ok 5 - the engine that stands alone is named wherever it sits
# pass 7
# fail 1
```

## A harness limit that was reported as an engine defect

`execFileSync` defaults to a 1 MB output buffer and rejects past it, so the run reported

```
1x could not serialize - spawnSync php ENOBUFS  [182-openers-past-the-nesting-cap-are-one-paragraph.crv]
```

as a carve-php finding. The engine was fine; the buffer belonged to the runner. Because the document produced no tree, it also dropped out of the three-way comparison with two votes left - a harness limit silently removing the one document most likely to expose a real difference. Raising the buffer surfaces 13 findings inside that document that the error had been standing in front of, which is why carve-php's count goes from 10 to 17 here without anything changing in carve-php.

## What the first real run says

613 documents, 610 unanimous, carve-js alone on none, carve-php alone on three. Two of those three are the nested-link rule: for

```
[[x](y)](z)
```

carve-php's tree carries a `link` inside a `link`, and for

```
[pre <http://h> post](/u)
```

an `autolink` inside the label, while carve-php's own HTML unwraps both and matches the corpus fixture exactly. Filed separately as markup-carve/carve-php#859. The third is the hoisted-definition order in #746.

Measured with fresh `origin/main` builds: carve-js 2d51125, carve-rs 1a594f0, carve-php 3550258.