### PR TITLE
spec: the term alphabet the oracle did not implement, and the corpus could not reach

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -8728,3 +8728,44 @@ covers fenced code content and inline code spans only (carve#698).
 ```
 
 :::
+
+## An abbreviation term is one ASCII alphanumeric word
+
+`abbreviation_term = (letter | digit)+`, and `letter` is enumerated as `a`..`z` plus `A`..`Z`. So the term is case-blind, may start with a digit, and may be a digit alone - every corpus abbreviation before this one was an uppercase multi-letter word, which is the one shape that hides all of those.
+
+::: compare
+
+```carve
+*[dl]: definition list
+*[3D]: three dimensional
+*[9]: nine
+
+A dl, a 3D one, and 9.
+```
+
+```html
+<p>A <abbr title="definition list">dl</abbr>, a <abbr title="three dimensional">3D</abbr> one, and <abbr title="nine">9</abbr>.</p>
+```
+
+:::
+
+A term outside that alphabet is not a definition, and the line stays as written rather than being dropped. An abbreviation has no marker at the use site, so a definition swallowed here would take its whole line of prose with it and leave nothing behind to explain the loss.
+
+::: compare
+
+```carve
+*[ß]: sharp s
+*[e.g.]: for example
+*[HTTP API]: an interface
+
+Text about ss and eg below.
+```
+
+```html
+<p>*[ß]: sharp s
+*[e.g.]: for example
+*[HTTP API]: an interface</p>
+<p>Text about ss and eg below.</p>
+```
+
+:::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,41 +17,46 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>611 / 611</strong>
+    <strong>611 / 613</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>611 / 611</strong>
+    <strong>610 / 613</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>611 / 611</strong>
+    <strong>610 / 613</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>1</strong>
+    <strong>8</strong>
     <span>cross-implementation diffs</span>
   </div>
 </div>
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `c3f5a12` | `611 / 611` | `0` | `0` | `2.31` |
-| JS | `bf8a695` | `611 / 611` | `0` | `0` | `56.16` |
-| PHP | `c3b630f` | `611 / 611` | `0` | `0` | `51.60` |
+| Rust | `49bf6ae` | `611 / 613` | `2` | `0` | `2.39` |
+| JS | `2ebf5ed` | `610 / 613` | `3` | `0` | `57.01` |
+| PHP | `9960d53` | `610 / 613` | `3` | `0` | `52.44` |
 
 Spec commit: `b539d14`, plus the corpus case this change adds
 
-Every engine renders every fixture case on every target that has one - 618 of
-618, zero mismatches and zero errors in all three - and every target agrees
-everywhere except one case on `markdown`.
+Three cases are ahead of the engines, which is what a spec-first corpus looks
+like between a clause landing and three ports catching up. None of them is a
+disagreement about a rule all three implement.
 
-That one is `217-a-heading-id-keeps-a-non-ascii-space`: carve-rs drops a
-heading's LEADING no-break space where carve-js and carve-php keep it
-(markup-carve/carve-rs#614). The case was added to pin an ID rule and pins the
-HTML target only - the divergence it exposed is on a target it does not pin, in
-a shape the corpus had never covered, since no heading in it began with a
-non-ASCII space. It is left visible here rather than papered over.
+`222-a-tab-as-the-first-character-of-a-definition-term` is the newest clause
+(carve#794): a tab after `:` is stripped, not preserved. carve-rs already did
+this and is the reference; carve-js and carve-php still keep the tab.
+
+`16-reference-link-4` and
+`195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column`
+diverge on the `carve` target only - the parse agrees in all three and what
+differs is the canonical spelling the formatter writes back.
+
+The counts here are documents, not runs: an engine that misses one case on two
+targets is one document behind, not two.
 
 That last part is new. The `carve` target carried 32 diffs in the previous
 snapshot and 5 the run before that, and it is the only target that ever has:
@@ -386,19 +391,26 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=611 targets=html,markdown,plain,carve,ansi
-rust: pass=618/618 mismatch=0 error=0 skipped=0 runs=3030 avg_ms=2.31
-js: pass=618/618 mismatch=0 error=0 skipped=0 runs=3030 avg_ms=56.16
-php: pass=618/618 mismatch=0 error=0 skipped=0 runs=3030 avg_ms=51.60
-cross_impl_diffs=1
-  DIFF [markdown] 217-a-heading-id-keeps-a-non-ascii-space
+profile=default/no-opt-in corpus=core corpus_pairs=613 targets=html,markdown,plain,carve,ansi
+rust: pass=623/625 mismatch=2 error=0 skipped=0 runs=3065 avg_ms=2.39
+  mismatch: carve 16-reference-link-4
+  mismatch: carve 195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column
+js: pass=622/625 mismatch=3 error=0 skipped=0 runs=3065 avg_ms=57.01
+  mismatch: carve 16-reference-link-4
+  mismatch: carve 195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column
+  mismatch: html 222-a-tab-as-the-first-character-of-a-definition-term
+php: pass=622/625 mismatch=3 error=0 skipped=0 runs=3065 avg_ms=52.44
+  mismatch: carve 16-reference-link-4
+  mismatch: carve 195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column
+  mismatch: html 222-a-tab-as-the-first-character-of-a-definition-term
+cross_impl_diffs=8
 
 Target agreement (implementations compared against each other)
-html: compared=611 diffs=0 errors=0 fixtures=yes
-markdown: compared=611 diffs=1 errors=0 fixtures=1
-plain: compared=611 diffs=0 errors=0 fixtures=1
-carve: compared=611 diffs=0 errors=0 fixtures=10
-ansi: compared=611 diffs=0 errors=0 fixtures=none
+html: compared=613 diffs=1 errors=0 fixtures=yes
+markdown: compared=613 diffs=1 errors=0 fixtures=1
+plain: compared=613 diffs=1 errors=0 fixtures=1
+carve: compared=613 diffs=4 errors=0 fixtures=10
+ansi: compared=613 diffs=1 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 611 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 613 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus with no HTML divergences.
 Pre-1.0, a minor release may still change the grammar.

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -26,3 +26,4 @@
 # Format: <slug><space><space><reason>
 221-a-heading-reference-folds-unicode-normalization-but-not-compatibility  the pinned build does not NFC-normalize the heading-reference key, so the precomposed reference misses the decomposed heading; fixed by carve-js#686, drops out at the next release
 222-a-tab-as-the-first-character-of-a-definition-term  the pinned build reads the tab after the marker's separator space as a paragraph opener instead of stripping it as ordinary leading whitespace, so no term forms yet; carve#698, drops out once carve-js ships the fix
+223-an-abbreviation-term-is-one-ascii-alphanumeric-word  the pinned build requires an abbreviation term to be all-uppercase, so the lowercase, digit-leading and digit-only terms form no definition and their uses render without <abbr>; fixed by carve-js#720, drops out at the next release

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -80,7 +80,11 @@ function splitTrailingAttrBlock(line) {
 // `"]:", space, inline_content`); a bare `[^label]:` is an ordinary
 // paragraph line (corpus 132).
 const FOOTNOTE_DEF = /^\[\^([^\]]+)\]: [ \t]*(\S.*)$/
-const ABBR_DEF = /^\*\[([^\]]+)\]: \s*(.+)$/
+// `abbreviation_term = (letter | digit)+`, and `letter` is enumerated ASCII.
+// This was `[^\]]+` - anything but a bracket - so the executable spec called
+// `*[e.g.]:` and `*[ß]:` definitions, which made their LINE disappear, while
+// all three engines kept it as paragraph text (carve#791).
+const ABBR_DEF = /^\*\[([A-Za-z0-9]+)\]: \s*(.+)$/
 const CAPTION = /^\^ (.*)$/
 // The run after the marker is SPACES ONLY: `-\titem` is a paragraph in every
 // engine, so a tab here must not open a list (PART 9 SS11). Its width is the
@@ -758,8 +762,10 @@ function parseBlocksImpl(lines, state, top, inItem = false) {
     // rewrites every occurrence of its term with nothing at the use site
     // pointing back, so it may not be written where quoted material lives.
     if (top && (m = ABBR_DEF.exec(line))) {
+      // No empty-term guard: `+` in ABBR_DEF cannot match zero characters, so
+      // one here could never fire. `*[]: x` fails the pattern and is a
+      // paragraph, which is what the production says it is.
       const term = m[1]
-      if (term === '') throw new Refuse('empty abbreviation term')
       // LAST definition wins (PART 9R state), like linkDefs below. This was
       // first-wins here while all three engines were last-wins, and PART 9R's
       // state table said nothing either way for abbrDefs - so the one place

--- a/tests/corpus/223-an-abbreviation-term-is-one-ascii-alphanumeric-word-2.crv
+++ b/tests/corpus/223-an-abbreviation-term-is-one-ascii-alphanumeric-word-2.crv
@@ -1,0 +1,5 @@
+*[ß]: sharp s
+*[e.g.]: for example
+*[HTTP API]: an interface
+
+Text about ss and eg below.

--- a/tests/corpus/223-an-abbreviation-term-is-one-ascii-alphanumeric-word-2.html
+++ b/tests/corpus/223-an-abbreviation-term-is-one-ascii-alphanumeric-word-2.html
@@ -1,0 +1,4 @@
+<p>*[ß]: sharp s
+*[e.g.]: for example
+*[HTTP API]: an interface</p>
+<p>Text about ss and eg below.</p>

--- a/tests/corpus/223-an-abbreviation-term-is-one-ascii-alphanumeric-word.crv
+++ b/tests/corpus/223-an-abbreviation-term-is-one-ascii-alphanumeric-word.crv
@@ -1,0 +1,5 @@
+*[dl]: definition list
+*[3D]: three dimensional
+*[9]: nine
+
+A dl, a 3D one, and 9.

--- a/tests/corpus/223-an-abbreviation-term-is-one-ascii-alphanumeric-word.html
+++ b/tests/corpus/223-an-abbreviation-term-is-one-ascii-alphanumeric-word.html
@@ -1,0 +1,1 @@
+<p>A <abbr title="definition list">dl</abbr>, a <abbr title="three dimensional">3D</abbr> one, and <abbr title="nine">9</abbr>.</p>

--- a/tests/spec/223-an-abbreviation-term-is-one-ascii-alphanumeric-word.test
+++ b/tests/spec/223-an-abbreviation-term-is-one-ascii-alphanumeric-word.test
@@ -1,0 +1,24 @@
+An abbreviation term is one ASCII alphanumeric word
+
+```
+*[dl]: definition list
+*[3D]: three dimensional
+*[9]: nine
+
+A dl, a 3D one, and 9.
+.
+<p>A <abbr title="definition list">dl</abbr>, a <abbr title="three dimensional">3D</abbr> one, and <abbr title="nine">9</abbr>.</p>
+```
+
+```
+*[ß]: sharp s
+*[e.g.]: for example
+*[HTTP API]: an interface
+
+Text about ss and eg below.
+.
+<p>*[ß]: sharp s
+*[e.g.]: for example
+*[HTTP API]: an interface</p>
+<p>Text about ss and eg below.</p>
+```


### PR DESCRIPTION
`abbreviation_term = (letter | digit)+`, and `letter` is enumerated as `a`..`z` plus `A`..`Z`. Four independent readings of that one line shipped:

| reading | held by | `*[dl]:` | `*[9]:` | `*[ß]:` | `*[e.g.]:` |
|---|---|---|---|---|---|
| uppercase-only | carve-js (#720) | paragraph | paragraph | paragraph | paragraph |
| numeric key crash | carve-php (#880) | definition | **`TypeError`** | paragraph | paragraph |
| Unicode alphanumeric | carve-rs (#660) | definition | definition | **definition** | paragraph |
| anything without a bracket | **this repo's oracle** | definition | definition | **definition** | **definition** |
| the production | - | definition | definition | paragraph | paragraph |

The three engines are fixed and merged. This is the oracle and the corpus.

## Why the corpus could not catch any of them

Every abbreviation document in the corpus used an uppercase multi-letter term - `HTML`, `CSS`, `A`. That is the one shape all four readings agree on. The four shapes that separate them - lowercase, mixed case, digit-leading, digit-only, non-ASCII - were unrepresented, so 611 pairs stated the rule and pinned none of it.

Two pairs now cover both directions, appended so nothing renumbers.

The rejecting one asserts the **line survives**:

```carve
*[ß]: sharp s
*[e.g.]: for example
*[HTTP API]: an interface

