### PR TITLE
spec: the code fence's metadata slots are padding, like the frontmatter opener's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **PART 7: the code fence's metadata slots are padding** (carve#894).
+  `fenced_code_block` had the same shape as `frontmatter_open` - a fence, a
+  whitespace slot, then a token that names a dialect - and carve#878 moved only
+  the second of the two, leaving the code fence spelled `space` for no reason a
+  reader could state. It is padding under the same discriminator: the backtick
+  or tilde run has already decided the block, and `js` selects nothing. So the
+  slot before the info string becomes `[whitespace]`, and `code_fence_info`'s
+  `"header"` and `[label]` slots become `whitespace+`, matching the admonition
+  opener's identical pair.
+
+  This one runs the OPPOSITE way from the colon fence. The colon fence is a
+  separator, and all four implementations have to stop accepting a tab there;
+  the code fence is padding, and carve-js, carve-php and the oracle already
+  accept one. carve-rs is the only implementation that rejects it, so this
+  edit makes three conforming without moving them and leaves one to relax.
+  `raw_block` keeps its `space`: the `=` after that slot selects a raw block
+  over a code block, which is a separator's job.
+
 - **PART 1 S4: an absorbed colon fence leaves the item's paragraph open**
   (carve#891). Corpus `86-list-lazy-continuation-9` pinned that the flush-left
   line after

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -349,13 +349,18 @@ code_block = fenced_code_block, [caption_slot] ;
    numbered LISTING. The caption may carry a `#` number placeholder, and a
    `</#id>` to the block resolves to "Listing N" (PART 9 §19). *)
 
-fenced_code_block = code_fence_open, [space], [code_fence_info], newline,
+fenced_code_block = code_fence_open, [whitespace], [code_fence_info], newline,
                     code_content,
                     code_fence_close, newline ;
-(* The space between the fence and the info string is OPTIONAL (lenient: both
-   ```php and ``` php are accepted; Markdown writes no space, Djot writes the
-   space). The no-space form (```php) is canonical and is what the X->Carve
-   converters emit. *)
+(* The whitespace between the fence and the info string is OPTIONAL (lenient:
+   both ```php and ``` php are accepted; Markdown writes no space, Djot writes
+   the space). The no-space form (```php) is canonical and is what the X->Carve
+   converters emit. It is a PADDING SLOT, not a marker separator (PART 7): the
+   fence run has already decided that this is a code block, and the info string
+   only names the language and carries metadata. So a tab satisfies it, and so
+   do the two slots inside code_fence_info below. Contrast raw_block (PART 9
+   §20), whose otherwise identical slot stays a `space`: there the `=` after it
+   SELECTS a raw block over a code block, which is a marker separator's job. *)
 (* CODE-FENCE INFO STRING -- NORMATIVE. After the optional language_info
    token the opener admits, in this fixed order, an optional "header" (a
    quoted_title -- the SAME token as the admonition header, PART 9 §12) and an
@@ -418,13 +423,18 @@ code_fence_close = (backtick_fence | tilde_fence):close
 backtick_fence = '`', '`', '`', {'`'} ;
 tilde_fence = '~', '~', '~', {'~'} ;
 
-code_fence_info = ( language_info, [space+, quoted_title], [space+, label] )
-                | ( quoted_title, [space+, label] )
+code_fence_info = ( language_info, [whitespace+, quoted_title], [whitespace+, label] )
+                | ( quoted_title, [whitespace+, label] )
                 | label ;
 (* fixed order: language, then "header", then [label]; each optional, but a
    non-empty info string matches one of these three shapes or it is an
    INVALID-FENCE FALLBACK (see the NORMATIVE note above). quoted_title is the
-   shared header token defined under Admonitions. *)
+   shared header token defined under Admonitions. Both metadata slots are
+   PADDING (PART 7), the same classification the admonition opener's identical
+   "title" and [label] slots carry: the fence has already decided the block. The
+   label slot appears in two alternatives and is one slot with one role, so both
+   spellings widen together -- otherwise ```js "T" [L] and ``` "T" [L] would
+   disagree about a tab for no reason a reader could state. *)
 language_info = (letter | digit | '-' | '_' | '+' | '#' | '.' | '/')+ ;  (* a single token; the punctuation covers real language tags like c++, c#, f#, asp.net, text/html. May start with a digit. The `/` is normative across all impls (so `text/html`, `image/svg` are language tokens, not split). A token MUST NOT start with `=`: a leading `=` is the raw_block opener (above), not a language. *)
 label = '[', { character - ']' }, ']' ;  (* structured metadata, e.g. [Installation]; not part of the class *)
 code_content = (* any text until matching fence, preserved literally *) ;
@@ -2109,9 +2119,20 @@ digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' ;
        admonition opener's `"title"` and `[label]` slots (the type word has
        already decided the block), `frontmatter_open`'s slot before the
        format token (the `---` pair has already decided the block; the token
-       only names the metadata dialect), `link_title`, and the
+       only names the metadata dialect), the code fence's slot before its
+       info string together with `code_fence_info`'s own `"header"` and
+       `[label]` slots (the fence run has already decided the block; the info
+       string names a language and carries metadata), `link_title`, and the
        reference-definition slot before its trailing `attributes` are all
        padding.
