### PR TITLE
spec: the two normative files answer link_title one way, and the oracle is watched

### DIFF
--- a/resources/carve-core.ohm
+++ b/resources/carve-core.ohm
@@ -280,7 +280,27 @@ CarveCore {
   destChar   = destEsc | destParens | (~("(" | ")" | " " | "\t" | newline) any)
   destEsc    = "\\" ("(" | ")" | "\\")
   destParens = "(" destChar* ")"
-  destTitle  = " "+ (quoted | squoted)
+  // A TAB, TOO. `link_title` is spelled `whitespace` in grammar.ebnf - a
+  // space or a tab - because the slot is PADDING rather than a marker
+  // separator: a link is already a link once its destination has been read,
+  // so the title is trailing metadata (PART 7, carve#878). This file said
+  // `" "` only, so the two normative files in `resources/` answered one
+  // production two ways and `[t](/u<TAB>"T")` rendered literally here while
+  // all three engines produced a titled link (carve#888). `destChar` already
+  // excludes both space and tab, so the destination still ends at either.
+  //
+  // CARDINALITY IS UNCHANGED, and deliberately so: this was `" "+` and stays a
+  // run, only a wider one. grammar.ebnf spells `link_title` as exactly ONE
+  // `whitespace`, so the run has always been the looser of the two, for spaces
+  // long before it admitted a tab. Tightening it here would not settle that
+  // disagreement, it would move it: measured, carve-js reads a title after two
+  // spaces AND after two tabs at both the inline and the definition site, so
+  // `exactly one` is a claim no implementation and neither executable file
+  // makes. Which side gives is a question for the production, not for this
+  // file, and narrowing to one would newly break `[t](/u<SP><SP>"T")` here
+  // while every engine kept reading it as a titled link.
+  destTitle  = titleSp+ (quoted | squoted)
+  titleSp    = " " | "\t"
   squoted    = "'" sqChar* "'"
   sqChar     = sqEsc | (~"'" ~newline any)
   sqEsc      = "\\" "'"

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -47,7 +47,23 @@ const QUOTE = /^>(?: (.*)|)$/
 // carried into the href. The rule is stated for the definition explicitly - it
 // "is built from this same `link_destination`" - so the oracle has to read it
 // the same way the inline form does (carve#806).
-const LINK_DEF = /^\[([^\]@][^\]]*)\]: \p{White_Space}*(\P{White_Space}+)(?:\p{White_Space}+"((?:\\"|[^"])*)")?(?:\p{White_Space}.*)?$/u
+//
+// The TITLE slot is the exception, and it is a different production. It is
+// `link_title`, whose separator grammar.ebnf spells `whitespace` = `' ' |
+// '\t'` because the slot is PADDING rather than a marker separator (PART 7,
+// carve#878). The whole White_Space property was two answers to one
+// production: `destTitle` in carve-core.ohm read the inline form's slot as a
+// literal space while this read the definition's as any Unicode space, so one
+// normative file admitted `[a]: /u<NBSP>"T"` and the other rejected
+// `[t](/u<TAB>"T")`. Both now spell it `' ' | '\t'` (carve#888).
+//
+// The two runs on either side of it deliberately keep the wider class. The
+// leading one is entangled with the destination class above: PART 9 §25's
+// scheme probe strips Unicode whitespace so an obfuscated destination cannot
+// slip past the denylist, which corpus case 121 pins with a U+202F before
+// `javascript:`. Narrowing that run is a separate question about
+// `link_destination`, not about `link_title`, and is left alone here.
+const LINK_DEF = /^\[([^\]@][^\]]*)\]: \p{White_Space}*(\P{White_Space}+)(?:[ \t]+"((?:\\"|[^"])*)")?(?:\p{White_Space}.*)?$/u
 
 /*
  * Split a TRAILING attribute block off a definition line (carve#604).

--- a/tests/separator-role-split.test.mjs
+++ b/tests/separator-role-split.test.mjs
@@ -15,6 +15,20 @@
  * production must carry, and the terminal it must NOT carry, so a silent
  * re-spelling in either direction fails here.
  *
+ * THREE CHECKS RUN PER PADDING SITE, against three different artifacts:
+ *
+ *   1. the grammar text, above - what resources/grammar.ebnf spells.
+ *   2. the ORACLE (scripts/spec/layout.mjs + resources/carve-core.ohm), which
+ *      is executable, so every padding site is checked and none is skipped.
+ *   3. the pinned ENGINE, which is skipped where `engineDeferred` says why.
+ *
+ * Check 2 is why every padding site now carries a tab/space fixture pair even
+ * when its engine half is deferred: the two artifacts are deferred for engine
+ * reasons that say nothing about the oracle, and the oracle is a spec artifact
+ * rather than an implementation. carve#888 found the gap this leaves - the
+ * oracle read `[t](/u<TAB>"T")` as literal text while grammar.ebnf had spelled
+ * that slot `whitespace` since carve#878, and nothing could see it.
+ *
  * The engine half is deliberately partial, and the two gaps are NOT the same
  * gap. The loop below runs one engine: the pinned `@markup-carve/carve`
  * (carve-js). So "checked against the engine" never means "checked against the
@@ -46,6 +60,8 @@ import { readFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { carveToHtml } from '@markup-carve/carve'
+import { parse } from '../scripts/spec/layout.mjs'
+import { renderDoc } from '../scripts/spec/html.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const repo = resolve(here, '..')
@@ -135,11 +151,13 @@ const SITES = [
     required: /fenced_code_block = code_fence_open, \[whitespace\], \[code_fence_info\]/,
     forbidden: /fenced_code_block = code_fence_open, \[space\]/,
     why: 'the fence run has already decided the block; the info string names a language',
+    tab: '```\tjs\nx\n```\n',
+    space: '``` js\nx\n```\n',
     engineDeferred:
       'carve-js already renders ```<tab>js identically to ``` js, so an assertion here ' +
       'would pass; it is omitted because carve#894 reports carve-rs as still rejecting ' +
       'the tab, and one green engine would misreport the ruling as implemented. See the ' +
-      'file header.',
+      'file header. The ORACLE half runs regardless - it is not an engine.',
   },
   {
     role: 'padding',
@@ -151,10 +169,13 @@ const SITES = [
       /code_fence_info = \( language_info, \[whitespace\+, quoted_title\], \[whitespace\+, label\] \) \| \( quoted_title, \[whitespace\+, label\] \) \| label ;/,
     forbidden: /code_fence_info = [^;]*\[space\+/,
     why: 'the same two metadata slots the admonition opener carries, after the block is decided',
+    tab: '``` js\t"T"\t[L]\nx\n```\n',
+    space: '``` js "T" [L]\nx\n```\n',
     engineDeferred:
       'same as the slot above, and separably testable (a tab after `js` needs no tab in ' +
       'the opener slot): carve-js already agrees, carve-rs is reported not to, so the ' +
-      'cross-engine gates carry this rather than one engine here.',
+      'cross-engine gates carry this rather than one engine here. The ORACLE half runs ' +
+      'regardless - it is not an engine.',
   },
 ]
 
@@ -184,18 +205,28 @@ for (const { role, site, required, forbidden, why } of SITES) {
   })
 }
 
-// A padding site is engine-checked unless it says in writing why it cannot be.
-// Without this, a site added with no `tab`/`space` fixtures would simply not
-// appear in the loop below and nobody would notice the engine half quietly
-// shrinking - the check-that-cannot-fail class tracked in carve#755.
-test('every padding site is either engine-checked or deferred with a reason', () => {
+// Every padding site carries fixtures, with no exception: the oracle loop
+// below runs them all, and a site with no fixtures would silently drop out of
+// it - the check-that-cannot-fail class tracked in carve#755. `engineDeferred`
+// no longer substitutes for fixtures; it only says why the ENGINE half of the
+// pair is skipped, which is a statement about carve-rs, not about the oracle.
+test('every padding site carries a tab/space fixture pair', () => {
   for (const s of SITES.filter((x) => x.role === 'padding')) {
-    const hasFixtures = typeof s.tab === 'string' && typeof s.space === 'string'
-    const deferred = typeof s.engineDeferred === 'string' && s.engineDeferred.length > 0
     assert.ok(
-      hasFixtures !== deferred,
-      `padding site "${s.site}" must carry either a tab/space fixture pair or a ` +
-        `written engineDeferred reason, and not both.`,
+      typeof s.tab === 'string' && typeof s.space === 'string',
+      `padding site "${s.site}" must carry a tab/space fixture pair; the oracle ` +
+        `check runs at every padding site and cannot skip one.`,
+    )
+  }
+})
+
+// A deferral is a claim about the engines, so it has to be written down and
+// readable. An empty string is not a reason.
+test('an engine deferral states its reason', () => {
+  for (const s of SITES.filter((x) => x.role === 'padding' && 'engineDeferred' in x)) {
+    assert.ok(
+      typeof s.engineDeferred === 'string' && s.engineDeferred.length > 0,
+      `padding site "${s.site}" declares engineDeferred but gives no reason.`,
     )
   }
 })
@@ -218,6 +249,66 @@ for (const { site, tab, space } of SITES.filter(
       `a tab in this padding slot no longer parses as the space form does.\n` +
         `  tab form:   ${JSON.stringify(tab)}\n  space form: ${JSON.stringify(space)}\n` +
         `  The production says \`whitespace\` here (PART 7, carve#878).`,
+    )
+  })
+}
+
+// The ORACLE half, at EVERY padding site including the engine-deferred ones.
+// resources/carve-core.ohm and scripts/spec/layout.mjs are the executable
+// spelling of these productions, so a slot they narrow to a literal space is
+// the same defect as grammar.ebnf spelling it `space` - and it is invisible
+// everywhere else, because the corpus only carries a tab in a padding slot
+// where someone thought to write one. carve#888: `destTitle` in the ohm file
+// read `" "+` while grammar.ebnf said `whitespace`, so `[t](/u<TAB>"T")`
+// rendered as literal text here and as a titled link in all three engines.
+for (const { site, tab, space } of SITES.filter((s) => s.role === 'padding')) {
+  test(`padding slot admits a tab in the oracle: ${site}`, () => {
+    assert.equal(
+      renderDoc(parse(tab)),
+      renderDoc(parse(space)),
+      `a tab in this padding slot does not parse as the space form does in the ` +
+        `executable spec (scripts/spec/layout.mjs, resources/carve-core.ohm).\n` +
+        `  tab form:   ${JSON.stringify(tab)}\n  space form: ${JSON.stringify(space)}\n` +
+        `  The production says \`whitespace\` here (PART 7, carve#878).`,
+    )
+  })
+}
+
+// The OTHER direction, for the one slot carve#888 narrowed.
+//
+// `whitespace` is `' ' | '\t'` and nothing else, so widening a padding slot
+// past that pair is as wrong as narrowing it - and scripts/spec/layout.mjs had
+// done exactly that, matching `\p{White_Space}` before the definition form's
+// title. Both spellings of `link_title` are checked, because the production is
+// one production used at two sites and the bug was that they disagreed.
+//
+// Checked against the ORACLE ONLY, deliberately. carve-js accepts the whole
+// White_Space property in this slot (measured: U+00A0, U+2003, U+202F and
+// U+0085 all yield `title="T"`), so it is wider than the production here and
+// an engine assertion would pin that. That divergence is reported upstream
+// rather than encoded, and no corpus case carries one of these characters, so
+// no cross-engine golden takes a position on it.
+//
+// Scope note, so a later reader does not mistake this for a general rule: the
+// oracle still admits the wider class at three other padding slots - the
+// frontmatter format token, the definition's trailing attributes, and the code
+// fence opener. That inconsistency is real and unfixed; it is simply not what
+// carve#888 changed, and pinning it here would assert a claim no artifact yet
+// makes good on.
+const OUTSIDE_CLASS = '\u00a0' // NBSP: White_Space, but neither ' ' nor '\t'
+
+for (const [form, outside, spaceForm] of [
+  ['inline', `[t](/u${OUTSIDE_CLASS}"T")\n`, '[t](/u "T")\n'],
+  ['reference definition', `[a]: /u${OUTSIDE_CLASS}"T"\n\n[a][]\n`, '[a]: /u "T"\n\n[a][]\n'],
+]) {
+  test(`link_title admits no whitespace outside ' ' | '\\t' in the oracle: ${form}`, () => {
+    assert.notEqual(
+      renderDoc(parse(outside)),
+      renderDoc(parse(spaceForm)),
+      `the oracle read a title after a whitespace character the production does not ` +
+        `admit.\n  outside-class form: ${JSON.stringify(outside)}\n` +
+        `  space form:         ${JSON.stringify(spaceForm)}\n` +
+        `  \`whitespace\` is \`' ' | '\\t'\` (PART 7, carve#878; carve#888).`,
     )
   })
 }


### PR DESCRIPTION
Two of the three items in the issue; the third is parked with a measurement.

Refs markup-carve/carve#888. Not `Closes` - item 3 stays open for a decision.

## What each item turned out to be

**Item 2 was already fixed.** `attrSp` reads `" " | "\t"` on main; markup-carve/carve#889 landed the tab and markup-carve/carve#897 dropped the `"\n"`. No change here.

**Item 1 reads as recorded.** `link_title` is one production used at two sites, and the two normative files in `resources/` answered it two ways, wrong in opposite directions:

- `resources/carve-core.ohm` required a literal space, so the oracle rendered this as literal text where all three engines produce a titled link:

  ```
  [t](/u	"T")
  ```

- `scripts/spec/layout.mjs` matched `\p{White_Space}` before the definition form's title, admitting characters the production never named.

Both now spell the slot `' ' | '\t'`.

**Item 3 is parked.** Its premise does not hold - detail in the issue comment. Short version: the example it cites renders identically with the continuation line flush left, so it is lazy continuation and cannot discriminate. With a blank line forcing the real branch, three and four spaces continue the body but a **tab does not**, in both the oracle and carve-js - the opposite of the claim that all four implementations already treat it as columns. Respelling the production as a column claim would make the grammar state something no implementation does, which is a spec change with engine fan-out rather than a cleanup.

## What is deliberately NOT narrowed

Only the title slot in `LINK_DEF` moved. The runs on either side keep `\p{White_Space}` because they are entangled with `link_destination`, not with `link_title`: PART 9 section 25's scheme probe strips Unicode whitespace so an obfuscated destination cannot slip past the denylist, and corpus case `121-scheme-probe-strips-unicode-whitespace` pins that with a U+202F before `javascript:`. Narrowing the leading run turns that document back into a paragraph and the case red. That is a separate question about the destination class and markup-carve/carve#806.

Cardinality is untouched. The ohm rule was already a run (`" "+`), and grammar.ebnf's "exactly one whitespace" is a claim neither executable file nor carve-js makes - measured, both read a title after two spaces and after two tabs, at both sites. Narrowing to one would newly break `[t](/u<SP><SP>"T")` in the oracle while every engine kept reading it as a titled link. Raised by the codex pass and left deliberately; recorded rather than silently widened.

## Observability

Both changed artifacts are EXECUTABLE, so they are pinned by running the oracle rather than by inspection. `tests/separator-role-split.test.mjs` is extended rather than joined by a third mechanism, and now runs three checks per padding site: the grammar text, the ORACLE, and the pinned engine.

The oracle check runs at all six padding sites, not four. The two code-fence sites are deferred for a reason about carve-rs, and the oracle is not an engine - so those entries now carry the fixture pairs they were previously excused from, and `engineDeferred` no longer substitutes for fixtures. It only says why the engine half is skipped.

The other direction is pinned too: the oracle must not read a title after a whitespace character outside `' ' | '\t'`, at both sites of the one production. Deliberately checked against the ORACLE ONLY - carve-js accepts the whole White_Space property in this slot (measured: U+00A0, U+2003, U+202F and U+0085 all yield `title="T"`), so it is wider than the production and an engine assertion would pin that instead of the ruling. No corpus case carries such a character, so no cross-engine golden takes a position on it.

## The checks were watched failing

| mutation | result |
|---|---|
| `destTitle` back to `" "+` | `padding slot admits a tab in the oracle: link_title` fails - and it is the ONLY failure in 1197 tests, with `core:check` still 672/672 green |
| `LINK_DEF` title slot back to `\p{White_Space}` | the `reference definition` outside-class assertion fails; the `inline` one does not, so the two are independently load-bearing rather than one covering for the other |
| `titleSp` widened to admit NBSP | passes - `destChar` eats the NBSP first. Widening BOTH `destChar` and `titleSp` fails the `inline` outside-class assertion, so that assertion is real but pins two lines, not one |
| fixtures removed from a deferred site | `every padding site carries a tab/space fixture pair` fails, plus the site's own oracle check - the shape the old XOR rule permitted |

The first row is the point: with the fix reverted, the whole rest of the suite and the corpus gate stay green. That is the markup-carve/carve#755 class this file exists to close.

## The corpus pin the issue asks for is not here

Adding a corpus pair moves the corpus count, and the counts in `docs/implementation-comparison.md` and `docs/index.md` are pasted `compare:impls` output measured across all three engines (markup-carve/carve#889 re-ran it rather than adjusting it). This host has zero engines available, so editing those numbers would fabricate a cross-engine measurement. The corpus pin wants a host with the three engines built; the oracle assertion above covers the same defect in the meantime.

## Gates

`gate-run` reports `partial`, the same outcome as the baseline on main. Green: `npm test` (1199), `npm run combinatorial:check`, `npm run core:check` (672/672 conformant, 0 defects), `npm run property:check`, `npm run test:conformance`. Could not run locally, quoted verbatim:

- `npm run ast:check` - a dependency outside the repository is missing: /tmp/carve-js/dist
- `npm run claims:check` - engine-claims: need all three engines, found 0 (none).
- `npm run degradation:check` - degradation-claims: need all three engines, found 0 (none).
- `npm run fmt:check` - fmt-fixture-claims: need all three engines, found 0 (none).

`resources/normative-clauses.txt` is unchanged, which is correct: no clause heading moved, and `resources/grammar.ebnf` is not touched by this branch at all.

Rebased onto `d5ea058` after markup-carve/carve#897 merged mid-work; it touches both changed files and claimed corpus number 253.
