### PR TITLE
test: pin the non-HTML shape the corpus had no document for

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -9535,3 +9535,22 @@ a
 ```
 
 :::
+
+## A block image is separated from the block after it on every target
+
+A lone image is a BLOCK, so whatever separates two blocks on a target separates this one from what follows. The corpus held no document where a block image is followed by another block, so no gate compared the engines on it - and one of them ran the alt text straight into the next paragraph on the plain and ANSI targets (`alt textfollowing paragraph`), which the two repos claiming non-HTML parity could not catch because each reads its own committed snapshot rather than the other engines (carve-rs#692, carve-js#762).
+
+::: compare
+
+```carve
+![alt text](img.png)
+
+following paragraph
+```
+
+```html
+<img src="img.png" alt="alt text">
+<p>following paragraph</p>
+```
+
+:::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>644 / 644</strong>
+    <strong>645 / 645</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>644 / 644</strong>
+    <strong>645 / 645</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>644 / 644</strong>
+    <strong>645 / 645</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,11 +36,11 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `470d389` | `644 / 644` | `0` | `0` | `2.73` |
-| JS | `94e3f85` | `644 / 644` | `0` | `0` | `71.01` |
-| PHP | `476c96b` | `644 / 644` | `0` | `0` | `63.26` |
+| Rust | `2119892` | `645 / 645` | `0` | `0` | `2.78` |
+| JS | `94e3f85` | `645 / 645` | `0` | `0` | `73.89` |
+| PHP | `4802645` | `645 / 645` | `0` | `0` | `66.16` |
 
-Spec commit: `f0b324c`, plus the two corpus cases this change adds
+Spec commit: `cab673a`, plus the corpus case this change adds
 
 The engines have caught up further since the last snapshot: the `carve`-target
 differences it listed - `16-reference-link-4`,
@@ -396,21 +396,21 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=644 targets=html,markdown,plain,carve,ansi
-rust: pass=658/658 mismatch=0 error=0 skipped=0 runs=3220 avg_ms=2.73
+profile=default/no-opt-in corpus=core corpus_pairs=645 targets=html,markdown,plain,carve,ansi
+rust: pass=659/659 mismatch=0 error=0 skipped=0 runs=3225 avg_ms=2.78
   mismatching documents: 0
-js: pass=658/658 mismatch=0 error=0 skipped=0 runs=3220 avg_ms=71.01
+js: pass=659/659 mismatch=0 error=0 skipped=0 runs=3225 avg_ms=73.89
   mismatching documents: 0
-php: pass=658/658 mismatch=0 error=0 skipped=0 runs=3220 avg_ms=63.26
+php: pass=659/659 mismatch=0 error=0 skipped=0 runs=3225 avg_ms=66.16
   mismatching documents: 0
 cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=644 diffs=0 errors=0 fixtures=yes
-markdown: compared=644 diffs=0 errors=0 fixtures=1
-plain: compared=644 diffs=0 errors=0 fixtures=1
-carve: compared=644 diffs=0 errors=0 fixtures=12
-ansi: compared=644 diffs=0 errors=0 fixtures=none
+html: compared=645 diffs=0 errors=0 fixtures=yes
+markdown: compared=645 diffs=0 errors=0 fixtures=1
+plain: compared=645 diffs=0 errors=0 fixtures=1
+carve: compared=645 diffs=0 errors=0 fixtures=12
+ansi: compared=645 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 644 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 645 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus with no HTML divergences.
 Pre-1.0, a minor release may still change the grammar.

--- a/tests/corpus/242-a-block-image-is-separated-from-the-block-after-it-on-every-target.crv
+++ b/tests/corpus/242-a-block-image-is-separated-from-the-block-after-it-on-every-target.crv
@@ -1,0 +1,3 @@
+![alt text](img.png)
+
+following paragraph

--- a/tests/corpus/242-a-block-image-is-separated-from-the-block-after-it-on-every-target.html
+++ b/tests/corpus/242-a-block-image-is-separated-from-the-block-after-it-on-every-target.html
@@ -1,0 +1,2 @@
+<img src="img.png" alt="alt text">
+<p>following paragraph</p>

--- a/tests/spec/242-a-block-image-is-separated-from-the-block-after-it-on-every-target.test
+++ b/tests/spec/242-a-block-image-is-separated-from-the-block-after-it-on-every-target.test
@@ -1,0 +1,10 @@
+A block image is separated from the block after it on every target
+
+```
+![alt text](img.png)
+
+following paragraph
+.
+<img src="img.png" alt="alt text">
+<p>following paragraph</p>
+```


### PR DESCRIPTION
Closes #849 (filed as part of the #755 audit). Completes markup-carve/carve-rs#692 / markup-carve/carve-js#762.

A lone image is a **block**, so whatever separates two blocks on a target separates it from what follows. No corpus document had a block image followed by another block, so `compare:impls` never compared the engines on it - and one of them ran the alt text straight into the next paragraph on the plain and ANSI targets:

```carve
![alt text](img.png)

following paragraph
```

gave `alt textfollowing paragraph`.

## Two repos claimed to check exactly this and could not

carve-rs's `tests/non_html_parity.rs` and carve-js's `test/non-html-renderers.test.ts` each called their own committed snapshot "carve-php's output" and concluded the three engines agree. Neither invokes carve-php. Both stayed green through the divergence, and the two snapshots had meanwhile drifted apart from each other - 34 cases against 31, different names for the same constructs, a same-named case with different input.

Their docblocks now say what they actually do (markup-carve/carve-rs#696, markup-carve/carve-js#766), and this is the shape moving to where the property is really checked.

`compare:impls` compares markdown, plain and ansi engine-to-engine across the whole corpus, so one document here covers all five targets at once - which is why the fix is a corpus case rather than a fourth snapshot. carve-php's divergence is fixed in markup-carve/carve-php#920.

Measured after: 645 pairs, 659/659 per engine, `cross_impl_diffs=0`.
