### PR TITLE
spec: table_cell.align no longer diverges

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -27,7 +27,6 @@
 # Format: <type.field>  <document-count>  <who diverges and where it is tracked>
 
 heading.attrs.id        45  carve-js publishes a GENERATED heading id, carve-rs and carve-php publish none (carve#750)
-table_cell.align         5  carve-php puts the column alignment on BODY cells, the other two on the header row only (carve#784)
 code_block.attrs.order   4  a fence title's synthesized key gets an order entry in carve-rs and carve-php, not in carve-js (carve#785)
 paragraph.attrs.order    1  carve-php lists a repeated attribute key twice where keyValues holds it once (carve-php#878)
 list.tight                1  carve-rs has not implemented the clause behind corpus 228 yet, so it builds a loose list where the other two build a tight one - the HTML comparison reports the same document (carve#801)


### PR DESCRIPTION
markup-carve/carve-php#895 landed the authored-versus-inherited rule for cell alignment, so the field agrees across all three engines and its declaration line goes. The gate named it:

```
FIXED      table_cell.align no longer diverges - delete its line
```

Second entry retired since the gate landed this morning, after `text.escapedLeadingCaret`. Four remain: the generated heading id (#750), a fence title's order key (#785), a repeated attribute key (markup-carve/carve-php#878), and carve-rs's lag on corpus 228 (#801).

`ast:check` is green with all three engines built from their current mains.