### PR TITLE
fix: gate carve-rb against carve-rs, and stop blaming it for the probe

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -897,6 +897,7 @@ let rsRootShaped = false
 }
 
 // ---- carve-rb: serializes carve-rs's tree ----------------------------------
+const rbShapes = new Map()
 if (existsSync(resolve(rbDir, 'lib/carve'))) {
   const rbFindings = []
   for (const { name, source } of satelliteSamples) {
@@ -904,7 +905,17 @@ if (existsSync(resolve(rbDir, 'lib/carve'))) {
     try {
       const out = execFileSync(
         'ruby',
-        ['-Ilib', '-e', 'require "carve"; require "json"; puts JSON.generate(Carve.parse(STDIN.read))'],
+        // `max_nesting: false`. Ruby's JSON.generate refuses past 100 levels by
+        // default, and the corpus deliberately holds documents deeper than
+        // that - so this probe raised JSON::NestingError and the run reported
+        // "carve-rb: could not serialize" for a document the binding parses
+        // perfectly well. The finding named the wrong component: nothing in
+        // carve-rb or carve-rs was involved (carve#868).
+        [
+          '-Ilib',
+          '-e',
+          'require "carve"; require "json"; puts JSON.generate(Carve.parse(STDIN.read), max_nesting: false)',
+        ],
         {
           cwd: rbDir,
           input: source,
@@ -921,6 +932,7 @@ if (existsSync(resolve(rbDir, 'lib/carve'))) {
     }
     checkDocument(name, doc, source, rbFindings)
     checkShapeParity(name, doc, rbFindings)
+    rbShapes.set(name, shapePaths(shapeOf(doc)).join('\n'))
   }
   // The compiled extension, not the Ruby source: carve-rb wraps carve-rs
   // through a native build, so a stale `.so` reports the PARSER's old behavior
@@ -938,6 +950,54 @@ if (existsSync(resolve(rbDir, 'lib/carve'))) {
   )
 } else {
   skip('carve-rb', 'checkout not found')
+}
+
+/*
+ * BINDING PARITY, and this one IS a gate.
+ *
+ * Every per-engine finding above is reported and almost none of it is gated,
+ * for a reason stated at the top of this file: a fix lands in one engine first
+ * and is ported over the following days, so the engine that is RIGHT is
+ * routinely the odd one out for a while.
+ *
+ * That is true of the three PEER engines. It is not true of carve-rb, and this
+ * file already says why - it serializes carve-rs's tree, which is why counting
+ * it in the panel would give that engine two votes. A binding over carve-rs
+ * cannot be ahead of carve-rs. Every difference between the two trees is the
+ * binding's: a stale pin, or a gap in the binding. There is no window in which
+ * it is the one that is right.
+ *
+ * So this compares carve-rb against carve-rs SPECIFICALLY - not against the
+ * reference, and not by folding it into the panel. The peer-engine rationale is
+ * untouched; this only asserts in code what the file already asserts in prose.
+ *
+ * What the other two checks could not see (carve#868): the daily run reported a
+ * 44-commit-stale pin and exited 0, and carve-rb's own corpus test compares
+ * HTML byte-for-byte - which cannot see an AST-only change, because a link
+ * reference definition renders nothing.
+ */
+const rsShapes = enginePaths.get('carve-rs')
+if (rbShapes.size > 0 && rsShapes) {
+  const drifted = []
+  for (const [name, shape] of rbShapes) {
+    const rs = rsShapes.get(name)
+    if (rs !== undefined && rs !== shape) drifted.push(name)
+  }
+  const compared = [...rbShapes.keys()].filter((name) => rsShapes.has(name)).length
+  if (drifted.length === 0) {
+    console.log(`BINDING PARITY: carve-rb's tree matches carve-rs on all ${compared} shared document(s).\n`)
+  } else {
+    console.error(
+      `BINDING PARITY: carve-rb's tree differs from carve-rs on ${drifted.length} of ${compared} document(s):`,
+    )
+    for (const name of drifted.slice(0, 10)) console.error(`  ${name}`)
+    if (drifted.length > 10) console.error(`  … and ${drifted.length - 10} more`)
+    console.error("A binding has no vote of its own - every one of these is carve-rb's, not carve-rs's.")
+    console.error('Usually a stale `ext/carve/Cargo.toml` pin; rebuild the extension after bumping it.\n')
+    if (process.env.CARVE_REQUIRE_ALL_ENGINES === '1') process.exit(1)
+  }
+} else if (rbShapes.size > 0) {
+  console.log('BINDING PARITY: not checked - carve-rs was not measured in this run.\n')
 }
 
 // ---- carve-php: serializes through bin/carve --json -------------------------


### PR DESCRIPTION
Closes markup-carve/carve#868.

Two changes, and the second is why the first was worth doing.

## The probe was wrong

The Ruby command this script runs serialized with `JSON.generate` at its default `max_nesting: 100`, and the corpus deliberately holds documents deeper than that. So the run reported

```
carve-rb: could not serialize - JSON::NestingError
```

for `182-openers-past-the-nesting-cap-are-one-paragraph.crv`, a document the binding parses perfectly well. The finding named the wrong component: nothing in carve-rb or carve-rs was involved.

It was wrong in both directions at once. Measured on fresh builds of both:

| probe | carve-rb | carve-rs |
| --- | --- | --- |
| `JSON.generate(...)` | 20 findings, 6 distinct | 27 findings, 5 distinct |
| `JSON.generate(..., max_nesting: false)` | 27 findings, 5 distinct | 27 findings, 5 distinct |

So it invented a divergence (different counts, an extra distinct shape) while hiding seven findings the binding does inherit. The binding is an exact mirror today.

## The gate

Every per-engine finding here is reported and almost none of it is gated, for the reason stated at the top of the file: a fix lands in one engine first and is ported over the following days, so the engine that is RIGHT is routinely the odd one out for a while.

That holds for the three peer engines. It does not hold for carve-rb, and the file already says why - it serializes carve-rs's tree, which is why counting it in the panel would give that engine two votes. A binding over carve-rs cannot be ahead of carve-rs: every difference between the two trees is the binding's, a stale pin or a gap in the binding. There is no window in which it is the one that is right.

carve-rb is now compared against carve-rs specifically - not against the reference, and not by folding it into the panel, so the peer-engine rationale is untouched. It reports always and exits non-zero only under `CARVE_REQUIRE_ALL_ENGINES=1`, the same contract the stale-build and not-measured roll-ups already use.

## Proof it fires

- Against a binding built three days ago: `carve-rb's tree differs from carve-rs on 129 of 672 document(s)`.
- With a single injected difference: exit 1 under the flag, exit 0 without it.
- Against current builds of both: `672 of 672` match, so this lands green.

The stale-binding run also trips the §1a adjacent-text check, which is why the injected-difference run is the one that isolates this gate rather than another.

## Why this is not duplicate coverage

The issue records both existing checks missing a 44-commit-stale pin: the daily run reported it and exited 0 by design, and carve-rb's own corpus test compares HTML byte-for-byte, which cannot see an AST-only change because a link reference definition renders nothing.