### PR TITLE
test: the unknown-property probe checks what §11 decided, not what was open

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -47,6 +47,7 @@ import { checkPositions } from './spec/ast-positions.mjs'
 import { checkReferenceFields } from './spec/ast-references.mjs'
 import {
   UNKNOWN_PROPERTY_PROBE,
+  unknownPropertyVerdict,
   countProbes,
   injectUnknownProperty,
 } from './spec/unknown-property-probe.mjs'
@@ -1001,26 +1002,28 @@ function checkUnknownPropertyIngest(name, doc, findings, reserialize) {
   const injected = injectUnknownProperty(payload).n
   if (injected === 0) return
   let out
+  let refused = false
   try {
     out = reserialize(JSON.stringify(payload))
   } catch {
-    // Refusing the payload is conformant: nothing invalid is published.
-    return
+    refused = true
   }
-  let round
-  try {
-    round = JSON.parse(out)
-  } catch {
-    findings.push(`${name}: ingest of a tree with an unknown property re-serialized to non-JSON`)
+  let echoed = 0
+  if (!refused) {
+    let round
+    try {
+      round = JSON.parse(out)
+    } catch {
+      findings.push(`${name}: ingest of a tree with an unknown property re-serialized to non-JSON`)
 
-    return
+      return
+    }
+    echoed = countProbes(round)
   }
-  const echoed = countProbes(round)
-  if (echoed === 0) return
-  findings.push(
-    `${name}: ingest echoed an unknown property on ${echoed} of ${injected} node(s), ` +
-      'so the re-published tree is invalid per additionalProperties: false',
-  )
+  // The verdict lives in the probe module, where a test can drive every branch
+  // without needing an engine that misbehaves.
+  const verdict = unknownPropertyVerdict({ refused, injected, echoed })
+  if (verdict !== null) findings.push(`${name}: ${verdict}`)
 }
 
 function checkIngestIdentity(name, doc, findings, reserialize) {

--- a/scripts/spec/unknown-property-probe.mjs
+++ b/scripts/spec/unknown-property-probe.mjs
@@ -2,16 +2,17 @@
  * A probe for the one thing an ingesting engine may never do.
  *
  * PART 12 pins the wire shape with `additionalProperties: false`. The engines
- * disagree about what to do with a property the schema does not name - carve-php
- * refuses the payload, carve-rs drops it, carve-js echoes it back
- * (carve-js#709) - and which of refuse-or-drop is right is open for §9
- * (carve#743).
+ * used to disagree about what to do with a property the schema does not name -
+ * carve-php refused the payload, carve-rs dropped it, carve-js echoed it back
+ * (carve-js#709) - and this probe was written while that was open, so it only
+ * refused to accept the ECHO.
  *
- * These helpers do not touch that question. Refusing is fine and so is dropping.
- * What is never fine is ACCEPTING and then re-publishing, because the result is
- * a tree the format rejects and the consumer that reads it and passes it on has
- * no way to know. Stated that way the bar follows from the schema contract that
- * already exists, so it can be measured before the decision lands.
+ * §11 has since decided it: an ingest MUST REFUSE, with a typed error naming
+ * the property and its path. Not a silent drop, for the reason §9(b) gives
+ * about depth - the caller is told the tree was accepted and learns nothing
+ * about what went missing. So the runner now reports a drop too, and these
+ * helpers stayed the same: they measure what came back, and the runner decides
+ * what that means.
  *
  * Kept here as pure functions so tests can drive them without an engine: the
  * version inside the runner could only be exercised by having an engine that
@@ -58,4 +59,33 @@ export function countProbes(node) {
   walk(node)
 
   return total
+}
+
+/**
+ * What an ingest's answer to the probe means, as a finding or `null`.
+ *
+ * SEPARATED FROM THE RUNNER on purpose. The runner's copy could only be reached
+ * by having an engine that misbehaves, which is the thing being looked for - so
+ * the branch that decides "this is a finding" was the one part of the apparatus
+ * nothing exercised. Now the runner measures and this decides, and a test can
+ * drive every verdict without an engine.
+ *
+ * `refused` means the ingest threw. That is the conformant answer and now the
+ * only one: PART 12 §11 requires a typed refusal naming the property, and rules
+ * out the silent drop for the reason §9(b) gives about depth - the caller is
+ * told the tree was accepted and learns nothing about what went missing.
+ */
+export function unknownPropertyVerdict({ refused, injected, echoed }) {
+  if (refused) return null
+  if (echoed > 0) {
+    return (
+      `ingest echoed an unknown property on ${echoed} of ${injected} node(s), ` +
+      'so the re-published tree is invalid per additionalProperties: false (PART 12 §11)'
+    )
+  }
+
+  return (
+    `ingest accepted a tree with an unknown property on ${injected} node(s) and ` +
+    'dropped it silently; §11 requires a typed refusal naming the property'
+  )
 }

--- a/tests/unknown-property-probe.test.mjs
+++ b/tests/unknown-property-probe.test.mjs
@@ -13,6 +13,7 @@ import {
   UNKNOWN_PROPERTY_PROBE,
   countProbes,
   injectUnknownProperty,
+  unknownPropertyVerdict,
 } from '../scripts/spec/unknown-property-probe.mjs'
 
 const tree = () => ({
@@ -46,7 +47,9 @@ test('pos and attrs are not nodes, so they are not probed', () => {
 })
 
 test('a dropped property counts as dropped', () => {
-  // What carve-rs does. The runner must read this as a pass.
+  // What carve-rs used to do. The COUNT is what these helpers report; §11 makes
+  // the runner treat an accepted-and-dropped payload as a finding all the same,
+  // because refusing is now the only conformant answer.
   const doc = tree()
   injectUnknownProperty(doc)
   const stripped = JSON.parse(
@@ -72,4 +75,34 @@ test('the probe name is not a field the schema declares', () => {
   // handling that field correctly and report it as a leak.
   assert.match(UNKNOWN_PROPERTY_PROBE, /^zz/)
   assert.ok(!/^(id|href|src|number|ref|rawRef|value|type)$/.test(UNKNOWN_PROPERTY_PROBE))
+})
+
+test('refusing the payload is the conformant answer', () => {
+  // PART 12 §11. Nothing else passes.
+  assert.equal(unknownPropertyVerdict({ refused: true, injected: 5, echoed: 0 }), null)
+})
+
+test('echoing the property is a finding, and says how much', () => {
+  const verdict = unknownPropertyVerdict({ refused: false, injected: 5, echoed: 3 })
+  assert.match(verdict, /echoed an unknown property on 3 of 5/)
+  assert.match(verdict, /additionalProperties/)
+})
+
+test('accepting and dropping is a finding too', () => {
+  // The half §11 decided. This branch is why the verdict lives here: the
+  // runner's copy could only be reached by having an engine that misbehaves,
+  // so nothing exercised the decision itself - and a check nothing exercises
+  // is the shape of every defect this repo keeps finding.
+  const verdict = unknownPropertyVerdict({ refused: false, injected: 5, echoed: 0 })
+  assert.match(verdict, /accepted a tree with an unknown property on 5 node\(s\)/)
+  assert.match(verdict, /typed refusal/)
+})
+
+test('the three answers are distinguishable', () => {
+  // The control on the two above: one message for both non-conformant answers
+  // would satisfy each match while telling a maintainer nothing about which
+  // engine did what.
+  const echoed = unknownPropertyVerdict({ refused: false, injected: 5, echoed: 3 })
+  const dropped = unknownPropertyVerdict({ refused: false, injected: 5, echoed: 0 })
+  assert.notEqual(echoed, dropped)
 })


### PR DESCRIPTION
Follow-up to #842, which added PART 12 §11.

The probe (#768) was written while the question was open, so it deliberately accepted two answers: refusing was fine and so was dropping, and only the **echo** was reported. §11 has since decided it - an ingest MUST refuse, with a typed error naming the property and its path - which left the runner measuring a weaker rule than the spec states. That is the "rule stated in one place and not enforced" shape.

An accepted-and-dropped payload is now a finding, with its own message so a maintainer can tell it from an echo.

All three engines refuse as of markup-carve/carve-js#763, markup-carve/carve-rs#693 and markup-carve/carve-php#913, so the tightened check reports nothing. Measured over 640 corpus documents plus 3 synthetic samples: zero unknown-property findings from any engine.

## The verdict moved out of the runner

That is the part worth reviewing. The module already said the runner's copy

> could only be exercised by having an engine that echoes, which is the thing it exists to look for

so the branch deciding "this is a finding" was the one piece of the apparatus nothing exercised - and tightening it in place would have made a second untested branch beside the first. Now the runner measures and `unknownPropertyVerdict` decides, and the tests drive all three answers directly, including a control that the two non-conformant ones do not collapse into a single message.
