### PR TITLE
test: one engine is not a cross-engine comparison

### DIFF
--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -12,6 +12,7 @@ import {
   targetOf,
 } from './lib/corpus-targets.mjs'
 import { phpDir, rustDir } from './lib/engine-locations.mjs'
+import { miscount, shortfall } from './spec/participants.mjs'
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)))
 const args = new Set(process.argv.slice(2))
@@ -504,6 +505,20 @@ function available(impl) {
   return result.ok ? { ok: true } : { ok: false, reason: result.stderr || result.error || `exit ${result.status}` }
 }
 
+/**
+ * How many cases this corpus OFFERS, independent of what the run loaded. The
+ * exact check above compares the two, so a filter that starts dropping cases
+ * fails rather than answering a smaller question.
+ */
+function availableCaseCount() {
+  if (!isOptional) {
+    return readdirSync(corpusDir).filter((f) => f.endsWith('.crv')).length
+  }
+  const manifest = JSON.parse(readFileSync(join(corpusDir, 'manifest.json'), 'utf8'))
+
+  return manifest.cases.length
+}
+
 function loadPairs() {
   if (!isOptional) {
     return readdirSync(corpusDir)
@@ -541,6 +556,31 @@ function loadPairs() {
 }
 
 const pairs = loadPairs()
+
+/*
+ * And how many CASES it saw. Without `--limit` the run must cover the corpus it
+ * loaded, so the check is exact; with one it is a floor, and `--limit=0` is a
+ * typo rather than a sample size - it used to run the engines over nothing and
+ * report `pass=0/0 mismatch=0`.
+ */
+const casePopulation = Number.isFinite(limit)
+  ? shortfall({
+      label: 'CASES',
+      actual: pairs.length,
+      atLeast: 1,
+      of: 'case(s)',
+      hint: 'Raise --limit, or drop it to compare the whole corpus.',
+    })
+  : miscount({
+      label: 'CASES',
+      actual: pairs.length,
+      expected: availableCaseCount(),
+      of: 'case(s)',
+    })
+if (casePopulation !== null) {
+  console.error(casePopulation)
+  process.exit(2)
+}
 
 /**
  * Per-target count of cases scored against a FILE, filled as the run walks the
@@ -608,6 +648,35 @@ for (const impl of impls) {
 if (active.length === 0) {
   console.error('No implementations are runnable.')
   process.exit(1)
+}
+
+/*
+ * ONE ENGINE IS NOT A COMPARISON.
+ *
+ * `active.length === 0` was the only floor, so a run with a single engine did
+ * the whole corpus, reported `pass=610/610 mismatch=0`, found zero cross-impl
+ * diffs BY CONSTRUCTION, and exited 0. Two missing checkouts is the ordinary
+ * state of a fresh environment, which is exactly when someone reads the summary
+ * and believes it.
+ *
+ * The fixture scoring below is still meaningful with one engine - it compares
+ * output to a FILE - so this does not abort. It says which half of the run is
+ * vacuous, and fails under the same flag CI uses for strictness, the convention
+ * the divergence gate already follows (carve#755, variant 2).
+ */
+const enginePopulation = shortfall({
+  label: 'CROSS-ENGINE',
+  actual: active.length,
+  atLeast: 2,
+  of: 'engine(s)',
+  hint: 'Fixture scoring below is still valid; every cross-engine claim in this run is not.',
+})
+if (enginePopulation !== null) {
+  console.log(enginePopulation)
+  if (failOnDiff) {
+    console.error('--fail-on-diff and fewer than two engines: nothing cross-engine was compared.')
+    process.exit(1)
+  }
 }
 
 const stats = Object.fromEntries(


### PR DESCRIPTION
The follow-up #776 named: `compare-impls.mjs` had the ad-hoc version of the participant check and should move onto the helper. Doing that turned up a live instance of the same variant.

## One engine is not a comparison

The script exists to compare engines against each other. Its only floor was `active.length === 0`. With **one** engine it ran the whole corpus, reported `pass=610/610 mismatch=0`, found zero cross-impl diffs by construction, and exited 0:

```
SKIP rust: spawnSync cargo ENOENT
SKIP php: spawnSync php ENOENT
js: pass=3/3 mismatch=0 error=0 skipped=0 runs=15
```

Nothing in that output says the cross-engine half of the run was empty. Two absent checkouts is the ordinary state of a fresh environment - which is exactly when someone reads that summary and believes it.

It does not abort, because the **fixture scoring is still meaningful with one engine** - that half compares output to a file. It names which half is vacuous, and fails under `--fail-on-diff`, the flag CI already uses for strictness and the convention the divergence gate follows:

```
CROSS-ENGINE: compared 1 engine(s) but expected at least 2. ... Fixture scoring below is
still valid; every cross-engine claim in this run is not.
--fail-on-diff and fewer than two engines: nothing cross-engine was compared.
$ echo $?
1
```

## Cases too

Without `--limit` the run must cover the corpus it loaded, so the comparison is exact - a filter that starts dropping cases fails rather than answering a smaller question. With a limit it is a floor, and `--limit=0` is a typo rather than a sample size; it used to run the engines over nothing and report `pass=0/0 mismatch=0`.

```
$ node scripts/compare-impls.mjs --limit=0
CASES: compared 0 case(s) but expected at least 1. ... Raise --limit, or drop it to
compare the whole corpus.
```

## Demonstrated, not asserted

| run | result |
|---|---|
| js only | CROSS-ENGINE line printed, exit 0 (informational) |
| js only, `--fail-on-diff` | same line plus a second, **exit 1** |
| `--limit=0` | rejected before any engine starts, exit 2 |
| all three, `--limit=4` | unchanged: `rust/js/php pass=4/4 mismatch=0`, exit 0 |

Both checks use the shared helper from #776 rather than a third hand-rolled copy. 1044 tests, 0 failures.

The remaining ad-hoc counter in this script is the optional-corpus `NOT COMPARED: n of m` roll-up, which already fails correctly for its own reason (#535) - worth folding onto the helper next time it is touched, but it is not silent today.
