### PR TITLE
spec: a tab is indentation only, so a padding slot takes a space too

### DIFF
--- a/resources/carve-core.ohm
+++ b/resources/carve-core.ohm
@@ -280,27 +280,31 @@ CarveCore {
   destChar   = destEsc | destParens | (~("(" | ")" | " " | "\t" | newline) any)
   destEsc    = "\\" ("(" | ")" | "\\")
   destParens = "(" destChar* ")"
-  // A TAB, TOO. `link_title` is spelled `whitespace` in grammar.ebnf - a
-  // space or a tab - because the slot is PADDING rather than a marker
-  // separator: a link is already a link once its destination has been read,
-  // so the title is trailing metadata (PART 7, carve#878). This file said
-  // `" "` only, so the two normative files in `resources/` answered one
-  // production two ways and `[t](/u<TAB>"T")` rendered literally here while
-  // all three engines produced a titled link (carve#888). `destChar` already
+  // NO TAB. `link_title` is spelled `space` in grammar.ebnf. The slot is
+  // PADDING rather than a marker separator - a link is already a link once its
+  // destination has been read, so the title is trailing metadata - but padding
+  // takes `space` too, because the slot sits after the first non-whitespace
+  // character of the line and a tab is syntax only in a leading indentation
+  // run (PART 7, MARKER SEPARATORS AND PADDING SLOTS; carve#901 correcting
+  // carve#878). This file briefly read `" " | "\t"` to match the widened
+  // production (carve#888); the production has since narrowed back, and the
+  // two normative files in `resources/` agree again. `destChar` already
   // excludes both space and tab, so the destination still ends at either.
   //
-  // CARDINALITY IS UNCHANGED, and deliberately so: this was `" "+` and stays a
-  // run, only a wider one. grammar.ebnf spells `link_title` as exactly ONE
-  // `whitespace`, so the run has always been the looser of the two, for spaces
-  // long before it admitted a tab. Tightening it here would not settle that
-  // disagreement, it would move it: measured, carve-js reads a title after two
-  // spaces AND after two tabs at both the inline and the definition site, so
-  // `exactly one` is a claim no implementation and neither executable file
-  // makes. Which side gives is a question for the production, not for this
-  // file, and narrowing to one would newly break `[t](/u<SP><SP>"T")` here
-  // while every engine kept reading it as a titled link.
+  // The three engines accept a tab here and now diverge from the production;
+  // that is reported upstream rather than encoded here. No corpus document
+  // carries a tab in this slot, so narrowing it moves no golden (measured:
+  // core:check stays 675/675).
+  //
+  // CARDINALITY IS UNCHANGED, and deliberately so: this stays a run rather
+  // than becoming exactly one. grammar.ebnf spells `link_title` as exactly ONE
+  // character, so the run has always been the looser of the two, and was so
+  // for spaces long before the tab question arose. Which side gives is a
+  // question for the production, not for this file: narrowing to one here
+  // would newly break `[t](/u<SP><SP>"T")`, which every engine reads as a
+  // titled link.
   destTitle  = titleSp+ (quoted | squoted)
-  titleSp    = " " | "\t"
+  titleSp    = " "
   squoted    = "'" sqChar* "'"
   sqChar     = sqEsc | (~"'" ~newline any)
   sqEsc      = "\\" "'"

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -196,15 +196,17 @@ frontmatter = &(frontmatter_open, {content_line - frontmatter_close}, frontmatte
    thematic break and the following lines are ordinary blocks (same lookahead
    model as PART 9 §10). *)
 (* The opening delimiter may carry a format token (yaml | json | toml | neon |
-   ...); a bare `---` defaults to `yaml`. The whitespace before the token is
+   ...); a bare `---` defaults to `yaml`. The space before the token is
    OPTIONAL (lenient: both `---yaml` and `--- yaml` are accepted; `---yaml` is
-   canonical) and it is a PADDING SLOT, not a marker separator (PART 7): the
-   `---` pair with its closer lookahead has already decided that this is
-   frontmatter, and the token only names the metadata dialect. So a tab
-   satisfies it, which is what all four implementations already do.
+   canonical) and it is a PADDING SLOT, not a marker separator (PART 7). Both
+   roles take `space`: the slot sits after the `---`, and a tab is syntax only
+   in a line's leading indentation run (PART 7, MARKER SEPARATORS AND PADDING SLOTS). So
+   `---<TAB>yaml` is not a typed opener; it is a thematic break followed by
+   ordinary lines. Implementations that read it as frontmatter today diverge
+   from this production (carve#901).
    The closing delimiter is always a bare `---`. The token distinguishes a typed
    opener from a thematic break. *)
-frontmatter_open = "---", [whitespace], [frontmatter_format], newline ;
+frontmatter_open = "---", [space], [frontmatter_format], newline ;
 frontmatter_close = "---", newline ;
 frontmatter_format = (letter | digit)+ ;
 frontmatter_content = {content_line - frontmatter_close} ;
@@ -349,18 +351,20 @@ code_block = fenced_code_block, [caption_slot] ;
    numbered LISTING. The caption may carry a `#` number placeholder, and a
    `</#id>` to the block resolves to "Listing N" (PART 9 §19). *)
 
-fenced_code_block = code_fence_open, [whitespace], [code_fence_info], newline,
+fenced_code_block = code_fence_open, [space], [code_fence_info], newline,
                     code_content,
                     code_fence_close, newline ;
