### PR TITLE
spec: code_block.attrs.order no longer diverges

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -27,6 +27,5 @@
 # Format: <type.field>  <document-count>  <who diverges and where it is tracked>
 
 heading.attrs.id        45  carve-js publishes a GENERATED heading id, carve-rs and carve-php publish none (carve#750)
-code_block.attrs.order   4  a fence title's synthesized key gets an order entry in carve-rs and carve-php, not in carve-js (carve#785)
 paragraph.attrs.order    1  carve-php lists a repeated attribute key twice where keyValues holds it once (carve-php#878)
 list.tight                1  carve-rs has not implemented the clause behind corpus 228 yet, so it builds a loose list where the other two build a tight one - the HTML comparison reports the same document (carve#801)


### PR DESCRIPTION
`resources/ast-value-divergence.txt` declares the fields the three engines publish different VALUES for, and it is exact in both directions: a field that stops diverging has to have its line deleted, or `npm run ast:check` fails until it does.

`code_block.attrs.order` no longer diverges. `attrs.order` is the source-appearance order of authored attribute slots, and a fence title is written after the language word rather than as `{title=...}`, so the key the parser synthesizes from it has no authored position to record. carve-js already published none; markup-carve/carve-rs#676 and markup-carve/carve-php#898 landed the same reading in the other two.

Measured on the three current mains - carve-js `9da4fd5`, carve-rs `c25ca3e`, carve-php `fa26840` - against this branch's corpus, all three now publish:

```json
{"keyValues":{"title":"src/Auth.php"}}
```

for

````
``` php "src/Auth.php"
$ok = true;
```
````

## The deletion is what the declaration asks for, and it was observed failing

With the line still present, `ast:check` exits 1 on exactly this:

```
THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:
  FIXED      code_block.attrs.order no longer diverges - delete its line
```

With it deleted, the same run exits 0 and reports the remaining three fields as "All declared". No other line moved: `heading.attrs.id` (45), `paragraph.attrs.order` (1) and `list.tight` (1) are unchanged, so this is not a count drift being papered over.

## Gates

`npm test`, `npm run combinatorial:check`, `npm run core:check`, `npm run property:check` and `npm run test:conformance` are green.

Two gates could not run against a plain checkout of this branch, because they compare against sibling engine checkouts that only a scheduled workflow provisions:

- `npm run ast:check` - "a dependency outside the repository is missing: /tmp/carve-js/dist"
- `npm run claims:check` - "engine-claims: need all three engines, found 0 (none)."

`ast:check` is the gate this change is about, so it was run separately with `CARVE_JS_DIR` / `CARVE_RS_DIR` / `CARVE_PHP_DIR` pointed at built checkouts of the three mains named above; that is the run quoted above. `claims:check` was not run.

Closes markup-carve/carve#785.
