### PR TITLE
audit: four more runners that report a pass over nothing, and one control

### DIFF
--- a/scripts/generate-corpus.mjs
+++ b/scripts/generate-corpus.mjs
@@ -2,6 +2,7 @@
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, renameSync, unlinkSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { shortfall } from './spec/participants.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, '..')
@@ -153,6 +154,37 @@ if (comparesOpened !== examples.length) {
   console.error(
     `generate-corpus: ${comparesOpened} compare blocks opened but ${examples.length} pairs written (unclosed block?).`,
   )
+  process.exit(1)
+}
+
+/*
+ * Both checks above compare the extraction against ITSELF, so both are 0 === 0
+ * on an empty read and report a clean run having produced nothing. Measured
+ * rather than reasoned: with the three example files emptied AND tests/corpus
+ * cleared, this script printed "Wrote 0 pairs" and exited 0 (carve#755).
+ *
+ * The renumber guard below does catch a partial loss - but only while
+ * tests/corpus still holds the previous generation to compare against, which is
+ * the shape carve#755 names as a gate that stops working once nothing is there
+ * to compare. `rm -rf tests/corpus && npm run corpus:build` is an ordinary way
+ * to clear stale artifacts and is exactly the state it cannot see.
+ *
+ * So the floor is absolute. The corpus is append-only - a category is removed
+ * only under CORPUS_RENUMBER=1 - so this number never needs lowering, and it
+ * sits far enough below today's count that no single category crosses it.
+ */
+const CORPUS_FLOOR = 700
+const thin = shortfall({
+  label: 'EXAMPLES',
+  actual: examples.length,
+  atLeast: CORPUS_FLOOR,
+  of: 'example pair(s)',
+  hint: 'docs/examples/{core,extensions,edge-cases}.md is where they come from; ' +
+    'an extraction that reached fewer of them writes a corpus every downstream ' +
+    'floor is happy with.',
+})
+if (thin) {
+  console.error(`generate-corpus: ${thin}`)
   process.exit(1)
 }
 

--- a/tests/ast-values.test.mjs
+++ b/tests/ast-values.test.mjs
@@ -83,6 +83,18 @@ test('the shipped declaration parses', () => {
   // MALFORMED one. The file is comment-only today, so this is currently the
   // empty list; it is asserted this way so the test keeps meaning something
   // once a line is added.
+  //
+  // A CONTROL, labelled rather than counted (carve#755). Coverage over the
+  // whole suite shows this line never executing, and blanking
+  // resources/ast-value-divergence.txt leaves the file exiting 0 - both true,
+  // and neither is a gap to fix. There is no participant floor to add here,
+  // because a declaration of zero divergences is the state the panel is trying
+  // to reach; a floor would be the inverse defect, a gate that only works while
+  // something is wrong. What proves the parser discriminates is the six tests
+  // above, each of which feeds it a literal line and reads the verdict.
+  // `tests/ast-spans.test.mjs` and `tests/ast-waivers.test.mjs` DO floor their
+  // declarations, and the difference is not an inconsistency: their ledgers are
+  // non-empty, so an emptied one there is loss rather than progress.
   for (const p of problems) assert.match(p, /^FIXED/, p)
 })
 

--- a/tests/corpus-targets.test.mjs
+++ b/tests/corpus-targets.test.mjs
@@ -23,6 +23,7 @@ import {
   targetNames,
   targetOf,
 } from '../scripts/lib/corpus-targets.mjs'
