### PR TITLE
spec: pin the definition half of the zero-width destination rule

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -9441,3 +9441,39 @@ see[^b] and[^a]
 ```
 
 :::
+
+## A zero-width character in a reference definition destination
+
+`link_destination` ends at Unicode whitespace, and a ZERO WIDTH NO-BREAK SPACE is not whitespace: it is an ordinary destination character. The same rule governs a reference definition, because the definition is built from that same production - so the character is neither skipped as the separator run nor read as the end of the destination.
+
+The inline form was already pinned. This is the definition form, where two engines kept the character and one dropped it or truncated at it, because the host language's own whitespace class holds U+FEFF and the Unicode property does not.
+
+::: compare
+
+```carve
+[r]: ﻿https://e.com/
+
+see [x][r]
+```
+
+```html
+<p>see <a href="﻿https://e.com/">x</a></p>
+```
+
+:::
+
+Position does not change the answer: a definition is not truncated at a zero-width character in the middle of its destination either.
+
+::: compare
+
+```carve
+[r]: https://e﻿.com/
+
+see [x][r]
+```
+
+```html
+<p>see <a href="https://e﻿.com/">x</a></p>
+```
+
+:::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -6,7 +6,7 @@ same `.crv` / `.html` pairs and reports default conformance, optional Tier-2
 adapter coverage, rough CLI timing, and the extension hook surface each
 implementation exposes.
 
-## Snapshot (2026-08-04)
+## Snapshot (2026-08-06)
 
 > Run with all three implementations built from their own `main`. Regenerate any
 > time with `npm run compare:impls`. Timings are from one machine and mean
@@ -17,39 +17,36 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>639 / 640</strong>
+    <strong>641 / 642</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>640 / 640</strong>
+    <strong>642 / 642</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>640 / 640</strong>
+    <strong>642 / 642</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>4</strong>
+    <strong>2</strong>
     <span>cross-implementation diffs</span>
   </div>
 </div>
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `93b0178` | `639 / 640` | `1` | `0` | `3.12` |
-| JS | `c9d8ef1` | `640 / 640` | `0` | `0` | `83.08` |
-| PHP | `a0d39be` | `640 / 640` | `0` | `0` | `73.82` |
+| Rust | `e912088` | `641 / 642` | `1` | `0` | `3.14` |
+| JS | `1aaaf94` | `642 / 642` | `0` | `0` | `78.95` |
+| PHP | `ef28bbf` | `642 / 642` | `0` | `0` | `69.88` |
 
-Spec commit: `d8dd824`, plus the corpus case this change adds
+Spec commit: `f0b324c`, plus the two corpus cases this change adds
 
-The engines have caught up on the clauses that were ahead of them in the last
-snapshot: the synthesized-backlink cases (carve#799) and the collected-definition
-cases (carve#801) all pass in all three now.
-
-What is left is the `carve` target: `16-reference-link-4` and
-`195-a-definition-inside-a-container-...` in all three, plus two more in
-carve-rs. The parse agrees everywhere and what differs is the canonical spelling
-the formatter writes back (carve#787).
+The engines have caught up further since the last snapshot: the `carve`-target
+differences it listed - `16-reference-link-4`,
+`195-a-definition-inside-a-container-...` and two more in carve-rs - are gone,
+and the `carve` target now has expected-output files for twelve cases rather
+than ten, so more of it is pinned rather than merely agreed.
 
 The counts here are documents, not runs: an engine that misses one case on two
 targets is one document behind, not two.
@@ -399,22 +396,22 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=640 targets=html,markdown,plain,carve,ansi
-rust: pass=651/652 mismatch=1 error=0 skipped=0 runs=3200 avg_ms=3.12
+profile=default/no-opt-in corpus=core corpus_pairs=642 targets=html,markdown,plain,carve,ansi
+rust: pass=655/656 mismatch=1 error=0 skipped=0 runs=3210 avg_ms=3.14
   mismatch: html 228-a-line-at-a-footnote-definition-s-own-column-followed-by-non-blank-text-forms-its-own-tight-block
   mismatching documents: 1
-js: pass=652/652 mismatch=0 error=0 skipped=0 runs=3200 avg_ms=83.08
+js: pass=656/656 mismatch=0 error=0 skipped=0 runs=3210 avg_ms=78.95
   mismatching documents: 0
-php: pass=652/652 mismatch=0 error=0 skipped=0 runs=3200 avg_ms=73.82
+php: pass=656/656 mismatch=0 error=0 skipped=0 runs=3210 avg_ms=69.88
   mismatching documents: 0
-cross_impl_diffs=4
+cross_impl_diffs=2
 
 Target agreement (implementations compared against each other)
-html: compared=640 diffs=1 errors=0 fixtures=yes
-markdown: compared=640 diffs=0 errors=0 fixtures=1
-plain: compared=640 diffs=0 errors=0 fixtures=1
-carve: compared=640 diffs=3 errors=0 fixtures=10
-ansi: compared=640 diffs=0 errors=0 fixtures=none
+html: compared=642 diffs=1 errors=0 fixtures=yes
+markdown: compared=642 diffs=0 errors=0 fixtures=1
+plain: compared=642 diffs=0 errors=0 fixtures=1
+carve: compared=642 diffs=1 errors=0 fixtures=12
+ansi: compared=642 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix
@@ -424,22 +421,21 @@ php: inline matcher, block matcher, parsed-document hook, before-render hook, re
 extension_profile_note=this run compares default/no-opt-in output. Use --corpus=optional for Tier-2 opt-in adapters.
 ```
 
