### PR TITLE
chore: split the corpus counts out of the five-target sweep

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -248,7 +248,29 @@ npm run compare:impls
 npm run compare:impls -- --corpus=optional
 npm run compare:impls -- --limit=20 --bench
 npm run compare:impls -- --targets=html          # fast path, HTML only
+npm run compare:counts                           # counts only, no five-target sweep
+npm run compare:counts -- --corpus=optional
 ```
+
+`compare:counts` is `compare:impls --counts-only`. It prints the corpus size and
+each engine's pass count - the two things
+`tests/implementation-comparison-counts.test.mjs` reads, and the only things it
+reads: that test asserts on no timing at all.
+
+It renders exactly what is SCORED: every document on the default target, plus
+any target that document carries an expected-output file for. That second part
+is not optional - a case may add a `.md`, `.txt` or `.fmt` beside its `.html`,
+and those files count toward `pass=N/M`, which is why the snapshot above reads
+`pass=690/690` under `corpus_pairs=675`. What it drops is the rest of the
+five-target sweep, where every document is rendered on every target to check
+the engines against each other. That is four extra renders per document against
+fifteen extra in total, and no count in the gate depends on it.
+
+Use it when a corpus change has made the quoted size stale. It is NOT the
+snapshot above: that block is a five-target transcript, and its per-target
+agreement rows are the substance of this page. A counts-only run measures one
+target and says so in its own output, so pasting it here would narrow what the
+page claims to have checked.
 
 ### Combinations, not just cases
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "docs:preview": "vitepress preview docs",
     "corpus:build": "node scripts/generate-corpus.mjs",
     "compare:impls": "node scripts/compare-impls.mjs",
+    "compare:counts": "node scripts/compare-impls.mjs --counts-only",
     "claims:check": "node scripts/engine-claims.mjs",
     "degradation:check": "node scripts/degradation-claims.mjs",
     "fmt:check": "node scripts/fmt-fixture-claims.mjs",

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -27,6 +27,19 @@ const roundtrip = args.has('--roundtrip')
 // disagreeing about a document's canonical form went unnoticed (carve#478).
 const failOnDiff = args.has('--fail-on-diff')
 
+// The cheap half of the run. `tests/implementation-comparison-counts.test.mjs`
+// reads exactly two things off this output - `corpus_pairs=N` and each engine's
+// `pass=N/M` - and NEITHER is a timing: `grep avg_ms` over that test returns
+// nothing. Everything else the default run produces is the five-target sweep,
+// which costs an order of magnitude more wall clock and, because it re-renders
+// every document five times, re-rolls per-engine `avg_ms` numbers no assertion
+// consumes. So a corpus commit paid twenty minutes to republish noise.
+//
+// This mode renders every document once per engine on the default target and
+// prints the count lines. It is the same claim, validated the same way, over a
+// fifth of the work (carve#804).
+const countsOnly = args.has('--counts-only')
+
 // Optional cases that reached fewer than two engines AND carry no recorded
 // reason. Gated on below, so a new one cannot join the roll-up unexplained.
 let undocumentedUnreachable = []
@@ -78,6 +91,20 @@ if (unknownTargets.length || targets.length === 0) {
   )
   process.exit(2)
 }
+
+// `--counts-only` OWNS the target set, so passing both is a request for two
+// different runs. Silently letting one win would produce counts under a target
+// set the caller did not get told about, and the counts are the whole output.
+if (countsOnly && targetsArg) {
+  console.error(
+    `--counts-only picks the target set itself, so it cannot be combined with ${targetsArg}. Drop one.`,
+  )
+  process.exit(2)
+}
+// NOTE: counts-only does NOT narrow `targets` here. Which targets a given case
+// runs on is decided per case in `targetsFor`, because "the default target" is
+// not the same set as "the targets this case is SCORED on" - see the comment
+// there.
 
 // In the optional corpus the manifest pins a target per case, so the target set
 // is not a free choice: each case runs on the target it pins and `--targets`
@@ -593,12 +620,33 @@ const fixtureCounts = {}
 // and `--targets` filters which cases that leaves. In the core corpus every case
 // runs on every requested target.
 function targetsFor(pair) {
-  if (!isOptional) return targets
-  return targets.includes(pair.target) ? [pair.target] : []
+  if (isOptional) return targets.includes(pair.target) ? [pair.target] : []
+  if (!countsOnly) return targets
+  // Counts-only renders exactly what is SCORED, which is not the same as "the
+  // default target". A core case may add an expected-output file on a non-html
+  // target (`NN-slug.md`, `.txt`, `.fmt`), and `expectedFor` scores it whenever
+  // that target is visited - so those files count toward the `pass=N/M` this
+  // mode exists to reproduce. The published snapshot shows the gap plainly:
+  // `corpus_pairs=675` against `pass=690/690`, the 15 extra being exactly those
+  // files. Forcing html would have reported `675/675` and quietly answered a
+  // smaller question than the one the page asks.
+  //
+  // What counts-only drops is the rest: every case rendered on every target for
+  // ENGINE-AGAINST-ENGINE agreement, which is the five-target sweep and which no
+  // count in the gate depends on. In the corpus as it stands that is 15 extra
+  // renders on top of one per document, against four extra per document.
+  return targets.filter(
+    (target) =>
+      target === DEFAULT_TARGET ||
+      (TARGET_EXTENSIONS[target] &&
+        existsSync(join(corpusDir, expectedFileFor(pair.slug, target)))),
+  )
 }
 
 const activeTargets = ALL_TARGETS.filter((target) =>
-  isOptional ? pairs.some((pair) => targetsFor(pair).includes(target)) : targets.includes(target),
+  isOptional || countsOnly
+    ? pairs.some((pair) => targetsFor(pair).includes(target))
+    : targets.includes(target),
 )
 
 /**
@@ -872,8 +920,13 @@ for (const impl of active) {
   const avg = s.runnable ? (s.ms / s.runnable).toFixed(2) : '0.00'
   // pass/mismatch score the fixtures only, so they are reported against the
   // pair count rather than the run count (which spans every target).
+  // `avg_ms` is dropped in counts-only mode rather than merely ignored. It is a
+  // wall-clock number from whatever machine ran it - the same three engines
+  // moved 70.80 -> 61.46 and 64.45 -> 56.84 between two runs with no engine
+  // changing - and printing one here would invite pasting it onto a page that
+  // already says the timings are not a benchmark (carve#836).
   console.log(
-    `${impl.name}: pass=${s.ok}/${s.ok + s.mismatch} mismatch=${s.mismatch} error=${s.error} skipped=${s.skipped} runs=${s.runnable} avg_ms=${avg}`,
+    `${impl.name}: pass=${s.ok}/${s.ok + s.mismatch} mismatch=${s.mismatch} error=${s.error} skipped=${s.skipped} runs=${s.runnable}${countsOnly ? '' : ` avg_ms=${avg}`}`,
   )
   // NAME the mismatching cases. `rust: pass=594/595 mismatch=1` was a number
   // with nothing to act on: the run took twenty minutes and finding the one
@@ -897,27 +950,44 @@ if (roundtrip) {
   )
 }
 
-console.log('\nTarget agreement (implementations compared against each other)')
-for (const target of activeTargets) {
-  const t = targetStats[target]
-  // How many of this target's cases were scored against a FILE rather than
-  // against the other engines. `yes` and `none` were the only two answers while
-  // html was the only core target with fixtures; a core case may now add one
-  // per target, so the honest report is the count.
-  const scored = fixtureCounts[target] ?? 0
-  const fixtures =
-    isOptional || target === DEFAULT_TARGET
-      ? ' fixtures=yes'
-      : scored > 0
-        ? ` fixtures=${scored}`
-        : ' fixtures=none'
-  console.log(`${target}: compared=${t.compared} diffs=${t.diffs} errors=${t.errors}${fixtures}`)
+// The per-target agreement block is the substance of the published snapshot, and
+// it is also the part a counts-only run has not measured: it ran one target. So
+// it is omitted rather than printed with one row, which would read as a
+// five-target result that happened to find nothing.
+if (!countsOnly) {
+  console.log('\nTarget agreement (implementations compared against each other)')
+  for (const target of activeTargets) {
+    const t = targetStats[target]
+    // How many of this target's cases were scored against a FILE rather than
+    // against the other engines. `yes` and `none` were the only two answers while
+    // html was the only core target with fixtures; a core case may now add one
+    // per target, so the honest report is the count.
+    const scored = fixtureCounts[target] ?? 0
+    const fixtures =
+      isOptional || target === DEFAULT_TARGET
+        ? ' fixtures=yes'
+        : scored > 0
+          ? ` fixtures=${scored}`
+          : ' fixtures=none'
+    console.log(`${target}: compared=${t.compared} diffs=${t.diffs} errors=${t.errors}${fixtures}`)
+  }
+  console.log(
+    isOptional
+      ? 'target_agreement_note=every optional case has an expected-output fixture on the target it pins; the counts here also assert that the implementations agree with each other.'
+      : 'target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.',
+  )
+} else {
+  // Say what was NOT measured, in the run's own output. A counts-only block that
+  // simply stopped after the pass lines is indistinguishable from a full run
+  // that printed nothing - the same observability defect the NOT COMPARED
+  // roll-up below exists to avoid.
+  console.log(
+    `\ncounts_only=1 targets_measured=${activeTargets.join(',')} of ${ALL_TARGETS.join(',')}`,
+  )
+  console.log(
+    'counts_only_note=this run validates the corpus counts only. Each document was rendered on the default target plus any target it carries an expected-output file for, so every SCORED case is scored - but nothing was compared engine-against-engine on an unscored target, so this makes no agreement claim and is not the published snapshot. Use `npm run compare:impls` for that.',
+  )
 }
-console.log(
-  isOptional
-    ? 'target_agreement_note=every optional case has an expected-output fixture on the target it pins; the counts here also assert that the implementations agree with each other.'
-    : 'target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.',
-)
 
 if (isOptional) {
   console.log('\nOptional feature coverage')

--- a/tests/implementation-comparison-counts.test.mjs
+++ b/tests/implementation-comparison-counts.test.mjs
@@ -102,10 +102,16 @@ for (const corpus of ['core', 'optional']) {
     // has ever added to it from a host that could not re-run the tool.
     const live =
       corpus === 'core' ? effectiveCore() : countPairs('tests/corpus-optional')
-    const rerun =
-      corpus === 'optional'
-        ? 'npm run compare:impls -- --corpus=optional'
-        : 'npm run compare:impls'
+    // Name the CHEAP command first. This message used to say `npm run
+    // compare:impls`, which is the five-target sweep - roughly twenty minutes -
+    // and it was the only instruction offered for a failure that turns on two
+    // numbers this test reads and no timing at all. `--counts-only` renders
+    // every document once per engine and emits both of them, so it is the
+    // honest answer to "this count is stale" (carve#804). The full sweep is
+    // still what the published snapshot is, so it is named too.
+    const suffix = corpus === 'optional' ? ' -- --corpus=optional' : ''
+    const rerun = `npm run compare:counts${suffix}`
+    const full = `npm run compare:impls${suffix}`
     const lagNote =
       corpus === 'core' && laggedPairs > 0
         ? ` (${laggedPairs} pair(s) in ${laggedCategories.length} declared-lag categor(ies) are excluded)`
