### PR TITLE
spec: four features the optional corpus already pins are Tier-2

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -44,9 +44,10 @@ Tier-2 / Tier-3 seam):
   byte-parity across all three engines. Changes require a coordinated minor.
 - **Tier-2 standard extensions** (citations incl. typed-locator + integral
   enrichment, bibliography, code callouts, glossary, index, heading numbers,
-  mentions/tags) are **stable and corpus-pinned** in 0.1. Their syntax and HTML
-  contract will not change without a minor bump.
-- **Tier-3 app-level extensions** (Mermaid, Tabs, table-of-contents, heading
+  mentions/tags, and the four block features pinned in `tests/corpus-optional` -
+  list tables, details, spoilers, tabs) are **stable and corpus-pinned** in 0.1.
+  Their syntax and HTML contract will not change without a minor bump.
+- **Tier-3 app-level extensions** (Mermaid, table-of-contents, heading
   permalinks, ColorSwatch, QR, static maps, and other host-dependent showcases)
   ship and are documented, but are **not covered by the 0.1 stability
   guarantee** - they may evolve in any release. Several depend on a host library

--- a/docs/.vitepress/examples/demo.crv
+++ b/docs/.vitepress/examples/demo.crv
@@ -195,7 +195,7 @@ Arrows and comparisons: -> <- <-> => , != <= >= , (c) (r) (tm).
 
 ---
 
-## List tables (Tier-3 extension)
+## List tables (Tier-2 extension)
 
 %% A `::: list-table` block authors a table as a nested list, so cells can hold
 %% full block content a native pipe table cannot. It only renders as a real
@@ -274,7 +274,7 @@ sequenceDiagram
 {"type":"bar","data":{"labels":["Q1","Q2","Q3","Q4"],"datasets":[{"label":"Revenue","data":[12,19,14,23]}]}}
 ```
 
-## Spoilers (Tier-3 extension)
+## Spoilers (Tier-2 extension)
 
 %% Inline :spoiler[…] blurs until you click it; a ::: spoiler block collapses to
 %% just its summary and expands on click. Without the extension they degrade to a

--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -314,7 +314,7 @@ async function renderCharts(): Promise<void> {
   }
 }
 
-// --- Spoiler (Tier-3): inline `:spoiler[…]` blurs, reveals on click/keyboard.
+// --- Spoiler (Tier-2): inline `:spoiler[…]` blurs, reveals on click/keyboard.
 // Block `::: spoiler` is a native <details>, so it needs no JS. ---
 function wireSpoilers(): void {
   const root = outputEl.value

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -570,7 +570,7 @@
   padding-bottom: 2px;
 }
 
-/* ---- Spoiler extension (Tier-3) ----
+/* ---- Spoiler extension (Tier-2) ----
    Inline `:spoiler[…]` blurs until clicked; block `::: spoiler` is a native
    <details> collapse. Reveal JS lives in Playground.vue (inline only). */
 .carve-render span.spoiler,

--- a/docs/examples/extensions.md
+++ b/docs/examples/extensions.md
@@ -35,7 +35,7 @@ A `::: name` opener's behavior keys off the **type word** (not a class). Only th
 |-----------|-----------|------------------|
 | `note` `tip` `warning` `danger` `info` `success` `example` `quote` | `<aside class="admonition {type}">` | Admonition (PART 9 §12); optional quoted title → `<p class="admonition-title">` |
 | `\|` (pipe) | `<div class="line-block">` | Line block - preserves the author's per-line layout / soft breaks (PART 9 §23). The token is the pipe, not a word; an inline `::: {.line-block}` is not a fence at all (strict djot) but an ordinary paragraph. |
-| *(any other word)* | `<div class="{word}">` | None in core, a generic fenced div; meaning supplied by a Tier-3 extension (e.g. `tabs`, `code-group`, `mermaid`). |
+| *(any other word)* | `<div class="{word}">` | None in core, a generic fenced div; meaning supplied by a Tier-2 or Tier-3 extension (e.g. `tabs`, `code-group`, `mermaid`). |
 
 Because the behavior keys to the bare type word, give a purely presentational container a class on an **attribute line before the opener** (`{.mybox}` then `:::`) so you never collide with a recognized type word. The `:::` fence takes no inline attributes (strict djot), so an inline `::: {.mybox}` is a paragraph, not a div.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -49,7 +49,8 @@ PART 9 §19); Tier-2 / Tier-3 are off until enabled.
 | Smart typography, `@mention`, `#tag`, `:symbol:` parsing | <Badge type="tip" text="core" /> | on | **yes** (§19) |
 | Citations `[@key]`, bare-URL autolinking, code callouts `<n>` | <Badge type="info" text="standard" /> | off | — |
 | Mention/tag → URL templates, symbol map (e.g. emoji glyphs), locale smart-quote sets | <Badge type="info" text="standard" /> | off | — |
