### PR TITLE
docs: the homepage said raw HTML is gated when it is on by default

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ features:
   - title: Built-in Extensions
     details: ":type[content]{attrs} for keyboard hints, semantic spans, video embeds. @mentions and #tags as you'd expect from social platforms."
   - title: Safe With Untrusted Input
-    details: "Always-on URL-scheme and attribute hardening, Trojan-Source stripping, and linear-time DoS limits neutralize the common Markdown attack classes with no separate sanitizer. Raw HTML is gated behind one switch (with a built-in safe mode), and Carve never executes embedded code (unlike MDX)."
+    details: "Always-on URL-scheme and attribute hardening, Trojan-Source stripping, and linear-time DoS limits neutralize the common Markdown attack classes with no separate sanitizer. Raw HTML passthrough is the one switch you own: on by default, off with a single flag or a safe mode. Carve never executes embedded code (unlike MDX)."
 ---
 
 ## Quick Reference


### PR DESCRIPTION
The landing page's security bullet said:

> Raw HTML is gated behind one switch (with a built-in safe mode)

"Gated behind one switch" reads as off-until-you-flip-it. It is on:

````
```=html
<script>alert(1)</script>
```
````

renders `<script>alert(1)</script>` live in all three engines at their library
and CLI defaults. Measured.

The security page already says this plainly, twice - a warning callout titled
"One thing you must still configure" that opens "**Raw HTML is on by default**",
and a comparison-table cell reading "on, one-flag opt-out / safe mode". The
landing page was the one place stating it backwards, and it is where a reader
forms their first impression of the posture.

Reworded to the security page's own framing. Nothing else in the bullet changes;
the always-on defenses and the no-embedded-code claim are accurate.

## Context: this came out of a clean sweep

I went looking for an integration that renders untrusted input with the
permissive default and did not find one. Every integration that takes untrusted
content overrides it explicitly:

| repo | posture |
|---|---|
| wp-carve (comments) | `SafeMode::strict()`, hardcoded per context, plus a `wp_kses` allowlist gate |
| laravel-carve | `safe_mode => true` in the shipped config, documented as "Safe by default" |
| carve-components | `allowRawHtml: false`, deliberately safer than the engine it wraps |
| shopware-carve, symfony-carve | explicit safe-mode / `allowRawHtml` configuration |
| carve-php-chat | restrictive `Profile` allowlist, and its output is chat markup, not HTML |
| carve-press, hugo, jekyll, mkdocs, eleventy, astro, vite | engine default, and their content is author-written |

Verified at the engine level too: carve-php's `SafeMode::strict()` removes a raw
block entirely and `SafeMode::defaults()` escapes it, so wp-carve's comment path
holds up where it matters.

So the wording was the only thing out of place - but it is the sentence doing the
reassuring.
