### PR TITLE
audit: a runner that compared nothing says so, rather than reporting a pass

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,6 +37,29 @@ For this repo in particular:
 - If you move the pinned `@markup-carve/carve` commit (`npm run bump-carve-pin`),
   pin only a commit merged to `carve-js` `main`, not a local branch build.
 
+## Every new guard ships with a demonstrated failure
+
+A check nobody has watched fail is not evidence of anything. This repo has found
+enough green checks that could not fail on their own subject
+(`markup-carve/carve#755` collects them) that the demonstration is now part of
+the change rather than a courtesy.
+
+- When you add or tighten a test, gate or assertion, break the thing it guards,
+  observe it fail, and put both in the PR body: the named mutation, and which
+  cases it broke. Then restore and confirm green again.
+- When you fix a defect, the same in reverse: put the old code back and say how
+  many of the new cases fail on it. A fix where that number is zero has not been
+  tested.
+- Say what the guard cannot see. A check is bounded by the inputs it is given,
+  and "no input we ever feed it would fail this" is the failure mode hardest to
+  spot in review.
+- A mutation that comes back green needs diagnosing before it is believed. A
+  no-op patch, a stale build and a genuinely unpinned rule all look the same.
+- Any runner that compares or conforms a population must state how large that
+  population should be and fail when it is smaller. Use `shortfall` and
+  `miscount` from `scripts/spec/participants.mjs` rather than printing a count
+  and trusting the reader to know the right one.
+
 ## Typical change order
 
 For a cross-cutting behavior change:

--- a/scripts/combinatorial-check.mjs
+++ b/scripts/combinatorial-check.mjs
@@ -38,6 +38,7 @@ import { join } from 'node:path'
 import { carveToHtml } from '@markup-carve/carve'
 import { parse as specParse, Refuse } from './spec/layout.mjs'
 import { renderDoc as specRender } from './spec/html.mjs'
+import { miscount, shortfall } from './spec/participants.mjs'
 import { phpDir, rustDir } from './lib/engine-locations.mjs'
 
 const verbose = process.argv.includes('--verbose')
@@ -326,6 +327,36 @@ try {
     }
 
     if (verbose) console.log(`  ${doc.id}`)
