### PR TITLE
docs: the list.tight divergence is gone - delete its line

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -26,4 +26,3 @@
 #
 # Format: <type.field>  <document-count>  <who diverges and where it is tracked>
 
-list.tight                1  carve-rs has not implemented the clause behind corpus 228 yet, so it builds a loose list where the other two build a tight one - the HTML comparison reports the same document (carve#801)


### PR DESCRIPTION
`resources/ast-value-divergence.txt` is exact in both directions: a field that diverges and is not listed fails, and **a listed field that no longer diverges fails until the line is deleted.** This is the second case.

The one entry was corpus 228 - carve-rs blanked the collected definition line and read that blank as an author's interior separator, so it built a loose list where the other two built a tight one. markup-carve/carve-rs#662 landed the fix: the placeholder that keeps such a line non-blank now also covers a definition at an item's content column, indented to that column so it does not close the item it exists to keep open.

Measured against fresh builds of all three engines rather than assumed:

```
THREE-WAY SHAPE COMPARISON (643 documents, 643 unanimous)
  no engine stood alone.

THREE-WAY VALUE COMPARISON: the engines publish the same values everywhere.
```

Worth naming: **the first run said the opposite.** A stale carve-rs binary still reported `carve-rs=false` for that document, and `ast:check`'s own STALE BUILDS warning is what caught it. The numbers above are from the re-run after rebuilding.

The file is now empty of entries, which is the state it was written to reach.