### PR TITLE
docs: raw_text is not carried on the wire, so profiles.md should not say it is

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -83,11 +83,17 @@ named fence" behavior denies both.
 
 This page answers "what can a profile deny", which is a smaller set than "what
 appears in the tree". A serialized AST (PART 12) therefore carries type names
-this vocabulary does not list - `tag`, `smart_punctuation`, `literal_inline`,
-`raw_text` and the `document` root - because denying them would mean nothing:
-they are either folded into another trust class or serve a formatter rather than
-the document. A consumer reading an AST should expect them; a profile author
-should not look for them here.
+this vocabulary does not list - `tag`, `smart_punctuation`, `literal_inline`
+and the `document` root - because denying them would mean nothing: they are
+folded into another trust class. A consumer reading an AST should expect them;
+a profile author should not look for them here.
+
+`raw_text` is a separate case and is NOT carried. It is formatter-internal, and
+PART 12 §5 keeps it off the wire; PART 12 §3a goes further and says there is no
+such node at all, because the reversion that would have needed one does not
+happen. So it is neither deniable nor serialized, and a consumer should not
+expect it. Measured: no engine emits it for any of the 655 corpus documents,
+and `resources/ast-schema.json` does not name it.
 
 ### A definition line is content, so both definition types are deniable
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -5240,8 +5240,8 @@ EOF = (* end of file *) ;
       answer, and nothing needs saying.
 
    5. WHAT IS NOT IN THE SERIALIZED FORM. Formatter-internal nodes (PART 11,
-      and the `raw_text` case profiles.md excludes) are not part of the
-      document and are not serialized. Resolution results that a consumer can
+      and the `raw_text` case profiles.md names as neither deniable nor
+      carried) are not part of the document and are not serialized. Resolution results that a consumer can
       recompute - footnote numbering, caption numbers, a generated heading id -
       ARE serialized, because recomputing them requires reimplementing PART 9R.
 


### PR DESCRIPTION
`docs/profiles.md` tells a consumer what to expect in a serialized AST beyond the deniable vocabulary:

> A serialized AST (PART 12) therefore carries type names this vocabulary does not list - `tag`, `smart_punctuation`, `literal_inline`, `raw_text` and the `document` root

Four of those five are right. **`raw_text` is not carried by anything**, and the grammar says so twice:

| clause | says |
| --- | --- |
| PART 12 §5 | formatter-internal nodes "are not part of the document and are not serialized", naming this case explicitly |
| PART 12 §3a | "SO THERE IS NO `raw_text`" - the reversion that would have needed the type does not happen, so the need does not arise |

So the page promised a node the normative text had already removed, and a consumer reading it would write a branch that never runs.

## Measured, not inferred

- Across all **655 corpus documents**, no engine emits a `raw_text` node.
- `resources/ast-schema.json` does not name the type.
- The other four in that list **do** appear: `tag`, `smart_punctuation` and `literal_inline` all show up in the corpus, and `document` is the root.

So this splits the sentence rather than deleting it, and gives `raw_text` its own paragraph saying it is neither deniable nor serialized.

## How it surfaced

Walking every corpus document's tree through carve-rb and diffing the set of type names produced against this page's vocabulary. Worth noting the same diff also reported `caption`, `citation_group` and `section` as vocabulary the DEFAULT corpus profile never produces - a different question (opt-in tiers and the sections option), and not a defect.

The grammar's own cross-reference is updated to match, so §5 and the page still describe each other.