### PR TITLE
docs: the S4 drift line names what is actually behind

### DIFF
--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,4 +24,4 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-86-list-lazy-continuation-9  PART 1 S4 folds the flush-left line into the item's open paragraph, because the `:::note` line failed §12's opener test and was absorbed as paragraph text rather than interrupting it (carve#891). The corpus and the executable spec answer that way now; no engine does yet, and the engine side is carve#891 steps 3 and 4.
+86-list-lazy-continuation-9  PART 1 S4 folds the flush-left line into the item's open paragraph, because the `:::note` line failed §12's opener test and was absorbed as paragraph text rather than interrupting it (carve#891). ALL THREE ENGINES ANSWER THAT WAY NOW (carve-js#792, carve-rs#718, carve-php#949); what is behind is the PUBLISHED carve-js this repo pins, 0.1.2, which predates the fix. The line clears itself on the next release rather than on any further engine work.


### PR DESCRIPTION
The entry says *"no engine does yet"*. That was true this morning and is not now:

| engine | |
| --- | --- |
| carve-js | markup-carve/carve-js#792 |
| carve-rs | markup-carve/carve-rs#718 |
| carve-php | markup-carve/carve-php#949 |

All three answer `86-list-lazy-continuation-9` the way PART 1 S4 does, and `compare:impls` is **690/690 with zero cross-implementation diffs** at those revisions.

What is still behind is the **published** carve-js this repo pins - 0.1.2, measured here rendering the old answer - so the line stays until the next release rather than until more engine work.

A declared-debt line that misnames its debt is worse than no line: the next reader goes looking for an engine gap that is closed.