### PR TITLE
chore: bump the carve-js pin to 52da7be

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#35c3164bc5b2b42d5bed6eeb6e9105e1c7306431",
+        "@markup-carve/carve": "github:markup-carve/carve-js#52da7be7c94b0166363487ec0bd3de43b3817855",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.42.1",
@@ -23,7 +23,7 @@
         "vitepress": "^1.5.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -985,8 +985,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#35c3164bc5b2b42d5bed6eeb6e9105e1c7306431",
-      "integrity": "sha512-CUCWScRr3gXNieIQjRyfcOKATgETA6iY8X/skdT0ycy/LrsL+OLRBke20HUhsk97p9Quj1pSXbG4B3jj3HPiHQ==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#52da7be7c94b0166363487ec0bd3de43b3817855",
+      "integrity": "sha512-ul4vK91c3q22vVE1JtxG9i2DXYnKV4lnJBVCppVMTDcmmNKZlgkRC8Ztf0vcZeVQmuqyYk/tqq740dB+8wqVKw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#35c3164bc5b2b42d5bed6eeb6e9105e1c7306431",
+    "@markup-carve/carve": "github:markup-carve/carve-js#52da7be7c94b0166363487ec0bd3de43b3817855",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.42.1",


### PR DESCRIPTION
The pin was seventy-six commits behind. That matters more than usual right now: the pinned build predates the position fixes for a leading byte order mark and for CRLF line endings (markup-carve/carve-js#780, markup-carve/carve-js#782), so a corpus document written in either shape would be measured here against an engine already known to report the wrong offsets for it. `tests/ast-positions.test.mjs` reads each fixture's real bytes, so it reports those offsets as findings against the document rather than against the engine.

Suite and `core:check` are clean against the new pin, and no fixture changed - this moves the reference build, not the corpus.

Unblocks the corpus pairs asked for in markup-carve/carve#872.