-**Two engines render every fixture case**, on every target that has one: 573 of
-573 in carve-js and carve-php, zero mismatches and zero errors. carve-rs misses
-the two newest, both pinning what a comment does to the item around it - a
-blank after one still ends the item, and a comment fence under a nested item
-does not close it. carve-js, carve-php and the executable spec agree on both;
-carve-rs is the sole outlier (markup-carve/carve-rs#578). Those two cases
-account for eight of the twelve diffs below, across four targets each.
+**Two engines render every case**, on every target: carve-js and carve-php are
+642 of 642 with zero mismatches and zero errors. carve-rs is one document
+behind - `228-a-line-at-a-footnote-definition-s-own-column-...` - and that one
+document accounts for BOTH diffs below, one on `html` and one on `carve`. No
+other document differs anywhere.
 
-**Four differences remain on the `carve` target** beyond them, which has an
-expected-output file for five cases and asserts engine agreement on the rest. All four are the
-formatter, and the rule behind the largest of them is one the writer has not
-caught up on: PART 11 §1's round trip does not hold for a resolved reference
-link in ANY engine - `[a][r]` plus its definition formats to the inline
-`[a](/u)`, so the `ref` and `rawRef` that §3a records are gone on reparse. That
-is [carve#642](https://github.com/markup-carve/carve/issues/642), a writer
-question rather than a parser one.
+**The `carve` target is down to that same one**, and it has an expected-output
+file for twelve cases now, asserting engine agreement on the rest. The rule
+behind the class of `carve`-target differences that keeps recurring is one the
+writer has not caught up on: PART 11 §1's round trip does not hold for a
+resolved reference link in ANY engine - `[a][r]` plus its definition formats to
+the inline `[a](/u)`, so the `ref` and `rawRef` that §3a records are gone on
+reparse. That is
+[carve#642](https://github.com/markup-carve/carve/issues/642), a writer question
+rather than a parser one.
 
 Optional raw output:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 640 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 642 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus with no HTML divergences.
 Pre-1.0, a minor release may still change the grammar.

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,3 +24,5 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
+240-a-zero-width-character-in-a-reference-definition-destination  the pinned build reads a BOM in a definition destination as separator whitespace and drops it; fixed in carve-js after this pin (carve#806)
+240-a-zero-width-character-in-a-reference-definition-destination-2  the pinned build truncates a definition destination at a BOM; fixed in carve-js after this pin (carve#806)

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -40,7 +40,14 @@ const QUOTE = /^>(?: (.*)|)$/
 // the PART 9 §10 note (and carve-rs, carve-php) read it as a link reference
 // definition whose label is `^`: an EMPTY footnote label is not a footnote
 // label, `footnote_label` being one-or-more (carve-rs#511, carve#589).
-const LINK_DEF = /^\[([^\]@][^\]]*)\]: \s*(\S+)(?:\s+"((?:\\"|[^"])*)")?(?:\s.*)?$/
+// Whitespace here is the Unicode White_Space property, NOT `\s`: JavaScript's
+// class also holds U+FEFF, which `link_destination` names as an ORDINARY
+// destination character, and omits U+0085, which is whitespace. So a BOM was
+// skipped as the separator run or ended the destination early, and U+0085 was
+// carried into the href. The rule is stated for the definition explicitly - it
+// "is built from this same `link_destination`" - so the oracle has to read it
+// the same way the inline form does (carve#806).
+const LINK_DEF = /^\[([^\]@][^\]]*)\]: \p{White_Space}*(\P{White_Space}+)(?:\p{White_Space}+"((?:\\"|[^"])*)")?(?:\p{White_Space}.*)?$/u
 
 /*
  * Split a TRAILING attribute block off a definition line (carve#604).

--- a/tests/corpus/240-a-zero-width-character-in-a-reference-definition-destination-2.crv
+++ b/tests/corpus/240-a-zero-width-character-in-a-reference-definition-destination-2.crv
@@ -1,0 +1,3 @@
+[r]: https://e﻿.com/
+
+see [x][r]

--- a/tests/corpus/240-a-zero-width-character-in-a-reference-definition-destination-2.html
+++ b/tests/corpus/240-a-zero-width-character-in-a-reference-definition-destination-2.html
@@ -1,0 +1,1 @@
+<p>see <a href="https://e﻿.com/">x</a></p>

--- a/tests/corpus/240-a-zero-width-character-in-a-reference-definition-destination.crv
+++ b/tests/corpus/240-a-zero-width-character-in-a-reference-definition-destination.crv
@@ -1,0 +1,3 @@
+[r]: ﻿https://e.com/
+
+see [x][r]

--- a/tests/corpus/240-a-zero-width-character-in-a-reference-definition-destination.html
+++ b/tests/corpus/240-a-zero-width-character-in-a-reference-definition-destination.html
@@ -1,0 +1,1 @@
+<p>see <a href="﻿https://e.com/">x</a></p>

--- a/tests/fixture-bytes.test.mjs
+++ b/tests/fixture-bytes.test.mjs
@@ -66,6 +66,21 @@ const INVENTORY = [
     crv: ['ZWSP'],
     html: ['ZWSP'],
   },
+  // The BOM is the case, on BOTH sides, and in the DEFINITION half of the rule:
+  // a zero-width character is an ordinary destination character there too,
+  // because the definition is built from the same `link_destination`. Strip it
+  // and the pair still matches, testing nothing - which is the shape that let
+  // carve#806 be closed while this half was still wrong.
+  {
+    base: '240-a-zero-width-character-in-a-reference-definition-destination',
+    crv: ['BOM'],
+    html: ['BOM'],
+  },
+  {
+    base: '240-a-zero-width-character-in-a-reference-definition-destination-2',
+    crv: ['BOM'],
+    html: ['BOM'],
+  },
 ]
 
 function scan(text) {

--- a/tests/spec/240-a-zero-width-character-in-a-reference-definition-destination.test
+++ b/tests/spec/240-a-zero-width-character-in-a-reference-definition-destination.test
@@ -1,0 +1,17 @@
+A zero-width character in a reference definition destination
+
+```
+[r]: ﻿https://e.com/
+
+see [x][r]
+.
+<p>see <a href="﻿https://e.com/">x</a></p>
+```
+
+```
+[r]: https://e﻿.com/
+
+see [x][r]
+.
+<p>see <a href="https://e﻿.com/">x</a></p>
+```


### PR DESCRIPTION
`link_destination` ends at Unicode whitespace, and a ZERO WIDTH NO-BREAK SPACE is not whitespace, so it is an ordinary destination character. `resources/grammar.ebnf` states that a second time for reference definitions, in as many words - "THE SAME RULE APPLIES IN A REFERENCE DEFINITION, because the definition is built from this same `link_destination`" - and nothing in this repository pinned that half.

Closes #806.

## Why the corpus needed this

The corpus had a zero-width character in an INLINE destination (case 238, from #782) and nowhere else. So an engine could satisfy every document here while, one shape over, dropping the character out of a definition, truncating the destination at it, or collapsing `[r]: <BOM>url>` to a destination of `<`. One did, for as long as the rule existed - and #806 was closed on the inline half before the definition half was measured.

Two cases, because the two failures have different causes and a single leading-position case would have caught only one:

```
[r]: <BOM>https://e.com/

see [x][r]
```

```html
<p>see <a href="<BOM>https://e.com/">x</a></p>
```

and

```
[r]: https://e<BOM>.com/

see [x][r]
```

```html
<p>see <a href="https://e<BOM>.com/">x</a></p>
```

Verified against fresh builds of all three engines - carve-js `1aaaf94`, carve-php `ef28bbf`, carve-rs `e912088`: all three reproduce both fixtures byte for byte. The engine half is markup-carve/carve-js#764, merged.

## The executable spec had the same defect

Writing the fixtures from the engines is what surfaced it: both cases failed against the oracle before `scripts/spec/layout.mjs` was changed, so the oracle disagreed with all three engines and with its own grammar.

`LINK_DEF` tested JavaScript's `\s`, which is the Unicode White_Space property PLUS U+FEFF and MINUS U+0085 - a legacy set, not a property. The oracle therefore skipped a BOM as the separator run, ended a destination on one, and carried U+0085 into an href where carve-php and carve-rs both end the destination. It now tests the property, exactly as the inline `destChar` rule in `resources/carve-core.ohm` already did.

Reverting that one regex against the committed fix fails both new cases and nothing else - 640 pass, 2 fail - and restoring it returns 642 of 642. That is the whole of the proof that the fixtures are load-bearing rather than transcripts.

## Fixture bytes

Both pairs carry the BOM raw on BOTH sides. That is the silent-decay shape `tests/fixture-bytes.test.mjs` exists for: strip the character from input and expectation together and the pair still matches while testing nothing. Both are registered in its inventory, so a formatter or editor that eats them turns the suite red instead of quiet.

## Declared drift, not a pin bump

The pinned reference build predates the engine fix, so it reads both documents the old way. `resources/engine-pin-drift.txt` names them with the reason, which is the normal window that file exists to describe; the two lines come out when the pin next moves. `npm run engine:report -- --check` and `tests/corpus-fmt-cross-read.test.mjs` are both satisfied by the declaration and would both go red if a slug were listed that the pin actually reproduces.

## What is deliberately not here

Measuring 34 shapes across four render targets turned up four more single-engine divergences that this rule does not settle - an abbreviation expansion losing a leading BOM, `[r]: <U+00A0>url` collected by two engines and left a paragraph by the third, a trailing BOM trimmed off any written line by carve-js's canonical writer, and `<https://e<BOM>.com/>` becoming an autolink in carve-php alone. Each is a different production with no clause deciding it, so folding them in here would have shipped four unmeasured behavior changes behind a destination fix. They are filed as #844.

The trailing-BOM one is why the fixtures use a leading and a middle position rather than a trailing one: a trailing-BOM definition would have failed a `.fmt` pin for a reason that has nothing to do with this rule.

## Draft overlap

Drafts #444 (docs migration prep) and #291 (file inclusion) both change `docs/examples/edge-cases.md`; expect a rebase against this once either lands. Neither touches this section or the corpus numbering.

## Gates

`npm test`, `npm run core:check`, `npm run combinatorial:check`, `npm run property:check` and `npm run test:conformance` green locally on the pushed commit. `npm run ast:check` and `npm run claims:check` could not run here - both compare against sibling engine checkouts that only the scheduled conformance workflow provisions, and neither is a job this PR's own CI runs. `npm run compare:impls` WAS run, with all three engines built from their own `main` (carve-rs `e912088`, carve-js `1aaaf94`, carve-php `ef28bbf`), and the comparison page quotes that run: 642 pairs, carve-js and carve-php 642 of 642, carve-rs one document behind on the footnote-definition-column case that was already the only one. A first run was discarded because it reported a spurious `plain`-target error that did not reproduce - other work of mine was loading the machine at the time - and the quoted run is the clean one.
