### PR TITLE
spec: a trailing zero-width character does not defeat a reference definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **PART 7: a trailing zero-width character does not defeat a reference
+  definition** (carve#953). The end-of-line anchor clause (carve#911, landed in
+  carve#934) listed `[a]: /u<U+FEFF>` among the shapes that are NOT
+  definitions, which does not follow from the anchor's own premise: the anchor
+  only sees what is LEFT OVER after the production, and U+FEFF is not
+  `White_Space`, so it never ends the destination. `link_destination` absorbs
+  it as an ordinary `unicode_url_char` and the character lands in the href, as
+  the note beside that production and corpus 240 already said. The clause now
+  strikes the row and states why, and the format-character exclusion is
+  attributed to `url_char` - the autolink body - where it actually lives. Prose
+  only: no production, no corpus document and no engine behavior moves, and
+  `docs/examples/edge-cases.md` already carried the correct reading.
+
 - **PART 4: a quoted attribute value stops at the newline** (carve#888).
   `quoted_value` built its value out of `character`, which is any Unicode
   character, so a line break inside the quotes was content - and it was the one

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1605,12 +1605,26 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
    THE LINE ENDING is `whitespace` -- `' ' | '\t'` -- the same terminal
    `blank_line = {whitespace}` takes (PART 1; carve#890). So `[a]: /u<SP>` and
    `[a]: /u<TAB>` are still definitions, while `[a]: /u<NBSP>`,
-   `[a]: /u<U+2000>`, `[a]: /u<U+FEFF>` and `[a]: /u<FF>` are not: every one of
-   those is CONTENT under that ruling, and content after the production is
-   exactly what the anchor rejects. An implementation spelling the ending as a
-   Unicode whitespace PROPERTY reads all six as a line ending, and a tab
-   fixture cannot see the difference, because a tab is inside the property too
+   `[a]: /u<U+2000>` and `[a]: /u<FF>` are not: every one of those is CONTENT
+   under that ruling, and content after the production is exactly what the
+   anchor rejects. An implementation spelling the ending as a Unicode
+   whitespace PROPERTY reads all five as a line ending, and a tab fixture
+   cannot see the difference, because a tab is inside the property too
    (carve#888).
+
+   A TRAILING ZERO-WIDTH CHARACTER IS NOT ON THAT LIST, and listing it there
+   was an error carried from carve#911's ruling prose into this clause
+   (carve#953). `[a]: /u<U+FEFF>` and `[a]: /u<U+200B>` ARE definitions. The
+   anchor only ever sees what is left over after the production, and here
+   nothing is: U+FEFF and U+200B are not `White_Space`, so they do not END the
+   destination -- `link_destination` absorbs them as ordinary
+   `unicode_url_char`s, exactly as the note beside that production states, and
+   the character is in the href. The anchor is therefore never reached, and it
+   is `url_char` -- the AUTOLINK body, a different production -- that excludes
+   format characters, not `link_destination` (corpus 240). The row is the
+   reason a mutant widening the line ending to "any invisible character"
+   survived: it asserted a differing render, which was true because the HREF
+   carried the character rather than because the line was rejected.
 
    WHAT THE ANCHOR DOES NOT REJECT. `[a]: /u{.c}` is still a definition, with
    destination `/u{.c}`: nothing is left over, because `link_destination`


### PR DESCRIPTION
Closes markup-carve/carve#953.

## The claim, verified rather than taken

The ticket said the end-of-line anchor clause lists a shape that its own premise
does not exclude. It does, and four checks agree.

**1. Where the clause actually lives.** Not in a `docs/**.md`. The normative
clause `carve#934` added is a `(* ... *)` comment on `reference_definition` in
`resources/grammar.ebnf`, and its "THE LINE ENDING" paragraph carried the row.
`docs/examples/edge-cases.md` already carries the CORRECT reading in prose, so
the grammar comment was the only artifact still holding the false example.

**2. The production that decides it is not the one the ticket cited.** The
ticket argued from `url_char`, whose last alternative really is
`unicode_url_char - format_char - control_char`. U+FEFF is General_Category Cf,
so `url_char` EXCLUDES it, and the ticket's reasoning does not work as written.
The conclusion still holds, from the production that actually applies:
`link_destination` admits `unicode_url_char` in its own right, and the grammar
states this beside that production, twice.

```
   ZERO-WIDTH characters (U+200B, U+FEFF) are NOT whitespace and ARE ordinary
   destination characters. The test is the Unicode White_Space property, not
   "is invisible".

   THE SAME RULE APPLIES IN A REFERENCE DEFINITION, because the definition is
   built from this same `link_destination`.
```

The autolink clause says the same thing from the other side: "`link_destination`
IS UNCHANGED. It admits `unicode_url_char` in its own right, so a format
character in an inline destination or a reference definition is still an
ordinary destination character." So the clause contradicted the same file, in
two places. The correction says which production is which rather than repeating
the ticket's attribution.

**3. Corpus 240.** Both documents pin U+FEFF as an ordinary destination
character, but in the LEADING and INTERIOR positions, not trailing. Worth
recording precisely: no corpus document pins the trailing shape - I checked
every `.crv` carrying a U+FEFF. What pins the trailing shape is
`tests/separator-role-split.test.mjs`, added by the same PR, which deliberately
omits the zero-width characters from its line-ending table and asserts them
separately with the exact href they produce. The test suite and the clause
disagreed.

**4. The oracle**, run on the shapes directly:

```
trailing BOM U+FEFF      | "<p>see <a href=\"/u﻿\">x</a></p>"
trailing ZWSP U+200B     | "<p>see <a href=\"/u​\">x</a></p>"
trailing NBSP U+00A0     | "<p>[a]: /u&nbsp;</p>\n<p>see [x][a]</p>"
trailing EN QUAD U+2000  | "<p>[a]: /u </p>\n<p>see [x][a]</p>"
trailing FF U+000C       | "<p>[a]: /u\f</p>\n<p>see [x][a]</p>"
trailing SP              | "<p>see <a href=\"/u\">x</a></p>"
trailing TAB             | "<p>see <a href=\"/u\">x</a></p>"
trailing junk zzz        | "<p>[a]: /u zzz</p>\n<p>see [x][a]</p>"
```

Three of the four listed shapes are correctly listed. The fourth is not.

## What changed

The row is struck from the list, and a paragraph says why: the anchor only ever
sees what is LEFT OVER after the production, and a character that is not
`White_Space` never ends the destination, so nothing is left over and the anchor
is never reached. The paragraph also records why the row survived review - a
mutant widening the line ending to "any invisible character" passed it, because
the assertion was "the render differs from the resolved form", true because the
HREF differed rather than because the line was rejected. That is the same
failure mode markup-carve/carve#755 catalogs.

The neighboring sentence said an implementation using a Unicode whitespace
PROPERTY "reads all six as a line ending". With the row struck it is five, and
now true: the remaining five are all `White_Space`, and U+FEFF never was.

## The stale corpus count

`16-reference-link-5.crv` exists and carries `[r]: a b c`, and its golden now
renders two paragraphs - so the ruling's "0 of 690 corpus documents carry it"
was wrong by one. It is already corrected in a normative file:
`resources/engine-pin-drift.txt` line 81 states the figure was wrong and names
the document. Grepping the whole tree finds the stale figure in no other
normative artifact. It survives only in the signoff comment on the ticket, which
is not a file a PR can edit, so a correcting comment goes on the ticket instead
of a diff hunk here.

## Scope and lock

Held the PER-REPO lock `markup-carve.carve`, not the org-wide sweep lock, so no
cross-engine sweep (`compare:impls`, `fuzz-impls`) was run and no engine
checkout was touched - three sibling agents hold their own locks in carve-js,
carve-php and carve-rs.

The brief for this tick scoped changes to `docs/**.md` outside `docs/examples/`
plus files a repo script derives from them. That scope rests on a premise this
ticket disproves: normative clauses live in `resources/grammar.ebnf`, and
`resources/normative-clauses.txt` derives from THAT, not from a docs page. The
edit is therefore in `resources/grammar.ebnf`, and it is confined to prose
inside a `(* ... *)` comment. No production, no corpus document, no fixture, no
`docs/examples/**` page and no golden moves - which is what the sweep lock
exists to protect. `node scripts/normative-clauses.mjs` was re-run and produced
no diff, since no clause heading changed.

There is no A/B to present here. A prose correction cannot fail a test, and the
behavior it now describes was already pinned by
`tests/separator-role-split.test.mjs` before this PR. The proof that the OLD
text was false is that the clause and that test file could not both be right,
and the oracle run above says which one was.

Gates were run against the pushed commit, and identically before the edit as a
baseline: `npm test`, `combinatorial:check`, `core:check`, `property:check` and
`test:conformance` all pass; `ast:check`, `claims:check`, `degradation:check`
and `fmt:check` are unrunnable on this host for lack of the sibling engine
checkouts, the same set as on the base commit.
