### PR TITLE
spec: say why §25's strip class stops at whitespace and the BOM

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -9368,3 +9368,19 @@ The `+` continuation marker replaces the leading pipe, and the row must close wi
 ```
 
 :::
+
+## A format character before a scheme is not stripped, and is inert
+
+§25's scheme probe strips leading controls, every Unicode space and the BOM. It stops there: the WHATWG URL parser strips C0 controls and space and nothing else, so a destination starting with ZERO WIDTH SPACE fails to parse as a URL at all and resolves as a relative path. It stays in the document as the author wrote it.
+
+::: compare
+
+```carve
+[x](​javascript:alert(1))
+```
+
+```html
+<p><a href="​javascript:alert(1)">x</a></p>
+```
+
+:::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,43 +17,39 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>626 / 637</strong>
+    <strong>634 / 638</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>632 / 637</strong>
+    <strong>635 / 638</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>633 / 637</strong>
+    <strong>636 / 638</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>21</strong>
+    <strong>6</strong>
     <span>cross-implementation diffs</span>
   </div>
 </div>
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `8869fb0` | `626 / 637` | `11` | `0` | `2.89` |
-| JS | `774d108` | `632 / 637` | `5` | `0` | `70.32` |
-| PHP | `db024e8` | `633 / 637` | `4` | `0` | `64.65` |
+| Rust | `2f4bb02` | `634 / 638` | `4` | `0` | `2.57` |
+| JS | `a89017d` | `635 / 638` | `3` | `0` | `61.46` |
+| PHP | `f3eec4f` | `636 / 638` | `2` | `0` | `56.84` |
 
 Spec commit: `b539d14`, plus the corpus case this change adds
 
-The engines are behind on three clauses that landed this week, which is what a
-spec-first corpus looks like between a rule and three ports catching up.
+The engines have caught up on the clauses that were ahead of them in the last
+snapshot: the synthesized-backlink cases (carve#799) and the collected-definition
+cases (carve#801) all pass in all three now.
 
-`225-a-footnote-body-s-last-block-...` is the synthesized-backlink clause
-(carve#799): carve-rs has none of it, carve-js has one shape left, carve-php has
-it. `226`/`227`/`228` are the collected-definition clauses (carve#801), where
-carve-rs is behind on three and the other two on one each.
-
-`16-reference-link-4` and
-`195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column`
-diverge on the `carve` target only - the parse agrees in all three and what
-differs is the canonical spelling the formatter writes back (carve#787).
+What is left is the `carve` target: `16-reference-link-4` and
+`195-a-definition-inside-a-container-...` in all three, plus two more in
+carve-rs. The parse agrees everywhere and what differs is the canonical spelling
+the formatter writes back (carve#787).
 
 The counts here are documents, not runs: an engine that misses one case on two
 targets is one document behind, not two.
@@ -391,41 +387,30 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=637 targets=html,markdown,plain,carve,ansi
-rust: pass=638/649 mismatch=11 error=0 skipped=0 runs=3185 avg_ms=2.89
+profile=default/no-opt-in corpus=core corpus_pairs=638 targets=html,markdown,plain,carve,ansi
+rust: pass=646/650 mismatch=4 error=0 skipped=0 runs=3190 avg_ms=2.57
   mismatch: carve 16-reference-link-4
   mismatch: carve 195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column
-  mismatch: html 225-a-footnote-body-s-last-block-when-it-is-not-a-paragraph-gets-a-synthesized-paragraph-for-the-backlink-2
-  mismatch: html 225-a-footnote-body-s-last-block-when-it-is-not-a-paragraph-gets-a-synthesized-paragraph-for-the-backlink-3
-  mismatch: html 225-a-footnote-body-s-last-block-when-it-is-not-a-paragraph-gets-a-synthesized-paragraph-for-the-backlink-4
-  mismatch: html 225-a-footnote-body-s-last-block-when-it-is-not-a-paragraph-gets-a-synthesized-paragraph-for-the-backlink-5
-  mismatch: html 225-a-footnote-body-s-last-block-when-it-is-not-a-paragraph-gets-a-synthesized-paragraph-for-the-backlink
   mismatch: html 226-a-definition-attached-by-a-continuation-marker-is-collected-and-the-item-keeps-no-trace
-  mismatch: html 227-a-definition-inside-a-definition-list-dd-is-collected-and-the-entry-keeps-no-trace-2
-  mismatch: html 227-a-definition-inside-a-definition-list-dd-is-collected-and-the-entry-keeps-no-trace
   mismatch: html 228-a-line-at-a-footnote-definition-s-own-column-followed-by-non-blank-text-forms-its-own-tight-block
-  mismatching documents: 11
-js: pass=644/649 mismatch=5 error=0 skipped=0 runs=3185 avg_ms=70.32
-  mismatch: carve 16-reference-link-4
-  mismatch: carve 195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column
-  mismatch: html 225-a-footnote-body-s-last-block-when-it-is-not-a-paragraph-gets-a-synthesized-paragraph-for-the-backlink-5
-  mismatch: html 227-a-definition-inside-a-definition-list-dd-is-collected-and-the-entry-keeps-no-trace
-  mismatch: html 228-a-line-at-a-footnote-definition-s-own-column-followed-by-non-blank-text-forms-its-own-tight-block
-  mismatching documents: 5
-php: pass=645/649 mismatch=4 error=0 skipped=0 runs=3185 avg_ms=64.65
-  mismatch: carve 16-reference-link-4
-  mismatch: carve 195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column
-  mismatch: html 227-a-definition-inside-a-definition-list-dd-is-collected-and-the-entry-keeps-no-trace-2
-  mismatch: html 227-a-definition-inside-a-definition-list-dd-is-collected-and-the-entry-keeps-no-trace
   mismatching documents: 4
-cross_impl_diffs=21
+js: pass=647/650 mismatch=3 error=0 skipped=0 runs=3190 avg_ms=61.46
+  mismatch: carve 16-reference-link-4
+  mismatch: carve 195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column
+  mismatch: html 228-a-line-at-a-footnote-definition-s-own-column-followed-by-non-blank-text-forms-its-own-tight-block
+  mismatching documents: 3
+php: pass=648/650 mismatch=2 error=0 skipped=0 runs=3190 avg_ms=56.84
+  mismatch: carve 16-reference-link-4
+  mismatch: carve 195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column
+  mismatching documents: 2
+cross_impl_diffs=6
 
 Target agreement (implementations compared against each other)
-html: compared=637 diffs=9 errors=0 fixtures=yes
-markdown: compared=637 diffs=2 errors=0 fixtures=1
-plain: compared=637 diffs=2 errors=0 fixtures=1
-carve: compared=637 diffs=6 errors=0 fixtures=10
-ansi: compared=637 diffs=2 errors=0 fixtures=none
+html: compared=638 diffs=2 errors=0 fixtures=yes
+markdown: compared=638 diffs=0 errors=0 fixtures=1
+plain: compared=638 diffs=0 errors=0 fixtures=1
+carve: compared=638 diffs=4 errors=0 fixtures=10
+ansi: compared=638 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 637 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 638 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus with no HTML divergences.
 Pre-1.0, a minor release may still change the grammar.

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3461,7 +3461,27 @@ EOF = (* end of file *) ;
         before matching the scheme, so an obfuscated `<U+202F>javascript:`
         destination cannot slip past the denylist. The corpus pins the
         U+202F case (docs/examples.md "Scheme probe strips Unicode
-        whitespace"). A `data:` exception for images, if offered, MUST be
+        whitespace").
+
+        THE CLASS STOPS THERE ON PURPOSE, and the reason is a property of URL
+        parsing rather than a judgement about which characters look
+        suspicious. The WHATWG URL parser strips leading C0 controls and
+        SPACE before reading a scheme, and nothing else. A destination
+        beginning with any other format character -- ZERO WIDTH SPACE
+        (U+200B), LEFT-TO-RIGHT MARK (U+200E), WORD JOINER (U+2060), SOFT
+        HYPHEN (U+00AD) -- therefore FAILS to parse as a URL at all, and a
+        consumer resolving it against a base gets a relative path, never a
+        `javascript:` navigation. Measured against the WHATWG parser: each of
+        those prefixes yields a parse failure, while a TAB or SPACE prefix
+        yields `javascript:` -- which is exactly the set already stripped.
+
+        So the probe strips what an eventual URL parser would strip (plus the
+        Unicode spaces and the BOM, which some parsers historically tolerated),
+        and it deliberately does NOT strip the wider `Cf` category: a
+        `<U+200B>javascript:` destination stays in the document as written and
+        is inert where it lands. Widening the class to all of `Cf` would blank
+        destinations that were never dangerous, and would make the rendered
+        `href` differ from the author's bytes for no gain (carve#782). A `data:` exception for images, if offered, MUST be
         opt-in. An attribute-block `href`/`src` override (PART 4) MUST NOT
         reintroduce a rejected scheme.
 

--- a/tests/corpus/238-a-format-character-before-a-scheme-is-not-stripped-and-is-inert.crv
+++ b/tests/corpus/238-a-format-character-before-a-scheme-is-not-stripped-and-is-inert.crv
@@ -1,0 +1,1 @@
+[x](​javascript:alert(1))

--- a/tests/corpus/238-a-format-character-before-a-scheme-is-not-stripped-and-is-inert.html
+++ b/tests/corpus/238-a-format-character-before-a-scheme-is-not-stripped-and-is-inert.html
@@ -1,0 +1,1 @@
+<p><a href="​javascript:alert(1)">x</a></p>

--- a/tests/fixture-bytes.test.mjs
+++ b/tests/fixture-bytes.test.mjs
@@ -57,6 +57,15 @@ const INVENTORY = [
   // heading id unchanged instead of being slugged to a separator, and the
   // id carries the character rather than an entity.
   { base: '217-a-heading-id-keeps-a-non-ascii-space', crv: ['NBSP'], html: ['NBSP'] },
+  // The ZERO WIDTH SPACE is the case, on BOTH sides: §25's scheme probe stops
+  // at whitespace-plus-BOM, so this destination keeps the character the author
+  // wrote and renders it into the href. Strip it and the fixture asserts
+  // nothing - it becomes an ordinary denied-scheme case (carve#782).
+  {
+    base: '238-a-format-character-before-a-scheme-is-not-stripped-and-is-inert',
+    crv: ['ZWSP'],
+    html: ['ZWSP'],
+  },
 ]
 
 function scan(text) {

--- a/tests/spec/238-a-format-character-before-a-scheme-is-not-stripped-and-is-inert.test
+++ b/tests/spec/238-a-format-character-before-a-scheme-is-not-stripped-and-is-inert.test
@@ -1,0 +1,7 @@
+A format character before a scheme is not stripped, and is inert
+
+```
+[x](​javascript:alert(1))
+.
+<p><a href="​javascript:alert(1)">x</a></p>
+```


### PR DESCRIPTION
Closes #782.

The open half was whether a browser resolves an obfuscated `<U+200B>javascript:` as a live URL. It does not, and the boundary follows from URL parsing rather than from a judgement about which characters look suspicious.

Measured against the WHATWG parser (Node 22, `new URL(dest, "https://e.com/")`):

| destination prefix | parses as |
|---|---|
| TAB (C0) | `javascript:` |
| SPACE | `javascript:` |
| BOM U+FEFF | throws - not a URL |
| ZWSP U+200B | throws - not a URL |
| LRM U+200E | throws - not a URL |
| WJ U+2060 | throws - not a URL |
| SHY U+00AD | throws - not a URL |

The parser strips leading C0 controls and space before reading a scheme, and nothing else. Confirmed end to end: all three engines render `href="<U+200B>javascript:alert(1)"` for that input, and resolving that href against a base gives `https:` - a relative path - not `javascript:`.

So the class strips exactly what an eventual URL parser strips, plus the Unicode spaces and the BOM that some parsers historically tolerated. Widening it to all of `Cf` would blank destinations that were never dangerous and make the rendered `href` differ from the author's bytes for no gain.

## The corpus pair, and why it needed a second edit

The new fixture's whole assertion is an invisible character, so `tests/fixture-bytes.test.mjs` rejected it until it was registered in that file's inventory - which is the check working: an editor or formatter that stripped the ZWSP would leave a fixture that still passes while asserting nothing.

## Comparison page

Re-pasted from a fresh run. The engines have caught up on #799 and #801, so the remaining mismatches are the `carve`-target formatter divergences from #787.

One thing the probe turned up that is **not** in scope here: `[x](<U+FEFF>https://e.com/)` parses as a link in carve-rs and carve-php and stays literal text in carve-js. That is a parse-stage question about `link_destination`, filed as #806.