-| Mermaid / FencedRender, MathBlock, ListTable, Glossary, Index, HeadingNumbers, Details, Spoiler, Tabs, CodeGroup | <Badge type="warning" text="extension" /> | off | — |
+| ListTable (§5), Details, Spoiler, Tabs — shipped in all three engines and pinned in `tests/corpus-optional` | <Badge type="info" text="standard" /> | off | — |
+| Mermaid / FencedRender, MathBlock, Glossary, Index, HeadingNumbers, CodeGroup | <Badge type="warning" text="extension" /> | off | — |
 | Bibliography (§6) — an **option on Citations**, not a separate registration: the host passes a CSL-JSON pool to the Citations extension | <Badge type="warning" text="extension" /> | off | — |
 | TableOfContents, HeadingPermalinks / LevelShift, ExternalLinks, Wikilinks, ColorSwatch, Lowercase/AsciiHeadingIds | <Badge type="warning" text="extension" /> | off | — |
 | SemanticSpan — **carve-php only** today; carve-js and carve-rs ship no such extension | <Badge type="warning" text="extension" /> | off | — |
@@ -68,34 +69,15 @@ differs by processor. The narrative below details each tier.
   corpus-pinned, but per grammar PART 9 §19 a processor MAY disable them.
 - Tier 2: configuration over Tier-1 syntax — mention/tag→URL, symbol map (e.g. emoji glyphs),
   locale smart-quote sets, bare-URL autolinking, citations (§4), and code
-  callouts (`<n>` markers inside fenced code + a bound explanation list; §10).
-- Tier 3 (non-exhaustive): FencedRender (a generic fenced-code-block factory
-  with Mermaid, D2, Graphviz, WaveDrom, ABC, PlantUML, Vega-Lite and Chart.js presets),
-  MathBlock (a ` ```math ` fenced block →
-  `<div class="math display">`, the GFM-style block form of Carve's `$…$`
-  math), ListTable (a `::: list-table` div whose nested list renders as a real
-  HTML `<table>`, so cells can hold block content the pipe-table syntax cannot;
-  `{header-rows}` / `{header-cols}` take a count or the boolean first-row/column
-  form, and `^` / `<` give pipe-table-parity rowspan / colspan; in carve-php,
-  carve-js and carve-rs), Bibliography (a reference list rendered from citation
-  keys (§4) resolved against an external CSL-JSON source named in front-matter,
-  reusing the `::: references` placeholder with mandated numeric output and
-  back-links; §6), Glossary (a `::: glossary` definition list whose terms become
-  `<dt id="gloss-{slug}">` entries that `:term[word]` links to; §7), Index
-  (invisible `:index[term]` markers collected into a sorted `::: index` list
-  with back-links to every occurrence; §8), Spoiler (the standard hidden-content role - inline
-  `:spoiler[text]` → `<span class="spoiler">` and block `::: spoiler` →
-  `<details class="spoiler">` disclosure; in carve-php, carve-js and carve-rs),
-  Tabs, CodeGroup, Details, TableOfContents,
-  HeadingPermalinks,
-  HeadingNumbers (auto-number sections - `<span class="section-number">1.2</span>`
-  on each heading - and rewrite auto-filled `</#id>` cross-references to
-  "Section 1.2 - Title"; opt-in, no new syntax; §9),
-  HeadingLevelShift, ExternalLinks, DefaultAttributes, Wikilinks,
-  SemanticSpan (carve-php only),
-  ColorSwatch (inline `:color[value]` -> a validated color chip; carve-php,
-  carve-js and carve-rs — see the [extension tutorial](./extension-tutorial)),
-  and the opt-in heading-id transforms (LowercaseHeadingIds, AsciiHeadingIds).
+  callouts (`<n>` markers inside fenced code + a bound explanation list; §10) —
+  plus four block features that ship in carve-js, carve-php and carve-rs and
+  carry pinned cases in `tests/corpus-optional`: ListTable (a `::: list-table`
+  div whose nested list renders as a real HTML `<table>`, so cells can hold
+  block content the pipe-table syntax cannot; `{header-rows}` /
+  `{header-cols}` take a count or the boolean first-row/column form, and `^` /
+  `<` give pipe-table-parity rowspan / colspan; §5), Details, Spoiler and Tabs.
+  Being off by default is what Tier-2 means; it is the cross-engine pin that
+  separates them from Tier 3.
 
   `Details` is a pure renderer extension over the existing `:::details`
   admonition (no new syntax): it emits the HTML5 `<details>/<summary>`
