### PR TITLE
test: the ansi record is a dated note now, not an open question

### DIFF
--- a/tests/ast-json-claims.test.mjs
+++ b/tests/ast-json-claims.test.mjs
@@ -186,20 +186,36 @@ test('the markup targets blank it, which is why the tree may keep it', () => {
   }
 })
 
-test('the ansi target does NOT blank it, and that is an open question', () => {
-  // Measured, not asserted as correct: all three engines print the destination
-  // as dim text after the label, byte for byte, while all three blank it in
-  // Markdown. Whether section 25 binds a destination a terminal auto-links is
-  // carve#765; this test pins the CURRENT answer so that whichever way it is
-  // settled, the change is deliberate and shows up here.
+/*
+ * THE ANSI TARGET IS BOUND TOO, and this suite's pin predates that.
+ *
+ * When this file first measured the four targets, all three engines printed
+ * `click (javascript:alert(1))` while blanking the same destination in Markdown.
+ * That was filed as carve#765 and answered by all three within the day -
+ * carve-js#711, carve-rs#652, carve-php#868 - and section 25 now names the
+ * terminal target explicitly (carve#773).
+ *
+ * The suite runs against the `@markup-carve/carve` PIN, which is older than the
+ * fix and still prints the scheme. So the retired behaviour is RECORDED rather
+ * than asserted as correct, and the record is GATED: when the pin moves past the
+ * fix this fails and says to delete it. Without the gate a stale pin keeps a
+ * retired behaviour looking like the rule, which is what this test was doing
+ * between the engines landing the fix and now.
+ *
+ * A "current engine" check does NOT belong here: this file imports the pin
+ * statically, so one would silently measure the pin again. That check lives in
+ * scripts/ast-conformance.mjs, which takes CARVE_JS_DIR and drives the
+ * satellites too.
+ */
+test('the pinned engine predates the ansi fix, and says so', () => {
   const out = carveToAnsi('[click](' + DANGEROUS + ')\n')
   assert.ok(
     out.includes(DANGEROUS),
-    'the ansi target stopped printing the destination. If that was deliberate, ' +
-      'carve#765 was answered - update this test and the docs paragraph together.',
+    'the pinned engine now blanks the ansi destination, which is what section 25 ' +
+      'requires - delete this test: it exists only to record that the pin was ' +
+      'behind the rule (carve#765).',
   )
 })
-
 test('feeding the tree back through the engine applies the denylist', () => {
   // The page tells a consumer this is the escape hatch: hand the tree back to a
   // conforming engine and it is a target, so it blanks. If that stopped being


### PR DESCRIPTION
Closes #765's remaining half.

#773 added the §25 clause naming the terminal target while this was in review, so only the test change is left here - and it is the part that was actively wrong.

`tests/ast-json-claims.test.mjs` measured all four targets and asserted that the ANSI one **prints** a denylisted destination. That was deliberate when written: #765 was open, and pinning the current answer meant any change would be visible. The question was answered the same day - markup-carve/carve-js#711, markup-carve/carve-rs#652, markup-carve/carve-php#868 - and the assertion outlived the answer.

It kept passing, because this suite runs against the `@markup-carve/carve` **pin**, which predates the fix and still prints the scheme. So a stale pin was holding a retired behavior in place as though it were the rule, in a file whose entire purpose is keeping measured claims from rotting.

## Now a dated record with a gate

When the pin moves past the fix, the test fails and says to delete itself. Verified by pretending the pin blanks it:

```
not ok 11 - the pinned engine predates the ansi fix, and says so
  error: 'the pinned engine now blanks the ansi destination, which is what section 25
  requires - delete this test: it exists only to record that the pin was behind the rule'
```

## One thing deliberately not added

A "current engine" check does not belong in this file: it imports the pin statically, so the check would silently measure the pin again. My first attempt did exactly that (and referenced a `jsDir` the file does not define). The current-engine check lives in `scripts/ast-conformance.mjs`, which already takes `CARVE_JS_DIR` and drives the satellites - the comment now says so, because the mistake is an easy one to repeat.

1039 tests, 0 failures.