### PR TITLE
spec: an ingest validates the whole payload against the AST schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   MARKER REQUIRES CONTENT still applies after the run: a marker followed by
   spaces and nothing else is a paragraph. Corpus 267 carries the ruling, with
   the tab separator, the spaces-only line and the one-space form as controls.
+- **PART 12 §12(d): an ingest validates the whole payload against
+  `resources/ast-schema.json`** (carve#881). Types and required fields
+  together, refused at decode with the typed error §12 already requires. One
+  clause rather than a row per field: the schema is the list, and it already
+  described every row that diverged.
+
+  Ruling them one at a time is what produced the state this replaces. After
+  §12(a)-(c) landed and all three engines agreed on those, a root `children` of
+  `null` was still read as an empty document by two of them, `attrs:
+  {"class":"x"}` was accepted and rendered as `class="x"` by carve-php while
+  the other two refused the payload, and `text.value: 7` made carve-php render
+  `<p>7</p>` - silent nonsense where a refusal is required. Two engines also
+  failed untyped, which §9(b) already forbids.
+
+  The shipped schema was measured against all sixteen shapes before the clause
+  was written and rejects every one, so it needed no tightening; each row is
+  now pinned in `tests/ast-schema.test.mjs` so a relaxed constraint cannot turn
+  the clause into a no-op in three engines at once. It rejects trees two
+  engines accept today, and every future schema addition becomes a potential
+  rejection for a producer that has not caught up.
 
 - **A reference definition is anchored at end of line** (carve#911).
   `reference_definition` ends in `newline`, and always did, but all three

--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -375,14 +375,30 @@ unknown-type refusal at decode. An ingest **must refuse**:
 | a root missing `type`, `children` or `srcByteLength` | §7 fixes the three and the schema marks them `required`; supplying a default turns a truncated document into a valid-looking one |
 | a root carrying a fourth field | `document` is closed with `additionalProperties: false` like every other node, so §11 already covers it |
 | a node whose `type` the schema does not name | **at decode**, not in a renderer - a formatter, a linter or a language server holds the tree and never reaches one |
+| anything else the schema rejects | §12(d): the WHOLE payload is validated against `resources/ast-schema.json`, types and required fields together |
 
 Same argument as §11, one level out: a reader that invents a missing field or
 ignores an unexpected one has silently repaired attacker-controlled input, which
 is the opposite of what an ingest boundary is for. The refusal has to be an error
 of its own, naming what was wrong - not whatever the JSON library raised.
 
+The last row is one clause rather than a list because ruling the rows one at a
+time is what produced the state it replaces. After the first three landed and
+all three engines agreed on them, a root `children` of `null` was still read as
+an empty document by two of them, `attrs: {"class":"x"}` was accepted and
+rendered by one, and `text.value: 7` rendered as `<p>7</p>` - silent nonsense
+where a refusal is required. The schema already described every one of those;
+nothing consulted it. Validate the payload against it and refuse with a typed
+error, rather than agreeing leniencies field by field.
+
+The cost is real and is the point: this rejects trees two engines accept today,
+and every future addition to the schema becomes a potential rejection for a
+producer that has not caught up. That is what makes the schema the contract
+instead of a description of one.
+
 The VALUE of `srcByteLength` is not checked. It is derivable and nothing depends
-on it, so all three engines ignore it - §12 is about the field being **there**.
+on it, so all three engines ignore it - §12 is about the field being **there**,
+and §12(d) about its type and sign, not about the number being right.
 
 One trap sits under the unknown-type rule, and it is worth knowing before you
 implement it. `attrs.keyValues` is the schema's only free-form map, its keys are

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -6180,10 +6180,48 @@ EOF = (* end of file *) ;
       of `attrs.keyValues`: its values are strings and hold no nodes at all,
       which is what the trap above turns on.
 
+      (d) THE WHOLE PAYLOAD, VALIDATED AGAINST `resources/ast-schema.json`
+          (carve#881). Types and required fields together, at DECODE, refused
+          with the same typed error (a), (b) and (c) already require. Not a
+          fourth list of leniency points -- the schema is the list, it already
+          describes every one of them, and the rows below were only ever
+          divergent because nothing consulted it.
+
+          One clause rather than a row per field, because ruling them one at a
+          time is what produced the state it replaces. Measured after (a)-(c)
+          landed, with all three engines agreeing on THOSE: a root `children`
+          of `null` was read as an empty document by carve-js and carve-php --
+          §12's own objection ("a reader that supplies a default has turned a
+          truncated document into an empty one") arriving through a door the
+          clause did not cover. `attrs: {"class":"x"}` was ACCEPTED by
+          carve-php and rendered as `class="x"`, while the other two refused
+          the payload: `class` is what the rendered HTML calls the thing, so it
+          is the natural producer mistake, and a producer testing against
+          carve-php ships something the other two reject outright.
+          `text.value: 7` made carve-php render `<p>7</p>` -- silent nonsense
+          where a refusal is required. And two engines failed UNTYPED, which
+          §9(b) already forbids: carve-php raised a bare `TypeError` from
+          `AstCodec::decodeNode()` for a null or string child, carve-js a
+          `TypeError: nodes is not iterable` from the RENDERER for a node
+          missing a required field.
+
+          THE COST, recorded: this is a bigger change in all three engines than
+          (a)-(c) were, it rejects trees two of them accept today, and every
+          future schema addition becomes a potential rejection for a producer
+          that has not caught up. That last one is the point rather than a side
+          effect -- it is what makes the schema the contract instead of a
+          description of it.
+
+          The rows already fixed are NOT reopened: an unnamed property under
+          §11 and a missing or non-string `type` under (c) landed separately
+          and keep their own clauses.
+
       A `srcByteLength` THAT IS PRESENT BUT WRONG IS NOT THIS CLAUSE'S
       BUSINESS. It is derivable from the payload and nothing in the tree
       depends on it, so all three engines ignore its value; that stays true and
-      is deliberate rather than unnoticed. (a) is about the field's PRESENCE.
+      is deliberate rather than unnoticed. (a) is about the field's PRESENCE,
+      and (d) does not reach it either -- the schema constrains the field's
+      TYPE and sign, not whether the number is the right one.
 
       MEASURED BEFORE RULING, engines at their own mains: root missing
       `srcByteLength` -- carve-rs rejected, carve-js and carve-php accepted.

--- a/tests/ast-schema.test.mjs
+++ b/tests/ast-schema.test.mjs
@@ -350,3 +350,155 @@ test('the schema accepts a minimal document', () => {
     `an empty document must validate: ${firstErrors()}`,
   )
 })
+
+/*
+ * PART 12 section 12(d): THE SCHEMA IS THE INGEST RULE (carve#881).
+ *
+ * The clause says an ingest validates the WHOLE payload against this file -
+ * types and required fields together, refused at decode. That is only a rule
+ * if the schema actually rejects the shapes it is supposed to, so each row
+ * below is asserted rather than assumed. It reads as a restatement of the
+ * schema, and that is the point: nothing else notices when a constraint is
+ * relaxed, and a relaxed constraint turns the clause into a no-op in three
+ * engines at once without any of them changing.
+ *
+ * Every row is one line of the divergence table on carve#881, where each of
+ * them was answered at least two ways by engines that had already agreed on
+ * (a), (b) and (c). The schema was measured to reject all sixteen before the
+ * clause was written; it needed no tightening, which is why the clause could
+ * be one sentence.
+ */
+
+const INGEST_POS = {
+  startLine: 1,
+  endLine: 1,
+  startColumn: 1,
+  endColumn: 2,
+  startOffset: 0,
+  endOffset: 1,
+}
+const ingestDoc = () => ({
+  type: 'document',
+  srcByteLength: 2,
+  children: [
+    {
+      type: 'paragraph',
+      pos: { ...INGEST_POS },
+      children: [{ type: 'text', value: 'x', pos: { ...INGEST_POS } }],
+    },
+  ],
+})
+
+/** The sixteen payloads section 12(d) refuses, each built from a valid one. */
+const INGEST_REFUSED = {
+  'a root srcByteLength of the wrong type': () => {
+    const d = ingestDoc()
+    d.srcByteLength = '2'
+    return d
+  },
+  'a negative root srcByteLength': () => {
+    const d = ingestDoc()
+    d.srcByteLength = -1
+    return d
+  },
+  'root children of the wrong type': () => {
+    const d = ingestDoc()
+    d.children = 'x'
+    return d
+  },
+  'root children of null': () => {
+    const d = ingestDoc()
+    d.children = null
+    return d
+  },
+  'a node missing type': () => {
+    const d = ingestDoc()
+    delete d.children[0].type
+    return d
+  },
+  'a node type that is not a string': () => {
+    const d = ingestDoc()
+    d.children[0].type = 7
+    return d
+  },
+  'a paragraph missing children': () => {
+    const d = ingestDoc()
+    delete d.children[0].children
+    return d
+  },
+  'a text node missing value': () => {
+    const d = ingestDoc()
+    delete d.children[0].children[0].value
+    return d
+  },
+  // The defect the clause was written to close: carve-php rendered <p>7</p>.
+  'a text value that is a number': () => {
+    const d = ingestDoc()
+    d.children[0].children[0].value = 7
+    return d
+  },
+  'a child that is null': () => {
+    const d = ingestDoc()
+    d.children[0].children = [null]
+    return d
+  },
+  'a child that is a string': () => {
+    const d = ingestDoc()
+    d.children[0].children = ['x']
+    return d
+  },
+  // The one a producer will actually write: `class` is what the HTML calls it.
+  'attrs spelled class': () => {
+    const d = ingestDoc()
+    d.children[0].attrs = { class: 'x' }
+    return d
+  },
+  'attrs carrying an unnamed key beside keyValues': () => {
+    const d = ingestDoc()
+    d.children[0].attrs = { keyValues: { a: 'b' }, bogus: 1 }
+    return d
+  },
+  'attrs of the wrong type': () => {
+    const d = ingestDoc()
+    d.children[0].attrs = 'x'
+    return d
+  },
+  'a pos carrying an extra key': () => {
+    const d = ingestDoc()
+    d.children[0].pos.extra = 1
+    return d
+  },
+  'a pos missing endOffset': () => {
+    const d = ingestDoc()
+    delete d.children[0].pos.endOffset
+    return d
+  },
+}
+
+for (const [what, build] of Object.entries(INGEST_REFUSED)) {
+  test(`section 12(d): the schema refuses ${what}`, () => {
+    assert.equal(
+      validate(build()),
+      false,
+      `the schema accepts ${what}, so section 12(d) refuses nothing for it`,
+    )
+  })
+}
+
+test('section 12(d): the payload the sixteen are built from is itself accepted', () => {
+  // Without this every row above would still pass if the BASE document were
+  // invalid - sixteen rejections of a document that was never valid, and a
+  // clause that appeared enforced while testing nothing. Same shape as the
+  // opt-in trap one module over (carve#755).
+  assert.ok(validate(ingestDoc()), `the base document must validate: ${firstErrors()}`)
+})
+
+test('section 12(d) does NOT reach a srcByteLength that is merely wrong', () => {
+  // (a) is about the field's PRESENCE and (d) about its TYPE. The value is
+  // derivable and nothing in the tree depends on it, so all three engines
+  // ignore it - a row the clause deliberately leaves alone, pinned so that
+  // tightening the schema cannot quietly annex it.
+  const d = ingestDoc()
+  d.srcByteLength = 99999
+  assert.ok(validate(d), `a wrong-but-present srcByteLength must still validate: ${firstErrors()}`)
+})


### PR DESCRIPTION
Implements the signoff on markup-carve/carve#881.

PART 12 §12 ruled three rows - a missing root field, an unexpected root field, an unknown node type - and all three engines now agree on them. Measuring 29 payload shapes to get there turned up more divergence ONE LEVEL DOWN than the ticket asked about, and none of it was ruled anywhere.

§12 gains a fourth item: **the WHOLE payload is validated against `resources/ast-schema.json`**, types and required fields together, refused at decode with the same typed error (a), (b) and (c) already require.

## One clause instead of a row per field

Ruling them one at a time is what produced the state it replaces. With §12(a)-(c) agreed by all three engines:

| shape | before |
| --- | --- |
| root `children` of `null` | read as an EMPTY DOCUMENT by carve-js and carve-php - §12's own objection ("a reader that supplies a default has turned a truncated document into an empty one") arriving through a door the clause did not cover |
| `attrs: {"class":"x"}` | ACCEPTED by carve-php and rendered as `class="x"`; the other two refuse the payload. `class` is what the rendered HTML calls the thing, so it is the natural producer mistake, and a producer testing against carve-php ships something the other two reject outright |
| `text.value: 7` | carve-php renders `<p>7</p>` - silent nonsense where a refusal is required |
| a null or string child | carve-php raises a bare PHP `TypeError` from `AstCodec::decodeNode()`; carve-js raises `TypeError: nodes is not iterable` from the RENDERER. §9(b) forbids both |

## The schema needed no tightening, and that is now asserted rather than assumed

It was measured against all sixteen shapes before the clause was written and rejects every one, which is why the clause could be one sentence. That measurement is now sixteen assertions in `tests/ast-schema.test.mjs` - because nothing else notices when a constraint is relaxed, and a relaxed constraint would turn the clause into a no-op in three engines at once without any of them changing.

Two assertions guard the guard:

- the base document the sixteen are BUILT FROM is itself asserted valid. Without it, sixteen rejections of a document that was never valid would read exactly like a clause being enforced.
- the row §12 deliberately leaves alone - a `srcByteLength` that is present but wrong - is pinned as ACCEPTED, so tightening the schema cannot quietly annex it. (a) is about the field's presence and (d) about its type and sign, not about the number being right.

## What is not reopened

An unnamed property under §11 and a missing or non-string `type` under §12(c) landed separately and keep their own clauses.

## Mutations

| mutation | result |
| --- | --- |
| Q1 `text.value` loses its string type | red: the number-valued text row |
| Q2 `attrs` opens to additional properties | red: the `class` row and the bogus-key row |
| Q3 `pos` loses its required `endOffset` | red: the missing-`endOffset` row |
| Q4 the base document is made invalid (`document` gains a required field) | red: the base-document guard, plus three pre-existing schema assertions |
| Q5 `srcByteLength` gains a maximum | red: the "does NOT reach a merely wrong `srcByteLength`" pin, plus the corpus round-trip |

None survived. Q4 and Q5 are the two guards firing on exactly the failure they exist for.

## Cost, recorded rather than discovered later

A bigger change in all three engines than (a)-(c) were, it rejects trees two of them accept today, and every future schema addition becomes a potential rejection for a producer that has not caught up. That last one is the point rather than a side effect - it is what makes the schema the contract instead of a description of it.

## Gates

`gate-run` reports **partial**. Five gates ran and passed - `npm test`, `combinatorial:check`, `core:check`, `property:check`, `test:conformance`. Four could not run on this host, each for a reason outside the repository, quoted verbatim:

- `npm run ast:check` - `a dependency outside the repository is missing: /tmp/carve-js/dist`
- `npm run claims:check` - `engine-claims: need all three engines, found 0 (none).`
- `npm run degradation:check` - `degradation-claims: need all three engines, found 0 (none).`
- `npm run fmt:check` - `fmt-fixture-claims: need all three engines, found 0 (none).`

Merging on local green gates rather than CI: GitHub Actions is degraded and the maintainer authorized it.

## Engine tickets

markup-carve/carve-js#826, markup-carve/carve-php#979, markup-carve/carve-rs#750.