+  }
+
+  /*
+   * HOW MANY DOCUMENTS THE MATRIX ACTUALLY PRODUCED (carve#755, variant 2).
+   *
+   * Measured before this guard existed: emptying HEADINGS left `documents()`
+   * yielding nothing, and the run printed `0 documents x 2 engines` followed by
+   * `no divergences` and exited 0. The engine guard above is the sibling check
+   * and does not cover this - a matrix with an empty dimension compares two
+   * real engines on nothing at all.
+   *
+   * Two different failures, so two checks. The floor catches a dimension that
+   * emptied; the exact count catches a `continue` in the loop above dropping
+   * cases the generator did produce. The expected value is the matrix's own
+   * dimensions, which is why it has to be read off the four lists rather than
+   * off `documents()` - a count compared against itself cannot fail.
+   */
+  const dimensions = HEADINGS.length * ATTRS.length * CONTAINERS.length * BODIES.length
+  const population =
+    shortfall({
+      label: 'MATRIX',
+      actual: count,
+      atLeast: 1,
+      of: 'document(s)',
+      hint: 'One of HEADINGS / ATTRS / CONTAINERS / BODIES is empty.',
+    }) ?? miscount({ label: 'MATRIX', actual: count, expected: dimensions, of: 'document(s)' })
+  if (population !== null) {
+    console.error(`\n${population}`)
+    console.error('No cross-engine claim below describes the matrix this script defines.')
+    process.exit(2)
   }
 
   const report = (title, rows, format) => {

--- a/scripts/engine-report.mjs
+++ b/scripts/engine-report.mjs
@@ -30,6 +30,7 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { resolve, dirname, basename } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { carveToHtml } from '@markup-carve/carve'
+import { shortfall } from './spec/participants.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const corpusDir = resolve(here, '..', 'tests/corpus')
@@ -40,6 +41,31 @@ const slugs = readdirSync(corpusDir)
   .filter((f) => f.endsWith('.crv'))
   .map((f) => basename(f, '.crv'))
   .sort()
+
+/*
+ * HOW MANY DOCUMENTS THE PIN WAS ACTUALLY MEASURED AGAINST (carve#755,
+ * variant 2).
+ *
+ * Measured before this guard existed: with tests/corpus emptied and no line in
+ * `engine-pin-drift.txt`, `--check` printed `corpus pairs: 0` followed by
+ * `Drift matches what is declared.` and exited 0. The declared-drift ledger
+ * looks like it covers this - an empty corpus turns every declared line STALE
+ * and goes red - but that only holds while the ledger is non-empty, and an
+ * empty ledger is the state this repository is trying to reach. A gate that
+ * stops working once its subject is healthy is not a gate.
+ */
+const population = shortfall({
+  label: 'CORPUS',
+  actual: slugs.length,
+  atLeast: 100,
+  of: 'document(s)',
+  hint: 'Run `npm run corpus:build`, or check the checkout.',
+})
+if (population !== null) {
+  console.error(population)
+  console.error('Nothing below describes how the pinned build reads the corpus.')
+  process.exit(2)
+}
 
 const mismatches = []
 const threw = []

--- a/scripts/formal-core-check.mjs
+++ b/scripts/formal-core-check.mjs
@@ -42,6 +42,7 @@ import { parse, Refuse } from './spec/layout.mjs'
 import { renderDoc } from './spec/html.mjs'
 // Shared with tests/corpus.test.mjs so both gates agree on deliberate refusals.
 import { REFUSED_ALLOW } from './spec/refused-allow.mjs'
+import { miscount, shortfall } from './spec/participants.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const repo = resolve(here, '..')
@@ -49,6 +50,32 @@ const corpusDir = resolve(repo, 'tests/corpus')
 const inputs = readdirSync(corpusDir)
   .filter((f) => f.endsWith('.crv'))
   .sort()
+
+/*
+ * HOW MANY DOCUMENTS THIS GATE ACTUALLY SAW (carve#755, variant 2).
+ *
+ * Measured before this guard existed: with tests/corpus emptied, this script
+ * printed `corpus inputs: 0 / conformant: 0 / DEFECTS: 0` and exited 0. A
+ * corpus that failed to build, a checkout without its fixtures, or a filter
+ * that stopped matching all read as a clean run of the executable spec.
+ *
+ * The floor is the shape of the population rather than its exact size, because
+ * the corpus is append-only and grows on most spec PRs. 100 is the same floor
+ * `scripts/ast-conformance.mjs` uses for the same reason: below it this is not
+ * the corpus this repository ships, whatever else it is.
+ */
+const population = shortfall({
+  label: 'CORPUS',
+  actual: inputs.length,
+  atLeast: 100,
+  of: 'document(s)',
+  hint: 'Run `npm run corpus:build`, or check the checkout.',
+})
+if (population !== null) {
+  console.error(population)
+  console.error('Nothing below describes the corpus this repository ships.')
+  process.exit(2)
+}
 
 const listMode = process.argv.includes('--list')
 const diffMode = process.argv.includes('--diff')
@@ -84,6 +111,24 @@ for (const f of inputs) {
   } else {
     diffs.push({ f, got, expected })
   }
+}
+
+/*
+ * And that every input landed in exactly one bucket. The floor above catches a
+ * corpus that is not there; this catches one that is there and is not being
+ * counted - a `continue` added to the loop, or a bucket that stops being
+ * appended to, would otherwise shrink the question silently rather than fail.
+ */
+const accounting = miscount({
+  label: 'BUCKETS',
+  actual: core + refused.length + diffs.length,
+  expected: inputs.length,
+  of: 'document(s)',
+})
+if (accounting !== null) {
+  console.error(accounting)
+  console.error('Some corpus documents were read and then counted nowhere.')
+  process.exit(2)
 }
 
 console.log(`\ncorpus inputs:               ${inputs.length}`)