@@ -106,6 +88,39 @@ differs by processor. The narrative below details each tier.
   Disabled, the block renders as the ordinary admonition
   div, so documents stay readable. See the per-impl `docs/extensions.md` in
   carve-js / carve-php / carve-rs.
+
+  `Spoiler` is the standard hidden-content role from the Extension Registry, with
+  no new syntax. Inline `:spoiler[text]` → `<span class="spoiler">text</span>`;
+  block `::: spoiler "Title"` → an HTML5 `<details class="spoiler">` disclosure
+  (native, keyboard- and screen-reader-accessible), defaulting to
+  `<summary>Spoiler</summary>` when title-less. Without the extension the inline
+  form stays the generic `<span class="ext-spoiler">` and the block stays a
+  plain `<div class="spoiler">`, so documents remain readable. Carve emits only
+  the marker; the blur + reveal is the host's CSS. Author attributes merge onto
+  the output element (the `spoiler` base class ahead of author classes) with the
+  always-on attribute hardening. In carve-php / carve-js / carve-rs.
+
+- Tier 3 (non-exhaustive): FencedRender (a generic fenced-code-block factory
+  with Mermaid, D2, Graphviz, WaveDrom, ABC, PlantUML, Vega-Lite and Chart.js presets),
+  MathBlock (a ` ```math ` fenced block →
+  `<div class="math display">`, the GFM-style block form of Carve's `$…$`
+  math), Bibliography (a reference list rendered from citation
+  keys (§4) resolved against an external CSL-JSON source named in front-matter,
+  reusing the `::: references` placeholder with mandated numeric output and
+  back-links; §6), Glossary (a `::: glossary` definition list whose terms become
+  `<dt id="gloss-{slug}">` entries that `:term[word]` links to; §7), Index
+  (invisible `:index[term]` markers collected into a sorted `::: index` list
+  with back-links to every occurrence; §8),
+  CodeGroup, TableOfContents,
+  HeadingPermalinks,
+  HeadingNumbers (auto-number sections - `<span class="section-number">1.2</span>`
+  on each heading - and rewrite auto-filled `</#id>` cross-references to
+  "Section 1.2 - Title"; opt-in, no new syntax; §9),
+  HeadingLevelShift, ExternalLinks, DefaultAttributes, Wikilinks,
+  SemanticSpan (carve-php only),
+  ColorSwatch (inline `:color[value]` -> a validated color chip; carve-php,
+  carve-js and carve-rs — see the [extension tutorial](./extension-tutorial)),
+  and the opt-in heading-id transforms (LowercaseHeadingIds, AsciiHeadingIds).
 
   `FencedRender` is the generic form of the Mermaid pattern: one configurable
   renderer claims fenced code blocks by language word and emits a single
@@ -147,17 +162,6 @@ differs by processor. The narrative below details each tier.
   the class first, carve-js emits attributes in author source order. (This is a
   pre-existing core-math divergence, not specific to MathBlock; the no-attribute
   output is identical everywhere.)
