### PR TITLE
docs: the fence-title order entry no longer diverges - delete its line

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -27,6 +27,5 @@
 # Format: <type.field>  <document-count>  <who diverges and where it is tracked>
 
 heading.attrs.id        45  carve-js publishes a GENERATED heading id, carve-rs and carve-php publish none (carve#750)
-code_block.attrs.order   4  a fence title's synthesized key gets an order entry in carve-rs and carve-php, not in carve-js (carve#785)
 paragraph.attrs.order    1  carve-php lists a repeated attribute key twice where keyValues holds it once (carve-php#878)
 list.tight                1  carve-rs has not implemented the clause behind corpus 228 yet, so it builds a loose list where the other two build a tight one - the HTML comparison reports the same document (carve#801)


### PR DESCRIPTION
carve-php#898 and carve-rs#676 both landed the rule carve#785 settled from
the schema: `attrs` is "the `{#id .class key=value}` block attached to the
node" and `order` is the "Source-appearance order of the slots", so a fence
title - written as fence metadata rather than a slot - has no source
appearance to record.

Measured with all three engines at main, the field agrees everywhere and
the gate says so itself:

    FIXED      code_block.attrs.order no longer diverges - delete its line

Three fields remain: the generated heading id (45 documents, carve#750),
carve-rs's lag on corpus 228 (`list.tight`, carve#801), and a repeated
attribute key (`paragraph.attrs.order`, carve-php#878).