@@ -113,7 +119,7 @@ for (const corpus of ['core', 'optional']) {
     assert.equal(
       entry.pairs,
       live,
-      `docs/implementation-comparison.md quotes corpus_pairs=${entry.pairs} for the ${corpus} corpus, which now holds ${live}${lagNote}. Re-run "${rerun}" and paste the current output.`,
+      `docs/implementation-comparison.md quotes corpus_pairs=${entry.pairs} for the ${corpus} corpus, which now holds ${live}${lagNote}. Re-run "${rerun}" for the counts this test reads, or "${full}" to retake the whole published snapshot.`,
     )
   })
 }


### PR DESCRIPTION
Closes #804.

`tests/implementation-comparison-counts.test.mjs` requires the comparison page to quote the live corpus size, and the only command it named to produce that number was `npm run compare:impls` - the five-target cross-engine sweep. Every corpus commit paid a run of that size to refresh two numbers.

The run is much larger than the assertion. That test reads exactly `corpus_pairs=N` and each engine's `pass=N/M`. It reads no timing at all - `grep avg_ms` over it returns nothing - yet re-running for the counts re-rolls the per-engine `avg_ms` the page publishes: the same three engines have moved 70.80 to 61.46 and 64.45 to 56.84 between two runs with no engine changing.

## What `--counts-only` does

