### PR TITLE
spec: record why the raw-block rule was settled, measured rather than assumed

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1002,9 +1002,24 @@ raw_block = code_fence_open, [space], "=", format_name, newline,
    `raw_block` the one block kind whose placement ignores its container, which
    is a second rule applying to one kind with nothing behind it.
 
-   Three engines gave three answers here, and the corpus could not tell them
-   apart because it pinned only a SINGLE-LINE raw block -- a shape on which
-   "indent the block" and "indent every line" agree (carve#800). *)
+   THE `<pre>` HAZARD IS WHAT THIS RULE FORECLOSES, NOT WHAT IT REPAIRED, and
+   the difference matters to anyone arguing the clause later. Taken literally,
+   "indent every line" does corrupt a `<pre>`, and the oracle did exactly that.
+   No ENGINE did: every one of them already suspended re-indentation inside an
+   open `<pre>`, so all three agreed on every `<pre>` shape both before and
+   after this rule landed. What actually had to be settled was the ordinary
+   interior line, where the cost is changed bytes rather than changed rendered
+   content. Argue this clause from the rule; the `<pre>` example illustrates
+   it, and never distinguished the engines.
+
+   A FIXTURE FOR THIS RULE MUST BE AT LEAST TWO LINES WITH AT LEAST ONE OF THEM
+   OUTSIDE A `<pre>`. The corpus could not tell the readings apart because it
+   pinned only a SINGLE-LINE raw block -- a shape on which "indent the block"
+   and "indent every line" agree. The `<pre>` pair pins the placement half, but
+   an engine that re-indents only its non-`<pre>` interior lines passes that
+   pair, so it cannot stand in for the other. Three engines gave three answers
+   when carve#800 was filed; by the time the rule landed carve-js had moved and
+   it was one engine against two. *)
 
 format_name = "html" | "latex" | identifier ;
 raw_content = (* any content until closing fence *) ;


### PR DESCRIPTION
Follow-up to markup-carve/carve#800, which is already closed by #848. No behavior changes and no normative sentence changes: this corrects the *reason* recorded next to the rule, because the reason the rule shipped with does not survive measurement and the next reader would inherit it.

## The argument that did not decide it

The issue, the ruling comment and #848's own body all rest on the same point: re-indenting a raw block's interior lines changes bytes the author wrote, "and that matters inside a `<pre>`, where leading whitespace is content".

Measured against fresh builds of all three engines, that never distinguished them. Every engine already suspended re-indentation inside an open `<pre>` - including carve-php, the one being corrected. On the issue's own `<pre>` example, all three were byte-identical *before* carve-php's fix landed:

```
[^a]: note

  ```=html
  <pre>
  a
    b
  </pre>
  ```

see[^a]
```

```html
    <li id="fn1">
      <p>note</p>
      <pre>
a
  b
</pre>
      <p><a href="#fnref1" role="doc-backlink">↩</a></p>
    </li>
```

The hazard is real for "indent every line" taken literally - `scripts/spec/html.mjs` did exactly that, with no `<pre>` exception, and did corrupt a `<pre>` - but no engine implemented it that way. So it is what the rule forecloses, not what it repaired. What actually had to be settled was the ordinary interior line, where the cost is changed bytes rather than changed rendered content. The rule is unaffected; only its stated justification is.

## The `<pre>` corpus pair cannot detect the engine defect

Pair `241-...-2` was added "because that is where the difference is visible as content rather than as whitespace". It is not, for an engine. Rendering both landed pairs with carve-php at the commit before its fix:

| pair | pre-fix carve-php | fixed carve-php |
|---|---|---|
| `241-...` (footnote, two lines, no `<pre>`) | FAIL | PASS |
| `241-...-2` (`<pre>` in a block quote) | PASS | PASS |

An engine that re-indents only its non-`<pre>` interior lines - precisely the reading this rule rejects - passes the `<pre>` pair. That pair pins the placement half and is load-bearing against a flush-everything reading, but it cannot stand in for the other half. The clause now says so, so the two-line non-`<pre>` fixture is not later treated as redundant.

## Also corrected

"Three engines gave three answers" was already one engine against two by the time the rule landed: markup-carve/carve-js#727 had merged and carve-js and carve-rs were byte-identical. The clause now records the filing state and the landing state separately.

## Measurement

Fresh clones built from each engine's current main - carve-js `d7eb728`, carve-php `83977e4`, carve-rs `82ce810`, plus carve-php at `476c96b~1` for the pre-fix comparison. Ten shapes, HTML target, indentation read with `cat -A`: the raw block alone at top level, in a footnote body at two and three lines, in a block quote, in a list item, in a nested list item at a deeper column, and four `<pre>` placements (`<pre>` only, `<pre>` after ordinary content, ordinary content after `</pre>`, `<pre>` in a block quote).

All three engines agree on all ten at current main. Against pre-fix carve-php, seven of the ten diverge and three agree - the three that agree are the top-level shape, which has no container column to apply, and the two shapes whose whole interior sits inside a `<pre>`.

## Load-bearing check

Both landed corpus pairs were confirmed able to fail, by mutating the oracle's `raw` case and restoring it:

| `scripts/spec/html.mjs` `raw` case | conformant | mismatches |
|---|---|---|
| as merged (pad the opening only) | 645 | none |
| pad every line (the pre-#848 bug) | 643 | both 241 pairs |
| pad nothing (carve-js's old reading) | 642 | both 241 pairs, plus 225 |
| restored | 645 | none |

## Gates

`npm test`, `combinatorial:check`, `core:check`, `property:check` and `test:conformance` all green, unchanged from the baseline on `main`. `ast:check`, `claims:check` and `degradation:check` could not run locally - they compare against sibling engine checkouts this host does not provide (`a dependency outside the repository is missing: /tmp/carve-js/dist`; `need all three engines, found 0 (none)`) and are provisioned only by a separate scheduled workflow, not by this repo's per-PR CI.
