### PR TITLE
spec: the margin rule is about the derivation, not the spelling

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3436,8 +3436,8 @@ EOF = (* end of file *) ;
         dropped the innermost paragraph and the Markdown / plain-text / ANSI
         renderers dropped the whole document.
 
-        THE MARGIN IS A MULTIPLE OF MAX_NESTING_DEPTH, NOT A FIXED OFFSET
-        BORROWED FROM ANOTHER IMPLEMENTATION'S UNIT -- the same shape as
+        THE MARGIN IS DERIVED IN THE IMPLEMENTATION'S OWN UNIT, NOT
+        BORROWED FROM ANOTHER IMPLEMENTATION'S -- the same shape as
         PART 12 §9(c)'s ingest-bound trap, at the other end of the same pipe.
         A render pass MAY count depth in whatever unit its own recursion
         uses, container depth (one step per nesting level) or AST node
@@ -3445,17 +3445,28 @@ EOF = (* end of file *) ;
         a list level costs ONE container-depth step but TWO AST node levels
         (`list`, then `list_item`) before its body reads as a further level
         down. A margin sized for one unit does not carry over to the other.
-        This repo's reference counts container depth and uses
-        MAX_NESTING_DEPTH + 32 = 232, a fixed offset that happens to be a
-        1.16x multiple in ITS unit; stating that SAME NUMBER as a fixed
-        offset in an AST-node-counting implementation understates the
-        multiple it actually needs by roughly half, and an ordinary
-        120-level list ladder -- well inside the parse cap of 200 -- reached
-        such a ceiling and silently dropped the innermost content
-        (carve#650). An implementation MUST THEREFORE STATE its margin as A
-        MULTIPLE OF MAX_NESTING_DEPTH derived from the worst per-level cost
-        of ITS OWN unit (as PART 12 §9(c) already requires for the ingest
-        bound), not adopt another implementation's absolute number.
+        This repo's reference counts container depth, where MAX_NESTING_DEPTH
+        + 32 = 232 covers the blocks a container subtree adds; restating that
+        SAME NUMBER in an AST-node-counting implementation understates what
+        that unit actually needs by roughly half, and an ordinary 120-level
+        list ladder -- well inside the parse cap of 200 -- reached such a
+        ceiling and silently dropped the innermost content (carve#650). An
+        implementation MUST THEREFORE DERIVE its margin from the worst
+        per-level cost of ITS OWN unit (as PART 12 §9(c) already requires for
+        the ingest bound), and MUST NOT adopt another implementation's number
+        without redoing that derivation.
+
+        HOW THE MARGIN IS SPELLED IS NOT THE REQUIREMENT. A multiple of
+        MAX_NESTING_DEPTH and an offset added to it are the same statement
+        once the offset has been shown to cover the worst per-level cost of
+        the unit in question: `+ 32` DERIVED for container depth satisfies
+        this clause, and the identical `+ 32` COPIED into an
+        AST-node-counting implementation does not. This paragraph previously
+        required the multiple FORM, which the reference itself did not use --
+        so the clause stated a rule its own reference broke, and an
+        implementation could satisfy the letter of it by writing
+        MAX_NESTING_DEPTH * 1.16 without anyone having thought about the
+        unit. The unit is what went wrong in carve#650 (carve#754).
 
         AT THE RENDER CEILING, A RENDERER REFUSES -- NORMATIVE. Reaching it
         MUST produce a typed, documented failure naming the depth bound. NOT


### PR DESCRIPTION
Closes #754, taking option 1.

## The contradiction

§25 required an implementation to STATE its render-ceiling margin as a multiple of MAX_NESTING_DEPTH. The same paragraph then recorded that the reference uses `MAX_NESTING_DEPTH + 32` - a fixed offset. So the clause stated a rule its own reference did not follow, and two of the three engines were non-conformant on how a constant is spelled while being correct in substance:

| engine | expression | value | form |
| --- | --- | --- | --- |
| carve-rs | `MAX_NESTING_DEPTH * 3 + 32` | 632 | a multiple |
| carve-js | `MAX_NESTING_DEPTH + 32` | 232 | a fixed offset |
| carve-php | `MAX_NESTING_DEPTH + 32` | 232 | a fixed offset |

## What the rule should say

What has to be true is that the margin was DERIVED from the worst per-level cost of the implementation's own unit rather than borrowed from another's. A multiple and an offset are the same statement once the offset has been shown to cover that cost: `+ 32` derived for container depth is fine, and the identical `+ 32` copied into an AST-node-counting implementation is precisely the bug the clause exists for (carve#650, where a 120-level list ladder inside the parse cap hit the ceiling and lost its innermost content).

Requiring the arithmetic FORM also lets an implementation comply by writing `MAX_NESTING_DEPTH * 1.16` without anyone having thought about the unit - and the unit is what went wrong. So:

- the MUST now names the derivation, and forbids adopting another implementation's number without redoing it;
- a following paragraph says outright that the spelling is not the requirement, and records why the previous form was withdrawn, so nobody restores it as a tightening;
- the reference's own number is described as covering the blocks a container subtree adds rather than as a coincidental 1.16x, since under the new rule it is a derivation rather than an exception.

## Scope

No engine changes and no behavior changes; all three become conformant as written. The normative clause inventory is untouched - this heading carries no NORMATIVE marker, and `node scripts/normative-clauses.mjs` regenerates `resources/normative-clauses.txt` byte-identically (86 clauses, 85 distinct headings).

`npm test` is 1013 passing with 4 failures, the same 4 present on `a9bdf49` without this change: the known `03-nested-list` fmt fixture group, which #715's own commit message records as failing before and after it.

Not in this PR: #754 also notes that `carve-php`'s `CarveRenderer` carries a comment calling the cross-engine number "still open", which this answers. That is a comment in another repo and gets its own change.
