### PR TITLE
spec: a definition line is content, so both definition types are deniable

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -27,7 +27,8 @@ spelling.
 `list_item`, `table`, `table_row`, `table_cell`, `thematic_break`, `div`,
 `admonition`, `raw_block`, `footnote`, `frontmatter`, `definition_list`,
 `definition_term`, `definition_description`, `section`, `line_block`,
-`comment`, `figure`, `caption`.
+`comment`, `figure`, `caption`, `abbreviation_def`,
+`link_reference_definition`.
 
 **Inline:** `text`, `emphasis`, `strong`, `underline`, `strike`,
 `inline_extension`, `mention`, `code`, `link`, `autolink`, `image`,
@@ -82,15 +83,65 @@ named fence" behavior denies both.
 
 This page answers "what can a profile deny", which is a smaller set than "what
 appears in the tree". A serialized AST (PART 12) therefore carries type names
-this vocabulary does not list - `tag`, `abbreviation_def`,
-`link_reference_definition`, `smart_punctuation`, `literal_inline`, `raw_text`
-and the `document` root - because denying them would mean nothing: they are
-either folded into another trust class, render nothing at all, or serve a
-formatter rather than the document. `link_reference_definition` is the
-`abbreviation_def` case exactly: the definition line renders nothing in HTML, so
-denying it would not stop anything reaching the page - the `link` or `image` it
-feeds is the node a profile denies. A consumer reading an AST should expect them; a profile author should not
-look for them here.
+this vocabulary does not list - `tag`, `smart_punctuation`, `literal_inline`,
+`raw_text` and the `document` root - because denying them would mean nothing:
+they are either folded into another trust class or serve a formatter rather than
+the document. A consumer reading an AST should expect them; a profile author
+should not look for them here.
+
+### A definition line is content, so both definition types are deniable
+
+`abbreviation_def` and `link_reference_definition` are in the Block vocabulary
+above, and both were kept out of it until carve#771 on the reasoning that a
+definition line renders nothing. That reasoning was measured against the HTML
+target only, and it does not survive the other three.
+
+**`abbreviation_def` is output today.** All three engines emit the definition
+line on `markdown`, `plain` and `ansi`, and drop it only on `html`:
+
+```
+HTML is fine.
+
+*[HTML]: HyperText
+```
+
+```
+html      <p><abbr title="HyperText">HTML</abbr> is fine.</p>
+markdown  <abbr title="HyperText">HTML</abbr> is fine.
+
+          *[HTML]: HyperText
+plain     HTML is fine.
+
+          *[HTML]: HyperText
+```
+
+A host restricting untrusted input on any of those three targets is looking at
+authored text it may have a reason to withhold, so it must be able to name the
+type. "Renders nothing" described one target out of four.
+
+**`link_reference_definition` moves with it**, which is what this page has always
+said - the two are one case. The reason is now PART 10 §10a rather than a
+measurement: that clause is normative, and since PART 12 §10 gave the link
+definition a node it covers all three definition kinds, requiring an unused
+definition of any kind to survive the Markdown, plain-text and terminal
+renderers. So the same authored line is required output there. Stated plainly
+because the page has been wrong here once already: **no engine emits the unused
+link definition line yet**, so denying the type withholds nothing on any target
+at the time of writing. Its vocabulary membership follows the clause, not the
+current output.
+
+What a deny takes is the definition LINE, never the EXPANSION it fed. The
+inline `abbreviation`, and the `link` or `image` a reference resolves to, are
+separate entries in this vocabulary and keep rendering. Denying the definition
+denies exactly the definition.
+
+The membership settles a second thing, which is why both types had to move
+together. A type outside the vocabulary resolves through the three steps below
+on its node's own axis, and the string-only form of the allow/deny query has no
+axis to resolve on - so a host that denied `abbreviation_def` and then asked
+`isTypeAllowed('abbreviation_def')` was told `true`, while the same profile
+answered `false` for the same node in the tree. Two APIs, one profile, opposite
+answers. In the vocabulary, both answer `false`.
 
 A **`tag`** node - the AST form of `#tag` - is deliberately **NOT** its own
 vocabulary entry: it is classified as **`mention`**, and all three