-
-  `Spoiler` is the standard hidden-content role from the Extension Registry, with
-  no new syntax. Inline `:spoiler[text]` → `<span class="spoiler">text</span>`;
-  block `::: spoiler "Title"` → an HTML5 `<details class="spoiler">` disclosure
-  (native, keyboard- and screen-reader-accessible), defaulting to
-  `<summary>Spoiler</summary>` when title-less. Without the extension the inline
-  form stays the generic `<span class="ext-spoiler">` and the block stays a
-  plain `<div class="spoiler">`, so documents remain readable. Carve emits only
-  the marker; the blur + reveal is the host's CSS. Author attributes merge onto
-  the output element (the `spoiler` base class ahead of author classes) with the
-  always-on attribute hardening. In carve-php / carve-js / carve-rs.
 
 Footnotes are **not** Tier 3. Reference footnotes `[^id]` and inline footnotes
 `^[content]` are both implemented Tier-1 core (`resources/grammar.ebnf` PART 9
@@ -454,7 +458,7 @@ An integral cluster wraps all its items in:
 - External bibliographies are handled by the Bibliography extension (§6, CSL-JSON
   via front-matter); `.bib` ingestion and narrative form remain out of scope.
 
-## 5. ListTable (Tier-3)
+## 5. ListTable (Tier-2)
 
 Tables whose cells hold block content (multiple paragraphs, lists, code), which
 pipe tables cannot express (issue #162). A `::: list-table` div whose body is a
@@ -496,11 +500,13 @@ cells), it renders as its ordinary `<div class="list-table">` containing the
 literal nested list - no content is ever dropped, and the deferred output is
 byte-identical to the plain div.
 
-### 5.4 Conformance (NOT corpus-pinned)
+### 5.4 Conformance (`tests/corpus-optional`)
 
-Tier-3, so not in the mandatory corpus. The contract is cross-impl parity: for a
+Tier-2, so not in the mandatory corpus: case `26-list-table-caption-inline` pins
+the caption's inline markup in `tests/corpus-optional`, run per §3 whenever the
+feature is enabled. The rest of the contract is cross-impl parity: for a
 given input the three implementations produce the same `<table>`, and spans match
-the equivalent pipe table. Each implementation pins this in its own test suite
+the equivalent pipe table. Each implementation pins that in its own test suite
 (block cells, caption, header rows/cols, spans, escape, ragged padding, the
 no-cell-row defer, and the thead/tbody rowspan clamp).
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -99,10 +99,10 @@ implementation — no configuration, no plugins.
 A few things are **opt-in**:
 
 - **Tier-2** — spec-defined but off by default, e.g. citations `[@key]`,
-  bare-URL autolinking, mention/tag → URL templates. Enable them in your
-  processor.
+  bare-URL autolinking, mention/tag → URL templates, a collapsible `details`
+  widget, `list-table`. Enable them in your processor.
 - **Tier-3** — per-implementation extensions, e.g. Mermaid diagrams, a
-  collapsible `details` widget, `list-table`. Register the ones you want.
+  table of contents, heading permalinks. Register the ones you want.
 
 The `:name[…]` (inline) and `::: name` (block) **syntax** is core, but whether a
 given `name` does something special depends on whether a handler is registered;

--- a/tests/examples/demo.html
+++ b/tests/examples/demo.html
@@ -173,8 +173,8 @@ An inline extension names a role: press <kbd>Ctrl+C</kbd> to copy.</p>
 Arrows and comparisons: → ← ↔ ⇒ , ≠ ≤ ≥ , © ® ™.</p>
     <hr>
   </section>
-  <section id="List-tables-Tier-3-extension">
-    <h2>List tables (Tier-3 extension)</h2>
+  <section id="List-tables-Tier-2-extension">
+    <h2>List tables (Tier-2 extension)</h2>
     <div class="list-table" header-rows="1">
       <p class="admonition-title">Quarterly results</p>
       <ul>
@@ -237,8 +237,8 @@ Arrows and comparisons: → ← ↔ ⇒ , ≠ ≤ ≥ , © ® ™.</p>
     <pre><code class="language-chart">{"type":"bar","data":{"labels":["Q1","Q2","Q3","Q4"],"datasets":[{"label":"Revenue","data":[12,19,14,23]}]}}
 </code></pre>
   </section>
-  <section id="Spoilers-Tier-3-extension">
-    <h2>Spoilers (Tier-3 extension)</h2>
+  <section id="Spoilers-Tier-2-extension">
+    <h2>Spoilers (Tier-2 extension)</h2>
     <p>The killer is <span class="ext-spoiler">the lighthouse keeper</span> - click the blur to reveal.</p>
     <div class="spoiler">
       <p class="admonition-title">Plot ending</p>

--- a/tests/extension-catalog-claims.test.mjs
+++ b/tests/extension-catalog-claims.test.mjs
@@ -47,9 +47,16 @@ const NOT_A_NAME = new Set([
   'Lowercase', 'AsciiHeadingIds', 'ImgFence',
 ])
 
-/** Extension names as the tier rows present them. */
+/**
+ * Extension names as the tier rows present them.
+ *
+ * BOTH opt-in tiers, not the extension row alone. ListTable, Details, Spoiler
+ * and Tabs moved to the standard row when they were relabeled Tier-2
+ * (carve#689), and a check that only reads the extension row would have let
+ * four names it used to cover leave measurement without saying so.
+ */
 function namedExtensions() {
-  const rows = page.split('\n').filter((line) => /Badge type="warning"/.test(line))
+  const rows = page.split('\n').filter((line) => /Badge type="(warning|info)"/.test(line))
   const names = new Set()
   for (const row of rows) {
     for (const match of row.matchAll(/\b([A-Z][A-Za-z]{3,})\b/g)) {


### PR DESCRIPTION
Closes #689

`docs/extensions.md` §3 says Tier-3 features are never in any corpus; §5 was titled
"ListTable (Tier-3)"; `tests/corpus-optional/manifest.json` carries cases 25-28 for
`details`, `list-table`, `spoiler` and `tabs`. The rule stays absolute and the four labels
change: shipped in all three engines, off by default, pinned cross-engine is the Tier-2
description on the same page.

## What changed

- `docs/extensions.md`: the four move from the extension row to a standard row and from the
  Tier-3 narrative to the Tier-2 one, carrying their `Details` and `Spoiler` descriptions
  with them. §5 becomes `ListTable (Tier-2)` and §5.4 names the case that pins it
  (`26-list-table-caption-inline`) instead of saying the feature is not corpus-pinned.
- §3's conformance sentence is **unchanged**, and so are `tests/corpus-optional/**`, the
  manifest and cases 25-28. `git diff` touches no file under `tests/corpus*`.
- `VERSIONING.md`, `docs/get-started.md`, `docs/examples/extensions.md` and the playground
  demo (`docs/.vitepress/examples/demo.crv`, its CSS and Playground comment) named one of
  the four with a tier and now agree. The demo snapshot `tests/examples/demo.html` is
  regenerated by `npm run examples:snapshot`.
- `tests/extension-catalog-claims.test.mjs` read only the `Badge type="warning"` rows, so
  moving four names to the standard row would have quietly dropped them from measurement.
  It now reads both opt-in rows.

## Consequences worth a reviewer's eye

`VERSIONING.md` draws the 0.1 stability line at the Tier-2 / Tier-3 seam, so relabeling
moves these four inside the "stable and corpus-pinned in 0.1" guarantee. That follows from
the label rather than being a separate decision, but it is the one place where this change
promises something new.

Separately, `VERSIONING.md` already listed bibliography, glossary, index and heading
numbers as Tier-2 while `docs/extensions.md` titles all four Tier-3. That is the same class
of contradiction as this ticket, for four features this ruling did not name, so it is left
alone here and filed as a follow-up.

## Verification

- `gate-run`: `partial`. Green: `npm test`, `npm run combinatorial:check`,
  `npm run core:check`, `npm run property:check`, `npm run test:conformance`. Not runnable
  on this host, and not part of this repo's per-PR CI: `npm run ast:check`
  ("a dependency outside the repository is missing: /tmp/carve-js/dist") and
  `npm run claims:check` ("engine-claims: need all three engines, found 0 (none)").
- The widened catalog check was proved load-bearing: renaming the standard row's
  `ListTable` to `ListTabler` fails it ("the page names extension(s) the reference engine
  does not export: ListTabler") and passes under the old warning-only regex.

Draft PR #444 (docs migration prep) also edits `docs/extensions.md` and
`docs/get-started.md` on unrelated prose; expect a rebase there once it lands.
