### PR TITLE
chore: the `+` writer debt is paid, so its declaration goes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#be96408bce932cfeaa3f1b9d9136981438b5ae6a",
+        "@markup-carve/carve": "github:markup-carve/carve-js#35c3164bc5b2b42d5bed6eeb6e9105e1c7306431",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.40.0",
@@ -982,8 +982,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#be96408bce932cfeaa3f1b9d9136981438b5ae6a",
-      "integrity": "sha512-SjKM7x9iFOBMtmuKn+6hobSdvCe7MBXq22xGtwnlYQAfvLw+qdDMvwBRfOqravGEh6RRdmbO9PBTqL1MlyNfGw==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#35c3164bc5b2b42d5bed6eeb6e9105e1c7306431",
+      "integrity": "sha512-CUCWScRr3gXNieIQjRyfcOKATgETA6iY8X/skdT0ycy/LrsL+OLRBke20HUhsk97p9Quj1pSXbG4B3jj3HPiHQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#be96408bce932cfeaa3f1b9d9136981438b5ae6a",
+    "@markup-carve/carve": "github:markup-carve/carve-js#35c3164bc5b2b42d5bed6eeb6e9105e1c7306431",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.40.0",

--- a/resources/engine-fmt-drift.txt
+++ b/resources/engine-fmt-drift.txt
@@ -24,4 +24,3 @@
 #
 # Format: <slug><space><space><reason>
 227-a-definition-inside-a-definition-list-dd-is-collected-and-the-entry-keeps-no-trace-2  the pinned build's initial render is already correct (<dd></dd>, the footnote resolves) - only the writer is broken: fmt collapses ":  [^f]: x" down to a bare ":", which the pin then reads back as "<dt>term\n:</dt>" instead of a separate <dd>; carve#666, drops out once carve-js ships the fix
-246-the-continuation-marker-at-an-item-s-own-column-and-what-follows-it-3  every writer drops the `+` and emits the attached paragraph indented, which re-parses as a lazy continuation of the item's first paragraph - so `to_html(fmt(x))` says `<li>a b</li>` where the source says two blocks; carve#861, and unusually this is not pin lag: carve-js, carve-rs and carve-php all do it, which is why no cross-engine gate saw it either


### PR DESCRIPTION
Closes #861.

`resources/engine-fmt-drift.txt` carried corpus 246's third pair because every writer dropped the `+` continuation marker and emitted the attached paragraph indented, where it re-parses as a lazy continuation of the paragraph above.

All three have since fixed it - markup-carve/carve-js#776, markup-carve/carve-rs#701, markup-carve/carve-php#927 - and each now writes the document back as

```carve
- a
+
b

x
```

verified against fresh builds of all three mains (carve-js `35c3164`, carve-rs `305e541`, carve-php `3f57554`).

The carve-js pin moves with the deletion, which is what the file's own header asks for: a declared slug that now round-trips is as loud a failure as an undeclared one that does not, so the entry cannot outlive the debt. `engine:report --check` reports "Drift matches what is declared".
