### PR TITLE
spec: A2a is agreement now, and the claims say so

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2853,20 +2853,28 @@ EOF = (* end of file *) ;
          carve-php dropped it over the two reference definitions and applied
          it over the other three, and carve-js dropped it over all five --
          self-consistent, and the only answer that throws the attribute away.
-         All three agree when nothing intervenes, so this is specifically
+         All three agree when nothing intervenes, so this was specifically
          about what an invisible construct does to a floating attribute.
          (carve#529)
 
-         The executable spec in scripts/spec already applies it over all five,
-         so the rule above is what this repository's own implementation does
-         rather than a new behavior invented for the clause.
+         ALL THREE NOW FOLLOW THIS RULE. Measured on each engine's own main:
+         every one of the five kinds gives `<p id="i">e</p>` in carve-js,
+         carve-rs and carve-php alike (carve#857). The executable spec in
+         scripts/spec applied it over all five from the start, so the clause
+         was never a behavior invented for it.
 
-         The divergence is PINNED, one claim per kind, in
-         scripts/engine-claims.mjs. That is the direction that matters here: a
-         documented divergence which is silently RESOLVED leaves a false
-         sentence behind, so when the engines move to this rule those five
-         claims start failing, and the failure is the signal to rewrite this
-         paragraph as agreement rather than to relax the check.
+         The AGREEMENT is pinned, one claim per kind, in
+         scripts/engine-claims.mjs -- the five that used to pin the
+         divergence. Keeping five rather than collapsing to one is deliberate:
+         the engines disagreed per kind and none was self-consistent across
+         all of them, so a single case would let four kinds regress unnoticed.
+
+         Worth recording how this was found, because the mechanism is the
+         point. The divergence was pinned as a divergence, so the claims began
+         FAILING on the day the last engine came into line, and the failure
+         said to rewrite this paragraph rather than to relax the check. A
+         resolved divergence that nothing pins leaves a false sentence behind
+         with nothing to notice it.
 
       A3 MERGE (over all pending blocks, source order):
          * id -> last one wins;

--- a/scripts/engine-claims.mjs
+++ b/scripts/engine-claims.mjs
@@ -67,43 +67,46 @@ const CLAIMS = [
    * constructs, so it needs five claims: the split is PER KIND, and one case
    * would pin the shape of the disagreement wrong.
    *
-   * These are the direction this checker cares most about - a documented
-   * divergence that gets silently RESOLVED leaves a false sentence in the
-   * grammar. A2a says what every engine should do; when they all move to it
-   * these five start failing, and the failure is the signal to rewrite the
-   * paragraph as agreement rather than to relax the check.
+   * THEY HAVE ALL MOVED TO A2a, and these five now pin the agreement instead.
+   * That is the outcome this checker was built for: a documented divergence
+   * that gets silently RESOLVED leaves a false sentence in the grammar, so the
+   * five claims failed on the day the last engine came into line and the
+   * failure said to rewrite the paragraph rather than relax the check
+   * (carve#529 measured the divergence; carve#857 measured its end).
    *
-   * The odd-engine-out values come from the matrix measured in carve#529.
+   * They stay one claim per KIND rather than collapsing into one: the engines
+   * disagreed per kind and none was self-consistent across all five, so a
+   * single case would let four kinds regress unnoticed.
    */
   {
     section: 'PART 9 §15 A2a, floating attribute over a footnote definition',
-    quote: 'carve-rs applies the attribute over a footnote definition where carve-js and carve-php drop it',
+    quote: 'every engine applies a floating attribute over a footnote definition',
     source: '{#i}\n[^f]: note\n\ne\n',
-    expect: ['rs'],
+    expect: 'agree',
   },
   {
     section: 'PART 9 §15 A2a, floating attribute over a link reference definition',
-    quote: 'carve-rs applies the attribute over a link reference definition where carve-js and carve-php drop it',
+    quote: 'every engine applies a floating attribute over a link reference definition',
     source: '{#i}\n[f]: u\n\ne\n',
-    expect: ['rs'],
+    expect: 'agree',
   },
   {
     section: 'PART 9 §15 A2a, floating attribute over an abbreviation definition',
-    quote: 'carve-php applies the attribute over an abbreviation definition where carve-js and carve-rs drop it',
+    quote: 'every engine applies a floating attribute over an abbreviation definition',
     source: '{#i}\n*[A]: b\n\ne\n',
-    expect: ['php'],
+    expect: 'agree',
   },
   {
     section: 'PART 9 §15 A2a, floating attribute over a line comment',
-    quote: 'carve-js drops the attribute over a line comment where carve-rs and carve-php apply it',
+    quote: 'every engine applies a floating attribute over a line comment',
     source: '{#i}\n%% c\n\ne\n',
-    expect: ['js'],
+    expect: 'agree',
   },
   {
     section: 'PART 9 §15 A2a, floating attribute over a comment block',
-    quote: 'carve-js drops the attribute over a comment block where carve-rs and carve-php apply it',
+    quote: 'every engine applies a floating attribute over a comment block',
     source: '{#i}\n%%%\nc\n%%%\n\ne\n',
-    expect: ['js'],
+    expect: 'agree',
   },
 ]
 


### PR DESCRIPTION
Closes #857.

PART 9 §15 A2a describes a floating attribute over the five invisible constructs, and the paragraph recorded a three-way divergence: carve-rs applied it over four kinds, carve-php over three, carve-js over none. Measured against each engine's own `main` today, all five kinds give `<p id="i">e</p>` in all three.

So the sentence was false, and the five claims in `scripts/engine-claims.mjs` that pinned the divergence had started failing - which is exactly what the paragraph said would happen, and what to do about it:

> a documented divergence which is silently RESOLVED leaves a false sentence behind, so when the engines move to this rule those five claims start failing, and the failure is the signal to rewrite this paragraph as agreement rather than to relax the check.

The paragraph now records the divergence as history and the agreement as current, with the measurement. The five claims flip from odd-engine-out to `agree`, so they keep failing if any engine regresses on any kind.

## They stay five

Rather than collapsing into one. The engines disagreed per **kind** and none was self-consistent across all of them, so a single case would let four kinds regress unnoticed - the same reason they were split when the divergence was pinned.

8/8 grammar claims hold, measured against carve-js `be96408`, carve-rs `b3f63fd` and carve-php `83977e4`.
