### PR TITLE
docs: say that AST destinations are the author's text, not a sanitized URL

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -223,6 +223,37 @@ the text they claim.
 that loses a field is not a lossy convenience; it is a consumer breaking silently
 one document later. Both halves are checked over the whole corpus.
 
+## Destinations are the author's text, not a sanitized URL
+
+`href`, `src` and every other destination field carry what the AUTHOR wrote,
+verbatim. §3a requires the tree to record the document rather than a rendering
+of it, so a blanked destination would make it lossy - and the round trip above
+would no longer hold.
+
+That means the tree can contain a scheme no target is allowed to emit:
+
+```
+[click](javascript:alert(1))
+```
+
+serializes as
+
+```json
+{"type":"link","href":"javascript:alert(1)","children":[...]}
+```
+
+while every renderer in every engine emits `href=""` for the same document, in
+HTML and in Markdown alike.
+
+**A consumer that renders a destination owns the denylist.** The rule is the URL-scheme denylist in
+[the security model](/security), and it is written to bind every target that
+emits a resolvable URL - the argument there is that a scheme "blanked here and passed
+through there is not blocked, it is deferred by one step", which applies to a
+tool reading this format exactly as it applies to a Markdown target.
+
+If you feed the tree back through a conforming engine, that engine applies the
+denylist for you. If you walk the tree and build your own output, it does not.
+
 ## How deep an ingested AST may nest
 
 Reading a serialized AST is a recursive descent over structure someone else


### PR DESCRIPTION
Documents part of #763. No engine change, and none wanted.

The serialized AST carries `href` and `src` verbatim, so it can hold a scheme no
target is allowed to emit. Measured on all three engines at their current mains:

```
[click](javascript:alert(1))

![i](ms-msdt:x)
```

| | carve-js | carve-rs | carve-php |
|---|---|---|---|
| HTML | `href=""`, `src=""` | same | same |
| Markdown | `[click]()`, `![i]()` | same | same |
| serialized AST | `"href":"javascript:alert(1)"` | same | same |

Three-way agreement, and the design is right: §3a requires the tree to record the
document rather than a rendering of it, so blanking the destination would make it
lossy and break the round trip. Feeding the same tree back through any conforming
engine re-blanks it, verified in all three.

What was missing is the sentence telling a consumer which side of that line they
are on. The obligation is in the security model under a heading about render
targets; `docs/ast-json.md` is 395 lines and mentioned security once, about the
depth bound.

The security model's own argument for the Markdown target - a scheme "blanked
here and passed through there is not blocked, it is deferred by one step" -
applies with more force to this format, since handing the tree to another tool is
what it exists for. pandoc-carve, carve-wysiwyg, carve-lsp and the ProseMirror
bridge all read it.

## Scope

`docs/ast-json.md` only. Whether PART 12's normative text should also carry a
MUST for consumers is the open half of #763 and is left for you - this PR only
writes down what the engines already do.

One note from writing it: `tests/normativity.test.mjs` caught a bare `§25` in
this file, because every `§N` there is read as a PART 12 clause reference. The
text now names the security model instead. The guard did its job.