+
+     The two fence openers land on opposite sides of this line, so state it
+     once: a COLON fence's slot is a separator, because `note` / `|` / `\` /
+     `[label]` after it pick one of four blocks; a CODE fence's slot is
+     padding, because the fence run already picked the block. The same is
+     true one production further on -- `raw_block`'s slot keeps `space`,
+     since the `=` after it selects a raw block over a code block. Identical
+     shape, different role; the role is what decides the terminal.
 
    A tab is otherwise meaningful ONLY as indentation, and indentation is at
    the START of a line (PART 9 §24 C1) -- a tab after a marker is neither

--- a/tests/separator-role-split.test.mjs
+++ b/tests/separator-role-split.test.mjs
@@ -5,22 +5,39 @@
  * on a marker line into two roles: the slot that decides WHICH construct the
  * line opens is a `space` and a tab never satisfies it, while whitespace
  * between two tokens on an already-decided line is a `whitespace` padding slot
- * and a tab does. Nine productions were classified under that rule (carve#878).
+ * and a tab does. Nine slots were classified under that rule (carve#878); the
+ * code fence's three joined them in carve#894, for twelve.
  *
  * Without this file the classification is unobservable. Every other gate reads
  * behavior, and no engine reads resources/grammar.ebnf, so flipping any of the
- * nine terminals back leaves the whole suite green - the defect class tracked
- * in carve#755. Each site below therefore pins BOTH directions: the terminal
- * the production must carry, and the terminal it must NOT carry, so a silent
+ * terminals back leaves the whole suite green - the defect class tracked in
+ * carve#755. Each site below therefore pins BOTH directions: the terminal the
+ * production must carry, and the terminal it must NOT carry, so a silent
  * re-spelling in either direction fails here.
  *
- * The engine half is deliberately asymmetric. The four PADDING sites are
- * additionally checked against the pinned engine, because the spec and the
- * implementations already agree there and must keep agreeing. The four MARKER
- * SEPARATOR sites are NOT checked against an engine: all four implementations
- * still accept a tab after the colon fence, which is what carve#878 step 2
- * corrects. Pinning today's behavior there would be pinning the bug, and the
- * test would have to be deleted by the fix.
+ * The engine half is deliberately partial, and the two gaps are NOT the same
+ * gap. The loop below runs one engine: the pinned `@markup-carve/carve`
+ * (carve-js). So "checked against the engine" never means "checked against the
+ * implementations", and the two omissions have to be read separately.
+ *
+ *   - The four MARKER SEPARATOR sites are omitted because carve-js gives the
+ *     PRE-ruling answer: it still accepts a tab after the colon fence, which
+ *     carve#878 step 2 corrects. Asserting it would pin the bug, and the fix
+ *     would have to delete the assertion.
+ *
+ *   - The two code-fence PADDING sites are omitted for a different reason.
+ *     carve-js already gives the POST-ruling answer here - measured while
+ *     writing this, ```<tab>js and ```js<tab>"T"<tab>[L] render byte-identical
+ *     to their space forms - so an assertion would pass today and keep
+ *     passing. It is left out because it would be misleading rather than
+ *     wrong: carve#894 reports carve-rs as still rejecting the tab, so the
+ *     ruling is not yet implemented across the engines, and a green
+ *     single-engine assertion in this file would read as though it were. The
+ *     cross-engine gates (claims:check, compare:impls) are where that question
+ *     belongs, and they are what should gain a row once carve-rs relaxes.
+ *
+ * Note the two corrections run in opposite directions: the colon fence tightens
+ * (four implementations lose the tab), the code fence relaxes (one gains it).
  */
 
 import { test } from 'node:test'
@@ -74,10 +91,9 @@ const SITES = [
     role: 'padding',
     site: 'admonition_open, the "title" and [label] metadata slots',
     // Anchored on the production: `code_fence_info` carries the same two
-    // metadata slots and still spells them `space+`. That is deliberate - the
-    // code fence is NOT one of the nine sites carve#878 ruled on - so an
-    // unanchored pattern would match it and this test would be about the
-    // wrong production.
+    // metadata slots, and since carve#894 spells them the same way. An
+    // unanchored pattern would match either production, so each site's
+    // assertion would stop being about the site it names.
     required: /admonition_open = [^;]*\[whitespace\+, quoted_title\], \[whitespace\+, label\] ;/,
     forbidden: /admonition_open = [^;]*\[space\+, (?:quoted_title|label)\]/,
     why: 'the type word has already decided the block; the title and label are metadata',
@@ -113,12 +129,39 @@ const SITES = [
     tab: '[a]: /u\t{.c}\n\n[a][]\n',
     space: '[a]: /u {.c}\n\n[a][]\n',
   },
+  {
+    role: 'padding',
+    site: 'fenced_code_block, the slot before the info string',
+    required: /fenced_code_block = code_fence_open, \[whitespace\], \[code_fence_info\]/,
+    forbidden: /fenced_code_block = code_fence_open, \[space\]/,
+    why: 'the fence run has already decided the block; the info string names a language',
+    engineDeferred:
+      'carve-js already renders ```<tab>js identically to ``` js, so an assertion here ' +
+      'would pass; it is omitted because carve#894 reports carve-rs as still rejecting ' +
+      'the tab, and one green engine would misreport the ruling as implemented. See the ' +
+      'file header.',
+  },
+  {
+    role: 'padding',
+    site: 'code_fence_info, the "header" and [label] metadata slots',
+    // One pattern covers all three spellings on purpose. The label slot is
+    // written twice, once per alternative, and it is one slot with one role:
+    // pinning them separately would let a half-revert pass.
+    required:
+      /code_fence_info = \( language_info, \[whitespace\+, quoted_title\], \[whitespace\+, label\] \) \| \( quoted_title, \[whitespace\+, label\] \) \| label ;/,
+    forbidden: /code_fence_info = [^;]*\[space\+/,
+    why: 'the same two metadata slots the admonition opener carries, after the block is decided',
+    engineDeferred:
+      'same as the slot above, and separably testable (a tab after `js` needs no tab in ' +
+      'the opener slot): carve-js already agrees, carve-rs is reported not to, so the ' +
+      'cross-engine gates carry this rather than one engine here.',
+  },
 ]
 
-test('all nine classified sites are present', () => {
-  assert.equal(SITES.length, 8, 'the nine slots live in eight productions')
+test('all twelve classified slots are present', () => {
+  assert.equal(SITES.length, 10, 'the twelve slots live in ten entries')
   assert.equal(SITES.filter((s) => s.role === 'separator').length, 4)
-  assert.equal(SITES.filter((s) => s.role === 'padding').length, 4)
+  assert.equal(SITES.filter((s) => s.role === 'padding').length, 6)
 })
 
 for (const { role, site, required, forbidden, why } of SITES) {
@@ -141,11 +184,33 @@ for (const { role, site, required, forbidden, why } of SITES) {
   })
 }
 
-// The padding half is the half the implementations already get right, so the
-// spec and the engine are checked against each other. A regression here means
-// either the engine narrowed a padding slot to a literal space, or the spec
-// widened a slot the engine never widened.
-for (const { site, tab, space } of SITES.filter((s) => s.role === 'padding')) {
+// A padding site is engine-checked unless it says in writing why it cannot be.
+// Without this, a site added with no `tab`/`space` fixtures would simply not
+// appear in the loop below and nobody would notice the engine half quietly
+// shrinking - the check-that-cannot-fail class tracked in carve#755.
+test('every padding site is either engine-checked or deferred with a reason', () => {
+  for (const s of SITES.filter((x) => x.role === 'padding')) {
+    const hasFixtures = typeof s.tab === 'string' && typeof s.space === 'string'
+    const deferred = typeof s.engineDeferred === 'string' && s.engineDeferred.length > 0
+    assert.ok(
+      hasFixtures !== deferred,
+      `padding site "${s.site}" must carry either a tab/space fixture pair or a ` +
+        `written engineDeferred reason, and not both.`,
+    )
+  }
+})
+
+// The engine-checked padding sites are the ones the implementations already get
+// right, so the spec and the engine are checked against each other. A
+// regression there means either the engine narrowed a padding slot to a literal
+// space, or the spec widened a slot the engine never widened.
+//
+// The code-fence sites are deliberately absent: carve-rs still rejects a tab in
+// a fence opener, so asserting today's behavior would pin exactly what
+// carve#894 rules against. Same reasoning as the separator half above.
+for (const { site, tab, space } of SITES.filter(
+  (s) => s.role === 'padding' && !s.engineDeferred,
+)) {
   test(`padding slot admits a tab in the pinned engine: ${site}`, () => {
     assert.equal(
       carveToHtml(tab),


### PR DESCRIPTION
Closes #894.

`fenced_code_block` has the same shape as `frontmatter_open` - a fence, a whitespace slot,
then a token that names a dialect. markup-carve/carve#886 classified the second and left
the first spelled `space`, stating the reason at the time: the code fence "is not one of
the nine sites and the implementations split 3-1 on it already."

Verified against `origin/main` (de95007) before touching anything: that is still exactly
the state. `resources/grammar.ebnf:352` read
`fenced_code_block = code_fence_open, [space], [code_fence_info], newline,`, `:421-423`
spelled `code_fence_info`'s metadata slots `space+`, `frontmatter_open:207` already carried
`[whitespace]`, and the terminals at `:2124-2125` were unchanged
(`whitespace = ' ' | '\t' ;`, `space = ' ' ;`). markup-carve/carve#886 also left its reason
in the code: `tests/separator-role-split.test.mjs` anchored its admonition assertion on the
production specifically because `code_fence_info` "still spells them `space+`. That is
deliberate."

Under the discriminator that ruling established - does the token after the whitespace
SELECT which construct the line opens? - the info string is padding. The backtick or tilde
run has already decided the block, and `js` names a language rather than choosing one
construct over another.

## The edit

- `fenced_code_block`'s slot: `[space]` becomes `[whitespace]`.
- `code_fence_info`'s two metadata slots become `whitespace+`. That is three textual
  spellings for two slots: the label slot is written once per alternative, and both widen
  together, since splitting them would make ```js "T" [L] and ``` "T" [L] disagree about a
  tab for no reason a reader could state.
- The PART 7 MARKER SEPARATORS AND PADDING SLOTS clause gains the code fence in its padding
  list, and now states the three neighboring fence openers together, because they carry two
  different answers within a few productions of each other.

`raw_block` deliberately keeps `[space]`. Its slot looks identical, but the `=` after it
selects a raw block over a code block, which is a marker separator's job. That is now
written down at both productions rather than left as an unexplained difference - the same
hazard this ticket exists to remove.

## This runs the OPPOSITE way from the colon fence

Worth stating plainly so nobody sweeps the two together:

- **Colon fence**: separator, stays `space`. All four implementations currently accept a
  tab and must stop. Four tighten.
- **Code fence**: padding, becomes `whitespace`. carve-js, carve-php and the oracle already
  accept a tab. carve-rs rejects it and is the one implementation currently conforming to
  the old `space` spelling. One relaxes.

So this edit makes three implementations conforming without moving them. The carve-rs
relaxation is filed separately as markup-carve/carve-rs#717 rather than done here, so
nobody "fixes" carve-rs toward the old production in the meantime.

## Observability

markup-carve/carve#886 established that nothing in this repo reads productions out of
`resources/grammar.ebnf` - `normativity.test.mjs` reads clause headings only, and no engine
reads the file - so flipping a terminal leaves the whole suite green. This extends the test
that PR added rather than adding a second mechanism:
`tests/separator-role-split.test.mjs` gains one site for `fenced_code_block` and one for
`code_fence_info`, each pinning both directions.

The code-fence sites are deliberately NOT asserted against the engine, and the reason is
recorded accurately rather than by analogy. That loop runs one engine, the pinned carve-js.
Measured while writing this, carve-js already renders ```<tab>js and ```js<tab>"T"<tab>[L]
byte-identical to their space forms, so an assertion would pass and keep passing - it is
omitted because carve-rs still diverges, and one green engine in this file would read as
though the ruling were implemented everywhere. The cross-engine gates are where that
question belongs, and markup-carve/carve-rs#717 says so.

That omission is now a named field carrying a written reason, not a silent absence: a new
assertion fails any padding site that carries neither engine fixtures nor a deferral
reason, so the engine half cannot quietly shrink again.

Each new assertion was proved load-bearing by mutating the terminal it pins, from a
committed HEAD:

- reverting `fenced_code_block` to `[space]` fails `padding: fenced_code_block, the slot
  before the info string` (15 pass, 1 fail).
- a HALF-revert of `code_fence_info`, changing only the second alternative's label slot back
  to `space+`, fails `padding: code_fence_info, the "header" and [label] metadata slots`
  (15 pass, 1 fail). One pattern covers all three spellings for exactly this reason.
- deleting one site's deferral reason fails `every padding site is either engine-checked or
  deferred with a reason` (15 pass, 2 fail).

Each restored clean (`git status --short` empty) and the file returns to 16 passing.

## Normative inventory

`resources/normative-clauses.txt` is unchanged, and that is the correct outcome here rather
than a missed step: the generator was re-run (`node scripts/normative-clauses.mjs`, 98
clauses / 97 distinct headings, byte-identical output) and `tests/normativity.test.mjs`
passes 9/9. The inventory tracks clause HEADINGS, and this change edits clause bodies and
productions without adding, removing or renaming a `-- NORMATIVE` heading. Same shape as
markup-carve/carve#895.

## Gates

`gate-run` reports `partial`, matching the baseline taken before any edit - every gate that
ran is green, and the same four could not run on this host:

- `npm test`, `npm run combinatorial:check`, `npm run core:check`, `npm run property:check`,
  `npm run test:conformance` all pass.
- `npm run ast:check` - "a dependency outside the repository is missing: /tmp/carve-js/dist".
- `npm run claims:check` - "engine-claims: need all three engines, found 0 (none)."
- `npm run degradation:check` - "degradation-claims: need all three engines, found 0 (none)."
- `npm run fmt:check` - "fmt-fixture-claims: need all three engines, found 0 (none)."

Those four need sibling engine checkouts that only a scheduled workflow provisions; none is
part of this PR's own per-PR CI.

## Reviewer notes

Draft #291 (file inclusion / transclusion) also changes `resources/grammar.ebnf`, in a
different region on an unrelated topic. Expect a rebase against it once it lands.

The codex pass raised one finding: that deferring the engine assertion on account of
carve-rs is odd when the loop only ever runs carve-js. Verified and partly upheld - the
premise is correct, and the deferral rationale was reworded to the accurate one above. The
assertion itself is still not added, deliberately, per the direction on this ticket.
