### PR TITLE
spec: code_block.attrs.order no longer diverges

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -27,6 +27,5 @@
 # Format: <type.field>  <document-count>  <who diverges and where it is tracked>
 
 heading.attrs.id        45  carve-js publishes a GENERATED heading id, carve-rs and carve-php publish none (carve#750)
-code_block.attrs.order   4  a fence title's synthesized key gets an order entry in carve-rs and carve-php, not in carve-js (carve#785)
 paragraph.attrs.order    1  carve-php lists a repeated attribute key twice where keyValues holds it once (carve-php#878)
 list.tight                1  carve-rs has not implemented the clause behind corpus 228 yet, so it builds a loose list where the other two build a tight one - the HTML comparison reports the same document (carve#801)


### PR DESCRIPTION
markup-carve/carve-php#898 and markup-carve/carve-rs#676 stopped recording an `order` slot for a code fence's title. The schema calls `order` the "Source-appearance order of the slots" in a `{#id .class key=value}` block, and a fence title is written as fence metadata - so it had no slot to record.

```
FIXED      code_block.attrs.order no longer diverges - delete its line
```

Third entry retired since the gate landed this morning, after `text.escapedLeadingCaret` and `table_cell.align`. Three remain: the generated heading id (#750), a repeated attribute key (markup-carve/carve-php#878), and carve-rs's lag on corpus 228 (#801).

carve-php needed a second fix along the way: with no `order` on the wire its decoder **invented** one from the attribute map's iteration order, so `encode → decode → encode` produced a different tree than `encode` alone.

`ast:check` is green with all three engines built from their current mains.