### PR TITLE
ci: a re-bumped PR's title names the rev it now carries

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -354,8 +354,18 @@ jobs:
             #
             # Failure is reported now rather than hidden: a body that did not
             # update is exactly the state that was invisible before.
-            if ! gh api "repos/$REPO/pulls/$existing" -X PATCH -f body="$body" >/dev/null; then
-              echo "::warning::could not update the body of $REPO#$existing - it may describe an earlier run"
+            # The TITLE moves with the body. It used to be written once, by
+            # the run that created the PR, and every later re-bump left it
+            # naming the first rev - so an open PR read "bump to carve
+            # 6611571" while its branch carried 555b980, and the squash
+            # message that landed on main inherited the wrong rev. Worse than
+            # cosmetic: the title is what a reviewer checks a bump against,
+            # and four repos went red on a category from the rev the title
+            # did not name.
+            if ! gh api "repos/$REPO/pulls/$existing" -X PATCH \
+              -f title="chore: bump spec corpus to carve $short" \
+              -f body="$body" >/dev/null; then
+              echo "::warning::could not update the title or body of $REPO#$existing - they may describe an earlier run"
             fi
             echo "Updated existing PR #$existing on $REPO (draft=${draft:+yes})."
           fi


### PR DESCRIPTION
The bump PR's title was written once, by the run that created it. Every later re-bump rewrites the branch and the body and leaves the title naming the **first** rev.

Seen today: carve-js#783 read `chore: bump spec corpus to carve 6611571` while its branch carried `555b980`, and the squash message on `main` inherited the wrong rev. The same happened on carve-rs, carve-php, carve-grammars and vscode-carve.

That is not cosmetic. The title is what a reviewer checks a bump against, and what the merge commit says forever. All four engine repos went red immediately after merging - the newer rev had added a corpus category (`a-continuation-marker-after-a-blank-line-in-a-loose-item`) that none of their allowlists knew about, and nothing on the PR named the rev that brought it.

The title now moves with the body, through the same REST PATCH the body already uses (the GraphQL path fails in this org on the Projects-classic deprecation, which the comment above it records).