### PR TITLE
spec: re-measure PART 12 §4's position status - a fourth document, autolink residue on two engines

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -340,7 +340,7 @@ The definition-list entry this paragraph used to name is fixed: carve-rs places
 `definition_term` and `definition_description` today, checked over every
 corpus document that contains one. What the same measurement does turn up is a
 different gap - carve-rs and carve-php leave the paragraphs a CAPPED container
-degrades to unplaced (`181-openers-past-the-nesting-cap-are-one-paragraph`),
+degrades to unplaced (`182-openers-past-the-nesting-cap-are-one-paragraph`),
 where carve-js places them against real offsets, so the reassembly exemption does
 not reach them ([carve#672](https://github.com/markup-carve/carve/issues/672)).
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -4998,12 +4998,12 @@ EOF = (* end of file *) ;
       option and enable them whenever they serialize, which is the arrangement
       the paragraph above permits. Measured over the corpus:
 
-        carve-js    3414 placed,  10 unplaced   (0.29%)
-        carve-rs    3389 placed,   9 unplaced   (0.26%)
-        carve-php   3405 placed,   5 unplaced   (0.15%)
+        carve-js    4159 placed,   9 unplaced   (0.22%)
+        carve-rs    4183 placed,  15 unplaced   (0.36%)
+        carve-php   4188 placed,  13 unplaced   (0.31%)
 
-      What is left is not a backlog. Every engine independently arrived at
-      nearly the same residue, on the same THREE documents -- a line block
+      Most of what is left is not a backlog. All three engines independently
+      arrive at residue on the same THREE documents -- a line block
       (41-line-blocks-9) and two table cells continued across lines
       (63-table-multi-line-cell-continuation,
       64-table-rowspan-with-multi-line-content). All of it is REASSEMBLED
@@ -5012,18 +5012,38 @@ EOF = (* end of file *) ;
       source lines by a space the source does not contain. None of it is a slice
       of the source at any offset, so no span selects it.
 
-      carve-rs additionally leaves the merged text of an unwrapped autolink
-      unplaced (03-links-12), for the same reason once §1a joins the run: the
-      `<` and `>` between the pieces are not in the value.
-
       This state is convergent rather than accidental, and it is the evidence
       that settled carve#490: THAT residue -- the reassembled content named
       above -- is the permitted category, not a shortfall each engine reports
       separately. The exemption is scoped to it and does not launder anything
-      else. docs/ast-json.md's table additionally records carve-rs leaving a
-      definition list's OWN parts unplaced; a `definition_term` is a slice of
-      the source like any other node, so if that is still true it is a gap, and
-      the numbers above were taken without separating it out.
+      else.
+
+      A FOURTH document is not part of that category. carve-rs and carve-php
+      also leave the paragraph, text and soft_break nodes a CAPPED container
+      degrades to unplaced (182-openers-past-the-nesting-cap-are-one-paragraph,
+      renumbered from 181 as the corpus grew) -- 8 of each engine's total above.
+      carve-js places the same nodes against real offsets there: a contiguous
+      slice of the document, not a reassembly. That is the evidence this
+      residue is a gap the clause above does not reach, not a fourth member of
+      the permitted category (carve#672).
+
+      carve-js AND carve-rs -- not carve-rs alone -- leave the merged text of
+      an unwrapped autolink unplaced (03-links-12), for the same reason once
+      §1a joins the run: the `<` and `>` between the pieces are not in the
+      value. carve-php does not.
+
+      A fifth residue is not yet triaged: carve-js and carve-rs both leave a
+      reference image's caption unplaced (207-a-reference-image-takes-a-caption,
+      one `figure` node each). It fits none of the categories above and is
+      counted in the totals above rather than dropped from them for being
+      unexplained.
+
+      docs/ast-json.md's table used to additionally record carve-rs leaving a
+      definition list's OWN parts unplaced. That is fixed: carve-rs places
+      `definition_term` and `definition_description` today, checked over every
+      corpus document that contains one, and the docs page reflects it. The
+      capped-container residue named above is what the same measurement turns
+      up instead.
 
       The earlier text here named per-engine gaps that no longer exist -- it
       described carve-rs as placing block nodes only, "869 block nodes and 54


### PR DESCRIPTION
Closes #672

PART 12 §4's IMPLEMENTATION STATUS paragraph recorded a position-coverage
measurement that no longer held: it named the same three documents as the
whole unplaced-node residue, and attributed the unwrapped-autolink gap to
carve-rs alone.

Re-measured against carve-js at the pin `package.json` names (`9dc8a94`,
rebuilt locally - the checkout on this host had drifted ahead of the pin),
carve-rs `main` (`d7f46a0`, `cargo build --release`) and carve-php `main`
(`a5496c4`), over the full 610-document corpus plus the 3 astral samples:

    carve-js    4159 placed,   9 unplaced   (0.22%)
    carve-rs    4183 placed,  15 unplaced   (0.36%)
    carve-php   4188 placed,  13 unplaced   (0.31%)

What changed in the prose, each backed by a direct node-by-node count against
these builds (script in the PR discussion below, not committed):

- The three reassembled-content documents (line block, two table-continuation
  cells) are unchanged and still shared by all three engines - that framing
  was correct and stays.
- A fourth document is not part of that category: carve-rs and carve-php both
  leave 8 nodes unplaced in `182-openers-past-the-nesting-cap-are-one-paragraph`
  (renumbered from `181` since the paragraph was last written - the corpus grew
  and the slug moved). carve-js places the same nodes against real offsets, so
  this is a genuine gap the reassembly exemption does not reach, not a fourth
  member of the permitted category.
- The autolink line was carve-rs-only; it is not. carve-js also leaves
  `03-links-12`'s merged autolink text unplaced. carve-php does not.
- A fifth residue turned up in this same run that isn't in the issue and isn't
  triaged: carve-js and carve-rs both leave a `figure` node unplaced in
  `207-a-reference-image-takes-a-caption`. It fits none of the named
  categories. It's called out by name rather than silently folded into the
  totals, since the totals above don't add up without it for carve-js and
  carve-rs.

Also fixed while in the neighborhood:

- `docs/ast-json.md` still named the nesting-cap document as `181` (the old
  slug); it's `182` now, same renumbering as above.
- `resources/grammar.ebnf`'s cross-reference to `docs/ast-json.md`'s
  definition-list note was itself stale - that note was already updated to say
  the definition-list gap is fixed. Updated the cross-reference to match what
  the docs page now says, and to point at the nesting-cap residue instead,
  which is what the same measurement turns up today.

Draft `#291` (file inclusion / transclusion, `spec/includes-section-19`) also
touches `resources/grammar.ebnf`, with no topic overlap with this change
(`draft-check` returned WARN, not BLOCK). Expect a rebase against this once
that draft eventually lands.

Gates run locally against this worktree: `npm test` (1062 pass, 1 skip, 0
fail), `npm run core:check` (610/610 conformant), `npm run test:conformance`
(same, via a fresh `corpus:build`). `npm run ast:check` and `npm run
claims:check` could not run through the standard gate harness - they compare
against sibling engine checkouts this repo's own per-PR CI does not provision
(a separate scheduled workflow does), and the sibling paths the harness looks
for by default (`../carve-js` etc.) aren't populated in this worktree's
parent. I ran the equivalent comparison by hand with `CARVE_JS_DIR` /
`CARVE_RS_DIR` / `CARVE_PHP_DIR` pointed at built sibling checkouts, which is
where the numbers above come from - but that is a manual run, not the gate.
Also verified locally, outside the standard gate set but present in this
repo's CI: `npm run docs:build` (clean) and `npm run lint:mermaid` (clean).

`codex review --uncommitted` was attempted but returned a usage-limit error
from the provider (available again 2026-08-08 per its own message), so no
automated diff review ran on this change. Disclosed rather than skipped
silently.