-(* The whitespace between the fence and the info string is OPTIONAL (lenient:
+(* The space between the fence and the info string is OPTIONAL (lenient:
    both ```php and ``` php are accepted; Markdown writes no space, Djot writes
    the space). The no-space form (```php) is canonical and is what the X->Carve
-   converters emit. It is a PADDING SLOT, not a marker separator (PART 7): the
-   fence run has already decided that this is a code block, and the info string
-   only names the language and carries metadata. So a tab satisfies it, and so
-   do the two slots inside code_fence_info below. Contrast raw_block (PART 9
-   §20), whose otherwise identical slot stays a `space`: there the `=` after it
-   SELECTS a raw block over a code block, which is a marker separator's job. *)
+   converters emit. It is a PADDING SLOT, not a marker separator (PART 7) --
+   the fence run has already decided that this is a code block, and the info
+   string only names the language and carries metadata -- but both roles take
+   `space`: the slot sits after the fence run, and a tab is syntax only in a
+   line's leading indentation run (PART 7, MARKER SEPARATORS AND PADDING SLOTS). The same
+   holds for the two slots inside code_fence_info below. raw_block (PART 9 §20)
+   spells its otherwise identical slot the same way, for the additional reason
+   that the `=` after it SELECTS a raw block over a code block. *)
 (* CODE-FENCE INFO STRING -- NORMATIVE. After the optional language_info
    token the opener admits, in this fixed order, an optional "header" (a
    quoted_title -- the SAME token as the admonition header, PART 9 §12) and an
@@ -423,18 +427,20 @@ code_fence_close = (backtick_fence | tilde_fence):close
 backtick_fence = '`', '`', '`', {'`'} ;
 tilde_fence = '~', '~', '~', {'~'} ;
 
-code_fence_info = ( language_info, [whitespace+, quoted_title], [whitespace+, label] )
-                | ( quoted_title, [whitespace+, label] )
+code_fence_info = ( language_info, [space+, quoted_title], [space+, label] )
+                | ( quoted_title, [space+, label] )
                 | label ;
 (* fixed order: language, then "header", then [label]; each optional, but a
    non-empty info string matches one of these three shapes or it is an
    INVALID-FENCE FALLBACK (see the NORMATIVE note above). quoted_title is the
    shared header token defined under Admonitions. Both metadata slots are
    PADDING (PART 7), the same classification the admonition opener's identical
-   "title" and [label] slots carry: the fence has already decided the block. The
+   "title" and [label] slots carry: the fence has already decided the block --
+   and padding takes `space`, because every one of these slots sits after the
+   first non-whitespace character of the line, where a tab is not syntax. The
    label slot appears in two alternatives and is one slot with one role, so both
-   spellings widen together -- otherwise ```js "T" [L] and ``` "T" [L] would
-   disagree about a tab for no reason a reader could state. *)
+   spellings carry the same terminal -- otherwise ```js "T" [L] and ``` "T" [L]
+   would disagree about a tab for no reason a reader could state. *)
 language_info = (letter | digit | '-' | '_' | '+' | '#' | '.' | '/')+ ;  (* a single token; the punctuation covers real language tags like c++, c#, f#, asp.net, text/html. May start with a digit. The `/` is normative across all impls (so `text/html`, `image/svg` are language tokens, not split). A token MUST NOT start with `=`: a leading `=` is the raw_block opener (above), not a language. *)
 label = '[', { character - ']' }, ']' ;  (* structured metadata, e.g. [Installation]; not part of the class *)
 code_content = (* any text until matching fence, preserved literally *) ;
@@ -904,15 +910,18 @@ admonition = admonition_open, newline,
        convention (those stay supported, deprecated). The `selected`
        default-tab marker is NOT a label -- it remains a boolean attribute on
        the preceding `{...}` line. *)
-(* The separator after the fence is a `space` and the two metadata slots take
-   `whitespace` -- the same line carries both roles, deliberately. The first
+(* The same line carries both roles, and both take `space`. The first
    separator is what makes this an admonition rather than a div, a line block
    or a local hard-break block, so it is a MARKER SEPARATOR; once
    `admonition_type` has been read the block is decided and the "title" and
    [label] slots are ordinary inter-token padding (PART 7, MARKER SEPARATORS
-   AND PADDING SLOTS). *)
+   AND PADDING SLOTS). The roles differ, the terminal does not: a padding slot
+   sits after the first non-whitespace character of the line, and a tab is
+   syntax only in a line's leading indentation run. `::: note<TAB>"T"` is not
+   an admonition opener -- the line stays prose, the same way a tab after a
+   marker leaves a line as prose (carve#692). *)
 admonition_open = colon_fence:open, space, admonition_type,
-                  [whitespace+, quoted_title], [whitespace+, label] ;
+                  [space+, quoted_title], [space+, label] ;
 admonition_close = colon_fence_close ;
 
 admonition_type = "note" | "tip" | "warning" | "danger" | "info"
@@ -1334,24 +1343,28 @@ unicode_url_char = (* any non-whitespace, non-ASCII Unicode character *) ;
    as the literal quote character and do NOT end the title. This is
    honored for the INLINE-link title (`[t](/url "ti\"tle")` -> title
    `ti"tle`); see the note at `reference_definition` for the ref-def slot. *)
-(* The whitespace before the quoted run is a PADDING SLOT, not a marker
-   separator (PART 7): a link is already a link once its destination has been
-   read, and a reference definition is already a definition, so the title is
-   optional trailing metadata in both. A tab satisfies it, which is what all
-   three engines already do at both sites. Cardinality is unchanged -- exactly
-   one whitespace character, as it was exactly one space. *)
-link_title = whitespace, ('"', {('\', '"') | (character - '"')}, '"')
-           | whitespace, ("'", {('\', "'") | (character - "'")}, "'") ;
+(* The space before the quoted run is a PADDING SLOT, not a marker separator
+   (PART 7): a link is already a link once its destination has been read, and a
+   reference definition is already a definition, so the title is optional
+   trailing metadata in both. It is spelled `space` all the same, because the
+   slot sits after the first non-whitespace character of the line and a tab is
+   syntax only in a line's leading indentation run. The three engines accept a
+   tab here today and diverge from this production (carve#901). Cardinality is
+   exactly one character, at both sites. *)
+link_title = space, ('"', {('\', '"') | (character - '"')}, '"')
+           | space, ("'", {('\', "'") | (character - "'")}, "'") ;
 
 reference_label = (character - ']' - '@'), {character - ']'} ;
-(* Both roles appear on this one line (PART 7). The `']' ':'` separator is a
-   MARKER SEPARATOR -- `space` only, settled in the note below and rejected by
-   all four implementations for a tab -- while the slot before the trailing
-   `attributes` is PADDING: the definition is already complete at
-   `[a]: /url`, the attribute block is optional trailing metadata, and
-   `attributes` itself already admits `whitespace` internally (PART 4). *)
+(* Both roles appear on this one line (PART 7), and both take `space`. The
+   `']' ':'` separator is a MARKER SEPARATOR -- settled in the note below and
+   rejected by all four implementations for a tab -- while the slot before the
+   trailing `attributes` is PADDING: the definition is already complete at
+   `[a]: /url` and the attribute block is optional trailing metadata. The role
+   differs, the terminal does not: the padding slot sits after the first
+   non-whitespace character of the line, where a tab is not syntax. What
+   `attributes` admits INTERNALLY is a separate production (PART 4). *)
 reference_definition = '[', reference_label, ']', ':', space, link_destination,
-                       [link_title], [whitespace, attributes], newline ;
+                       [link_title], [space, attributes], newline ;
 (* TRAILING ATTRIBUTES ON A DEFINITION -- NORMATIVE. A `{...}` block at the end
    of the definition line attaches to the DEFINITION, and PART 9R R1 already
    says what that means: the attributes transfer to every link OR IMAGE that
@@ -2112,9 +2125,21 @@ letter = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j'
 
 digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' ;
 
-(* MARKER SEPARATORS AND PADDING SLOTS -- NORMATIVE. Which of the two
-   whitespace terminals a production takes is decided by the ROLE the
-   whitespace plays, and the two roles are:
+(* MARKER SEPARATORS AND PADDING SLOTS -- NORMATIVE. A tab is syntax ONLY in a
+   line's LEADING INDENTATION RUN. From the first non-whitespace character of
+   the line onward a tab is not relevant to syntax at all: it satisfies no slot
+   in any production, and no construct is recognized by it. Two consequences
+   settle every whitespace slot in this grammar.
+
+   FIRST, the leading run itself. `indent = whitespace, {whitespace}` is where
+   a tab belongs, and `blank_line = {whitespace}` is the degenerate case of the
+   same position -- no non-whitespace character precedes either one. A leading
+   run is tabs OR spaces, never both.
+
+   SECOND, everything after it. Whitespace past the first non-whitespace
+   character of a line falls into one of two ROLES. The roles are still worth
+   naming, because they decide what a FAILED match means; they no longer decide
+   the terminal, since both are spelled `space`:
 
      - A MARKER SEPARATOR is the whitespace that stands between a marker and
        the token that SELECTS which construct the line opens. It is spelled
@@ -2129,33 +2154,52 @@ digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' ;
 
      - A PADDING SLOT is whitespace between two tokens on a line whose
        construct is ALREADY fixed. It carries no recognition and its width
-       means nothing, so it is spelled `whitespace` and admits a tab. The
-       admonition opener's `"title"` and `[label]` slots (the type word has
-       already decided the block), `frontmatter_open`'s slot before the
-       format token (the `---` pair has already decided the block; the token
-       only names the metadata dialect), the code fence's slot before its
-       info string together with `code_fence_info`'s own `"header"` and
-       `[label]` slots (the fence run has already decided the block; the info
-       string names a language and carries metadata), `link_title`, and the
-       reference-definition slot before its trailing `attributes` are all
-       padding.
+       means nothing. It is spelled `space` all the same, because it sits
+       after the first non-whitespace character of the line. The padding
+       slots are: the admonition opener's `"title"` and `[label]` slots (the
+       type word has already decided the block), `frontmatter_open`'s slot
+       before the format token (the `---` pair has already decided the block;
+       the token only names the metadata dialect), the code fence's slot
+       before its info string together with `code_fence_info`'s own
+       `"header"` and `[label]` slots (the fence run has already decided the
+       block; the info string names a language and carries metadata),
+       `link_title`, and the reference-definition slot before its trailing
+       `attributes`.
 
-     The two fence openers land on opposite sides of this line, so state it
-     once: a COLON fence's slot is a separator, because `note` / `|` / `\` /
-     `[label]` after it pick one of four blocks; a CODE fence's slot is
-     padding, because the fence run already picked the block. The same is
-     true one production further on -- `raw_block`'s slot keeps `space`,
-     since the `=` after it selects a raw block over a code block. Identical
-     shape, different role; the role is what decides the terminal.
+     The two fence openers land on opposite sides of the ROLE line, so state
+     it once: a COLON fence's slot is a separator, because `note` / `|` / `\`
+     / `[label]` after it pick one of four blocks; a CODE fence's slot is
+     padding, because the fence run already picked the block. Both are
+     `space`. So is `raw_block`'s otherwise identical slot, which is a
+     separator because the `=` after it selects a raw block over a code
+     block. Identical shape, different role, same terminal.
 
-   A tab is otherwise meaningful ONLY as indentation, and indentation is at
-   the START of a line (PART 9 §24 C1) -- a tab after a marker is neither
-   (carve#692, carve#698, carve#878).
+   What the role decides is the FAILURE, not the terminal. A separator that
+   does not match leaves the line unrecognized as that construct; a padding
+   slot that does not match leaves a token unconsumed, and the surrounding
+   production then rejects the line. Either way the line falls back to
+   ordinary prose rather than silently re-indenting or silently dropping
+   metadata -- the same visible failure a tab after a marker already produces
+   (carve#692, carve#698).
 
-   Cardinality is a separate question from the terminal: a slot that took
-   exactly one `space` takes exactly one `whitespace`, and a `space+` run
-   becomes a `whitespace+` run. Widening a slot's terminal never widens how
-   many characters it accepts. *)
+   Cardinality is a separate question from the terminal: a slot spelled
+   `space` admits exactly one character, and a `space+` run admits one or
+   more.
+
+   NOT YET RECONCILED. Three table-cell productions (`delimiter_cell`,
+   `header_cell`, `data_cell`) and the interior of an attribute block
+   (`opt_ws`, `attribute_list`) still spell inline padding `whitespace`. Both
+   predate this clause, and both are inline by the rule above, so both are
+   divergences from it rather than exceptions to it. The attribute-block one
+   is pinned by corpus 252, which all three engines produce, so correcting it
+   is a behavior change and is tracked separately (carve#901).
+
+   HISTORY. carve#878 split the two roles apart and widened every padding slot
+   to `whitespace`, on the reading that a slot carrying no recognition could
+   admit a tab harmlessly. carve#901 corrects that reading: the question is
+   not what a slot recognizes but WHERE it sits, and every padding slot named
+   above sits inline. Engines that accept a tab in one of them today diverge
+   from the production. *)
 whitespace = ' ' | '\t' ;
 space = ' ' ;
 newline = '\n' | '\r\n' | '\r' ;

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -49,13 +49,15 @@ const QUOTE = /^>(?: (.*)|)$/
 // the same way the inline form does (carve#806).
 //
 // The TITLE slot is the exception, and it is a different production. It is
-// `link_title`, whose separator grammar.ebnf spells `whitespace` = `' ' |
-// '\t'` because the slot is PADDING rather than a marker separator (PART 7,
-// carve#878). The whole White_Space property was two answers to one
-// production: `destTitle` in carve-core.ohm read the inline form's slot as a
-// literal space while this read the definition's as any Unicode space, so one
-// normative file admitted `[a]: /u<NBSP>"T"` and the other rejected
-// `[t](/u<TAB>"T")`. Both now spell it `' ' | '\t'` (carve#888).
+// `link_title`, whose separator grammar.ebnf spells `space`. The slot is
+// PADDING rather than a marker separator, but padding takes `space` too: it
+// sits after the first non-whitespace character of the line, and a tab is
+// syntax only in a leading indentation run (PART 7, MARKER SEPARATORS AND
+// PADDING SLOTS; carve#901 correcting carve#878). The whole White_Space
+// property was two answers to one production: `destTitle` in carve-core.ohm
+// read the inline form's slot one way while this read the definition's as any
+// Unicode space, so one normative file admitted `[a]: /u<NBSP>"T"` and the
+// other rejected `[t](/u<TAB>"T")` (carve#888). Both now spell it `' '`.
 //
 // The two runs on either side of it deliberately keep the wider class. The
 // leading one is entangled with the destination class above: PART 9 §25's
@@ -63,7 +65,7 @@ const QUOTE = /^>(?: (.*)|)$/
 // slip past the denylist, which corpus case 121 pins with a U+202F before
 // `javascript:`. Narrowing that run is a separate question about
 // `link_destination`, not about `link_title`, and is left alone here.
-const LINK_DEF = /^\[([^\]@][^\]]*)\]: \p{White_Space}*(\P{White_Space}+)(?:[ \t]+"((?:\\"|[^"])*)")?(?:\p{White_Space}.*)?$/u
+const LINK_DEF = /^\[([^\]@][^\]]*)\]: \p{White_Space}*(\P{White_Space}+)(?: +"((?:\\"|[^"])*)")?(?:\p{White_Space}.*)?$/u
 
 /*
  * Split a TRAILING attribute block off a definition line (carve#604).
@@ -73,9 +75,12 @@ const LINK_DEF = /^\[([^\]@][^\]]*)\]: \p{White_Space}*(\P{White_Space}+)(?:[ \t
  * drops every attribute on the line silently. The scan tracks quote state, so
  * only a `}` outside quotes closes the block.
  *
- * The block must be preceded by whitespace and end the line, so `[a]: /u{.x}`
+ * The block must be preceded by a SPACE and end the line, so `[a]: /u{.x}`
  * keeps the braces in the DESTINATION, as the production's `space, attributes`
- * requires. Returns [lineWithoutBlock, blockText|null].
+ * requires. A tab does not separate it either: the slot is padding, and padding
+ * takes `space` because it sits after the first non-whitespace character of the
+ * line (PART 7, MARKER SEPARATORS AND PADDING SLOTS; carve#901).
+ * Returns [lineWithoutBlock, blockText|null].
  */
 function splitTrailingAttrBlock(line) {
   const trimmedEnd = line.replace(/\s+$/, '')
@@ -92,8 +97,8 @@ function splitTrailingAttrBlock(line) {
     if (c === '"' || c === "'") { quote = c; continue }
     if (c === '{') { if (open === -1) open = i; continue }
     if (c === '}' && open !== -1 && i === trimmedEnd.length - 1) {
-      // Must be separated from what precedes it by whitespace.
-      if (open === 0 || !/\s/.test(trimmedEnd[open - 1])) return [line, null]
+      // Must be separated from what precedes it by a space (PART 7).
+      if (open === 0 || trimmedEnd[open - 1] !== ' ') return [line, null]
       return [trimmedEnd.slice(0, open).replace(/\s+$/, ''), trimmedEnd.slice(open)]
     }
   }
@@ -327,12 +332,17 @@ function parseColonOpener(tail) {
     out.type = ty[1]
     s = s.slice(ty[0].length)
   }
-  const qt = /^[ \t]+"([^"]*)"/.exec(s)
+  // The `"title"` and `[label]` slots are PADDING and take `space`: they sit
+  // after the first non-whitespace character of the line, and a tab is syntax
+  // only in a leading indentation run (PART 7; carve#901). A tab here leaves
+  // the token unconsumed, so the trailing-junk check below turns the line into
+  // an ordinary paragraph rather than silently dropping the metadata.
+  const qt = /^ +"([^"]*)"/.exec(s)
   if (qt) {
     out.title = qt[1]
     s = s.slice(qt[0].length)
   }
-  const lb = /^[ \t]*\[([^\]]*)\]/.exec(s)
+  const lb = /^ *\[([^\]]*)\]/.exec(s)
   if (lb) {
     out.label = lb[1]
     s = s.slice(lb[0].length)
@@ -601,7 +611,10 @@ export function parse(src) {
   }
   // frontmatter (PART 1): consumed; renders nothing. The closer-lookahead
   // guard: with no closing --- the line is an ordinary thematic break.
-  if (lines[0] !== undefined && /^---(\s|[A-Za-z0-9]+\s*$|$)/.test(lines[0])) {
+  // The slot before the format token is PADDING and takes `space` (PART 7;
+  // carve#901): it sits after the `---`, and a tab is syntax only in a leading
+  // indentation run. `---<TAB>yaml` is therefore not a typed opener.
+  if (lines[0] !== undefined && /^---( |[A-Za-z0-9]+[ \t]*$|$)/.test(lines[0])) {
     for (let j = 1; j < lines.length; j++) {
       if (/^---[ \t]*$/.test(lines[j])) {
         lines.splice(0, j + 1)
@@ -1386,19 +1399,26 @@ function findCloser(lines, openIdx, run) {
 // { lang, title, label } or null on any other shape (INVALID-FENCE
 // FALLBACK: the line is not a fence).
 function parseFenceInfo(raw) {
-  let s = raw.trim()
+  // The opener slot before the info string, and the `"header"` / `[label]`
+  // slots inside it, are all PADDING and all take `space` (PART 7; carve#901):
+  // each sits after the first non-whitespace character of the line, and a tab
+  // is syntax only in a leading indentation run. So the leading run is stripped
+  // as spaces only - ```<TAB>js leaves the tab in place, matches no shape, and
+  // the line is not a fence at all. Only TRAILING whitespace keeps the wider
+  // class, which is the line-ending rule rather than a slot.
+  let s = raw.replace(/^ +/, '').replace(/[ \t]+$/, '')
   const out = { lang: '', title: null, label: null }
   const lm = /^([A-Za-z0-9\-_+#.=/]+)/.exec(s)
   if (lm) {
     out.lang = lm[1]
     s = s.slice(lm[0].length)
   }
-  const tm = /^[ \t]*"([^"]*)"/.exec(s)
+  const tm = /^ *"([^"]*)"/.exec(s)
   if (tm) {
     out.title = tm[1]
     s = s.slice(tm[0].length)
   }
-  const lb = /^[ \t]*\[([^\]]*)\]/.exec(s)
+  const lb = /^ *\[([^\]]*)\]/.exec(s)
   if (lb) {
     out.label = lb[1]
     s = s.slice(lb[0].length)

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -97,8 +97,14 @@ function splitTrailingAttrBlock(line) {
     if (c === '"' || c === "'") { quote = c; continue }
     if (c === '{') { if (open === -1) open = i; continue }
     if (c === '}' && open !== -1 && i === trimmedEnd.length - 1) {
-      // Must be separated from what precedes it by a space (PART 7).
-      if (open === 0 || trimmedEnd[open - 1] !== ' ') return [line, null]
+      // Must be separated from what precedes it by a run of SPACES (PART 7).
+      // The whole run is checked, not just the character adjacent to the `{`:
+      // `[a]: /u<TAB><SP>{.c}` puts a space next to the brace while the run
+      // still holds a tab, and the trailing-strip below would then swallow the
+      // tab and attach the block anyway.
+      if (open === 0) return [line, null]
+      const sep = /[ \t]*$/.exec(trimmedEnd.slice(0, open))[0]
+      if (sep === '' || sep.includes('\t')) return [line, null]
       return [trimmedEnd.slice(0, open).replace(/\s+$/, ''), trimmedEnd.slice(open)]
     }
   }
@@ -614,7 +620,15 @@ export function parse(src) {
   // The slot before the format token is PADDING and takes `space` (PART 7;
   // carve#901): it sits after the `---`, and a tab is syntax only in a leading
   // indentation run. `---<TAB>yaml` is therefore not a typed opener.
-  if (lines[0] !== undefined && /^---( |[A-Za-z0-9]+[ \t]*$|$)/.test(lines[0])) {
+  //
+  // The lookahead, rather than narrowing the alternation, is what makes
+  // `---<SP><TAB>yaml` fail too. Narrowing the first alternative to a literal
+  // space only rejects a run that STARTS with a tab; a mixed run reaches the
+  // token just as well, and the rule is about the whole padding run rather
+  // than its first character. Trailing whitespace after the token is a
+  // different question - the line-ending rule, not this slot - so a tab is
+  // still tolerated there.
+  if (lines[0] !== undefined && /^---(?![ \t]*\t)(\s|[A-Za-z0-9]+\s*$|$)/.test(lines[0])) {
     for (let j = 1; j < lines.length; j++) {
       if (/^---[ \t]*$/.test(lines[j])) {
         lines.splice(0, j + 1)

--- a/tests/separator-role-split.test.mjs
+++ b/tests/separator-role-split.test.mjs
@@ -135,9 +135,15 @@ const SITES = [
     required: /admonition_open = [^;]*\[space\+, quoted_title\], \[space\+, label\] ;/,
     forbidden: /admonition_open = [^;]*\[whitespace\+?, (?:quoted_title|label)\]/,
     why: 'the type word has already decided the block; the title and label sit inline',
-    // `::: note` is fixed before either slot is reached.
-    tab: '::: note\t"T"\t[L]\nx\n:::\n',
-    space: '::: note "T" [L]\nx\n:::\n',
+    // ONE PAIR PER SLOT. `::: note` is fixed before either slot is reached, and
+    // the two slots revert independently, so a fixture carrying a tab at BOTH
+    // cannot tell them apart: with either one narrowed the line is unrecognized
+    // and the render differs from the space form regardless. Measured - a
+    // single two-tab fixture survived reverting each slot on its own.
+    fixtures: [
+      { slot: 'the "title" slot', tab: '::: note\t"T" [L]\nx\n:::\n', space: '::: note "T" [L]\nx\n:::\n' },
+      { slot: 'the [label] slot', tab: '::: note "T"\t[L]\nx\n:::\n', space: '::: note "T" [L]\nx\n:::\n' },
+    ],
     engineDeferred: ENGINE_DEFERRED,
   },
   {
@@ -146,8 +152,9 @@ const SITES = [
     required: /frontmatter_open = "---", \[space\], \[frontmatter_format\]/,
     forbidden: /frontmatter_open = "---", \[whitespace\]/,
     why: 'the `---` pair has already decided the block; the token sits inline after it',
-    tab: '---\tyaml\na: 1\n---\nx\n',
-    space: '--- yaml\na: 1\n---\nx\n',
+    fixtures: [
+      { slot: 'the format-token slot', tab: '---\tyaml\na: 1\n---\nx\n', space: '--- yaml\na: 1\n---\nx\n' },
+    ],
     engineDeferred: ENGINE_DEFERRED,
   },
   {
@@ -157,8 +164,16 @@ const SITES = [
     required: /link_title = space, \('"'.*\| space, \("'"/,
     forbidden: /link_title = whitespace,|\| whitespace, \("'"/,
     why: 'a link is a link once its destination is read; the title sits inline after it',
-    tab: '[t](/u\t"T")\n',
-    space: '[t](/u "T")\n',
+    // ONE PAIR PER SITE THE PRODUCTION IS USED AT. `link_title` is one
+    // production read by two different pieces of the oracle - the inline form
+    // by `destTitle` in resources/carve-core.ohm, the definition form by
+    // `LINK_DEF` in scripts/spec/layout.mjs - and carve#888 was precisely that
+    // the two disagreed. With only the inline fixture, widening `LINK_DEF`
+    // back to `[ \t]+` broke nothing here: measured.
+    fixtures: [
+      { slot: 'the inline form', tab: '[t](/u\t"T")\n', space: '[t](/u "T")\n' },
+      { slot: 'the definition form', tab: '[a]: /u\t"T"\n\n[a][]\n', space: '[a]: /u "T"\n\n[a][]\n' },
+    ],
     engineDeferred: ENGINE_DEFERRED,
   },
   {
@@ -167,8 +182,9 @@ const SITES = [
     required: /\[link_title\], \[space, attributes\], newline/,
     forbidden: /\[link_title\], \[whitespace, attributes\]/,
     why: 'the definition is complete at `[a]: /url`; the attribute block sits inline after it',
-    tab: '[a]: /u\t{.c}\n\n[a][]\n',
-    space: '[a]: /u {.c}\n\n[a][]\n',
+    fixtures: [
+      { slot: 'the trailing-attributes slot', tab: '[a]: /u\t{.c}\n\n[a][]\n', space: '[a]: /u {.c}\n\n[a][]\n' },
+    ],
     engineDeferred: ENGINE_DEFERRED,
   },
   {
@@ -177,8 +193,9 @@ const SITES = [
     required: /fenced_code_block = code_fence_open, \[space\], \[code_fence_info\]/,
     forbidden: /fenced_code_block = code_fence_open, \[whitespace\]/,
     why: 'the fence run has already decided the block; the info string sits inline after it',
-    tab: '```\tjs\nx\n```\n',
-    space: '``` js\nx\n```\n',
+    fixtures: [
+      { slot: 'the info-string slot', tab: '```\tjs\nx\n```\n', space: '``` js\nx\n```\n' },
+    ],
     engineDeferred: ENGINE_DEFERRED,
   },
   {
@@ -192,8 +209,14 @@ const SITES = [
       /code_fence_info = \( language_info, \[space\+, quoted_title\], \[space\+, label\] \) \| \( quoted_title, \[space\+, label\] \) \| label ;/,
     forbidden: /code_fence_info = [^;]*\[whitespace\+?/,
     why: 'the same two metadata slots the admonition opener carries, both inline',
-    tab: '``` js\t"T"\t[L]\nx\n```\n',
-    space: '``` js "T" [L]\nx\n```\n',
+    // One pair per slot, for the reason spelled out at the admonition opener:
+    // these two revert independently and a two-tab fixture cannot separate
+    // them. The tab goes after `js` in the first and after the title in the
+    // second, so neither needs a tab in the OPENER slot above.
+    fixtures: [
+      { slot: 'the "header" slot', tab: '```js\t"T" [L]\nx\n```\n', space: '```js "T" [L]\nx\n```\n' },
+      { slot: 'the [label] slot', tab: '```js "T"\t[L]\nx\n```\n', space: '```js "T" [L]\nx\n```\n' },
+    ],
     engineDeferred: ENGINE_DEFERRED,
   },
 ]
@@ -230,12 +253,57 @@ for (const { role, site, required, forbidden, why } of SITES) {
 // it - the check-that-cannot-fail class tracked in carve#755. `engineDeferred`
 // does not substitute for fixtures; it only says why the ENGINE half of the
 // pair is skipped, which is a statement about carve-js, not about the oracle.
-test('every padding site carries a tab/space fixture pair', () => {
+test('every padding site carries a tab/space fixture pair per slot', () => {
   for (const s of SITES.filter((x) => x.role === 'padding')) {
     assert.ok(
-      typeof s.tab === 'string' && typeof s.space === 'string',
-      `padding site "${s.site}" must carry a tab/space fixture pair; the oracle ` +
-        `check runs at every padding site and cannot skip one.`,
+      Array.isArray(s.fixtures) && s.fixtures.length > 0,
+      `padding site "${s.site}" must carry at least one tab/space fixture pair; ` +
+        `the oracle check runs at every padding site and cannot skip one.`,
+    )
+    for (const f of s.fixtures) {
+      assert.ok(
+        typeof f.slot === 'string' &&
+          typeof f.tab === 'string' &&
+          typeof f.space === 'string',
+        `padding site "${s.site}" has a fixture entry missing slot/tab/space.`,
+      )
+      assert.notEqual(
+        f.tab,
+        f.space,
+        `padding site "${s.site}" fixture "${f.slot}" has identical tab and space ` +
+          `forms, so it can never discriminate.`,
+      )
+      assert.ok(
+        f.tab.includes('\t'),
+        `padding site "${s.site}" fixture "${f.slot}" is named a tab fixture but ` +
+          `carries no tab.`,
+      )
+    }
+  }
+})
+
+// A site whose production has TWO independently-revertible slots needs TWO
+// fixtures, or a half-revert passes. This is the carve#896 shape, found again
+// here by mutation: the admonition opener and code_fence_info each carry a
+// "title" and a [label] slot, and a single fixture with a tab at BOTH survived
+// reverting either one on its own - with either slot narrowed the line is
+// unrecognized and the render differs from the space form regardless.
+// link_title is the same shape for a different reason: one production, two
+// pieces of the oracle reading it, which is exactly what carve#888 was about.
+const MULTI_SLOT = {
+  'admonition_open, the "title" and [label] metadata slots': 2,
+  'code_fence_info, the "header" and [label] metadata slots': 2,
+  'link_title, the slot before the quoted run': 2,
+}
+test('a site with independently-revertible slots carries a fixture for each', () => {
+  for (const [site, n] of Object.entries(MULTI_SLOT)) {
+    const entry = SITES.find((s) => s.site === site)
+    assert.ok(entry, `MULTI_SLOT names a site that is not in SITES: ${site}`)
+    assert.equal(
+      entry.fixtures.length,
+      n,
+      `padding site "${site}" reverts in ${n} independent places and needs ${n} ` +
+        `fixture pairs; one pair covering both lets a half-revert through.`,
     )
   }
 })
@@ -268,19 +336,22 @@ test('every padding site states why its engine half is deferred', () => {
 // the deferral and assert the corrected behavior instead. A test that pinned
 // the bug would go red on the FIX and have to be deleted to allow it; this one
 // goes red on the fix and tells you what to write in its place.
-for (const { site, tab, space } of SITES.filter((s) => s.role === 'padding')) {
-  test(`the engine deferral still holds - carve-js admits a tab: ${site}`, () => {
-    assert.equal(
-      carveToHtml(tab),
-      carveToHtml(space),
-      `carve-js no longer parses a tab in this padding slot as the space form.\n` +
-        `  tab form:   ${JSON.stringify(tab)}\n  space form: ${JSON.stringify(space)}\n` +
-        `  This is GOOD NEWS: the engine has caught up with the production ` +
-        `(PART 7, carve#901).\n` +
-        `  Drop \`engineDeferred\` at this site and assert the corrected behavior ` +
-        `instead of deferring it.`,
-    )
-  })
+for (const { site, fixtures } of SITES.filter((s) => s.role === 'padding')) {
+  for (const { slot, tab, space } of fixtures) {
+    test(`the engine deferral still holds - carve-js admits a tab: ${site} - ${slot}`, () => {
+      assert.equal(
+        carveToHtml(tab),
+        carveToHtml(space),
+        `carve-js no longer parses a tab in this padding slot as the space form.\n` +
+          `  slot:       ${slot}\n` +
+          `  tab form:   ${JSON.stringify(tab)}\n  space form: ${JSON.stringify(space)}\n` +
+          `  This is GOOD NEWS: the engine has caught up with the production ` +
+          `(PART 7, carve#901).\n` +
+          `  Drop \`engineDeferred\` at this site and assert the corrected behavior ` +
+          `instead of deferring it.`,
+      )
+    })
+  }
 }
 
 // The ORACLE half, at EVERY padding site. resources/carve-core.ohm and
@@ -294,18 +365,21 @@ for (const { site, tab, space } of SITES.filter((s) => s.role === 'padding')) {
 // form does. carve#888 ran this same pair the other way round, when the
 // production was `whitespace`; the pair is what makes either reading
 // observable.
-for (const { site, tab, space } of SITES.filter((s) => s.role === 'padding')) {
-  test(`padding slot rejects a tab in the oracle: ${site}`, () => {
-    assert.notEqual(
-      renderDoc(parse(tab)),
-      renderDoc(parse(space)),
-      `a tab in this padding slot parsed as the space form does in the ` +
-        `executable spec (scripts/spec/layout.mjs, resources/carve-core.ohm).\n` +
-        `  tab form:   ${JSON.stringify(tab)}\n  space form: ${JSON.stringify(space)}\n` +
-        `  The production says \`space\` here: a tab is syntax only in a leading\n` +
-        `  indentation run (PART 7, carve#901).`,
-    )
-  })
+for (const { site, fixtures } of SITES.filter((s) => s.role === 'padding')) {
+  for (const { slot, tab, space } of fixtures) {
+    test(`padding slot rejects a tab in the oracle: ${site} - ${slot}`, () => {
+      assert.notEqual(
+        renderDoc(parse(tab)),
+        renderDoc(parse(space)),
+        `a tab in this padding slot parsed as the space form does in the ` +
+          `executable spec (scripts/spec/layout.mjs, resources/carve-core.ohm).\n` +
+          `  slot:       ${slot}\n` +
+          `  tab form:   ${JSON.stringify(tab)}\n  space form: ${JSON.stringify(space)}\n` +
+          `  The production says \`space\` here: a tab is syntax only in a leading\n` +
+          `  indentation run (PART 7, carve#901).`,
+      )
+    })
+  }
 }
 
 // A SECOND character outside the slot's class, at both spellings of the one

--- a/tests/separator-role-split.test.mjs
+++ b/tests/separator-role-split.test.mjs
@@ -152,8 +152,14 @@ const SITES = [
     required: /frontmatter_open = "---", \[space\], \[frontmatter_format\]/,
     forbidden: /frontmatter_open = "---", \[whitespace\]/,
     why: 'the `---` pair has already decided the block; the token sits inline after it',
+    // The second pair is a MIXED run. A padding rule stated as "the slot takes
+    // a space" is easy to implement as "the first character must be a space",
+    // which passes the tab-first fixture and still lets `---<SP><TAB>yaml`
+    // through - the rule is about the whole run. Found by review, not by the
+    // tab-first fixture, which is exactly why it is pinned separately.
     fixtures: [
       { slot: 'the format-token slot', tab: '---\tyaml\na: 1\n---\nx\n', space: '--- yaml\na: 1\n---\nx\n' },
+      { slot: 'the format-token slot, mixed run', tab: '--- \tyaml\na: 1\n---\nx\n', space: '--- yaml\na: 1\n---\nx\n' },
     ],
     engineDeferred: ENGINE_DEFERRED,
   },
@@ -182,8 +188,14 @@ const SITES = [
     required: /\[link_title\], \[space, attributes\], newline/,
     forbidden: /\[link_title\], \[whitespace, attributes\]/,
     why: 'the definition is complete at `[a]: /url`; the attribute block sits inline after it',
+    // The second pair puts the tab at the FAR end of the separator run, with a
+    // space adjacent to the `{`. The oracle scans this run backwards from the
+    // brace, so a check that reads only the adjacent character passes while a
+    // tab still sits in the run - the same mixed-run hole as the frontmatter
+    // slot above, reached from the other side.
     fixtures: [
       { slot: 'the trailing-attributes slot', tab: '[a]: /u\t{.c}\n\n[a][]\n', space: '[a]: /u {.c}\n\n[a][]\n' },
+      { slot: 'the trailing-attributes slot, mixed run', tab: '[a]: /u\t {.c}\n\n[a][]\n', space: '[a]: /u {.c}\n\n[a][]\n' },
     ],
     engineDeferred: ENGINE_DEFERRED,
   },

--- a/tests/separator-role-split.test.mjs
+++ b/tests/separator-role-split.test.mjs
@@ -1,57 +1,60 @@
 /*
  * The separator/padding split is a spec decision that nothing else can see.
  *
- * PART 7's MARKER SEPARATORS AND PADDING SLOTS clause divides the whitespace
- * on a marker line into two roles: the slot that decides WHICH construct the
- * line opens is a `space` and a tab never satisfies it, while whitespace
- * between two tokens on an already-decided line is a `whitespace` padding slot
- * and a tab does. Nine slots were classified under that rule (carve#878); the
- * code fence's three joined them in carve#894, for twelve.
+ * PART 7's MARKER SEPARATORS AND PADDING SLOTS clause names two roles for the
+ * whitespace on a marker line: the slot that decides WHICH construct the line
+ * opens is a MARKER SEPARATOR, and whitespace between two tokens on an
+ * already-decided line is a PADDING SLOT. Both are spelled `space`, and a tab
+ * satisfies neither.
+ *
+ * That last sentence is what carve#901 corrected. carve#878 split the roles
+ * apart and widened every padding slot to `whitespace`, on the reading that a
+ * slot carrying no recognition could admit a tab harmlessly; carve#894 widened
+ * the code fence's three the same way. The rule is not about what a slot
+ * recognizes but about WHERE it sits: a tab is syntax ONLY in a line's leading
+ * indentation run, and every padding slot in this grammar sits after the first
+ * non-whitespace character of its line. So the terminal is `space` on both
+ * sides of the role line, and the role now decides only what a FAILED match
+ * means, not which terminal the slot takes.
  *
  * Without this file the classification is unobservable. Every other gate reads
  * behavior, and no engine reads resources/grammar.ebnf, so flipping any of the
- * terminals back leaves the whole suite green - the defect class tracked in
+ * terminals leaves the whole suite green - the defect class tracked in
  * carve#755. Each site below therefore pins BOTH directions: the terminal the
  * production must carry, and the terminal it must NOT carry, so a silent
  * re-spelling in either direction fails here.
  *
- * THREE CHECKS RUN PER PADDING SITE, against three different artifacts:
+ * TWO CHECKS RUN PER PADDING SITE, against two different artifacts:
  *
- *   1. the grammar text, above - what resources/grammar.ebnf spells.
+ *   1. the grammar text - what resources/grammar.ebnf spells.
  *   2. the ORACLE (scripts/spec/layout.mjs + resources/carve-core.ohm), which
  *      is executable, so every padding site is checked and none is skipped.
- *   3. the pinned ENGINE, which is skipped where `engineDeferred` says why.
  *
- * Check 2 is why every padding site now carries a tab/space fixture pair even
- * when its engine half is deferred: the two artifacts are deferred for engine
- * reasons that say nothing about the oracle, and the oracle is a spec artifact
- * rather than an implementation. carve#888 found the gap this leaves - the
- * oracle read `[t](/u<TAB>"T")` as literal text while grammar.ebnf had spelled
- * that slot `whitespace` since carve#878, and nothing could see it.
+ * Check 2 is why every padding site carries a tab/space fixture pair: the
+ * oracle is a spec artifact rather than an implementation, so it tracks the
+ * production immediately. carve#888 found the gap this closes from the other
+ * direction - the oracle read `[t](/u<TAB>"T")` as literal text while
+ * grammar.ebnf had spelled that slot `whitespace`, and nothing could see it.
+ * The same pair now catches the reverse: an oracle that still admits a tab
+ * where the production says `space`.
  *
- * The engine half is deliberately partial, and the two gaps are NOT the same
- * gap. The loop below runs one engine: the pinned `@markup-carve/carve`
- * (carve-js). So "checked against the engine" never means "checked against the
- * implementations", and the two omissions have to be read separately.
+ * THE ENGINE HALF IS GONE, deliberately, and this is the third time its scope
+ * has moved - so the reason is written down rather than inferred.
  *
- *   - The four MARKER SEPARATOR sites are omitted because carve-js gives the
- *     PRE-ruling answer: it still accepts a tab after the colon fence, which
- *     carve#878 step 2 corrects. Asserting it would pin the bug, and the fix
- *     would have to delete the assertion.
+ * The loop that used to live here ran ONE engine, the pinned
+ * `@markup-carve/carve` (carve-js), and asserted that a tab in a padding slot
+ * parses as the space form does. Under carve#901 that assertion is exactly
+ * backwards: carve-js DOES still accept a tab at all six padding slots
+ * (measured while writing this - all six tab forms render byte-identical to
+ * their space forms), which is now a divergence from the production rather
+ * than conformance with it. Asserting today's behavior would pin the bug and
+ * the fix would have to delete the assertion; asserting the corrected behavior
+ * would fail on an engine that has not been changed yet.
  *
- *   - The two code-fence PADDING sites are omitted for a different reason.
- *     carve-js already gives the POST-ruling answer here - measured while
- *     writing this, ```<tab>js and ```js<tab>"T"<tab>[L] render byte-identical
- *     to their space forms - so an assertion would pass today and keep
- *     passing. It is left out because it would be misleading rather than
- *     wrong: carve#894 reports carve-rs as still rejecting the tab, so the
- *     ruling is not yet implemented across the engines, and a green
- *     single-engine assertion in this file would read as though it were. The
- *     cross-engine gates (claims:check, compare:impls) are where that question
- *     belongs, and they are what should gain a row once carve-rs relaxes.
- *
- * Note the two corrections run in opposite directions: the colon fence tightens
- * (four implementations lose the tab), the code fence relaxes (one gains it).
+ * So every padding site carries `engineDeferred` with its reason, and the test
+ * below requires it. The engine question belongs in the cross-engine gates
+ * (claims:check, compare:impls), which is where it should gain a row once the
+ * engines narrow.
  */
 
 import { test } from 'node:test'
@@ -70,6 +73,17 @@ const grammar = readFileSync(resolve(repo, 'resources/grammar.ebnf'), 'utf8')
 // Productions wrap, so match against the flattened text rather than line by
 // line - the same normalization scripts/normative-clauses.mjs uses.
 const flat = grammar.replace(/\n\s*/g, ' ')
+
+// One reason, shared by all six padding sites, because it IS one fact about
+// one engine rather than six. Measured on the pinned `@markup-carve/carve`
+// build: all six tab forms below render byte-identical to their space forms.
+const ENGINE_DEFERRED =
+  'carve-js accepts a tab in this slot - measured on the pinned build, the tab form ' +
+  'renders byte-identical to the space form - so it diverges from the production ' +
+  'since carve#901 narrowed it back to `space`. Asserting the current behavior would ' +
+  'pin the divergence; asserting the corrected behavior would fail on an engine that ' +
+  'has not been changed yet. The cross-engine gates (claims:check, compare:impls) ' +
+  'carry the question. The ORACLE half runs regardless - it is not an engine.'
 
 const SITES = [
   // --- MARKER SEPARATORS: `space`, a tab never satisfies them ---------------
@@ -102,80 +116,85 @@ const SITES = [
     why: 'the backslash token selects a local hard-break block',
   },
 
-  // --- PADDING SLOTS: `whitespace`, a tab satisfies them --------------------
+  // --- PADDING SLOTS: `space`, a tab satisfies them either -------------------
+  //
+  // Same terminal as the separators above, different reason. A separator is a
+  // `space` because the token after it selects the construct; a padding slot is
+  // a `space` because it sits after the first non-whitespace character of the
+  // line, where a tab is not syntax (PART 7, carve#901).
+  //
+  // Every one of these carries `engineDeferred`: carve-js accepts a tab at all
+  // six and so diverges from the production. See the file header.
   {
     role: 'padding',
     site: 'admonition_open, the "title" and [label] metadata slots',
     // Anchored on the production: `code_fence_info` carries the same two
-    // metadata slots, and since carve#894 spells them the same way. An
-    // unanchored pattern would match either production, so each site's
-    // assertion would stop being about the site it names.
-    required: /admonition_open = [^;]*\[whitespace\+, quoted_title\], \[whitespace\+, label\] ;/,
-    forbidden: /admonition_open = [^;]*\[space\+, (?:quoted_title|label)\]/,
-    why: 'the type word has already decided the block; the title and label are metadata',
+    // metadata slots, and spells them the same way. An unanchored pattern would
+    // match either production, so each site's assertion would stop being about
+    // the site it names.
+    required: /admonition_open = [^;]*\[space\+, quoted_title\], \[space\+, label\] ;/,
+    forbidden: /admonition_open = [^;]*\[whitespace\+?, (?:quoted_title|label)\]/,
+    why: 'the type word has already decided the block; the title and label sit inline',
     // `::: note` is fixed before either slot is reached.
     tab: '::: note\t"T"\t[L]\nx\n:::\n',
     space: '::: note "T" [L]\nx\n:::\n',
+    engineDeferred: ENGINE_DEFERRED,
   },
   {
     role: 'padding',
     site: 'frontmatter_open, the slot before the format token',
-    required: /frontmatter_open = "---", \[whitespace\], \[frontmatter_format\]/,
-    forbidden: /frontmatter_open = "---", \[space\]/,
-    why: 'the `---` pair has already decided the block; the token names the metadata dialect',
+    required: /frontmatter_open = "---", \[space\], \[frontmatter_format\]/,
+    forbidden: /frontmatter_open = "---", \[whitespace\]/,
+    why: 'the `---` pair has already decided the block; the token sits inline after it',
     tab: '---\tyaml\na: 1\n---\nx\n',
     space: '--- yaml\na: 1\n---\nx\n',
+    engineDeferred: ENGINE_DEFERRED,
   },
   {
     role: 'padding',
     site: 'link_title, the slot before the quoted run',
     // Both alternatives, double- and single-quoted, carry the same terminal.
-    required: /link_title = whitespace, \('"'.*\| whitespace, \("'"/,
-    forbidden: /link_title = space,|\| space, \("'"/,
-    why: 'a link is a link once its destination is read; the title is trailing metadata',
+    required: /link_title = space, \('"'.*\| space, \("'"/,
+    forbidden: /link_title = whitespace,|\| whitespace, \("'"/,
+    why: 'a link is a link once its destination is read; the title sits inline after it',
     tab: '[t](/u\t"T")\n',
     space: '[t](/u "T")\n',
+    engineDeferred: ENGINE_DEFERRED,
   },
   {
     role: 'padding',
     site: 'reference_definition, the slot before the trailing attributes',
-    required: /\[link_title\], \[whitespace, attributes\], newline/,
-    forbidden: /\[link_title\], \[space, attributes\]/,
-    why: 'the definition is complete at `[a]: /url`; the attribute block is trailing metadata',
+    required: /\[link_title\], \[space, attributes\], newline/,
+    forbidden: /\[link_title\], \[whitespace, attributes\]/,
+    why: 'the definition is complete at `[a]: /url`; the attribute block sits inline after it',
     tab: '[a]: /u\t{.c}\n\n[a][]\n',
     space: '[a]: /u {.c}\n\n[a][]\n',
+    engineDeferred: ENGINE_DEFERRED,
   },
   {
     role: 'padding',
     site: 'fenced_code_block, the slot before the info string',
-    required: /fenced_code_block = code_fence_open, \[whitespace\], \[code_fence_info\]/,
-    forbidden: /fenced_code_block = code_fence_open, \[space\]/,
-    why: 'the fence run has already decided the block; the info string names a language',
+    required: /fenced_code_block = code_fence_open, \[space\], \[code_fence_info\]/,
+    forbidden: /fenced_code_block = code_fence_open, \[whitespace\]/,
+    why: 'the fence run has already decided the block; the info string sits inline after it',
     tab: '```\tjs\nx\n```\n',
     space: '``` js\nx\n```\n',
-    engineDeferred:
-      'carve-js already renders ```<tab>js identically to ``` js, so an assertion here ' +
-      'would pass; it is omitted because carve#894 reports carve-rs as still rejecting ' +
-      'the tab, and one green engine would misreport the ruling as implemented. See the ' +
-      'file header. The ORACLE half runs regardless - it is not an engine.',
+    engineDeferred: ENGINE_DEFERRED,
   },
   {
     role: 'padding',
     site: 'code_fence_info, the "header" and [label] metadata slots',
     // One pattern covers all three spellings on purpose. The label slot is
     // written twice, once per alternative, and it is one slot with one role:
-    // pinning them separately would let a half-revert pass.
+    // pinning them separately would let a half-revert pass. carve#896 found
+    // that gap; carve#901 reverts through the same pattern.
     required:
-      /code_fence_info = \( language_info, \[whitespace\+, quoted_title\], \[whitespace\+, label\] \) \| \( quoted_title, \[whitespace\+, label\] \) \| label ;/,
-    forbidden: /code_fence_info = [^;]*\[space\+/,
-    why: 'the same two metadata slots the admonition opener carries, after the block is decided',
+      /code_fence_info = \( language_info, \[space\+, quoted_title\], \[space\+, label\] \) \| \( quoted_title, \[space\+, label\] \) \| label ;/,
+    forbidden: /code_fence_info = [^;]*\[whitespace\+?/,
+    why: 'the same two metadata slots the admonition opener carries, both inline',
     tab: '``` js\t"T"\t[L]\nx\n```\n',
     space: '``` js "T" [L]\nx\n```\n',
-    engineDeferred:
-      'same as the slot above, and separably testable (a tab after `js` needs no tab in ' +
-      'the opener slot): carve-js already agrees, carve-rs is reported not to, so the ' +
-      'cross-engine gates carry this rather than one engine here. The ORACLE half runs ' +
-      'regardless - it is not an engine.',
+    engineDeferred: ENGINE_DEFERRED,
   },
 ]
 
@@ -190,17 +209,18 @@ for (const { role, site, required, forbidden, why } of SITES) {
     assert.match(
       flat,
       required,
-      `resources/grammar.ebnf no longer spells this slot as a ${role} ` +
-        `(${role === 'separator' ? '`space`' : '`whitespace`'}).\n` +
+      `resources/grammar.ebnf no longer spells this ${role} slot \`space\`.\n` +
         `  ${site}\n  role: ${why}\n` +
-        `  See PART 7, MARKER SEPARATORS AND PADDING SLOTS (carve#878).`,
+        `  Both roles take \`space\`; a tab is syntax only in a leading indentation run.\n` +
+        `  See PART 7, MARKER SEPARATORS AND PADDING SLOTS (carve#901).`,
     )
     assert.doesNotMatch(
       flat,
       forbidden,
-      `resources/grammar.ebnf spells this slot with the OTHER role's terminal.\n` +
+      `resources/grammar.ebnf spells this ${role} slot \`whitespace\`, which admits a tab.\n` +
         `  ${site}\n  role: ${why}\n` +
-        `  See PART 7, MARKER SEPARATORS AND PADDING SLOTS (carve#878).`,
+        `  Padding is not a reason to admit a tab - the slot's POSITION is what decides,\n` +
+        `  and this one sits inline. See PART 7 (carve#901, correcting carve#878).`,
     )
   })
 }
@@ -208,8 +228,8 @@ for (const { role, site, required, forbidden, why } of SITES) {
 // Every padding site carries fixtures, with no exception: the oracle loop
 // below runs them all, and a site with no fixtures would silently drop out of
 // it - the check-that-cannot-fail class tracked in carve#755. `engineDeferred`
-// no longer substitutes for fixtures; it only says why the ENGINE half of the
-// pair is skipped, which is a statement about carve-rs, not about the oracle.
+// does not substitute for fixtures; it only says why the ENGINE half of the
+// pair is skipped, which is a statement about carve-js, not about the oracle.
 test('every padding site carries a tab/space fixture pair', () => {
   for (const s of SITES.filter((x) => x.role === 'padding')) {
     assert.ok(
@@ -221,66 +241,86 @@ test('every padding site carries a tab/space fixture pair', () => {
 })
 
 // A deferral is a claim about the engines, so it has to be written down and
-// readable. An empty string is not a reason.
-test('an engine deferral states its reason', () => {
-  for (const s of SITES.filter((x) => x.role === 'padding' && 'engineDeferred' in x)) {
+// readable. An empty string is not a reason, and a MISSING field is not one
+// either: with the engine loop gone, a padding site that declared nothing
+// would look identical to one that had been checked, which is precisely the
+// carve#755 shape. So the field is required at every padding site, and adding
+// a seventh without a reason fails here.
+test('every padding site states why its engine half is deferred', () => {
+  for (const s of SITES.filter((x) => x.role === 'padding')) {
     assert.ok(
       typeof s.engineDeferred === 'string' && s.engineDeferred.length > 0,
-      `padding site "${s.site}" declares engineDeferred but gives no reason.`,
+      `padding site "${s.site}" must state why the engine half is deferred. ` +
+        `carve-js accepts a tab at every padding slot and so diverges from the ` +
+        `production; if that has changed, assert it here instead of deferring.`,
     )
   }
 })
 
-// The engine-checked padding sites are the ones the implementations already get
-// right, so the spec and the engine are checked against each other. A
-// regression there means either the engine narrowed a padding slot to a literal
-// space, or the spec widened a slot the engine never widened.
+// The deferral REASON is itself a measurement, so it is measured rather than
+// asserted in prose. carve#896's first attempt at a deferral gave a rationale
+// that measurement showed was false for the engine actually executed, and
+// nothing caught it - a written reason nobody re-runs is a claim, not a check.
 //
-// The code-fence sites are deliberately absent: carve-rs still rejects a tab in
-// a fence opener, so asserting today's behavior would pin exactly what
-// carve#894 rules against. Same reasoning as the separator half above.
-for (const { site, tab, space } of SITES.filter(
-  (s) => s.role === 'padding' && !s.engineDeferred,
-)) {
-  test(`padding slot admits a tab in the pinned engine: ${site}`, () => {
+// This is NOT pinning the divergence. The assertion is "the reason for
+// deferring still holds", and its failure mode is the useful one: the day
+// carve-js narrows a padding slot to `space`, this goes red and says to delete
+// the deferral and assert the corrected behavior instead. A test that pinned
+// the bug would go red on the FIX and have to be deleted to allow it; this one
+// goes red on the fix and tells you what to write in its place.
+for (const { site, tab, space } of SITES.filter((s) => s.role === 'padding')) {
+  test(`the engine deferral still holds - carve-js admits a tab: ${site}`, () => {
     assert.equal(
       carveToHtml(tab),
       carveToHtml(space),
-      `a tab in this padding slot no longer parses as the space form does.\n` +
+      `carve-js no longer parses a tab in this padding slot as the space form.\n` +
         `  tab form:   ${JSON.stringify(tab)}\n  space form: ${JSON.stringify(space)}\n` +
-        `  The production says \`whitespace\` here (PART 7, carve#878).`,
+        `  This is GOOD NEWS: the engine has caught up with the production ` +
+        `(PART 7, carve#901).\n` +
+        `  Drop \`engineDeferred\` at this site and assert the corrected behavior ` +
+        `instead of deferring it.`,
     )
   })
 }
 
-// The ORACLE half, at EVERY padding site including the engine-deferred ones.
-// resources/carve-core.ohm and scripts/spec/layout.mjs are the executable
-// spelling of these productions, so a slot they narrow to a literal space is
-// the same defect as grammar.ebnf spelling it `space` - and it is invisible
-// everywhere else, because the corpus only carries a tab in a padding slot
-// where someone thought to write one. carve#888: `destTitle` in the ohm file
-// read `" "+` while grammar.ebnf said `whitespace`, so `[t](/u<TAB>"T")`
-// rendered as literal text here and as a titled link in all three engines.
+// The ORACLE half, at EVERY padding site. resources/carve-core.ohm and
+// scripts/spec/layout.mjs are the executable spelling of these productions, so
+// a slot they widen to admit a tab is the same defect as grammar.ebnf spelling
+// it `whitespace` - and it is invisible everywhere else, because no corpus
+// document carries a tab in one of these slots (measured: core:check is
+// 675/675 both before and after carve#901 narrowed them).
+//
+// The direction is the one carve#901 settled: a tab must NOT parse as the space
+// form does. carve#888 ran this same pair the other way round, when the
+// production was `whitespace`; the pair is what makes either reading
+// observable.
 for (const { site, tab, space } of SITES.filter((s) => s.role === 'padding')) {
-  test(`padding slot admits a tab in the oracle: ${site}`, () => {
-    assert.equal(
+  test(`padding slot rejects a tab in the oracle: ${site}`, () => {
+    assert.notEqual(
       renderDoc(parse(tab)),
       renderDoc(parse(space)),
-      `a tab in this padding slot does not parse as the space form does in the ` +
+      `a tab in this padding slot parsed as the space form does in the ` +
         `executable spec (scripts/spec/layout.mjs, resources/carve-core.ohm).\n` +
         `  tab form:   ${JSON.stringify(tab)}\n  space form: ${JSON.stringify(space)}\n` +
-        `  The production says \`whitespace\` here (PART 7, carve#878).`,
+        `  The production says \`space\` here: a tab is syntax only in a leading\n` +
+        `  indentation run (PART 7, carve#901).`,
     )
   })
 }
 
-// The OTHER direction, for the one slot carve#888 narrowed.
+// A SECOND character outside the slot's class, at both spellings of the one
+// production that is used at two sites.
 //
-// `whitespace` is `' ' | '\t'` and nothing else, so widening a padding slot
-// past that pair is as wrong as narrowing it - and scripts/spec/layout.mjs had
-// done exactly that, matching `\p{White_Space}` before the definition form's
-// title. Both spellings of `link_title` are checked, because the production is
-// one production used at two sites and the bug was that they disagreed.
+// The loop above already rejects a TAB at `link_title`. This one rejects NBSP,
+// and it is not redundant: the two would be rejected for different reasons if
+// the slot ever regressed. scripts/spec/layout.mjs matched `\p{White_Space}`
+// before the definition form's title until carve#888, which is a bug a tab
+// fixture alone cannot see - a tab is inside `\p{White_Space}`, so the tab
+// fixture would still have said "admits it" while the slot was wide open to
+// U+2003 and U+0085. NBSP is the fixture that separates "narrowed to `' '`"
+// from "narrowed to a whitespace PROPERTY". Both spellings of `link_title` are
+// checked, because the production is one production used at two sites and the
+// carve#888 bug was that they disagreed.
 //
 // Checked against the ORACLE ONLY, deliberately. carve-js accepts the whole
 // White_Space property in this slot (measured: U+00A0, U+2003, U+202F and
@@ -288,27 +328,20 @@ for (const { site, tab, space } of SITES.filter((s) => s.role === 'padding')) {
 // an engine assertion would pin that. That divergence is reported upstream
 // rather than encoded, and no corpus case carries one of these characters, so
 // no cross-engine golden takes a position on it.
-//
-// Scope note, so a later reader does not mistake this for a general rule: the
-// oracle still admits the wider class at three other padding slots - the
-// frontmatter format token, the definition's trailing attributes, and the code
-// fence opener. That inconsistency is real and unfixed; it is simply not what
-// carve#888 changed, and pinning it here would assert a claim no artifact yet
-// makes good on.
-const OUTSIDE_CLASS = '\u00a0' // NBSP: White_Space, but neither ' ' nor '\t'
+const OUTSIDE_CLASS = '\u00a0' // NBSP: White_Space, but not ' '
 
 for (const [form, outside, spaceForm] of [
   ['inline', `[t](/u${OUTSIDE_CLASS}"T")\n`, '[t](/u "T")\n'],
   ['reference definition', `[a]: /u${OUTSIDE_CLASS}"T"\n\n[a][]\n`, '[a]: /u "T"\n\n[a][]\n'],
 ]) {
-  test(`link_title admits no whitespace outside ' ' | '\\t' in the oracle: ${form}`, () => {
+  test(`link_title admits no whitespace outside ' ' in the oracle: ${form}`, () => {
     assert.notEqual(
       renderDoc(parse(outside)),
       renderDoc(parse(spaceForm)),
       `the oracle read a title after a whitespace character the production does not ` +
         `admit.\n  outside-class form: ${JSON.stringify(outside)}\n` +
         `  space form:         ${JSON.stringify(spaceForm)}\n` +
-        `  \`whitespace\` is \`' ' | '\\t'\` (PART 7, carve#878; carve#888).`,
+        `  \`link_title\` takes \`space\` (PART 7, carve#901; carve#888).`,
     )
   })
 }


### PR DESCRIPTION
Closes #901.

`carve#878` split the whitespace on a marker line into two roles and widened every padding slot to `whitespace`, on the reading that a slot carrying no recognition could admit a tab harmlessly. `carve#894` widened the code fence's three the same way, and the two executable spellings followed in `carve#889` and `carve#898`.

The reading was wrong, and the rule it missed is simpler than the split it replaced: **a tab is syntax only in a line's leading indentation run.** From the first non-whitespace character onward a tab is not relevant to syntax at all. The question a slot poses is therefore not what it recognizes but WHERE it sits, and every padding slot in this grammar sits inline.

This lands rules 1, 2 and 4. Rule 3 is measured below, not implemented.

## The nine positions, all confirmed still tab-permitting before reverting

Each was read at the line given, not from the ticket. `carve#898` found one item on its own ticket had already been fixed by a concurrent PR, so each of these was re-checked against `main` at `dcedf39` first; none had.

| # | file:line as read | was | now |
| --- | --- | --- | --- |
| 1 | `resources/grammar.ebnf:207` | `frontmatter_open = "---", [whitespace], [frontmatter_format], newline ;` | `[space]` |
| 2 | `resources/grammar.ebnf:1343` | `link_title = whitespace, ('"', ...)` | `space` |
| 3 | `resources/grammar.ebnf:1344` | `| whitespace, ("'", ...)` | `space` |
| 4 | `resources/grammar.ebnf:1354` | `[link_title], [whitespace, attributes], newline` | `[space, attributes]` |
| 5 | `resources/grammar.ebnf:915` | `[whitespace+, quoted_title]` | `[space+, quoted_title]` |
| 6 | `resources/grammar.ebnf:915` | `[whitespace+, label] ;` | `[space+, label] ;` |
| 7 | `resources/grammar.ebnf:352` | `fenced_code_block = code_fence_open, [whitespace], ...` | `[space]` |
| 8 | `resources/grammar.ebnf:426` | `code_fence_info = ( language_info, [whitespace+, quoted_title], ...` | `[space+, ...]` |
| 9 | `resources/grammar.ebnf:426` | `..., [whitespace+, label] )` | `[space+, label] )` |
| 9b | `resources/grammar.ebnf:427` | `| ( quoted_title, [whitespace+, label] )` | `[space+, label] )` |
| 10 | `resources/carve-core.ohm:303` | `titleSp = " " | "\t"` | `" "` |

`code_fence_info`'s label slot is written once per alternative, which is why 9 and 9b are separate rows: `carve#896` found that pinning them separately lets a half-revert through, so one assertion covers all three spellings, and the half-revert mutation is run below to prove it.

## What was verified as unchanged

Read before editing anything near it, and all confirmed already correct:

- All four colon-fence separators keep `space` (`admonition_open`, `div_open`, `line_block_open`, `local_hard_break_block_open`).
- `reference_definition`'s `':', space`, and the three definition markers.
- `indent = whitespace, {whitespace}` at `:617` - the leading run, where a tab belongs.
- `blank_line = {whitespace}` at `:244` - no non-whitespace character precedes.
- `carve#888`'s `definition_continuation` ruling, untouched.

## The rewritten PART 7 clause

Rebuilt around the position rule rather than the role rule. The roles are kept, because they still decide what a FAILED match means - a separator that does not match leaves the line unrecognized as that construct, a padding slot that does not match leaves a token unconsumed - but they no longer decide the terminal. The heading is unchanged, so `resources/normative-clauses.txt` does not move.

The clause also now names what it does NOT cover, rather than reading as though the grammar were already consistent:

> NOT YET RECONCILED. Three table-cell productions (`delimiter_cell`, `header_cell`, `data_cell`) and the interior of an attribute block (`opt_ws`, `attribute_list`) still spell inline padding `whitespace`. Both predate this clause, and both are inline by the rule above, so both are divergences from it rather than exceptions to it.

## The oracle moves with the production

At all six padding sites, because it is a spec artifact rather than an implementation: `titleSp` in `resources/carve-core.ohm`, and five slots in `scripts/spec/layout.mjs` - the frontmatter format token, the colon opener's title and label, the fence opener and its two info slots, the reference definition's title and its trailing attribute block.

No corpus document carries a tab in any of these slots, so narrowing them moves no golden. `core:check` is 675/675 before and after.

## `attrSp` is deliberately NOT reverted, and the measurement is why

The ticket lists `resources/carve-core.ohm`'s `attrSp` among the nine. Reverting it was measured first, and it is not a revert:

```
attrSp = " " | "\t"   ->   " "
corpus inputs:               675
executable-spec conformant:  673
DEFECTS (parse but diff):    2
  252-a-tab-separates-two-attributes-and-pads-a-block-as-a-space-does.crv
  252-a-tab-separates-two-attributes-and-pads-a-block-as-a-space-does-2.crv
```

Those two goldens are what all three engines produce - `carve#889` measured `*x*{.a<TAB>.b}` as `class="a b"` in carve-js, carve-php and carve-rs. Its grammar.ebnf counterparts (`opt_ws`, `attribute_list`) are not among the nine either, so narrowing only the executable file would re-open the two-normative-files disagreement `carve#889` closed.

It is a behavior change of the same class as rule 3, so it is measured and reported rather than landed. Recorded in the PART 7 clause and on the ticket.

## Table cells: filed, not fixed

`delimiter_cell`, `header_cell` and `data_cell` use `{whitespace}` for inline padding. Same violation, older. Measured: no corpus document carries a tab in a table row, but both the oracle and carve-js accept one, so correcting it needs an oracle change and its own fixtures. Filed as #904 and named in the clause so it is not left unstated.

## Rule 3 blast radius, measured

Not implemented here. Counted across all 675 corpus documents:

```
corpus .crv files scanned: 675
files with a MIXED leading run: 2
  224-a-tab-reaches-a-footnote-body-s-column-just-as-two-spaces-do-2.crv  line 3: ' \t'
  245-sibling-markers-that-reach-one-column-are-one-list.crv             line 3: ' \t'
```

Both are documents whose entire subject is that a mixed run reaches a column, and both currently render as structure rather than prose. Under rule 3 both become paragraphs, so rule 3 does not merely affect two documents - it reverses two existing corpus rulings. Full numbers on the ticket.

## Observability

`tests/separator-role-split.test.mjs` is the existing mechanism, extended rather than duplicated. Every assertion it makes about a reverted site is flipped: the required and forbidden patterns swap at all six padding sites, and the oracle loop asserts that a tab does NOT parse as the space form where it asserted the opposite before.

The engine loop is deleted. carve-js accepts a tab at all six slots, so it now diverges from the production and asserting that would pin the divergence. Every padding site instead carries `engineDeferred`, and a new test MEASURES that the stated reason still holds against the pinned engine - `carve#896`'s first deferral gave a rationale that measurement showed was false for the engine actually executed. Its failure mode is the useful one: the day carve-js narrows a slot, it goes red and says to delete the deferral and assert the corrected behavior instead.

Two structural gaps were found by mutation and closed:

- A site with two independently-revertible slots had one fixture with a tab at both, so a half-revert survived. The admonition opener and `code_fence_info` now carry one pair per slot, and a `MULTI_SLOT` table asserts the count.
- `link_title` is one production read by two pieces of the oracle. With only the inline fixture, widening `LINK_DEF` back broke nothing. It now carries the definition form too.

Two more were found by review, both the same mistake - "the slot takes a space" implemented as "the first character is a space" while the rest of the run went unchecked. `---<SP><TAB>yaml` and `[a]: /u<TAB><SP>{.c}` both slipped through. Each is fixed and pinned by its own mixed-run fixture pair.

### Every check was watched failing

21 mutations, each applied to the committed fix and reverted with `git restore --source=HEAD`. Every one failed an assertion naming the exact slot; no anchor missed, so no mutation was a no-op reported as evidence. Ten grammar mutations fail the grammar-text assertion for their production, including each of `code_fence_info`'s three spellings separately. Eleven oracle mutations fail the oracle assertion for their slot.

## Gates

`gate-run` reports `partial`, `failed: []`, identical to the baseline taken on `main` before any edit. Ran: `npm test`, `combinatorial:check`, `core:check`, `property:check`, `test:conformance`.

Four gates could not run on this host, the same four as at baseline, none of them run by this repo's per-PR CI:

- `npm run ast:check` - `a dependency outside the repository is missing: /tmp/carve-js/dist`
- `npm run claims:check` - `engine-claims: need all three engines, found 0 (none).`
- `npm run degradation:check` - `degradation-claims: need all three engines, found 0 (none).`
- `npm run fmt:check` - `fmt-fixture-claims: need all three engines, found 0 (none).`

## Downstream

Engines now diverge from six padding slots, which is the intended consequence of correcting the clause rather than a regression introduced here. Three engine tickets are already open against the clause this corrects; they should be re-read against the corrected production before further work.
