### PR TITLE
ci: bump downstream when divergence-from-djot.md changes

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -30,6 +30,12 @@ on:
       - 'tests/corpus/**'
       - 'tests/spec/**'
       - 'docs/examples.md'
+      # carve-skill's spec-review record is generated FROM this document
+      # (scripts/record-spec-review.mjs reads spec/docs/divergence-from-djot.md),
+      # so a change here has to reach it the same way a corpus change does.
+      # carve#455 rewrote its container sections and no bump fired, leaving the
+      # satellite on a stale copy with every check green (carve#823).
+      - 'docs/divergence-from-djot.md'
       - 'resources/grammar.ebnf'
   workflow_dispatch:
 


### PR DESCRIPTION
`bump-downstream.yml` fired only on `tests/corpus/**`, `tests/spec/**`,
`docs/examples.md` and `resources/grammar.ebnf`. A change to
`docs/divergence-from-djot.md` opened no bump PR, so a satellite that
consumes it sat on a stale copy indefinitely with every check green.

The consumer is carve-skill, and it is not incidental - the spec-review
record is GENERATED from that file:

    scripts/record-spec-review.mjs:15
      const specDoc = join(root, 'spec', 'docs', 'divergence-from-djot.md')
    scripts/record-spec-review.mjs:44
      source: 'spec/docs/divergence-from-djot.md'

This already bit once. carve#455 inverted the container rule in section 13
of that document and rewrote section 12 the same way; neither push touched
a watched path, so nothing downstream moved (carve#823).

Narrow rather than `docs/**` on purpose: the other thirty-one documents in
`docs/` are prose the satellites vendor but do not generate from, so
watching them all would fire a bump on every wording change. This adds the
one file a satellite reads as input, and the next one that becomes input
should be added the same way - with the consumer named, so a later reader
can tell whether the entry is still earning its place.

Closes #823.