### PR DESCRIPTION
Closes #771

`abbreviation_def` and `link_reference_definition` join the normative Block vocabulary, and the paragraph that excluded them is rewritten rather than trimmed - its reasoning was the actual defect.

## What the old text claimed, and what is measured

The page said denying these "would mean nothing" because "the definition line renders nothing in HTML". Measured from fresh checkouts of all three engines, on markdown, plain and ansi as well:

```
HTML is fine.

*[HTML]: HyperText
```

| target | carve-js | carve-rs | carve-php |
|---|---|---|---|
| html | `<p><abbr title="HyperText">HTML</abbr> is fine.</p>` | same | same |
| markdown | `<abbr …>HTML</abbr> is fine.` + `*[HTML]: HyperText` | same | same |
| plain | `HTML is fine.` + `*[HTML]: HyperText` | same | same |
| ansi | same, dimmed | same | same |

The definition line is real output on three targets out of four. A host restricting untrusted input on any of them is looking at authored text it may have a reason to withhold, and could not name the type.

## `link_reference_definition` moves for a stated, different reason

The page has always said the two are one case, and they stay one case - but the reason recorded here is now PART 10 §10a rather than a measurement. That clause is normative, and since PART 12 §10 gave the link definition a node it covers all three definition kinds, requiring an unused definition to survive the Markdown, plain-text and terminal renderers.

Measured honestly and said so on the page: **no engine emits that line yet**, so denying the type withholds nothing on any target today. Its membership follows the clause, not the current output. The page was wrong here once by asserting an unverified premise; replacing it with a second one would repeat the defect rather than fix it.

## The two-API contradiction this settles

A type outside the vocabulary resolves through the three steps on its node's own axis, and the string-only query has no axis to resolve on. Measured with the type explicitly denied:

| engine | `isTypeAllowed('abbreviation_def')` | with the axis |
|---|---|---|
| carve-js | `true` | `false` |
| carve-rs | `true` | `false` |
| carve-php | `true` | `false` |

Two APIs, one profile, opposite answers - in all three engines, carve-php included. markup-carve/carve-php#866 removed `abbreviation_def` from that engine's non-deniable list but never added it to the vocabulary, so the contradiction survived there too. Vocabulary membership is what closes it, which is why the ticket says both types settle only together.

## Scope

The deny takes the definition LINE, never the EXPANSION. The inline `abbreviation`, and the `link` or `image` a reference resolves to, are separate vocabulary entries and keep rendering - all three engines already behave this way. What denying the definition means on the HTML target, where the line never appeared, is markup-carve/carve#813 and is deliberately not answered here.

## Verification

No corpus case, and this is a deliberate call rather than an omission: this page's own opening states profiles are configuration and are not pinned by the conformance corpus, and the change alters no rendered output on any target - a `.crv`/`.html` pair has nothing to discriminate on. The behavior is pinned where the engines already read this page: `canonical-vocabulary-matches-the-spec.test.ts` (carve-js), `canonical_vocabulary_matches_the_spec.rs` (carve-rs) and `NodeTypeVocabularyTest.php` (carve-php) compare their lists against the `**Block:**` list in both directions, so this commit makes all three fail until they follow. Both extraction regexes were run against the edited page and pick the list up as 25 entries including the two new ones.

Local gates: `npm test`, `combinatorial:check`, `core:check`, `property:check` and `test:conformance` all green. Two gates could not run on this host and are disclosed rather than claimed: `npm run ast:check` ("a dependency outside the repository is missing: /tmp/carve-js/dist") and `npm run claims:check` ("engine-claims: need all three engines, found 0 (none)"). Neither is part of this repo's per-PR CI; both are provisioned by a separate scheduled workflow.

Found while implementing this and filed separately rather than folded in: `docs/ast-json.md` still states there is "no node type for a `[label]: url` link reference definition", which PART 12 §10 contradicts.
