### PR TITLE
spec: heading.attrs.id no longer diverges

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -26,5 +26,4 @@
 #
 # Format: <type.field>  <document-count>  <who diverges and where it is tracked>
 
-heading.attrs.id        45  carve-js publishes a GENERATED heading id, carve-rs and carve-php publish none (carve#750)
 list.tight                1  carve-rs has not implemented the clause behind corpus 228 yet, so it builds a loose list where the other two build a tight one - the HTML comparison reports the same document (carve#801)


### PR DESCRIPTION
markup-carve/carve-rs#680 published the field, so all three engines agree and the last non-lag entry goes:

```
FIXED      heading.attrs.id no longer diverges - delete its line
```

Fifth entry retired since the gate landed this morning, and the largest - 45 of the 56 documents the value comparison ever reported.

What remains is **one** line, and it is not an engine defect: carve-rs's `list.tight` on corpus 228 is lag on a clause it has not implemented (#801), which the HTML comparison reports for the same document.

`ast:check` with all three engines at their current mains:

```
THREE-WAY VALUE COMPARISON: 1 field(s) disagree, across 1 document(s)
  All declared in resources/ast-value-divergence.txt (carve#786).
```