### PR TITLE
docs: bibliography, glossary, index and heading numbers are Tier-3

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -43,12 +43,13 @@ Tier-2 / Tier-3 seam):
   (grammar PART 9 §25/§26) are **normative and stable** - corpus-pinned with
   byte-parity across all three engines. Changes require a coordinated minor.
 - **Tier-2 standard extensions** (citations incl. typed-locator + integral
-  enrichment, bibliography, code callouts, glossary, index, heading numbers,
-  mentions/tags, and the four block features pinned in `tests/corpus-optional` -
-  list tables, details, spoilers, tabs) are **stable and corpus-pinned** in 0.1.
+  enrichment, code callouts, mentions/tags, and the four block features pinned
+  in `tests/corpus-optional` - list tables, details, spoilers, tabs) are
+  **stable and corpus-pinned** in 0.1.
   Their syntax and HTML contract will not change without a minor bump.
-- **Tier-3 app-level extensions** (Mermaid, table-of-contents, heading
-  permalinks, ColorSwatch, QR, static maps, and other host-dependent showcases)
+- **Tier-3 app-level extensions** (bibliography, glossary, index, heading
+  numbers, Mermaid, table-of-contents, heading permalinks, ColorSwatch, QR,
+  static maps, and other host-dependent showcases)
   ship and are documented, but are **not covered by the 0.1 stability
   guarantee** - they may evolve in any release. Several depend on a host library
   or service and so cannot be normatively corpus-pinned like core.


### PR DESCRIPTION
VERSIONING.md listed all four among the Tier-2 extensions that are
"stable and corpus-pinned in 0.1", and docs/extensions.md titles each of
them Tier-3 with a "Conformance (NOT corpus-pinned)" note. The two
documents have disagreed since #689 relabeled the other four.

docs/extensions.md states the criterion outright - "it is the cross-engine
pin that separates them from Tier 3" - so this is settled by counting
fixtures rather than by preference.

Counted across all 638 corpus documents and all 33 optional ones, by
filename, by body content, and by the construct spellings themselves
(`::: glossary`, `:index[...]`, the bibliography option, `headingNumbers`):

    bibliography     0 fixtures
    glossary         0 fixtures
    index            0 fixtures
    heading numbers  0 fixtures

For contrast, the four features #811 promoted DO have them -
25-details-summary-inline, 26-list-table-caption-inline,
27-spoiler-summary-inline and 28-tabs-panel-title - which is what made
that promotion correct.

So extensions.md describes what is true and VERSIONING.md is the drift.
The four move to the Tier-3 list, where the surrounding sentence already
says what applies to them: they ship and are documented, and are not
covered by the 0.1 stability guarantee.

This narrows what 0.1 promises. It does not change any behavior, and it
does not close the other direction - adding optional-corpus fixtures and
promoting them stays open, and would be a deliberate widening rather than
a correction.

Closes #815.