### PR TITLE
fix: the bump-matrix guard can report, and pandoc-carve is bumped

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -78,6 +78,11 @@ jobs:
             lang: node
             test: npm ci && npm run build && npm run test:grammar
             allowlist: the `covered` / `skip` lists in `tests/categories.json`
+          - repo: markup-carve/pandoc-carve
+            submodule: spec
+            lang: node
+            test: npm ci && npm test
+            allowlist: none - its conversion tests read the corpus directly
           - repo: markup-carve/carve-skill
             submodule: spec
             lang: node
@@ -415,14 +420,14 @@ jobs:
           while IFS= read -r repo; do
             [ -z "$repo" ] && continue
             if ! grep -qx "$repo" <<< "$matrix" && [ -z "${EXCEPT[$repo]:-}" ]; then
-              missing="$missing- `\$repo` carries the spec submodule and nothing bumps it"$'\n'
+              missing="$missing- \`$repo\` carries the spec submodule and nothing bumps it"$'\n'
             fi
           done <<< "$carrying"
 
           stale_except=""
           for repo in "${!EXCEPT[@]}"; do
             if ! grep -qx "$repo" <<< "$carrying"; then
-              stale_except="$stale_except- `\$repo` is listed as an exception but no longer carries the submodule"$'\n'
+              stale_except="$stale_except- \`$repo\` is listed as an exception but no longer carries the submodule"$'\n'
             fi
           done
 


### PR DESCRIPTION
`main` is red. Two things are wrong, and the second is why the first went unnoticed.

## pandoc-carve carries the spec submodule and nothing bumped it

Its `.gitmodules` has `[submodule "spec"]` pointing at this repo, and it appears
neither in the bump matrix nor in `EXCEPT`. The guard is right to fail.

Added to the matrix as a node repo. Its `npm test` is
`npm run build && node --test test/*.test.mjs`, and its conversion tests read the
corpus directly, so there is no category allowlist to keep in step - unlike the
engines, whose `IMPLEMENTED` slices are the reason that column exists.

## The guard could not say so

Both report lines wrap the repo name in a markdown code span inside a
double-quoted shell string. A backtick opens a command substitution there, so
instead of quoting the name the shell ran it:

```
line 26: markup-carve/pandoc-carve: No such file or directory
Process completed with exit code 127
```

instead of

```
## Bump matrix is out of date

- markup-carve/pandoc-carve carries the spec submodule and nothing bumps it
```

Reproduced both forms in a scratch shell before and after the change: the old one
prints exactly the CI message, the new one prints the intended line.

This is a failure path that only runs when something is already wrong, so it had
never executed. The guard has been able to DETECT a gap and unable to DESCRIBE
one for as long as it has existed - which is also why a reader of that log had no
way to tell a broken workflow from a real coverage gap. It was both.

Escaping the backticks fixes both lines; the `stale_except` branch had the
identical bug and would have failed the same way the first time an exception went
stale.

## Verified

Spec suite: 1039 pass, 0 fail. The workflow parses as YAML. The matrix entry
follows the shape of the existing node entries.
