### PR TITLE
docs: say that avg_ms on the comparison page is not a benchmark

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -383,6 +383,18 @@ CARVE_PHP_DIR=../carve-php \
 node scripts/compare-impls.mjs
 ```
 
+`avg_ms` IS NOT A BENCHMARK. It is wall-clock from whichever machine last
+refreshed this page, on whatever else that machine was doing, and it is
+re-rolled every time the block is regenerated for an unrelated reason - the
+corpus-size gate below requires a fresh run whenever the corpus grows, so these
+numbers change without any engine changing. The same three engines measured
+2.37 / 59.31 / 54.50 in one run and 3.21 / 83.35 / 75.68 in the next, purely
+from load.
+
+Read the `pass=` and `mismatch=` counts, which are facts about the engines.
+For a timing claim, use a benchmark run on an idle machine and say what it was
+measured on (carve#804).
+
 Default raw output:
 
 ```text


### PR DESCRIPTION
The page publishes per-engine `avg_ms` inside a verbatim run block, and the
corpus-size gate requires that block to be refreshed whenever the corpus
grows. So the timings are re-rolled by corpus edits that change nothing
about any engine, on whatever machine happened to run it, under whatever
else it was doing.

The issue that raised this recorded the spread from two consecutive runs of
the same three engines: 2.37 / 59.31 / 54.50, then 3.21 / 83.35 / 75.68
(carve#804). A reader has no way to tell that from a real change.

The counts are the point of the gate and are facts about the engines; the
timings ride along and look like data. This says so above the block rather
than deleting the numbers, because the block is verbatim script output and
editing fields out of it would make it something else.

This is option 3 of the four that issue lists. Option 1 - a cheaper run for
the counts - is a change to what the gate requires and what the page shows,
which is not an editing decision; the measurement for it is on the issue.

Refs #804.