+import { shortfall } from '../scripts/spec/participants.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const corpusDir = resolve(here, 'corpus-optional')
@@ -43,7 +44,22 @@ test('a core case may pin a non-HTML target by adding the file', () => {
   const known = new Set(Object.values(TARGET_EXTENSIONS))
   const stray = []
   const orphaned = []
-  for (const name of readdirSync(core)) {
+  const entries = readdirSync(core)
+  // Both assertions below are NEGATIVE: they pass when two lists came out
+  // empty, and an empty directory listing produces exactly that. Measured, not
+  // argued - with tests/corpus cleared this file passed all eleven of its tests
+  // (carve#755, variant 2). The floor is what makes the two empty lists mean
+  // something.
+  const thin = shortfall({
+    label: 'CORPUS',
+    actual: entries.length,
+    atLeast: 100,
+    of: 'file(s) in tests/corpus',
+    hint: 'run `npm run corpus:build` first; a sweep over an unbuilt corpus ' +
+      'finds no stray extension because it looked at nothing.',
+  })
+  assert.equal(thin, null, thin ?? '')
+  for (const name of entries) {
     // The directory's own README is prose, not an expectation.
     if (name === 'README.md') continue
     const ext = name.slice(name.lastIndexOf('.') + 1)
@@ -127,9 +143,24 @@ test('a non-html case does not also carry an html fixture', () => {
   // the old code looked for: the target is the pairing rule, not a fallback
   // chain, and two fixtures for one case would let the two runners disagree
   // about which one is authoritative.
-  for (const entry of manifest.cases) {
+  //
+  // The `continue` is a filter, and the assertion below it is only ever made
+  // about what survives it. Drop every non-html entry from the manifest and
+  // this test passes over zero cases while the optional runner quietly stops
+  // comparing eight of them - so the surviving subset gets a floor of its own.
+  // The subset is small on purpose: one is enough to catch it emptying, and an
+  // exact count would churn on every non-html case added.
+  const nonDefault = manifest.cases.filter((entry) => targetOf(entry) !== DEFAULT_TARGET)
+  const thin = shortfall({
+    label: 'NON-HTML',
+    actual: nonDefault.length,
+    atLeast: 1,
+    of: 'optional case(s) pinning a target other than html',
+    hint: 'the pairing rule this file exists for is unexercised without one.',
+  })
+  assert.equal(thin, null, thin ?? '')
+  for (const entry of nonDefault) {
     const target = targetOf(entry)
-    if (target === DEFAULT_TARGET) continue
     const slug = basename(entry.slug)
     assert.ok(
       !existsSync(resolve(corpusDir, `${slug}.html`)),

--- a/tests/optional-corpus.test.mjs
+++ b/tests/optional-corpus.test.mjs
@@ -18,6 +18,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { basename, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { expectedFileFor, targetOf } from '../scripts/lib/corpus-targets.mjs'
+import { miscount, shortfall } from '../scripts/spec/participants.mjs'
 import {
   autolink,
   carveToAnsi,
@@ -134,7 +135,22 @@ const DECLARED_UNIMPLEMENTED = {
     'the reference engine has no quote-locale option at all; carve-php has the extension (carve#560)',
 }
 
+/*
+ * What the loop below actually reached. A runner that generates its cases from
+ * a manifest reports a clean run when the manifest is empty, because zero tests
+ * pass: measured, `manifest.cases = []` left this file exiting 0 with nothing
+ * registered (carve#755, variant 2). `tests/corpus-targets.test.mjs` does floor
+ * the manifest at one case, but a partial loss - the eight non-html entries
+ * removed, say - passes there and silently deletes eight comparisons here.
+ *
+ * `compared` is the count that matters, and it is deliberately not
+ * `manifest.cases.length`: a case that reached a `continue` above the assertion
+ * is a case nobody compared, and the two numbers are how you tell them apart.
+ */
+let reached = 0
+let compared = 0
 for (const entry of manifest.cases) {
+  reached++
   const slug = basename(entry.slug)
   const targetName = targetOf(entry)
   const target = targets[targetName]
@@ -176,6 +192,7 @@ for (const entry of manifest.cases) {
     continue
   }
 
+  compared++
   test(`${slug} (${entry.feature}, ${targetName})`, () => {
     assert.ok(existsSync(crvPath), `missing ${slug}.crv pair`)
     assert.ok(existsSync(expectedPath), `missing ${expectedFile} pair`)
@@ -184,3 +201,33 @@ for (const entry of manifest.cases) {
     assert.equal(runner(source, target.render).trim(), expected.trim())
   })
 }
+
+test('the run compared the cases the manifest declares', () => {
+  // The floor is what a manifest emptied or halved cannot get past. It is well
+  // under the count today (38 of 39 cases compare; one is a declared skip), for
+  // the same reason the other floors in this repo are: the optional corpus is
+  // append-only, so a number below it can only be reached by loss.
+  const thin = shortfall({
+    label: 'OPTIONAL',
+    actual: compared,
+    atLeast: 30,
+    of: 'case(s)',
+    hint: 'tests/corpus-optional/manifest.json is the population; a run over ' +
+      'fewer of it registers fewer tests and still exits 0.',
+  })
+  assert.equal(thin, null, thin ?? '')
+
+  // And the floor cannot see a case the loop reached and dropped, which is the
+  // failure a floor alone leaves standing (carve#955's M3). Every entry either
+  // compares or is one of the declared skips above.
+  const declaredSkips = manifest.cases.filter(
+    (e) => !featureRunners[e.feature] && DECLARED_UNIMPLEMENTED[e.feature],
+  ).length
+  const wrong = miscount({
+    label: 'OPTIONAL',
+    actual: compared + declaredSkips,
+    expected: reached,
+    of: 'case(s) compared or declared unimplemented',
+  })
+  assert.equal(wrong, null, wrong ?? '')
+})


### PR DESCRIPTION
The unfinished half of `markup-carve/carve#755`. markup-carve/carve#955 reached
about 3 of roughly 20 runners in this repo; this drove the rest.

## What was measured, before anything was changed

Each runner was given an emptied or filtered population and its exit code read.
Four reported a pass over nothing:

```
$ node scripts/generate-corpus.mjs     # docs/examples emptied AND tests/corpus cleared
Wrote 0 pairs to tests/corpus
Wrote 0 .test files to tests/spec
EXIT=0
```

```
$ node scripts/generate-corpus.mjs     # only docs/examples/core.md kept, corpus cleared
Wrote 199 pairs to tests/corpus        # 830 -> 199, a 76% loss
EXIT=0
```

```
$ node --test tests/optional-corpus.test.mjs   # manifest.cases = []
# tests 0
EXIT=0
```

```
$ node --test tests/corpus-targets.test.mjs    # tests/corpus cleared
# pass 11 / # fail 0
EXIT=0
```

```
$ node --test tests/corpus-targets.test.mjs    # the 8 non-html manifest entries removed
# pass 11 / # fail 0                           # and optional-corpus quietly drops 8 comparisons
EXIT=0
```

`generate-corpus` is the one that matters most, because it is the population
SOURCE that every downstream floor protects. Its two existing checks compare the
extraction against itself, blocks opened against pairs written, so both read
`0 === 0` on an empty read. Its renumber guard does catch a partial loss, but
only while `tests/corpus` still holds the previous generation to compare
against - the fourth shape on the ticket, a gate that stops working once there
is nothing there. `rm -rf tests/corpus && npm run corpus:build` is an ordinary
way to clear stale artifacts, and is exactly the state it cannot see. The 199
pair run above would have satisfied every downstream floor in the repo, all of
which sit at 100.

### Examined and already guarded, so the list above means something

Driven the same way and each one refused correctly:

- `roundtrip`, `examples`, `corpus-fmt-roundtrip`, `corpus-fmt-cross-read`,
  `ast-positions`, `schema-fields-are-produced`,
  `implementation-comparison-counts`, `normativity`, `ast-shape`,
  `ast-schema`, `ast-waivers`, `corpus.test.mjs` - all fail on an emptied
  population.
- the claims tests over a parsed document - `ast-json-claims`,
  `degradation-claims`, `extension-catalog-claims`, `lint-rule-table-claims`,
  `migration-claims`, `node-vocabulary`, `divergence-claims`, `ast-spans`,
  `denylist-follows-the-clause`, `separator-role-split`, `ohm-block-layer`,
  `optional-feature-adapters` - each was re-run with the document it parses
  blanked, and each failed.
- `claims:check`, `degradation:check` and `fmt:check` refuse on fewer than
  three engines; `ast:check` refuses without the sibling build.

A V8 coverage run over the whole suite was used to find assertion lines that
never execute, which is how the two vacuous loop bodies below were located
rather than guessed at.

## The mutations, and what each broke

Applied to a throwaway export of the committed tree, never to the branch. Each
carries its control at the commit before the fix.

| mutation | runner | before | after |
| --- | --- | --- | --- |
| M8 examples emptied, corpus cleared | `corpus:build` | exit 0, "Wrote 0 pairs" | exit 1, `EXAMPLES: compared 0 example pair(s) but expected at least 700` |
| M9 only `core.md` kept, corpus cleared | `corpus:build` | **exit 0, "Wrote 199 pairs"** | exit 1, `compared 199 ... expected at least 700` |
| M10 `manifest.cases = []` | `optional-corpus` | exit 0, zero tests registered | exit 1, `OPTIONAL: compared 0 case(s) but expected at least 30` |
| M11 a `continue` dropping every 5th case | `optional-corpus` | **exit 0, 32 of 39 pass** | exit 1, `OPTIONAL: compared 32 case(s) ..., expected exactly 39` |
| M12 `tests/corpus` cleared | `corpus-targets` | exit 0, 11 of 11 pass | exit 1, `CORPUS: compared 0 file(s) in tests/corpus but expected at least 100` |
| M13 the 8 non-html manifest entries removed | `corpus-targets` | exit 0, 11 of 11 pass | exit 1, `NON-HTML: compared 0 optional case(s) pinning a target other than html` |

M11 is why `optional-corpus` gets a floor AND a reconciliation, for the reason
markup-carve/carve#955 gave two of its runners both: with 7 of 39 cases dropped
inside the loop, the population is still 39 and the floor of 30 is still
satisfied, so only the reconciliation moves.

Every one of these six mutations applies at the healthy baseline. None of them
needs something to be already wrong first, which is the fourth shape the ticket
records.

## One case is a control, and is labelled rather than fixed

`tests/ast-values.test.mjs` - `for (const p of problems) assert.match(p, /^FIXED/)`
never executes, and blanking `resources/ast-value-divergence.txt` leaves the file
exiting 0. Both true, and neither is a gap. That ledger is comment-only, and a
declaration of zero value divergences is the state the panel is trying to reach;
a floor there would be the inverse defect, a gate that only works while
something is wrong. What proves that parser discriminates is the six tests above
it, each feeding it a literal line and reading the verdict. `ast-spans` and
`ast-waivers` DO floor their declarations, and the difference is not an
inconsistency: their ledgers are non-empty, so an emptied one there is loss
rather than progress. Recorded in the file so the next sweep does not re-open it.

`tests/corpus-targets.test.mjs`'s "asking for a fixtureless target's filename is
still an error" is a second control, and already says so in its own comment.

## A prediction from markup-carve/carve#955 has come true

That PR recorded `engine:report --check` as looking guarded only because
`resources/engine-pin-drift.txt` was non-empty, and warned that an empty ledger
is the state the repo is heading for. It is empty now, as of
markup-carve/carve#958. The corpus floor added in markup-carve/carve#955 is what
still fails there:

```
$ node scripts/engine-report.mjs --check     # corpus cleared, ledger now empty
CORPUS: compared 0 document(s) but expected at least 100
EXIT=2
```

Without that floor this runner would today be reporting "Drift matches what is
declared" over nothing at all.

## What these guards cannot see

- `generate-corpus`'s floor is absolute at 700 against 830 today. The corpus is
  append-only - a category is removed only under `CORPUS_RENUMBER=1` - so it
  never needs lowering, but it also cannot see a drop from 830 to 750.
- `NON-HTML`'s floor is 1. It catches the subset emptying, not it shrinking. An
  exact count would churn on every non-html case added, and the subset exists to
  be added to.
- All of them count what the runner reached, never whether the population is the
  RIGHT one. That is variant 1b on the ticket and a different fix.

## One helper, four new call sites

`scripts/spec/participants.mjs` is unchanged. Each runner still names its own
population, floor and hint, because only the runner knows what it should have
compared.

## Lock and gates

Taken under the per-repo `markup-carve.carve` lock, which is sufficient: the
diff is `scripts/**` and `tests/**` only. No corpus document, no
`docs/examples/**`, no production in `resources/grammar.ebnf`. No cross-engine
sweep was run, because engine agents hold their own repo locks concurrently and
a sweep against engines being edited fabricates diffs.

`npm test` is 1802 -> 1803 passing, `corpus:build`, `core:check`,
`combinatorial:check`, `property:check` and `engine:report --check` all green.
Four gates could not run on this host, verbatim reasons:

- `npm run ast:check` - `carve-js build not found at /tmp/carve-js/dist - run npm run build there first.`
- `npm run claims:check` - `engine-claims: need all three engines, found 0 (none).`
- `npm run degradation:check` - `degradation-claims: need all three engines, found 0 (none).`
- `npm run fmt:check` - `fmt-fixture-claims: need all three engines, found 0 (none).`
