### PR TITLE
spec: carve lint gains two opt-in, platform-scoped autolink rules

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -43,6 +43,14 @@ semantic shifts flagged too:
 carve lint --from-djot doc.crv
 ```
 
+Pass `--platform` when the output is destined for a host that re-linkifies bare
+tokens in the text it renders. The flag is repeatable, and the rules it enables
+report nothing without it:
+
+```sh
+carve lint --platform github doc.crv
+```
+
 ## Programmatic API
 
 JavaScript and TypeScript callers can use `lintCarve` directly:
@@ -96,6 +104,8 @@ the command-line and editor behavior stay aligned.
 | `carve-version-unsupported` | a document declaring a Carve spec version the processor does not implement, so constructs added after that version render as something else without any error |
 | `unclosed-container-fence` | a `:::` opener with no matching closer; the container runs to end of input, which is legal (PART 9 §12) and rarely what was meant |
 | `fence-title-syntax` | text after a fence type word that is neither a quoted `"title"` nor a `[label]`, which makes the whole opener line plain text |
+| `platform-mention-token` | an at-prefixed word in text the document publishes, which a host platform re-linkifies into a user mention; opt-in and off by default, see [platform autolink rules](#platform-autolink-rules) |
+| `platform-issue-reference` | a hash-number in text the document publishes, which a host platform re-linkifies into an issue reference; opt-in and off by default, see [platform autolink rules](#platform-autolink-rules) |
 
 ### Declaring a target version
 
@@ -121,6 +131,120 @@ document targets, versus what last processed it - and the rule is about intent.
 See [versioning](./versioning) for what a version difference means for a stored
 document.
 
+### Platform autolink rules
+
+`platform-mention-token` and `platform-issue-reference` are the only rules here
+that read the document as text some **other** system will re-scan, rather than as
+Carve. They are opt-in, platform-scoped, and **off by default**.
+
+A host that renders published Carve output often re-scans the resulting text and
+linkifies two token shapes on its own: an at-prefixed word becomes a user
+mention, which notifies whoever owns that handle, and a hash-number becomes an
+issue reference, which posts a backlink on whatever it resolves to. Neither was
+meant as a reference in documents that merely discuss cron shortcuts, docblock
+tags, decorators, package scope prefixes or numbered list items.
+
+**No render-time construct prevents this.** The inline literal in PART 9 §27
+guarantees that the *renderer* emits its content verbatim; it cannot bind a
+platform that consumes the rendered HTML and re-parses the characters, because by
+then the literal marker is gone and only the characters remain. Nor are inline
+code spans a reliable escape: fenced code blocks survive on the hosts measured so
+far, but some host surfaces linkify inside a code span. The source is the only
+place the author's intent still exists, which is what makes this a linter's job
+rather than the parser's.
+
+#### Selecting a platform
+
+A processor MUST NOT report either rule unless the caller names at least one
+platform. The selection is a **list of host names**, not a boolean, so a second
+host can bring its own token table without a second flag:
+
+```ts
+lintCarve(source)                              // neither rule can fire
+lintCarve(source, { platforms: ['github'] })   // both rules are enabled
+```
+
+```sh
+carve lint --platform github doc.crv
+```
+
+The command-line flag is repeatable. An unknown platform name is **ignored** on
+the programmatic API and **refused** on the command line. The asymmetry is
+deliberate: an API caller has a type checker to catch a misspelling, while a
+misspelt flag that silently reported nothing would be indistinguishable from a
+clean document.
+
+`github` is the one platform name this specification defines. See
+[what is left unspecified](#what-is-left-unspecified) below.
+
+#### What each rule flags
+
+For `github`:
+
+`platform-mention-token` flags an `@` that is **not** preceded by a word
+character, another `@`, a dot, a hyphen or a slash, followed by a name that
+starts with a letter, digit or underscore and continues over letters, digits,
+underscores, hyphens and interior dots. So an email address is not a mention,
+while a scope prefix and a docblock tag are:
+
+```
+Write to user@example.com today.       no finding
+Install @types/node now.               platform-mention-token
+The @param annotation.                 platform-mention-token
+```
+
+`platform-issue-reference` flags a `#` that is **not** preceded by a word
+character, another `#` or a slash, followed by **digits only** and not by a word
+character or hyphen. So a heading marker, an id-shaped token and a version tag
+are not issue references:
+
+```
+See #42 now.                           platform-issue-reference
+See (#123) now.                        platform-issue-reference
+The #a1 selector.                      no finding
+The #release-1.0 tag.                  no finding
+```
+
+Both rules read **prose and inline code spans**, for the reason given above:
+a code span is not reliably safe on every host.
+
+Each finding names the host, quotes the token, and suggests moving the example
+into a fenced code block, stripping the sigil and rephrasing, or rewriting an
+enumerated reference as "item 1" / "point 1".
+
+#### What neither rule flags
+
+Neither rule fires on text a host never renders as prose. That is one principle
+with several consequences, and a conforming implementation MUST apply all of
+them, because a rule that reports a token nobody can see is the over-eager rule
+this design exists to avoid:
+
+- **fenced code blocks**, which are reliably safe;
+- **raw blocks** and **comments**;
+- **frontmatter**, which the renderer omits from the body;
+- **link reference definitions** and **abbreviation definitions**, which render
+  as the empty string;
+- a **footnote definition that is never referenced**, which is dropped from the
+  output entirely and which `unused-footnote-definition` already reports;
+- an **inline link's destination**, and the path, query and fragment of a **bare
+  URL**, because the host linkifies those as a URL rather than as a separate
+  mention or reference.
+
+Two surfaces that look excluded are deliberately checked, because both reach the
+published page: the **caption of a captioned listing**, and the body of a
+**referenced** footnote.
+
+#### What is left unspecified
+
+- **Which host platforms exist beyond `github`.** The signoff on
+  [carve#297](https://github.com/markup-carve/carve/issues/297) settled that the
+  rules are enabled per platform; it did not enumerate the platforms. Adding one
+  means defining its token table with the same precision as the `github` table
+  above, since the ids are shared and two engines flagging different token sets
+  under one id is the portability break the next section forbids.
+- **Whether a processor may offer a per-rule opt-in** rather than only a
+  per-platform one. Nothing here forbids it; nothing requires it.
+
 ### Which implementations provide these rules
 
 The table above is carve-js. The other engines do not currently match it, and
@@ -129,8 +253,14 @@ The table above is carve-js. The other engines do not currently match it, and
 | implementation | `carve lint` | covers |
 |---|---|---|
 | carve-js | yes | the rules above, plus the Djot/Markdown migration checks |
-| carve-php | yes | Markdown-habit checks only (`markdown-strong-asterisks`, `markdown-strong-underscores`, `markdown-strikethrough`); none of the semantic rules above |
+| carve-php | yes | Markdown-habit checks only (`markdown-strong-asterisks`, `markdown-strong-underscores`, `markdown-strikethrough`); none of the semantic rules above, and neither platform autolink rule |
 | carve-rs | no | the binary has no `lint` command |
+
+The two platform autolink rules are carve-js only today. They are specified here
+rather than left to one engine because the ids are shared surface: a second
+engine implementing the same condition takes the same two ids, the same
+`platforms` selection, and the same token tables, or a `--platform` config stops
+being portable the moment it moves between engines.
 
 ### A rule id is a contract
 

--- a/tests/lint-rule-table-claims.test.mjs
+++ b/tests/lint-rule-table-claims.test.mjs
@@ -34,7 +34,21 @@ import { lintCarve } from '@markup-carve/carve'
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const page = readFileSync(resolve(root, 'docs/validation.md'), 'utf8')
 
-/** A document that provokes each documented rule. */
+/**
+ * A document that provokes each documented rule, with the options it needs.
+ *
+ * A bare string is a document linted with DEFAULT options, which is what every
+ * rule reporting a silent failure in Carve takes. The two platform autolink
+ * rules are opt-in and platform-scoped (carve#297), so they carry a `platforms`
+ * selection with them - a rule nothing can call is undocumentable, and before
+ * this map could pass options, adding those rows to the page would have failed
+ * the "can actually be emitted" check below for the wrong reason.
+ *
+ * The default-off half is then asserted SEPARATELY rather than inferred from
+ * the shape of this map. An engine that started reporting them unasked would
+ * satisfy every check here, because a rule that fires under both default and
+ * opt-in options provokes its trigger either way.
+ */
 const TRIGGERS = {
   'duplicate-heading-id': '# A\n\n# A\n',
   'broken-crossref': 'see </#nope>\n',
@@ -50,6 +64,29 @@ const TRIGGERS = {
   'carve-version-unsupported': '---\ncarve-version: 99.0\n---\n\nx\n',
   'unclosed-container-fence': '::: note\nbody\n',
   'fence-title-syntax': '::: note Some Title\nbody\n:::\n',
+  'platform-mention-token': {
+    source: 'Use @minutely for that cron alias.\n',
+    options: { platforms: ['github'] },
+  },
+  'platform-issue-reference': {
+    source: 'See #123 for the discussion.\n',
+    options: { platforms: ['github'] },
+  },
+}
+
+/** The rules this map calls with options, i.e. the ones that are not default-on. */
+const OPT_IN = Object.entries(TRIGGERS)
+  .filter(([, entry]) => typeof entry !== 'string')
+  .map(([rule]) => rule)
+
+/** `{ source, options }` for either spelling of a trigger entry. */
+function trigger(entry) {
+  return typeof entry === 'string' ? { source: entry, options: undefined } : entry
+}
+
+/** The rule ids a document provokes under the given options. */
+function rulesFor({ source, options }) {
+  return (lintCarve(source, options) ?? []).map((w) => w.rule)
 }
 
 /** Rule ids the table lists, as data. */
@@ -62,8 +99,8 @@ function documentedRules() {
 /** Every rule id this engine emits across the triggers. */
 function emittedRules() {
   const seen = new Set()
-  for (const source of Object.values(TRIGGERS)) {
-    for (const warning of lintCarve(source) ?? []) seen.add(warning.rule)
+  for (const entry of Object.values(TRIGGERS)) {
+    for (const rule of rulesFor(trigger(entry))) seen.add(rule)
   }
 
   return [...seen].sort()
@@ -80,8 +117,8 @@ test('every trigger provokes the rule it names', () => {
   // first: an entry that stopped provoking its rule would silently shrink the
   // emitted set and make the page look complete.
   const broken = []
-  for (const [rule, source] of Object.entries(TRIGGERS)) {
-    const ids = (lintCarve(source) ?? []).map((w) => w.rule)
+  for (const [rule, entry] of Object.entries(TRIGGERS)) {
+    const ids = rulesFor(trigger(entry))
     if (!ids.includes(rule)) broken.push(`${rule} (got ${ids.join(', ') || 'nothing'})`)
   }
   assert.deepEqual(broken, [], `trigger(s) that no longer provoke their rule: ${broken.join('; ')}`)
@@ -94,6 +131,40 @@ test('every rule the engine emits is on the page', () => {
     [],
     `carve-js emits rule id(s) docs/validation.md does not list: ${undocumented.join(', ')}. ` +
       'The page calls a rule id spec surface, so an id nobody can look up is a broken contract.',
+  )
+})
+
+test('an opt-in rule reports nothing until it is asked for', () => {
+  // carve#297 ruled these rules OFF BY DEFAULT, and that is the load-bearing
+  // half rather than a convenience. Every other rule on the page reports a
+  // silent failure IN CARVE; these two report a hazard in some other system's
+  // re-rendering of the output, which is meaningless for a PDF pipeline. The
+  // ruling's own argument is that an over-eager rule people disable wholesale
+  // would be worse than no rule.
+  //
+  // Nothing above this line would notice a regression: a rule that fired under
+  // both default and opt-in options provokes its trigger either way, and would
+  // be on the page and emittable exactly as required.
+  assert.ok(OPT_IN.length > 0, 'no opt-in rule in TRIGGERS; this check would be vacuous')
+  const leaked = []
+  for (const rule of OPT_IN) {
+    const { source } = trigger(TRIGGERS[rule])
+    // The same document its own trigger uses, linted with NO options - so a
+    // pass cannot come from a document that fails to carry the token.
+    const ids = rulesFor({ source, options: undefined })
+    if (ids.includes(rule)) leaked.push(rule)
+    // An explicitly EMPTY selection is the other spelling of "not asked for",
+    // and it is the one a config file threading a list through is most likely
+    // to produce.
+    const empty = rulesFor({ source, options: { platforms: [] } })
+    if (empty.includes(rule)) leaked.push(`${rule} (empty platform list)`)
+  }
+  assert.deepEqual(
+    leaked,
+    [],
+    `rule(s) reported without being asked for: ${leaked.join(', ')}. ` +
+      'docs/validation.md states a processor MUST NOT report these unless the ' +
+      'caller names a platform.',
   )
 })
 

--- a/tests/lint-rule-table-claims.test.mjs
+++ b/tests/lint-rule-table-claims.test.mjs
@@ -22,6 +22,13 @@
  *
  * The trigger map is what makes the second direction checkable, so it is itself
  * asserted: every entry must actually provoke the rule it names.
+ *
+ * A THIRD DIRECTION arrived with carve#297's opt-in rules, and neither of the
+ * two above reaches it. A rule the page documents as OFF BY DEFAULT that fires
+ * anyway is on the page, is emittable, and provokes its trigger - green on
+ * every check here - while breaking the one property the ruling turned on. So
+ * "reports nothing until asked for" is asserted on its own, against the same
+ * documents the triggers use.
  */
 
 import { test } from 'node:test'


### PR DESCRIPTION
Closes markup-carve/carve#297.

Writes the signoff (direction `397e1bb50638`) into `docs/validation.md`: the
rules are opt-in, platform-scoped and off by default, they flag the two token
shapes in prose and in inline code spans, they never flag a fenced code block, a
raw block or a comment, and each finding suggests fencing the example, stripping
the sigil, or rewording.

This documents what shipped in markup-carve/carve-js#856 rather than what was
proposed. The ruling deliberately left two values to the engine and the engine
fixed them:

- **Two ids, not one** - `platform-mention-token` and `platform-issue-reference`,
  split by token shape. The shapes have different false-positive profiles, and
  an author who cannot silence one without the other silences both, which is the
  wholesale disabling the ruling argues against.
- **A list of host names**, not a boolean - so a second host brings its own
  token table without a second flag.

## Why the clause pins so much detail

The page already says a rule id is spec surface and that two engines detecting
the same condition MUST use the same id. That makes the id portable only if what
fires under it is portable too. So the clause states the selection shape, the
exact token boundaries for the one platform that ships named, and the full set
of surfaces neither rule reads. Two engines agreeing on an id while disagreeing
on which tokens it covers would break a shared config exactly the way two ids
would.

Every boundary written down was measured against the installed engine rather
than read off its source comments - an email address, a scope prefix, a docblock
tag, a heading marker, an id-shaped token, a version tag, a URL fragment, a link
destination, frontmatter and a reference definition were each run through
`lintCarve` and the page says what came back.

The never-published set is wider than the ruling names, deliberately. Beyond
fenced code, raw blocks and comments it covers frontmatter, link and
abbreviation definitions, an unreferenced footnote definition, an inline link's
destination and the interior of a bare URL, while a captioned listing's caption
and a referenced footnote's body stay checked because both reach the page. A
rule reporting a token nobody can see is the over-eager rule the ruling warns
about, so the exclusions are normative rather than incidental.

## Left explicitly unspecified

Rather than filled in:

- **which host platforms exist beyond the one named.** The signoff settled that
  the rules are enabled per platform; it did not enumerate platforms, and
  inventing more here would commit a second engine to token tables nobody has
  measured.
- **whether a processor may offer a per-rule opt-in** alongside the
  per-platform one. Nothing here forbids it; nothing requires it.

## The harness needed real work, not just two rows

`tests/lint-rule-table-claims.test.mjs` read every trigger with default options,
which no default-off rule can satisfy - that is why the spec side could not lead
and the ticket sat parked. A trigger entry may now carry the options its rule
needs.

That alone would have been a hole. A rule firing under both default and opt-in
options provokes its trigger either way and would look correct on every check in
the file. So the default-off half is asserted separately, over the same
documents the triggers use and over an explicitly empty platform list, which is
the spelling a config threading a list through is most likely to produce. The
file header now records this as a third direction alongside the two it already
gated.

Both directions were proved by named mutation rather than argued. Adding a row
naming an id no engine emits fails `every rule the page lists can actually be
emitted` with that id as the sole entry; reading the opt-in rule under its
opt-in options instead of the default ones fails `an opt-in rule reports nothing
until it is asked for`. Both were reverted from a committed HEAD.

`carve-php` implements neither rule yet and the coverage table now says so. A
tracking ticket follows this merge.
