### PR TITLE
test: the bump-workflow fixtures do not assume TMPDIR is a real absolute path

### DIFF
--- a/tests/bump-downstream-early-exit.test.mjs
+++ b/tests/bump-downstream-early-exit.test.mjs
@@ -30,9 +30,9 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, chmodSync, existsSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, chmodSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { resolve, dirname, join } from 'node:path'
+import { resolve, dirname, join, isAbsolute } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
@@ -231,8 +231,21 @@ exit 0
   return stub
 }
 
+/*
+ * `os.tmpdir()` is whatever TMPDIR says, and TMPDIR is not always an absolute
+ * path that exists: a sandbox that sets it to a relative `.tmp` made every
+ * scenario below fail on `mkdtemp ENOENT` while the same test passed on the
+ * machine it was written on. Fall back to a directory that certainly exists,
+ * and never resolve a relative one - that would drop fixtures into the repo.
+ */
+function fixtureRoot() {
+  const t = tmpdir()
+  if (isAbsolute(t) && existsSync(t)) return t
+  return '/tmp'
+}
+
 function runScenario({ humanCommit, branchAfterBump = false, botExtraFile = false }) {
-  const root = mkdtempSync(join(tmpdir(), 'carve-bump-'))
+  const root = mkdtempSync(join(fixtureRoot(), 'carve-bump-'))
   const carve = buildCarveRemote(root)
   const downstreamBare = buildDownstream(root, carve, { humanCommit, branchAfterBump, botExtraFile })
 
@@ -280,13 +293,17 @@ function runScenario({ humanCommit, branchAfterBump = false, botExtraFile = fals
     output = `${err.stdout ?? ''}${err.stderr ?? ''}`
   }
 
-  return {
+  const result = {
     status,
     output,
     calls: readFileSync(log, 'utf8'),
     prStillOpen: existsSync(prState) && readFileSync(prState, 'utf8').trim() !== '',
     carve,
   }
+  // Several git repositories per scenario; leaving them behind fills the temp
+  // directory over a run of the suite.
+  rmSync(root, { recursive: true, force: true })
+  return result
 }
 
 test('the Bump step carries no workflow templating, so it can be run as written', () => {


### PR DESCRIPTION
A follow-up on #945, found by running its own test under a different sandbox.

`os.tmpdir()` returns whatever `TMPDIR` says, and `TMPDIR` is not always an absolute path that exists. A sandbox that sets it to a relative `.tmp` makes all four scenarios in `tests/bump-downstream-early-exit.test.mjs` fail on `mkdtemp ENOENT`, while the same suite is green on the machine the test was written on. Reproduced directly:

```
TMPDIR=.tmp node --test tests/bump-downstream-early-exit.test.mjs
  not ok 2 - a bump that already matches closes the bump PR the workflow itself left open
    error: "ENOENT: no such file or directory, mkdtemp '.tmp/carve-bump-XXXXXX'"
  ... 4 of 5 fail
```

Resolving the relative path instead of rejecting it would be worse than the crash: the fixtures are several git repositories per scenario, and they would land inside the repository.

The root is now checked for both properties - absolute, and exists - and falls back to `/tmp`. Each scenario also removes its own root, which none of them did.

With the fix, both spellings pass:

```
node --test tests/bump-downstream-early-exit.test.mjs              # 5 pass
TMPDIR=.tmp node --test tests/bump-downstream-early-exit.test.mjs  # 5 pass
```

and no `.tmp` directory is left in the working tree either way.

## Gates

Local gates only. Actions is degraded, so this merges on local green with the maintainer's authorization; CI was not waited on.

`gate-run` reports `partial`: every gate that ran was green, four could not run on this host. Verbatim:

```
npm run ast:check        - a dependency outside the repository is missing: /tmp/carve-js/dist
npm run claims:check     - engine-claims: need all three engines, found 0 (none).
npm run degradation:check - degradation-claims: need all three engines, found 0 (none).
npm run fmt:check        - fmt-fixture-claims: need all three engines, found 0 (none).
```

Ran and passed: `npm test`, `npm run combinatorial:check`, `npm run core:check`, `npm run property:check`, `npm run test:conformance`. None of them reads a temp directory this way.
