### PR TITLE
fix: the value signature walks children in key order, not object order

### DIFF
--- a/scripts/spec/ast-values.mjs
+++ b/scripts/spec/ast-values.mjs
@@ -61,8 +61,15 @@ export function valueSignature(node, out = [], path = '$') {
     out.push({ path, type: node.type, fields })
   }
 
-  for (const [key, value] of Object.entries(node)) {
+  // SORTED BY KEY, like shapeOf does, and for the same reason: the engines
+  // serialize a node's fields in different orders. carve-php writes a table's
+  // `caption` before its `rows`, carve-js and carve-rs after - the same fields
+  // either way, and JSON object order carries no meaning. Walking in object
+  // order made the caption's text pair with a body cell's text and reported a
+  // `text.value` disagreement that is not one (carve#791).
+  for (const key of Object.keys(node).sort()) {
     if (POSITION_KEYS.has(key) || key === 'attrs') continue
+    const value = node[key]
     if (value && typeof value === 'object') valueSignature(value, out, `${path}.${key}`)
   }
 


### PR DESCRIPTION
Fixes a false positive in the panel I added in #790, found by investigating one of its own rows.

## The false row

```
10x  text.value
     carve-js="Fruit prices"  carve-rs="Fruit prices"  carve-php="$2"
```

That is not a disagreement. `Fruit prices` is a table's caption and `$2` is a body cell, and both trees hold both, in the same structure. The engines differ only in the ORDER they serialize a table node's fields:

| engine | `table` node keys |
|---|---|
| carve-js, carve-rs | `["type","rows","caption"]` |
| carve-php | `["type","caption","rows"]` |

JSON object key order carries no meaning. My walk followed `Object.entries`, so the caption's text landed at a different traversal index in carve-php than in the other two, and the index-based pairing compared it against a body cell.

`shapeOf` solved this when it was written, and said why:

> Sorted by key: engines serialize their fields in different orders, and a signature that inherited that order would report every one of them as a shape difference.

The new signature did not copy it. One-line fix.

## Effect

Two rows disappear - `text.value` (10 documents) and `table_cell.header` (1), both artifacts of the same cause. The panel goes from 7 fields / 63 documents to **5 fields / 56 documents**, and the five that remain are the real ones, unchanged:

```
72x  heading.attrs.id        (#750)
10x  table_cell.align        (#784)
 4x  code_block.attrs.order  (#785)
 1x  text.escapedLeadingCaret
 1x  paragraph.attrs.order   (markup-carve/carve-php#878)
```

## Verified both directions

- A real divergence is still caught: two trees differing only by `table_cell.align` still report `table_cell.align`.
- The artifact is now silent: two trees differing only in `table` key order report nothing.
- `npm test`: 1062 pass, 0 fail.

Worth noting the panel earned its keep in the same run: `heading_ref.href` dropped off the list because markup-carve/carve-php#877 was fixed, so it is already working as a regression detector in both directions.
