### PR TITLE
spec: §25 names the terminal target, and what is blanked

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3333,6 +3333,24 @@ EOF = (* end of file *) ;
         sink was first identified; the scoping was not a decision that other
         targets are safe. A target that emits no URL, such as plain text, has
         nothing to blank and is unaffected.
+
+        "EMITS A RESOLVABLE URL" IS ABOUT THE URL REACHING A READER THAT
+        RESOLVES IT, not about the target emitting a hyperlink construct. The
+        TERMINAL target is bound: it prints a link's destination beside the text,
+        and every current terminal emulator autolinks a URL in its output and
+        hands the scheme to the OS handler when the reader clicks it -- the same
+        one step as Markdown, reached without any anchor or OSC 8 sequence being
+        written. This needed saying because the two text targets differ only by
+        accident of their formats: plain text drops the destination and so never
+        faces the question, while the terminal printed it, and all three engines
+        printed `javascript:` and the OS-handler class there while blanking both
+        in Markdown (carve#765).
+
+        WHAT IS BLANKED IS THE DESTINATION, NOT THE TEXT. A denied autolink's
+        visible text IS its URL, and every target shows it: HTML inside
+        `<a href="">`, Markdown as the label of `[...]()`, plain text and the
+        terminal as the characters themselves. Blanking there would edit what the
+        author wrote rather than withhold a destination, and it is not required.
       - ATTRIBUTE NAME/VALUE HARDENING. On EVERY rendered element -- including
         elements emitted by extensions -- an HTML renderer MUST drop
         attributes whose name begins with `on` (case-insensitive) and the


### PR DESCRIPTION
Closes #765, the spec half. The three engine halves are merged: markup-carve/carve-js#711, markup-carve/carve-rs#652, markup-carve/carve-php#868.

## What was unstated

§25 said the denylist binds "every target that emits a resolvable URL" and then named only the target that is EXEMPT:

> A target that emits no URL, such as plain text, has nothing to blank and is unaffected.

The one target that actually prints a destination went unnamed. So the rule read as covering it without saying so, and all three engines printed `javascript:` and the OS protocol-handler class to a terminal while blanking both in Markdown. The two text targets differed only by accident of their formats - plain text drops the destination and so never faces the question; the terminal printed it.

## Two sentences, because two things were missing

**"Emits a resolvable URL" is about the URL reaching a reader that resolves it**, not about the target emitting a hyperlink construct. That was the whole of the against-binding argument in the issue: the ANSI writer produces no OSC 8 sequence, no anchor, just characters. But the clause's own justification never depended on structure - a scheme "blanked here and passed through there is not blocked, it is deferred by one step" - and a terminal that autolinks visible text and hands the scheme to the OS handler on click IS that step.

**What is blanked is the DESTINATION, not the text.** A denied autolink's visible text is its URL, and every target shows it: HTML inside `<a href="">`, Markdown as the label of `[...]()`, plain text and the terminal as the characters themselves. This needed writing down because the natural summary of the clause - "no target passes the scheme through" - reads as forbidding output all three engines produce and should keep producing. It also turned out to be the trap in the engine fixes: deciding WHETHER to show the destination from the sanitized value rather than the authored one turns a denied autolink into `javascript:alert(1) ()`.

## Scope

Prose only, inside the existing §25 paragraph. No normative clause heading is added, so `resources/normative-clauses.txt` regenerates byte-identically. `npm test` is 1035 passing with the 4 failures also present on `e6b207b` without this change - the known `03-nested-list` fmt fixture group. Docs build clean.

Both sentences describe what the engines now do, so nothing here asks for further engine work.