Text about ss and eg below.
```

```html
<p>*[ß]: sharp s
*[e.g.]: for example
*[HTTP API]: an interface</p>
<p>Text about ss and eg below.</p>
```

An abbreviation has no marker at the use site, so a definition wrongly claimed here does not render *wrong*, it renders *nothing* and takes its line of prose with it. Before this change `scripts/spec/layout.mjs` produced only the second paragraph.

## The guard that could not fire

```js
const term = m[1]
if (term === '') throw new Refuse('empty abbreviation term')
```

`ABBR_DEF` ends in `+`, which cannot match zero characters, so no input could reach that throw. Removed rather than kept as decoration: `*[]: x` fails the pattern and is a paragraph, which is what the production says it is.

## The two siblings, checked

`LINK_DEF` against `reference_label = (character - ']' - '@'), {character - ']'}` and `FOOTNOTE_DEF` against `footnote_label = {character - ']'}+`. Both are exact transcriptions. Abbreviation was the only pattern that had drifted from its production.

## The comparison page

The count gate forced a re-paste, and the fresh run of all three engines at their own `main` no longer shows an all-green board:

| | before | now |
|---|---|---|
| Rust | 611 / 611 | 611 / 613 |
| JS | 611 / 611 | 610 / 613 |
| PHP | 611 / 611 | 610 / 613 |

Three cases are ahead of the engines, which is what a spec-first corpus looks like between a clause landing and three ports catching up - the newest clause (a tab after the definition separator, #794, where carve-rs is the reference and the other two still keep the tab) plus two `carve`-target formatter divergences. None is a disagreement about a rule all three implement, and the two cases added here are not among them: zero diffs across three engines and five targets.

## Still out there

The same production is spelled five more times in the satellite grammars, in both wrong directions - `[A-Z][A-Z0-9]*` in carve-grammars' TextMate and Prism grammars (and the vscode-carve and intellij-carve copies of the first), `[^\]]+` in its highlight.js grammar and in tree-sitter-carve. Being handled separately in those repos.
