### PR TITLE
spec: gate the three-way value comparison against a declared debt

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -1,0 +1,33 @@
+# Fields the three engines publish DIFFERENT VALUES for.
+#
+# `npm run ast:check` compares every corpus document's AST across carve-js,
+# carve-rs and carve-php three ways: the SHAPE (node types and nesting), the
+# schema, and - here - the scalar VALUES. The first two cannot see a field whose
+# value differs while its presence and type do not, which is where every
+# divergence found by hand in August 2026 lived (carve#750, #758, #784, #785,
+# carve-php#877).
+#
+# The comparison reported those and gated nothing, because a gate would have
+# failed on day one for reasons already tracked. So the debt is DECLARED
+# instead, and the declaration is exact in three directions:
+#
+#   - a field diverges and is not listed        -> new divergence, fails
+#   - a listed field no longer diverges         -> fixed, delete the line, fails
+#     until you do
+#   - a listed field's DOCUMENT COUNT moves     -> the divergence spread or
+#     shrank, fails
+#
+# The count is what keeps the second and third honest. A list of document names
+# would churn on every corpus insertion and describe five facts in a hundred
+# lines; a count describes the same fact and still fails when the fact changes.
+#
+# Grouped by `type.field` for the same reason the report is: each of these is
+# one field behaving one way everywhere it appears.
+#
+# Format: <type.field>  <document-count>  <who diverges and where it is tracked>
+
+heading.attrs.id        45  carve-js publishes a GENERATED heading id, carve-rs and carve-php publish none (carve#750)
+table_cell.align         5  carve-php puts the column alignment on BODY cells, the other two on the header row only (carve#784)
+code_block.attrs.order   4  a fence title's synthesized key gets an order entry in carve-rs and carve-php, not in carve-js (carve#785)
+text.escapedLeadingCaret 1  carve-js publishes a flag beside the escaped_text node it duplicates; nothing else has it (carve#793)
+paragraph.attrs.order    1  carve-php lists a repeated attribute key twice where keyValues holds it once (carve-php#878)

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -314,17 +314,23 @@ const engineValues = new Map()
  * divergence look like a majority.
  */
 /**
- * Report where the engines publish DIFFERENT VALUES in the same node.
+ * Where the engines publish DIFFERENT VALUES in the same node.
  *
  * Separate from the shape panel because it answers a separate question, and
  * separate from the schema check because every field involved is optional there
  * - a tree that omits `align` validates exactly as well as one that carries it.
  *
- * REPORTS, does not gate. There are known divergences today (carve#750, #784,
- * #785, carve-php#877), and a gate would fail on day one for reasons already
- * being tracked. Grouped by `type.field` rather than by document because each
- * of those is one field behaving one way everywhere it appears: a per-document
- * list is 107 entries describing five facts.
+ * GATES against resources/ast-value-divergence.txt, which declares the known
+ * ones with a DOCUMENT COUNT each. This used to report and gate nothing, on the
+ * grounds that a gate would fail on day one for reasons already tracked - true,
+ * and the same shape as a check that cannot fail: the numbers moved and nothing
+ * said so. Declaring the debt keeps both halves, and the count makes the
+ * declaration fail in three directions rather than one (carve#786).
+ *
+ * Grouped by `type.field` rather than by document because each of these is one
+ * field behaving one way everywhere it appears: a per-document list is 107
+ * entries describing five facts, and a node path churns on every corpus
+ * insertion.
  */
 function reportValueDisagreements(present) {
   const byKey = new Map()
@@ -358,12 +364,54 @@ function reportValueDisagreements(present) {
   console.log(`THREE-WAY VALUE COMPARISON: ${byKey.size} field(s) disagree, across ${total} document(s)`)
   for (const [key, { engines, docs }] of [...byKey].sort((a, b) => b[1].docs.length - a[1].docs.length)) {
     const who = Object.entries(engines).map(([e, v]) => `${e}=${v}`).join('  ')
-    console.log(`  ${String(docs.length).padStart(4)}x  ${key}`)
+    console.log(`  ${String(new Set(docs).size).padStart(4)} doc(s)  ${key}`)
     console.log(`        ${who}`)
     console.log(`        e.g. ${docs.slice(0, 2).join(', ')}`)
   }
-  console.log('  Reported, not gated: see carve#786 for why, and which of these are already tracked.')
+
+  // The declaration, and the three ways it can be wrong.
+  const declared = new Map()
+  for (const line of readFileSync(VALUE_DIVERGENCE_FILE, 'utf8').split('\n')) {
+    const text = line.trim()
+    if (text === '' || text.startsWith('#')) continue
+    const [key, count] = text.split(/\s+/)
+    declared.set(key, Number(count))
+  }
+
+  const problems = []
+  for (const [key, { docs }] of byKey) {
+    // DOCUMENTS, not occurrences: `heading.attrs.id` diverges 72 times across
+    // 56 documents, and a declaration whose unit disagrees with its own header
+    // is a number nobody can check.
+    const documents = new Set(docs).size
+    if (!declared.has(key)) {
+      problems.push(`NEW        ${key} diverges in ${documents} document(s) and is not declared`)
+    } else if (declared.get(key) !== documents) {
+      problems.push(
+        `COUNT      ${key} declares ${declared.get(key)} document(s), measured ${documents}`,
+      )
+    }
+  }
+  for (const key of declared.keys()) {
+    if (!byKey.has(key)) {
+      problems.push(`FIXED      ${key} no longer diverges - delete its line`)
+    }
+  }
+
+  if (problems.length > 0) {
+    console.error('')
+    console.error('THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:')
+    for (const p of problems) console.error(`  ${p}`)
+    console.error('')
+    console.error('Each line there is a field the engines disagree about, with the number of')
+    console.error('documents it shows up in. Update it in the commit that moves the number.')
+    process.exit(1)
+  }
+
+  console.log('  All declared in resources/ast-value-divergence.txt (carve#786).')
 }
+
+const VALUE_DIVERGENCE_FILE = resolve(here, '..', 'resources', 'ast-value-divergence.txt')
 
 const INDEPENDENT_ENGINES = ['carve-js', 'carve-rs', 'carve-php']
 let panelRan = false


### PR DESCRIPTION
Closes #786.

The three-way value comparison already existed and already reported the five fields the engines publish different **values** for - the ones neither the shape panel nor the schema check can see, because `shapeOf` drops every scalar and every field involved is optional in the schema. What it did not do is fail, deliberately: a gate would have failed on day one for reasons already tracked.

That is the same shape as a check that cannot fail. The numbers moved through August and nothing said so.

## The declaration

`resources/ast-value-divergence.txt`, one line per `type.field` with the number of documents it diverges in:

```
heading.attrs.id        45  carve-js publishes a GENERATED heading id, carve-rs and carve-php publish none (carve#750)
table_cell.align         5  carve-php puts the column alignment on BODY cells, the other two on the header row only (carve#784)
code_block.attrs.order   4  a fence title's synthesized key gets an order entry in carve-rs and carve-php, not in carve-js (carve#785)
text.escapedLeadingCaret 1  carve-js publishes a flag beside the escaped_text node it duplicates; nothing else has it (carve#793)
paragraph.attrs.order    1  carve-php lists a repeated attribute key twice where keyValues holds it once (carve-php#878)
```

## Exact in three directions, each verified by sabotage

| sabotage | reported |
|---|---|
| delete the `table_cell.align` line | `NEW table_cell.align diverges in 5 document(s) and is not declared` |
| change `45` to `44` | `COUNT heading.attrs.id declares 44 document(s), measured 45` |
| add a line for `link.destination` | `FIXED link.destination no longer diverges - delete its line` |

Run before the commit, not asserted after it.

## On the granularity, which was the open question

Per `type.field`, not per `(document, node path, field)`. Each of these is one field behaving one way everywhere it appears, so the per-document form would be 107 entries describing five facts - and a node path is a position in a tree, so any corpus insertion renumbers entries that describe an unchanged divergence. That churn is how a declared debt turns back into noise.

## The count is documents, not occurrences

The first draft declared `56` for `heading.attrs.id`, which is the union across all five fields; the field itself spans **45** documents and diverges 72 times. The gate caught that, which is the argument for having it: the roll-up now prints `45 doc(s)` in the same unit the file declares, so the two cannot drift apart silently.
