### PR TITLE
docs: say that the render ceiling is per-engine and why

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -82,6 +82,68 @@ expected-output fixtures, so agreement between engines was its only check
 > little against the previous snapshot's. The counts are what this table is
 > for.
 
+## The render ceiling is per-engine, deliberately
+
+Nothing above measures the depth at which a renderer refuses, and the three
+engines refuse at three different depths. That is by design rather than by
+neglect, and it is worth stating because the numbers look like a disagreement.
+
+PART 9 §25 requires each implementation to DERIVE its render-ceiling margin from
+the worst per-level cost of **its own unit**, and forbids adopting another
+implementation's number without redoing that derivation. The units differ: two
+engines count container depth (one step per nesting level), one counts AST node
+levels, where a single list level costs two. A margin sized for one unit does not
+carry to the other - copying one across is what silently truncated a 120-level
+list in [carve#650](https://github.com/markup-carve/carve/issues/650). So three
+derivations produce three ceilings, and all three are conformant.
+
+The constants are not quoted here on purpose. Each lives in its own engine, next
+to the derivation it came from, and a table of them in this repository would be a
+number nobody checks - the same way this page once claimed 302 corpus pairs when
+there were 529.
+
+**What it means in practice.** No tree the parser produces can reach any of them:
+the parse path caps containers at `MAX_NESTING_DEPTH`, and every ceiling exceeds
+that cap by construction in its own unit. Only a programmatically built tree - an
+AST-JSON ingest, an editor bridge, a formatter driving a rewritten tree - reaches
+the band where the engines differ, and there the same document can be rendered by
+one engine and refused by another. Every refusal is typed and names its bound, so
+a caller is told which one it hit; none of them truncates.
+
+A host that needs one answer across engines should bound its own trees rather
+than rely on the ceilings agreeing, because §25 says they will not.
+
+## The render ceiling is per-engine, deliberately
+
+Nothing above measures the depth at which a renderer refuses, and the three
+engines refuse at three different depths. That is by design rather than by
+neglect, and it is worth stating because the numbers look like a disagreement.
+
+PART 9 §25 requires each implementation to DERIVE its render-ceiling margin from
+the worst per-level cost of **its own unit**, and forbids adopting another
+implementation's number without redoing that derivation. The units differ: two
+engines count container depth (one step per nesting level), one counts AST node
+levels, where a single list level costs two. A margin sized for one unit does not
+carry to the other - copying one across is what silently truncated a 120-level
+list in [carve#650](https://github.com/markup-carve/carve/issues/650). So three
+derivations produce three ceilings, and all three are conformant.
+
+The constants are not quoted here on purpose. Each lives in its own engine, next
+to the derivation it came from, and a table of them in this repository would be a
+number nobody checks - the same way this page once claimed 302 corpus pairs when
+there were 529.
+
+**What it means in practice.** No tree the parser produces can reach any of them:
+the parse path caps containers at `MAX_NESTING_DEPTH`, and every ceiling exceeds
+that cap by construction in its own unit. Only a programmatically built tree - an
+AST-JSON ingest, an editor bridge, a formatter driving a rewritten tree - reaches
+the band where the engines differ, and there the same document can be rendered by
+one engine and refused by another. Every refusal is typed and names its bound, so
+a caller is told which one it hit; none of them truncates.
+
+A host that needs one answer across engines should bound its own trees rather
+than rely on the ceilings agreeing, because §25 says they will not.
+
 ## Optional Tier-2 Profile
 
 The optional profile enables a shared adapter per feature where each


### PR DESCRIPTION
Closes #741.

## Where that issue stands now

Two of its three findings have already moved.

**php's internal split is gone.** The issue lists carve-php twice - 512 for HTML/markdown/plain and 232 for the canonical writer - and that was the real defect in it: the same tree at depth 300 was rendered to HTML and refused by `fmt` in one engine. carve-php#844 raised the writer to match, and carve-php#864 made it one constant on `RendererInterface` with the derivation written down and checked. There is one number per engine now.

**The portability question is answered.** carve#761 rewrote §25's margin rule: each implementation MUST derive its margin from the worst per-level cost of ITS OWN unit and MUST NOT adopt another's. Two engines count container depth, one counts AST node levels where a list level costs two, so the derivations cannot land on the same number - and copying one across units is precisely what truncated a 120-level list in #650. So the answer to "is the render ceiling meant to be portable" is no, deliberately.

## Re-measured, since the issue's table predates both

Programmatically built nested block quotes through each engine's AST-JSON ingest, on `afd6cc5` / `04f6ed8` / `1ebaba7` / `529de20`:

| depth | carve-js | carve-rs | carve-php |
| --- | --- | --- | --- |
| 210 | renders | renders | renders |
| 300 | refuses | renders | renders |
| 550 | refuses | renders | refuses |
| 640 | refuses at the INGEST bound | refuses at the ingest bound | refuses at the ingest bound |

The last row is a different rule: at 640 all three stop at PART 12 §9(c)'s ingest bound before any render ceiling is reached.

One note on how easily that table lies: my first run had carve-rs refusing at every depth, which looked like a ceiling of nothing. The fixture was missing `srcByteLength`, so rs was rejecting a malformed payload and never got as far as the ceiling. The numbers above are from a fixture that decodes.

## What this PR does about the third finding

The issue's remaining point is that nothing in the org states or measures this. A cross-engine gate is not available here - the comparison harness drives sibling checkouts and does not run in CI - so this documents the rule instead, on the page that already carries cross-engine behavior.

The three constants are deliberately NOT quoted in it. Each lives in its own engine beside the derivation it came from, and a table of them in this repo would be a number nobody checks: this page once claimed 302 corpus pairs when there were 529, which is why those counts are pinned by a test now. What the section does state is the part a host acts on - no parsed tree can reach any ceiling, only a programmatically built one can, and there the same document may be rendered by one engine and refused by another, always with a typed error and never truncated.