It renders exactly what is SCORED: every document on the default target, plus any target that document carries an expected-output file for.

That second half is load-bearing, not a refinement. A core case may add a `.md`, `.txt` or `.fmt` beside its `.html`, and `expectedFor` scores those whenever the target is visited, so they count toward `pass=N/M`. The published snapshot shows the gap plainly - `pass=690/690` under `corpus_pairs=675`, the 15 extra being exactly those files. A first cut of this that forced the default target alone would have reported `675/675`: a cheaper run that quietly answered a smaller question than the page asks.

What it drops is the rest of the sweep - every document rendered on every target to check the engines against each other. Four extra renders per document, against fifteen extra in total, and no count in the gate depends on any of them.

It states its own limits rather than passing for a small full run. It prints

```text
counts_only=1 targets_measured=html,markdown,plain,carve of html,markdown,plain,carve,ansi
```

plus a note that it makes no engine-agreement claim and is not the published snapshot, and it omits the per-target agreement block rather than printing a one-row version of it.

Two details it has to respect:

- it refuses `--targets=` alongside, which would otherwise produce counts under a target set the caller was never told about;
- it leaves the OPTIONAL corpus's target selection alone, where the manifest pins one target per case. Forcing a target there pairs a Markdown case with an `.html` file that was never written, which is the bug carve#360 fixed.

