### PR TITLE
spec: paragraph.attrs.order no longer diverges

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -27,5 +27,4 @@
 # Format: <type.field>  <document-count>  <who diverges and where it is tracked>
 
 heading.attrs.id        45  carve-js publishes a GENERATED heading id, carve-rs and carve-php publish none (carve#750)
-paragraph.attrs.order    1  carve-php lists a repeated attribute key twice where keyValues holds it once (carve-php#878)
 list.tight                1  carve-rs has not implemented the clause behind corpus 228 yet, so it builds a loose list where the other two build a tight one - the HTML comparison reports the same document (carve#801)


### PR DESCRIPTION
markup-carve/carve-php#900 widened the slot dedup to cover every slot, not just `#id` and `.class`, so a repeated key takes one entry as it does in the other two engines.

```
FIXED      paragraph.attrs.order no longer diverges - delete its line
```

Fourth entry retired since the gate landed this morning, after `text.escapedLeadingCaret`, `table_cell.align` and `code_block.attrs.order`.

Two remain, and neither is a plain engine defect:

- `heading.attrs.id` needs the §5 clause decided first (#750)
- `list.tight` is carve-rs lag on a clause it has not implemented (#801), which the HTML comparison reports for the same document

`ast:check` is green with all three engines built from their current mains.