### PR TITLE
feat: compare the engines' AST values, not only their shapes

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -42,6 +42,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Ajv2020 } from 'ajv/dist/2020.js'
 import { classifyShapeDisagreement, shapeOf, shapePaths } from './spec/ast-shape.mjs'
+import { compareValues, valueSignature } from './spec/ast-values.mjs'
 import { checkPositions } from './spec/ast-positions.mjs'
 import { checkReferenceFields } from './spec/ast-references.mjs'
 import {
@@ -290,6 +291,13 @@ function checkShapeParity(name, doc, findings) {
 const referenceShapes = new Map()
 
 /**
+ * Every engine's SCALAR-field signatures, per document. The shape map beside
+ * this one answers whether the engines build the same tree; this one answers
+ * whether they put the same values in it (carve#786).
+ */
+const engineValues = new Map()
+
+/**
  * Every independent engine's tree signature, kept so the run can compare the
  * engines to EACH OTHER and not only to the one that was chosen as reference.
  *
@@ -305,6 +313,58 @@ const referenceShapes = new Map()
  * counting it would give that engine two votes and make a real carve-rs
  * divergence look like a majority.
  */
+/**
+ * Report where the engines publish DIFFERENT VALUES in the same node.
+ *
+ * Separate from the shape panel because it answers a separate question, and
+ * separate from the schema check because every field involved is optional there
+ * - a tree that omits `align` validates exactly as well as one that carries it.
+ *
+ * REPORTS, does not gate. There are known divergences today (carve#750, #784,
+ * #785, carve-php#877), and a gate would fail on day one for reasons already
+ * being tracked. Grouped by `type.field` rather than by document because each
+ * of those is one field behaving one way everywhere it appears: a per-document
+ * list is 107 entries describing five facts.
+ */
+function reportValueDisagreements(present) {
+  const byKey = new Map()
+  const names = engineValues.get(present[0])
+  if (!names) return
+
+  for (const name of names.keys()) {
+    const signatures = new Map()
+    let complete = true
+    for (const engine of present) {
+      const sig = engineValues.get(engine)?.get(name)
+      if (!sig) { complete = false; break }
+      signatures.set(engine, sig)
+    }
+    if (!complete) continue
+
+    for (const found of compareValues(signatures, name)) {
+      if (!byKey.has(found.key)) byKey.set(found.key, { engines: found.engines, docs: [] })
+      byKey.get(found.key).docs.push(found.sample)
+    }
+  }
+
+  console.log('')
+  if (byKey.size === 0) {
+    console.log('THREE-WAY VALUE COMPARISON: the engines publish the same values everywhere.')
+
+    return
+  }
+
+  const total = new Set([...byKey.values()].flatMap((v) => v.docs)).size
+  console.log(`THREE-WAY VALUE COMPARISON: ${byKey.size} field(s) disagree, across ${total} document(s)`)
+  for (const [key, { engines, docs }] of [...byKey].sort((a, b) => b[1].docs.length - a[1].docs.length)) {
+    const who = Object.entries(engines).map(([e, v]) => `${e}=${v}`).join('  ')
+    console.log(`  ${String(docs.length).padStart(4)}x  ${key}`)
+    console.log(`        ${who}`)
+    console.log(`        e.g. ${docs.slice(0, 2).join(', ')}`)
+  }
+  console.log('  Reported, not gated: see carve#786 for why, and which of these are already tracked.')
+}
+
 const INDEPENDENT_ENGINES = ['carve-js', 'carve-rs', 'carve-php']
 let panelRan = false
 const enginePaths = new Map()
@@ -316,6 +376,16 @@ function recordShape(engine, name, doc) {
     enginePaths.set(engine, perDoc)
   }
   perDoc.set(name, shapePaths(shapeOf(doc)).join('\n'))
+
+  // The same tree, signed a second way. `shapeOf` drops every scalar, so this
+  // is what carries `align`, `href`, `order` and the rest to the panel below
+  // (carve#786).
+  let perDocValues = engineValues.get(engine)
+  if (!perDocValues) {
+    perDocValues = new Map()
+    engineValues.set(engine, perDocValues)
+  }
+  perDocValues.set(name, valueSignature(doc))
 }
 
 /**
@@ -373,6 +443,9 @@ function reportEngineDisagreement() {
     console.log(`  all three differed on ${threeWay.length}: ${examples(threeWay)}`)
   }
   if (compared === unanimous) console.log('  no engine stood alone.')
+
+  reportValueDisagreements(present)
+
   // A document one engine could not serialize leaves the panel with two votes,
   // so it is not compared. Say how many, or a run where half the corpus dropped
   // out reads the same as one where none did.

--- a/scripts/spec/ast-values.mjs
+++ b/scripts/spec/ast-values.mjs
@@ -1,0 +1,119 @@
+/*
+ * SCALAR-FIELD signatures for the three-way engine comparison.
+ *
+ * `shapeOf` in ./ast-shape.mjs keeps a node's `type` and any child that is
+ * itself an object or array. Every SCALAR is skipped, so the shape comparison
+ * answers "do the engines build the same tree" and not "do they put the same
+ * VALUES in it". Both questions matter and only the first was being asked:
+ *
+ *   shapeOf({type:'table_cell', align:'right', children:[...]})
+ *   shapeOf({type:'table_cell',                children:[...]})
+ *   // identical
+ *
+ * Five known divergences live in exactly that gap - a table cell's `align`
+ * (carve#784), a crossref's `href` (carve-php#877), a fence title's `order`
+ * (carve#785), a generated heading id (carve#750) and, until it was fixed, a
+ * stale footnote number (carve#758). Each renders identically in all three
+ * engines, so corpus conformance cannot see them either, and each was found by
+ * hand.
+ *
+ * The schema does not close it: every one of those fields is OPTIONAL, so a
+ * tree that omits it validates exactly as well as one that carries it. That is
+ * right for a schema - a programmatically built tree may lack them - and it is
+ * why "validates" and "agrees" are different questions.
+ */
+
+/** Fields that are positions rather than content; compared elsewhere. */
+const POSITION_KEYS = new Set([
+  'pos', 'startLine', 'endLine', 'startColumn', 'endColumn', 'startOffset', 'endOffset',
+  'srcByteLength',
+])
+
+/**
+ * One entry per node, in document order: `type` plus every scalar field it
+ * carries, sorted by key.
+ *
+ * `attrs` is flattened rather than skipped - it holds `id`, `classes` and
+ * `keyValues`, which is where the heading-id and fence-title divergences sit -
+ * but its ORDER array is compared as a whole, since that is the field's meaning.
+ */
+export function valueSignature(node, out = [], path = '$') {
+  if (Array.isArray(node)) {
+    node.forEach((n, i) => valueSignature(n, out, `${path}[${i}]`))
+
+    return out
+  }
+  if (!node || typeof node !== 'object') return out
+
+  if (typeof node.type === 'string') {
+    const fields = []
+    for (const key of Object.keys(node).sort()) {
+      if (key === 'type' || POSITION_KEYS.has(key)) continue
+      const value = node[key]
+      if (value === null || typeof value !== 'object') {
+        fields.push(`${key}=${JSON.stringify(value)}`)
+      } else if (key === 'attrs') {
+        for (const attrKey of Object.keys(value).sort()) {
+          fields.push(`attrs.${attrKey}=${JSON.stringify(value[attrKey])}`)
+        }
+      }
+    }
+    out.push({ path, type: node.type, fields })
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (POSITION_KEYS.has(key) || key === 'attrs') continue
+    if (value && typeof value === 'object') valueSignature(value, out, `${path}.${key}`)
+  }
+
+  return out
+}
+
+/**
+ * Where the engines disagree about a VALUE, keyed by `type.field` rather than
+ * by document.
+ *
+ * Keyed that way on purpose: each known divergence is one field behaving one
+ * way everywhere it appears, so a per-document list would be 107 entries
+ * describing five facts. `table_cell.align` is one line whether it shows up in
+ * five documents or fifty.
+ *
+ * Returns `[{ key, engines, sample }]` - `engines` maps each engine to what it
+ * published, `sample` is a document exhibiting it.
+ */
+export function compareValues(signaturesByEngine, documentName) {
+  const engines = [...signaturesByEngine.keys()]
+  const lengths = new Set(engines.map((e) => signaturesByEngine.get(e).length))
+  // Different node counts is a SHAPE disagreement; ast-shape.mjs reports it,
+  // and pairing values across trees of different lengths would compare
+  // unrelated nodes and invent divergences that are not there.
+  if (lengths.size !== 1) return []
+
+  const count = signaturesByEngine.get(engines[0]).length
+  const found = []
+  for (let i = 0; i < count; i += 1) {
+    const nodes = new Map(engines.map((e) => [e, signaturesByEngine.get(e)[i]]))
+    const types = new Set([...nodes.values()].map((n) => n.type))
+    if (types.size !== 1) continue // shape disagreement again
+
+    const keys = new Set()
+    for (const node of nodes.values()) {
+      for (const f of node.fields) keys.add(f.slice(0, f.indexOf('=')))
+    }
+    for (const key of keys) {
+      const published = new Map()
+      for (const [engine, node] of nodes) {
+        const hit = node.fields.find((f) => f.startsWith(`${key}=`))
+        published.set(engine, hit === undefined ? '(absent)' : hit.slice(key.length + 1))
+      }
+      if (new Set(published.values()).size === 1) continue
+      found.push({
+        key: `${[...types][0]}.${key}`,
+        engines: Object.fromEntries(published),
+        sample: documentName,
+      })
+    }
+  }
+
+  return found
+}


### PR DESCRIPTION
Builds what I offered on #786. Reports rather than gates, so it can land without settling the allowlist question first.

## The gap

`shapeOf` keeps a node's `type` and any child that is itself an object or array. Every scalar is skipped:

```js
shapeOf({type:'table_cell', align:'right', children:[…]})
shapeOf({type:'table_cell',                children:[…]})
// identical
```

So the three-way panel answers "do the engines build the same tree" and never "do they put the same values in it". The schema check does not cover it either - every field involved is optional, so a tree omitting one validates exactly as well as one carrying it. That is correct for a schema, and it is why *validates* and *agrees* are different questions.

## What it reports today

Against the three engines at their current mains:

```
THREE-WAY VALUE COMPARISON: 8 field(s) disagree, across 66 document(s)
    72x  heading.attrs.id
        carve-js="H"  carve-rs=(absent)  carve-php=(absent)
    10x  table_cell.align
        carve-js=(absent)  carve-rs=(absent)  carve-php="left"
    10x  text.value
        carve-js="Fruit prices"  carve-rs="Fruit prices"  carve-php="$2"
     4x  code_block.attrs.order
        carve-js=(absent)  carve-rs=["title"]  carve-php=["title"]
     4x  heading_ref.href
        carve-js="#fig-sun"  carve-rs="#fig-sun"  carve-php=(absent)
     1x  table_cell.header
     1x  text.escapedLeadingCaret
        carve-js=true  carve-rs=(absent)  carve-php=(absent)
     1x  paragraph.attrs.order
        carve-js=["#id","key",".class"]  carve-php=["#id","key",".class","key"]
```

Six were already tracked - #750, #784, #785, markup-carve/carve-php#877 among them. **Two were not:**

- **`paragraph.attrs.order`** - carve-php lists a repeated key twice while `keyValues` holds it once, so a consumer rebuilding the source from `order` emits `key` twice. Verified by hand on `89-block-attribute-lines-2`; filed as markup-carve/carve-php#878.
- **`text.escapedLeadingCaret`** - a field the schema declares and only carve-js publishes.

## Design notes

**Grouped by `type.field`, not by document.** Each of these is one field behaving one way everywhere it appears; a per-document list is 66 entries describing eight facts. `table_cell.align` is one line whether it shows up in ten documents or fifty.

**Reports, does not gate.** Known divergences exist and a gate fails on day one for reasons already being tracked. Gating is a separate decision once the list is agreed - and this output IS the list, which is the part that was missing.

**Node-count mismatches are skipped.** That is a shape disagreement, already reported by the panel above; pairing values across trees of different lengths would compare unrelated nodes and invent divergences.

**`attrs` is flattened rather than skipped**, since `attrs.id` and `attrs.order` are where three of the eight live.

## Verified

`npm test`: 1062 pass, 0 fail. The panel's numbers are stable across a genuine rebuild of the reference engine - the script's own STALE BUILDS warning fired on my symlinked checkout, so I rebuilt carve-js and re-ran before recording anything, and the eight rows were unchanged.
