### PR TITLE
docs: a link reference definition has a node, so §3a's reason is a different one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,11 +162,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **PART 12 §3a: a RESOLVED reference keeps its destination** (carve#524). The
   clause pinned `href: ""` for every reference, resolved or not. Under it the
-  destination had nowhere to live: the vocabulary has no node type for a
+  destination had nowhere to live: the vocabulary then had no node type for a
   `[label]: url` link reference definition - a document holding only `[lbl]: /u`
-  publishes zero children - so a serialized resolved reference kept `ref` and
+  published zero children - so a serialized resolved reference kept `ref` and
   `rawRef` and dropped `/start` outright, and a consumer decoding it rendered a
-  link to nothing. `href` is now empty ONLY where nothing resolved the
+  link to nothing. PART 12 §10 has since given the definition its own
+  `link_reference_definition` node, so that premise no longer holds; the rule
+  below stands on §5's added-alongside rule, which is what it was argued from.
+  `href` is now empty ONLY where nothing resolved the
   reference, which is §5's added-alongside rule applied to links exactly as it
   already applies to footnote numbering: the authored construct (`ref`,
   `rawRef`) survives and the resolution result sits beside it. All three engines

--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -48,8 +48,9 @@ Five rules carry most of the weight:
 (PART 12 §7). Frontmatter and definitions are **block nodes in the tree**, not
 root fields, because a root field cannot carry a position and both are source an
 editor navigates to. A definition is a child of the **document** even when it was
-authored inside a container - footnote and abbreviation alike - because its scope
-is the document wherever it was written. Its `pos` still says where that was.
+authored inside a container - footnote, link reference and abbreviation alike -
+because its scope is the document wherever it was written. Its `pos` still says
+where that was.
 
 **Field names are spec surface** (§3). `href`, `src`, `value`, `level`,
 `children`. An implementation whose internals differ maps on the way out; it does
@@ -74,11 +75,14 @@ added-alongside rule - the same one that lets a resolved footnote reference keep
 its label and gain its number - not a retreat from pre-resolve: the authored
 construct is `ref` and `rawRef`, and it survives intact.
 
-It has to work this way, because the destination has nowhere else to live. There
-is **no node type for a `[label]: url` link reference definition** - a document
-holding only `[lbl]: /u` publishes zero children. An empty `href` on a resolved
-reference would discard `/start` outright, and a consumer decoding that tree
-would render a link to nothing with no second stage available to it.
+It works this way because a consumer should not have to resolve references
+itself. The definition does survive the trip: **§10 gives `[label]: url` its own
+`link_reference_definition` node**, hoisted to the document, so `/start` is not
+stored only on the link. What an empty `href` would cost is the second stage -
+every consumer that wanted to render that link would first have to collect the
+definitions and match their labels, and one that skipped the step would render a
+link to nothing. §5's added-alongside rule publishes the result next to the
+authored construct instead of leaving it to be recomputed.
 
 For the collapsed form `[getting started][]`, `ref` is the **derived** label
 (`getting started`) - the label the reference resolves by. `rawRef` holds the


### PR DESCRIPTION
Closes #828

`docs/ast-json.md` justified §3a's resolved-reference rule with a premise that is
false in both halves: that there is **no node type for a `[label]: url` link
reference definition**, and that a document holding only `[lbl]: /u` **publishes
zero children**.

## Both premises checked, not taken on trust

`resources/grammar.ebnf` on `main` at 1df14e9, line 5463:

```
   10. A LINK REFERENCE DEFINITION IS A NODE -- NORMATIVE.
      `type: "link_reference_definition"`, carrying:
```

and the clause goes on: `IT HOISTS TO THE DOCUMENT, exactly as §7 requires of the
other two definition kinds`.

Measured in three checkouts cloned and built fresh for this, rather than read off
any existing working copy. Input:

```
[lbl]: /u
```

| Engine | `children` |
|---|---|
| carve-js | `["link_reference_definition"]` |
| carve-php | `["link_reference_definition"]` |
| carve-rs | `["link_reference_definition"]` |

One child each, not zero. Authored inside a container:

```
> Quoted.
>
> [inq]: /u
```

all three publish `["block_quote", "link_reference_definition"]`, so the hoist is
real too.

## The argument was rewritten, not struck

The conclusion the paragraph exists to support is untouched. §3a's normative text
still keeps `href` on a resolved reference, and the reasons it gives never rested
on the false premise: the `[a][]` versus `[a](#a)` distinction is carried
entirely by `ref` and `rawRef`, and §5's added-alongside rule publishes a
resolution result rather than leaving it to be recomputed.

So the justification is replaced with the one that survives - what an empty
`href` would cost is not the destination, which the definition node holds, but
the second stage: every consumer that wanted to render the link would first have
to collect the definitions and match their labels itself.

Two further corrections on the same drift:

- The §7 bullet listed what hoists to the document as "footnote and abbreviation
  alike", which left this page - the PART 12 prose page - never naming
  `link_reference_definition` anywhere.
- `CHANGELOG.md` repeated the sentence verbatim, under `[Unreleased]` and in the
  present tense. It describes the state before carve#524, so it is moved into the
  past tense that frame already half-used, and names §10 as what changed it.

## Sweep for the same claim

Every `.md` in the repo was grepped for the claim in each of its spellings ("zero
children", "nowhere else to live", "no node type for", `[lbl]: /u`). It appeared
in **two** files, `docs/ast-json.md` and `CHANGELOG.md`; both are fixed here.

The same grep over `resources/`, `scripts/` and `tests/` found **one more**, and
it is the important one: `resources/grammar.ebnf` §3a carries the identical claim
in its own `WITHOUT IT THE DESTINATION HAS NOWHERE TO LIVE` block at line 4761,
so the grammar contradicts itself between §3a and §10. That is a normative
artifact and takes the org-wide sweep lock rather than the per-repo lock this
change ran under, so it is filed as #831 rather than folded in. Codex's diff
review raised the same point independently; it is a real finding, deliberately
deferred rather than dismissed.

## Lock

This ran under the **per-repo `markup-carve.carve` lock**, not the org-wide sweep
lock, under the narrow doc-only exception in the org profile: the diff touches
only `CHANGELOG.md` and `docs/ast-json.md`, both `*.md` outside `docs/examples/`,
and adds no corpus case, no fixture and no grammar production. A change that
cannot alter engine behavior cannot fabricate a `compare:impls` diff, which is
what that lock exists to prevent. The sweep lock was held by concurrent
three-engine work on #805 throughout.

## The new citation is load-bearing

The rewritten paragraph cites PART 12 §10, and `tests/normativity.test.mjs`
resolves bare `§N` citations on this page against the grammar's real PART 12
clauses. Proven rather than assumed: mutating the citation to `§99` fails test 6,
`every PART 12 section reference resolves to a real clause`; restoring `§10`
passes 9 of 9. Before this change the paragraph cited no section at all, so
nothing bound it to the grammar.

## Gates

`gate-run` reports `partial`, identical to the baseline taken before any edit -
five gates ran and passed (`npm test`, `npm run combinatorial:check`, `npm run
core:check`, `npm run property:check`, `npm run test:conformance`), zero failed.
Two could not run on this host, neither of them run by this repo's per-PR CI:

- `npm run ast:check` - `a dependency outside the repository is missing: /tmp/carve-js/dist`
- `npm run claims:check` - `engine-claims: need all three engines, found 0 (none).`

Those two are not claimed as verified.
