### PR TITLE
spec: drop the footnote refId the schema promised and nothing produced

### DIFF
--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -1162,10 +1162,6 @@
           "type": "integer",
           "description": "Assigned during resolution, by document reference order."
         },
-        "refId": {
-          "type": "string",
-          "description": "Assigned during resolution: the backlink target id."
-        },
         "attrs": {
           "$ref": "#/$defs/attrs"
         },
@@ -1973,9 +1969,6 @@
         },
         "number": {
           "type": "integer"
-        },
-        "refId": {
-          "type": "string"
         },
         "attrs": {
           "$ref": "#/$defs/attrs"

--- a/tests/ast-schema.test.mjs
+++ b/tests/ast-schema.test.mjs
@@ -76,8 +76,36 @@ function* walk(node) {
   }
 }
 
+/*
+ * TWO STAGES, both spec surface, and this file used to see only the first.
+ *
+ * PART 12 §3a describes the PRE-RESOLVE tree - an unresolved reference is a link
+ * node carrying `ref` and `rawRef`, fields the schema says are "present only
+ * between parse and resolve". The RESOLVED tree is what a consumer actually
+ * receives, and it is the one scripts/ast-conformance.mjs measures, deliberately
+ * (carve#486: a `ref` surviving into the reference AST means the AST was taken
+ * before resolve).
+ *
+ * Checking only `parse()` meant every resolution result was unvalidated here:
+ * `caption_number.n`, `footnote_ref.number`, `inline_footnote.number` and
+ * `heading_ref.href` do not exist at that stage, so the schema's description of
+ * them was never measured against anything. Checking only `resolve()` would drop
+ * §3a's fields the other way. So: validate both, and count a type or field as
+ * produced if EITHER stage produces it.
+ */
 function serialize(source) {
   return lib.toAstJson(lib.parse(source))
+}
+
+function serializeResolved(source) {
+  return lib.toAstJson(
+    typeof lib.resolve === 'function' ? lib.resolve(lib.parse(source)) : lib.parse(source),
+  )
+}
+
+/** Both stages of one document, for the checks that are about coverage. */
+function bothStages(source) {
+  return [serialize(source), serializeResolved(source)]
 }
 
 function firstErrors(n = 4) {
@@ -102,7 +130,8 @@ test('the corpus is non-trivial', () => {
 test('every corpus document serializes to a schema-valid AST', () => {
   const failures = []
   for (const { name, source } of corpus) {
-    if (!validate(serialize(source))) failures.push(`${name}: ${firstErrors()}`)
+    if (!validate(serialize(source))) failures.push(`${name} (parse): ${firstErrors()}`)
+    if (!validate(serializeResolved(source))) failures.push(`${name} (resolved): ${firstErrors()}`)
   }
   assert.deepEqual(failures.slice(0, 8), [], `${failures.length} documents fail the schema`)
 })
@@ -111,7 +140,7 @@ test('every node type the reference emits is declared in the schema', () => {
   const declared = declaredTypes()
   const seen = new Set()
   for (const { source } of corpus) {
-    for (const node of walk(serialize(source))) seen.add(node.type)
+    for (const tree of bothStages(source)) for (const node of walk(tree)) seen.add(node.type)
   }
   const undeclared = [...seen].filter((t) => !declared.has(t)).sort()
   assert.deepEqual(undeclared, [], `node types emitted but not in the schema: ${undeclared.join(', ')}`)
@@ -141,7 +170,7 @@ const NOT_PRODUCIBLE = {
 test('every node type the schema declares is produced by a corpus document, or named as unproducible', () => {
   const seen = new Set()
   for (const { source } of corpus) {
-    for (const node of walk(serialize(source))) seen.add(node.type)
+    for (const tree of bothStages(source)) for (const node of walk(tree)) seen.add(node.type)
   }
   const missing = [...declaredTypes()]
     .filter((type) => !seen.has(type) && !(type in NOT_PRODUCIBLE))
@@ -158,7 +187,7 @@ test('every node type the schema declares is produced by a corpus document, or n
 test('every unproducible exemption is still needed', () => {
   const seen = new Set()
   for (const { source } of corpus) {
-    for (const node of walk(serialize(source))) seen.add(node.type)
+    for (const tree of bothStages(source)) for (const node of walk(tree)) seen.add(node.type)
   }
   const stale = Object.keys(NOT_PRODUCIBLE).filter((type) => seen.has(type)).sort()
   assert.deepEqual(

--- a/tests/schema-fields-are-produced.test.mjs
+++ b/tests/schema-fields-are-produced.test.mjs
@@ -1,5 +1,6 @@
 /*
- * Every field the AST schema names is produced by at least one corpus document.
+ * Every field the AST schema names is produced by at least one corpus document,
+ * ON THE TYPE THAT DECLARES IT.
  *
  * A field in `resources/ast-schema.json` is a promise: a consumer may write
  * `if (node.attribution)` against it. A field nothing produces is either DEAD
@@ -13,6 +14,16 @@
  * `block_quote.attribution`, described as "the `-- attribution` line" - a syntax
  * the grammar does not define, that no engine emits, and that two engines carry
  * dead plumbing for (carve#599).
+ *
+ * PER TYPE, because per NAME was not enough. This check used to collect every
+ * field name appearing anywhere in the produced trees into one set, so a name
+ * produced by ONE type covered every other type that declared it - and an
+ * attribute key or a `pos` component counted too. `refId` slipped through
+ * exactly that way (carve#749): declared on `footnote_ref` and
+ * `inline_footnote`, produced by neither, and exempted with the reason "index
+ * terms (Tier-3)" - a feature the schema has no type for at all. The reason
+ * being free text is why nobody noticed the entry did not describe the field it
+ * excused.
  *
  * The exemption list below is the point of the test: an opt-in feature's fields
  * are legitimately absent from a default-profile run, and each has to say which
@@ -34,70 +45,135 @@ const repo = resolve(here, '..')
  * belongs to. Tier-2 and Tier-3 features are off unless a host enables them, so
  * their fields never appear in the core corpus - `tests/corpus-optional` is
  * where those are exercised, through per-feature adapters.
+ *
+ * Keyed `<type>.<field>`, or `<type>.*` when the whole type is unproduced and
+ * every field goes with it. The granularity is the fix for the reason above: an
+ * entry now says which TYPE's promise it is excusing, so it cannot quietly
+ * excuse a different one.
  */
 const OPT_IN_ONLY = {
-  locator: 'citations (Tier-2)',
-  locatorLabel: 'citations (Tier-2)',
-  locatorValue: 'citations (Tier-2)',
-  mode: 'citations (Tier-2): the integral `+` form',
-  prefix: 'citations (Tier-2)',
-  suffix: 'citations (Tier-2)',
-  suppressAuthor: 'citations (Tier-2)',
-  raw: 'citations (Tier-2): the undefined-key literal fallback',
-  refId: 'index terms (Tier-3): the backlink target id',
-  useIndex: 'index terms (Tier-3): the per-key use-site index',
+  'citation.*': 'citations (Tier-2): the citation item shape, including its resolution results',
+  'citation_group.*': 'citations (Tier-2): the group wrapper and the integral `+` form',
+  'link_reference_definition.*':
+    'the reference engine does not emit the node yet (carve-js#690), so none of its ' +
+    'fields can appear; carve-php does emit it',
 }
+
+/**
+ * `attrs` and `pos` are shared `$ref`s every node may carry. They are not a
+ * promise an individual type makes, and the corpus attaches attributes to about
+ * half the vocabulary - listing the other half as orphans would bury real
+ * findings under noise no fix would ever clear.
+ */
+const UNIVERSAL_FIELDS = new Set(['attrs', 'pos'])
 
 const schema = JSON.parse(readFileSync(resolve(repo, 'resources/ast-schema.json'), 'utf8'))
 
-const declaredFields = () => {
-  const found = new Set()
-  const walk = (node) => {
-    if (Array.isArray(node)) return node.forEach(walk)
-    if (!node || typeof node !== 'object') return
-    if (node.properties && typeof node.properties === 'object') {
-      for (const key of Object.keys(node.properties)) found.add(key)
-    }
-    for (const value of Object.values(node)) walk(value)
+/**
+ * Declared fields, keyed by the type that declares them.
+ *
+ * A `$defs` entry that pins `type` is keyed by that type. One that does not -
+ * `attrs`, `pos`, `citation` - has no `type` on the wire, so an instance cannot
+ * be attributed to it; those are keyed by their `$defs` name and their fields
+ * are looked for ANYWHERE, which is the old behavior kept only where per-type
+ * attribution is impossible.
+ */
+function declaredFields() {
+  const byType = new Map()
+  const anywhere = new Map()
+  for (const [name, def] of Object.entries(schema.$defs)) {
+    const properties = def.properties
+    if (!properties) continue
+    const own = Object.keys(properties).filter(
+      (key) => key !== 'type' && !UNIVERSAL_FIELDS.has(key),
+    )
+    if (own.length === 0) continue
+    const constant = properties.type?.const
+    const target = constant ? byType : anywhere
+    const label = constant ?? name
+    target.set(label, new Set([...(target.get(label) ?? []), ...own]))
   }
-  walk(schema)
-  return found
+
+  return { byType, anywhere }
 }
 
-const producedFields = () => {
-  const found = new Set()
+/**
+ * What the corpus produces, at BOTH stages.
+ *
+ * PART 12 §3a describes the pre-resolve tree and a consumer receives the
+ * resolved one, so a field produced at either stage has a producer. Resolution
+ * results (`number`, `caption_number.n`, `heading_ref.href`) exist only after
+ * resolve; `ref` and `rawRef` only before it.
+ */
+function producedFields() {
+  const byType = new Map()
+  const anywhere = new Set()
   const walk = (node) => {
     if (Array.isArray(node)) return node.forEach(walk)
     if (!node || typeof node !== 'object') return
+    if (typeof node.type === 'string') {
+      let own = byType.get(node.type)
+      if (!own) {
+        own = new Set()
+        byType.set(node.type, own)
+      }
+      for (const key of Object.keys(node)) if (key !== 'type') own.add(key)
+    }
     for (const [key, value] of Object.entries(node)) {
-      found.add(key)
+      anywhere.add(key)
       walk(value)
     }
   }
   const dir = resolve(repo, 'tests/corpus')
-  for (const name of readdirSync(dir).filter((f) => f.endsWith('.crv'))) {
+  for (const name of readdirSync(dir).filter((file) => file.endsWith('.crv'))) {
     const source = readFileSync(resolve(dir, name), 'utf8')
+    const parsed = parse(source, { positions: true })
+    walk(toAstJson(parsed))
     walk(toAstJson(resolveDoc(parse(source, { positions: true }))))
   }
-  return found
+
+  return { byType, anywhere }
+}
+
+/** Every promise the schema makes, as `<type>.<field>`. */
+function orphanedPromises() {
+  const declared = declaredFields()
+  const produced = producedFields()
+  const orphans = []
+  for (const [type, fields] of declared.byType) {
+    const seen = produced.byType.get(type)
+    for (const field of fields) {
+      if (seen?.has(field)) continue
+      // A type nothing produces is one finding, not one per field: the
+      // type-level gate in tests/ast-schema.test.mjs owns it.
+      orphans.push(seen ? `${type}.${field}` : `${type}.*`)
+    }
+  }
+  for (const [name, fields] of declared.anywhere) {
+    for (const field of fields) {
+      if (!produced.anywhere.has(field)) orphans.push(`${name}.*`)
+    }
+  }
+
+  return [...new Set(orphans)].sort()
 }
 
 test('every schema field is produced by a corpus document, or named as opt-in', () => {
   const declared = declaredFields()
-  const produced = producedFields()
-  assert.ok(declared.size > 50, `schema walk found only ${declared.size} fields`)
+  assert.ok(
+    declared.byType.size > 40,
+    `schema walk found only ${declared.byType.size} types with fields`,
+  )
 
-  const orphaned = [...declared]
-    .filter((field) => !produced.has(field) && !(field in OPT_IN_ONLY))
-    .sort()
+  const orphaned = orphanedPromises().filter((key) => !(key in OPT_IN_ONLY))
 
   assert.deepEqual(
     orphaned,
     [],
-    'field(s) the schema names that no corpus document produces: ' +
-      `${orphaned.join(', ')}. Either the corpus is missing a case for it, or the ` +
-      'field describes something the language does not have. If it belongs to an ' +
-      'opt-in feature, add it to OPT_IN_ONLY with the feature name.',
+    'promise(s) the schema makes that no corpus document keeps: ' +
+      `${orphaned.join(', ')}. Either the corpus is missing a case, or the field ` +
+      'describes something the language does not have. If it belongs to an opt-in ' +
+      'feature, add it to OPT_IN_ONLY keyed by the TYPE that declares it.',
   )
 })
 
@@ -105,28 +181,29 @@ test('every opt-in exemption is still needed', () => {
   // An exemption is a claim that the core corpus cannot reach the field. When a
   // feature moves into the core, or a corpus case starts covering it, the entry
   // stops being true and turns into a hole in the check above.
-  const produced = producedFields()
+  const orphans = new Set(orphanedPromises())
   const stale = Object.keys(OPT_IN_ONLY)
-    .filter((field) => produced.has(field))
+    .filter((key) => !orphans.has(key))
     .sort()
 
   assert.deepEqual(
     stale,
     [],
-    `OPT_IN_ONLY names field(s) the corpus now produces: ${stale.join(', ')}. ` +
+    `OPT_IN_ONLY names promise(s) the corpus now keeps: ${stale.join(', ')}. ` +
       'Remove the entry - the exemption is hiding a field that is covered.',
   )
 })
 
-test('every opt-in exemption names a field the schema still declares', () => {
+test('every opt-in exemption names a type the schema still declares', () => {
   const declared = declaredFields()
+  const known = new Set([...declared.byType.keys(), ...declared.anywhere.keys()])
   const unknown = Object.keys(OPT_IN_ONLY)
-    .filter((field) => !declared.has(field))
+    .filter((key) => !known.has(key.slice(0, key.lastIndexOf('.'))))
     .sort()
 
   assert.deepEqual(
     unknown,
     [],
-    `OPT_IN_ONLY names field(s) the schema no longer declares: ${unknown.join(', ')}.`,
+    `OPT_IN_ONLY names type(s) the schema no longer declares: ${unknown.join(', ')}.`,
   )
 })


### PR DESCRIPTION
Closes #749.

The schema declared `refId` on `footnote_ref` and `inline_footnote`, described as "assigned during resolution: the backlink target id". No engine assigns it. It is a rendering convention - `fnref1` - not a resolution result a consumer needs PART 9R to recompute: given `number`, a consumer spells the backlink however its own output wants.

## It was not harmless

A tree carrying `refId` validates against the current schema. Fed to each engine's reader:

| engine | result |
|---|---|
| carve-js 2d51125 | echoes `refId` |
| carve-rs 1a594f0 | echoes `refId` |
| carve-php 3550258 | refuses the document |

carve-php's message:

```
Error: Decoding lost 1 field(s) the payload carried:
document.children.paragraph.children.footnote_ref.refId
```

So a field nobody produces made one engine reject a document the other two emit. That is what PART 12 §1 exists to prevent, and it was reachable through the schema's own declaration.

## Why the field check did not catch it

`tests/schema-fields-are-produced.test.mjs` was keyed by field NAME. It collected every key appearing anywhere in the produced trees into a single set, so a name produced by one type covered every other type that declared it - and an attribute key or a `pos` component counted as a producer too.

`refId` also carried an exemption reading `index terms (Tier-3): the backlink target id`. The schema declares no index-term type at all, so that entry excused two footnote promises while describing neither. `useIndex` had the same problem: its reason also said index terms, while the field sits on `citation`, titled "Citation item".

Nothing can check that an exemption's reason is TRUE - it is free text. What can be checked is the granularity, so exemptions are now keyed `<type>.<field>` or `<type>.*`, and an entry names the type whose promise it excuses.

Verified both directions rather than assumed:

- rewritten check, `refId` put back on `footnote_ref` only: `not ok 1 - ... promise(s) the schema makes that no corpus document keeps: footnote_ref.refId`
- old check, same schema, its exemption still in place: `# pass 3 # fail 0`

## A second blind spot in the same area

`tests/ast-schema.test.mjs` serialized `parse()` only. Every resolution result was therefore unvalidated there: `caption_number.n`, `footnote_ref.number`, `inline_footnote.number` and `heading_ref.href` do not exist at that stage, so the schema's description of them was never measured against anything.

Proof, using the true file from `origin/main`: delete `footnote_ref.number` from the schema and the whole suite passes, `# pass 22 # fail 0`. With this change it fails, naming documents:

```
111-cross-references-resolve-inside-footnote-bodies.crv (resolved): /children/1/children/1 must NOT have additional properties (number)
```

Validating only the resolved tree would drop §3a's `ref` and `rawRef` the other way - the schema calls them "present only between parse and resolve" - so both stages are validated, and type/field coverage counts a producer at either.

## Follow-ups, not in this PR

With the field gone, carve-js and carve-rs echo a field the format no longer declares. Filed as markup-carve/carve-js#707 and markup-carve/carve-rs#648.

Measured with fresh `origin/main` builds: carve-js 2d51125, carve-rs 1a594f0, carve-php 3550258.