--- a/scripts/fuzz-impls.mjs
+++ b/scripts/fuzz-impls.mjs
@@ -62,6 +62,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { phpDir, rustDir } from './lib/engine-locations.mjs'
+import { shortfall } from './spec/participants.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
@@ -91,6 +92,29 @@ if (!Object.hasOwn(JS_ENTRY, target)) {
 const seed = numeric('seed', 1)
 const count = numeric('count', 200)
 const maxFindings = numeric('max-findings', 8)
+
+/*
+ * HOW MANY CASES THIS RUN WILL FUZZ (carve#755, variant 2).
+ *
+ * `--count=0` runs the loop zero times and reports `0 distinct divergence(s)`
+ * with exit 0 - a clean differential sweep that swept nothing.
+ *
+ * Deliberately BEFORE the three engine probes below, for two reasons. A caller
+ * error does not depend on the environment, and a guard that can only be
+ * reached on a host with all three engines built is one almost nobody can
+ * demonstrate: this one fails on any checkout.
+ */
+const population = shortfall({
+  label: 'CASES',
+  actual: count,
+  atLeast: 1,
+  of: 'case(s)',
+  hint: 'Raise --count.',
+})
+if (population !== null) {
+  console.error(population)
+  process.exit(2)
+}
 
 /**
  * Fragments biased toward where the corpus is thin: container openers and

--- a/scripts/property-check.mjs
+++ b/scripts/property-check.mjs
@@ -29,6 +29,7 @@ import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { tmpdir } from 'node:os'
+import { shortfall } from './spec/participants.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
@@ -63,6 +64,29 @@ function generate() {
 const lib = await import('@markup-carve/carve')
 
 const docs = Array.from({ length: count }, generate)
+
+/*
+ * HOW MANY DOCUMENTS THIS RUN GENERATED (carve#755, variant 2).
+ *
+ * Measured before this guard existed: `--count=0` printed `generated 0
+ * documents / idempotence failures: 0 / meaning changed: 0 / threw: 0` and
+ * exited 0. This script is a report rather than a gate, which makes the guard
+ * more necessary and not less: the number it reports is the whole product, and
+ * zero failures over zero documents is the reading a caller is most likely to
+ * carry away as "the invariants hold".
+ */
+const population = shortfall({
+  label: 'GENERATED',
+  actual: docs.length,
+  atLeast: 1,
+  of: 'document(s)',
+  hint: 'Raise --count.',
+})
+if (population !== null) {
+  console.error(population)
+  process.exit(2)
+}
+
 const failures = { idempotence: [], meaning: [], threw: [] }
 
 for (const src of docs) {


### PR DESCRIPTION
Closes the two concrete asks on `markup-carve/carve#755`: the participant-count
meta-check for variant 2, and the convention in CONTRIBUTING.

## What was measured, before anything was changed

Every comparison and conformance runner in `scripts/` and `tests/` was driven
with an empty or short population and its exit code read. Three reported
success over nothing:

```
$ node scripts/formal-core-check.mjs          # tests/corpus emptied, 830 -> 0
corpus inputs:               0
executable-spec conformant:  0
DEFECTS (parse but diff):    0
EXIT=0
```

```
$ node scripts/engine-report.mjs --check      # same corpus, declared drift emptied
corpus pairs:            0
reproduced:              0
declared drift:          0
Drift matches what is declared.
EXIT=0
```

```
$ node scripts/combinatorial-check.mjs        # HEADINGS emptied
0 documents x 2 engines
divergences: 0
no divergences
EXIT=0
```

`engine:report` deserves a note, because it looks guarded and is not. With the
committed `engine-pin-drift.txt` in place, an empty corpus turns all 86 declared
lines STALE and the run goes red - so the ledger reads like a population check.
It only works while the ledger is non-empty, and an empty ledger is the state
this repo is trying to reach. A gate that stops working once its subject is
healthy is not a gate.

`property:check --count=0` and `fuzz-impls --count=0` are the same shape reached
through an argument: both ran their loop zero times and exited 0.

### Examined and already guarded, so the list above means something

- `ast:check` and `compare:impls` already use `shortfall` / `miscount` (carve#776).
- `claims:check`, `degradation:check`, `fmt:check` and `fuzz-impls` refuse on
  fewer than three engines; `fmt:check` also floors its fixtures at 5.
- `tests/corpus.test.mjs` throws on an empty corpus; `roundtrip`,
  `corpus-fmt-roundtrip`, `corpus-fmt-cross-read`, `ast-schema`, `examples` and
  `node-vocabulary` all carry floors.
- `tests/fixture-bytes.test.mjs` and `tests/schema-fields-are-produced.test.mjs`
  have no explicit floor and do not need one: both compare a corpus-derived set
  against a committed list, so an empty corpus makes the comparison fail rather
  than pass. Labelling them controls rather than proof - no mutation here breaks
  them, because there was nothing to break.

## The mutations, and what each broke

Each was applied to a throwaway export of the committed tree, never to the
branch. `M3` also carries its control: the same mutation against the code one
commit earlier.

| mutation | runner | before | after |
| --- | --- | --- | --- |
| M1 `tests/corpus` emptied, 830 -> 0 | `core:check` | exit 0, "conformant: 0" | exit 2, `CORPUS: compared 0 document(s) but expected at least 100` |
| M1 | `engine:report --check` | exit 0, "Drift matches what is declared." | exit 2, same finding |
| M2 corpus narrowed to 50 of 830 | `core:check` | exit 0 | exit 2, `compared 50 ... expected at least 100` |
| M3 `continue` dropping every 10th document in the render loop | `core:check` | **exit 0, "conformant: 747" of 830** | exit 2, `BUCKETS: compared 747 document(s), expected exactly 830` |
| M4 `HEADINGS = []` | `combinatorial:check` | exit 0, "no divergences" | exit 2, `MATRIX: compared 0 document(s) but expected at least 1` |
| M5 `continue` skipping every 4th matrix case | `combinatorial:check` | exit 0 | exit 2, `MATRIX: compared 90 document(s), expected exactly 120` |
| M6 `--count=0` | `property:check` | exit 0, "generated 0 documents" | exit 2, `GENERATED: compared 0 document(s)` |
| M7 `--count=0` | `fuzz-impls` | loop runs zero times | exit 2, `CASES: compared 0 case(s)` |

M3 and M5 are why two runners get both a floor and an exact count: a floor
cannot see a population that is present and being dropped by the loop. M3's
control shows the pre-fix code printing a visibly wrong conformance number and
exiting 0, which is the failure mode a floor alone would have left in place.

## What these guards cannot see

- They count what the runner reached, not whether the population is the RIGHT
  one. A corpus with 830 documents none of which exercise a rule still passes -
  that is variant 1b on the ticket, and a different fix.
- The floors are 100 for the two corpus runners, chosen to match
  `ast-conformance.mjs`, so a drop from 830 to 150 still passes. An exact count
  is wrong here: the corpus is append-only and grows on most spec PRs.
- `combinatorial:check`'s exact count is the product of its own four dimension
  lists. It catches a loop that drops cases, not a dimension that was edited
  deliberately.
- M7 was demonstrated without engines, which is deliberate: the fuzzer's count
  guard sits before its three engine probes so it is reachable on any checkout.
  Nothing here exercised `fuzz-impls` past that point.

## One helper, five call sites

`scripts/spec/participants.mjs` already existed and is unchanged. Each runner
still names its own population, floor and hint, because only the runner knows
what it should have compared - a helper that guessed would be the vacuous check
this ticket is about.

## Lock and gates

Taken under the per-repo `markup-carve.carve` lock, which is sufficient: the
diff touches `scripts/**` and `.github/CONTRIBUTING.md` only. No corpus document,
no `docs/examples/**`, no production in `resources/grammar.ebnf`. No cross-engine
sweep was run, because three engine agents hold their own repo locks concurrently
and a sweep against engines being edited fabricates diffs.

Four gates could not run on this host, verbatim reasons:

- `npm run ast:check` - a dependency outside the repository is missing: `/tmp/carve-js/dist`
- `npm run claims:check` - `engine-claims: need all three engines, found 0 (none).`
- `npm run degradation:check` - `degradation-claims: need all three engines, found 0 (none).`
- `npm run fmt:check` - `fmt-fixture-claims: need all three engines, found 0 (none).`
