### PR TITLE
test: pin definition order in the direction the corpus never had

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -9384,3 +9384,60 @@ The `+` continuation marker replaces the leading pipe, and the row must close wi
 ```
 
 :::
+
+## A link definition written before a footnote stays before it
+
+§7 orders collected definitions by source position, and PART 11 §6 binds the writer to the order the tree holds. The corpus pinned only the shape where the footnote comes first (`a definition on a footnote body's continuation line`), and a writer that emits footnotes in a fixed position - first or last - is correct on exactly that shape. This is its mirror: every engine's `carve` output for it must put the link definition first, because the author did.
+
+::: compare
+
+```carve
+see[^a] and [t][r]
+
+[r]: /u
+
+[^a]: note
+```
+
+```html
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and <a href="/u">t</a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+:::
+
+Two definitions of the SAME kind pin the other half of the rule: a writer that sorts them by label rather than by position reverses these two.
+
+::: compare
+
+```carve
+see[^b] and[^a]
+
+[^b]: bee
+
+[^a]: ay
+```
+
+```html
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>bee<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>ay<a href="#fnref2" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+:::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,30 +17,30 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>634 / 638</strong>
+    <strong>639 / 640</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>635 / 638</strong>
+    <strong>640 / 640</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>636 / 638</strong>
+    <strong>640 / 640</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>6</strong>
+    <strong>4</strong>
     <span>cross-implementation diffs</span>
   </div>
 </div>
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `2f4bb02` | `634 / 638` | `4` | `0` | `2.57` |
-| JS | `a89017d` | `635 / 638` | `3` | `0` | `61.46` |
-| PHP | `f3eec4f` | `636 / 638` | `2` | `0` | `56.84` |
+| Rust | `93b0178` | `639 / 640` | `1` | `0` | `3.12` |
+| JS | `c9d8ef1` | `640 / 640` | `0` | `0` | `83.08` |
+| PHP | `a0d39be` | `640 / 640` | `0` | `0` | `73.82` |
 
