### PR TITLE
spec: the value declaration moves in both directions, as designed

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -29,5 +29,5 @@
 heading.attrs.id        45  carve-js publishes a GENERATED heading id, carve-rs and carve-php publish none (carve#750)
 table_cell.align         5  carve-php puts the column alignment on BODY cells, the other two on the header row only (carve#784)
 code_block.attrs.order   4  a fence title's synthesized key gets an order entry in carve-rs and carve-php, not in carve-js (carve#785)
-text.escapedLeadingCaret 1  carve-js publishes a flag beside the escaped_text node it duplicates; nothing else has it (carve#793)
 paragraph.attrs.order    1  carve-php lists a repeated attribute key twice where keyValues holds it once (carve-php#878)
+list.tight                1  carve-rs has not implemented the clause behind corpus 228 yet, so it builds a loose list where the other two build a tight one - the HTML comparison reports the same document (carve#801)


### PR DESCRIPTION
The gate added in #803 moved in both directions within hours of existing.

**FIXED** - markup-carve/carve-js#735 dropped `escapedLeadingCaret` from the wire, so the field no longer diverges and its line has to go. The run named it:

```
FIXED      text.escapedLeadingCaret no longer diverges - delete its line
```

**NEW** - the same run reported one the declaration did not cover:

```
NEW        list.tight diverges in 1 document(s) and is not declared
```

`list.tight` is `true` in carve-js and carve-php and `false` in carve-rs on corpus `228-a-line-at-a-footnote-definition-s-own-column-...`.

## The new one is not an independent bug

carve-rs has not implemented the clause behind that document yet, and the HTML comparison already reports the same file:

```
rust: mismatch: html 228-a-line-at-a-footnote-definition-s-own-column-followed-by-non-blank-text-forms-its-own-tight-block
```

Its tree says `tight: false` and it renders `<li><p>a</p><p>more</p></li>` where the corpus expects a tight item - so the tree and the output agree with each other and both lag the clause. Declared as engine lag; it drops out when carve-rs catches up.

## Why this is worth a PR of its own

Before #803 this was a report. It would have printed both lines - a fixed divergence still listed, and a new one nobody declared - and required nobody to act on either. That is the state the gate exists to end, and this is the first time it has been exercised.

`ast:check` is green again with all three engines built from their current mains.