## Measured

One frozen single-engine harness, whole 711-document core corpus, the two runs back to back. The engine checkouts on this host were mid-edit and could not be driven, so this is a self-consistency measurement of the runner rather than a three-engine conformance result - which is what the claim needs.

| run | `corpus_pairs` | `pass` | conversions |
|---|---|---|---|
| `compare-impls.mjs` | 711 | `677/726 mismatch=49` | 3555 |
| `compare-impls.mjs --counts-only` | 711 | `677/726 mismatch=49` | 726 |

Same counts, and the same 49 named documents in the same order. 4.9x less work. The 49 are the frozen harness lagging the corpus and are identical on both sides, which is the point - the agreement holds on a non-trivial run, not only where everything passes.

## Also here

- `npm run compare:counts` alias, and `-- --corpus=optional` for the other corpus.
- The gate's failure message named the twenty-minute command as the only remedy for a stale count. It now names the cheap one for the counts it reads, and the full sweep for the published snapshot.
- The "Running It" section documents the new script and says explicitly that its output is not the snapshot.

## Deliberately not here

The snapshot block itself is untouched. Whether the five-target transcript stays required-and-current or becomes labelled-and-dated changes what a published page guarantees, and the ticket's own discussion leaves that open. Nothing here weakens a published claim: the page still says what it always said, and the gate still fails when the quoted size drifts.

Re-derived while working: the core corpus is **711** documents and the optional corpus **33**, not the 622-669 the ticket quotes. The page's `corpus_pairs=675` is 711 minus the 36 pairs in the three declared-lag categories, so it passes today.