-Spec commit: `b539d14`, plus the corpus case this change adds
+Spec commit: `d8dd824`, plus the corpus case this change adds
 
 The engines have caught up on the clauses that were ahead of them in the last
 snapshot: the synthesized-backlink cases (carve#799) and the collected-definition
@@ -399,30 +399,22 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=638 targets=html,markdown,plain,carve,ansi
-rust: pass=646/650 mismatch=4 error=0 skipped=0 runs=3190 avg_ms=2.57
-  mismatch: carve 16-reference-link-4
-  mismatch: carve 195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column
-  mismatch: html 226-a-definition-attached-by-a-continuation-marker-is-collected-and-the-item-keeps-no-trace
+profile=default/no-opt-in corpus=core corpus_pairs=640 targets=html,markdown,plain,carve,ansi
+rust: pass=651/652 mismatch=1 error=0 skipped=0 runs=3200 avg_ms=3.12
   mismatch: html 228-a-line-at-a-footnote-definition-s-own-column-followed-by-non-blank-text-forms-its-own-tight-block
-  mismatching documents: 4
-js: pass=647/650 mismatch=3 error=0 skipped=0 runs=3190 avg_ms=61.46
-  mismatch: carve 16-reference-link-4
-  mismatch: carve 195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column
-  mismatch: html 228-a-line-at-a-footnote-definition-s-own-column-followed-by-non-blank-text-forms-its-own-tight-block
-  mismatching documents: 3
-php: pass=648/650 mismatch=2 error=0 skipped=0 runs=3190 avg_ms=56.84
-  mismatch: carve 16-reference-link-4
-  mismatch: carve 195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column
-  mismatching documents: 2
-cross_impl_diffs=6
+  mismatching documents: 1
+js: pass=652/652 mismatch=0 error=0 skipped=0 runs=3200 avg_ms=83.08
+  mismatching documents: 0
+php: pass=652/652 mismatch=0 error=0 skipped=0 runs=3200 avg_ms=73.82
+  mismatching documents: 0
+cross_impl_diffs=4
 
 Target agreement (implementations compared against each other)
-html: compared=638 diffs=2 errors=0 fixtures=yes
-markdown: compared=638 diffs=0 errors=0 fixtures=1
-plain: compared=638 diffs=0 errors=0 fixtures=1
-carve: compared=638 diffs=4 errors=0 fixtures=10
-ansi: compared=638 diffs=0 errors=0 fixtures=none
+html: compared=640 diffs=1 errors=0 fixtures=yes
+markdown: compared=640 diffs=0 errors=0 fixtures=1
+plain: compared=640 diffs=0 errors=0 fixtures=1
+carve: compared=640 diffs=3 errors=0 fixtures=10
+ansi: compared=640 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 638 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 640 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus with no HTML divergences.
 Pre-1.0, a minor release may still change the grammar.

--- a/tests/corpus-fmt-roundtrip.test.mjs
+++ b/tests/corpus-fmt-roundtrip.test.mjs
@@ -1,8 +1,9 @@
 /*
  * The formatter preserves the document, over the WHOLE corpus.
  *
- * tests/corpus-roundtrip/ pins the canonical writer against ten hand-written
- * documents, chosen for their escaping decisions. That is the right shape for
+ * tests/corpus-roundtrip/ pins the canonical writer against eleven hand-written
+ * documents, chosen for their escaping decisions and - since carve#787 - for
+ * the ORDER the writer emits collected definitions in. That is the right shape for
  * pinning bytes, and it is a thin sample: the corpus has 500+ documents that
  * exercise every construct in the language, and none of them were ever put
  * through the writer.

--- a/tests/corpus-roundtrip/11-two-footnotes-in-source-order.crv
+++ b/tests/corpus-roundtrip/11-two-footnotes-in-source-order.crv
@@ -1,0 +1,5 @@
+see[^b] and[^a]
+
+[^b]: bee
+
+[^a]: ay

--- a/tests/corpus-roundtrip/11-two-footnotes-in-source-order.expected.crv
+++ b/tests/corpus-roundtrip/11-two-footnotes-in-source-order.expected.crv
@@ -1,0 +1,5 @@
+see[^b] and[^a]
+
+[^b]: bee
+
+[^a]: ay

--- a/tests/corpus-roundtrip/README.md
+++ b/tests/corpus-roundtrip/README.md
@@ -76,6 +76,31 @@ means the engine matches the spec, not that the spec was written down from the
 engine. The other two engines still over-escape; these bytes are what they are
 measured against.
 
+## 11-two-footnotes-in-source-order
+
+Not an escaping case. §7 orders collected definitions by source position and
+PART 11 §6 binds the writer to the order the tree holds, and nothing here pinned
+it: every fixture had at most one definition.
+
+The cost showed up in all three engines at once (carve#787). Each writer used a
+FIXED order - carve-js and carve-rs appended footnotes last, carve-rs also
+sorted them by label, carve-php emitted them first - and each looked correct on
+exactly the documents whose source order happened to match its rule. The corpus
+had one shape (`202-a-definition-on-a-footnote-body-s-continuation-line-is-
+collected`, footnote written first), so footnotes-first passed there for as long
+as it existed.
+
+Two footnotes written `[^b]` then `[^a]` separate the rules with nothing else in
+play: source order says `[^b]` first, label order says `[^a]`, and position is
+the only thing that distinguishes them.
+
+The MIRROR shape - a link definition written before a footnote - belongs here
+too and is not, because the pinned build predates carve#642 and inlines the
+resolved reference, so its fmt output drops the definition entirely. It lives in
+the corpus instead (`a link definition written before a footnote stays before
+it`), where `compare:impls` checks the three engines against each other on the
+`carve` target. Once the pin moves past that fix, it can be added here as bytes.
+
 ## Regenerating
 
 Do **not** regenerate expected files from an implementation's current output -

--- a/tests/corpus/239-a-link-definition-written-before-a-footnote-stays-before-it-2.crv
+++ b/tests/corpus/239-a-link-definition-written-before-a-footnote-stays-before-it-2.crv
@@ -1,0 +1,5 @@
+see[^b] and[^a]
+
+[^b]: bee
+
+[^a]: ay

--- a/tests/corpus/239-a-link-definition-written-before-a-footnote-stays-before-it-2.html
+++ b/tests/corpus/239-a-link-definition-written-before-a-footnote-stays-before-it-2.html
@@ -1,0 +1,12 @@
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>bee<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>ay<a href="#fnref2" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>

--- a/tests/corpus/239-a-link-definition-written-before-a-footnote-stays-before-it.crv
+++ b/tests/corpus/239-a-link-definition-written-before-a-footnote-stays-before-it.crv
@@ -1,0 +1,5 @@
+see[^a] and [t][r]
+
+[r]: /u
+
+[^a]: note

--- a/tests/corpus/239-a-link-definition-written-before-a-footnote-stays-before-it.html
+++ b/tests/corpus/239-a-link-definition-written-before-a-footnote-stays-before-it.html
@@ -1,0 +1,9 @@
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and <a href="/u">t</a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>

--- a/tests/spec/239-a-link-definition-written-before-a-footnote-stays-before-it.test
+++ b/tests/spec/239-a-link-definition-written-before-a-footnote-stays-before-it.test
@@ -1,0 +1,40 @@
+A link definition written before a footnote stays before it
+
+```
+see[^a] and [t][r]
+
+[r]: /u
+
+[^a]: note
+.
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and <a href="/u">t</a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+```
+see[^b] and[^a]
+
+[^b]: bee
+
+[^a]: ay
+.
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>bee<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>ay<a href="#fnref2" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```


### PR DESCRIPTION
Refs #786.

PART 7 orders collected definitions by **source position**, and PART 11 §6 binds the writer to the order the tree holds. The corpus pinned exactly one shape for that rule - "a definition on a footnote body's continuation line" - where the footnote comes first. A writer that emits footnotes in a **fixed** position, first or last, passes that case for the wrong reason: it happens to agree with the author on the one document being asked.

Two cases add the missing directions.

A link definition written before a footnote:

```carve
see[^a] and [t][r]

[r]: /u

[^a]: note
```

The link definition must be written back first, because the author wrote it first. A fixed-position writer that hoists footnotes to the front reverses it.

Two definitions of the same kind, out of label order:

```carve
see[^b] and[^a]

[^b]: bee

[^a]: ay
```

A writer that sorts by label rather than by position swaps these two. The HTML fixture alone would not catch it: numbering follows the **references**, so html agrees either way. The round-trip case covers this shape through `fmt`, where an ordering bug actually lands, since the `carve` target has to reproduce the author's sequence.

Measured across all three engines: 640 pairs, rust 639/640 (its one open mismatch is corpus 228, unrelated), js and php 640/640. The comparison page and the landing page quote the new size, which `tests/implementation-comparison-counts.test.mjs` enforces.