### PR TITLE
spec: the AST declarations say what the engines now do, and the owed half is empty

### DIFF
--- a/resources/ast-position-waivers.txt
+++ b/resources/ast-position-waivers.txt
@@ -16,9 +16,21 @@
 # Printed as one number the two were indistinguishable, so the total moved
 # whenever the CORPUS grew and nobody could tell which half moved. Measured over
 # the three engines' mains on 2026-08-06 that is not hypothetical: the permitted
-# half is 16 findings in each of the three engines and grew with the fixtures
+# half was 16 findings in each of the three engines and grew with the fixtures
 # added over the preceding week, while the owed half - 7 in carve-js, 17 in
 # carve-rs, 4 in carve-php - did not move at all.
+#
+# THE OWED HALF IS NOW EMPTY. Re-measured 2026-08-07 at carve-js 39b9223,
+# carve-rs 0d560cc and carve-php d45e250 over 833 documents, every one of those
+# 28 owed findings is gone: carve-js#813 and carve-js#814, carve-rs#716, #736
+# and #737, and carve-php#965 all landed, and the run reports 28 findings in
+# carve-js and 16 in each of the other two, all of them waived and none
+# outstanding. What remains below is the permitted half alone.
+#
+# That is the state this file was written to reach, and it is not a reason to
+# retire the file: the permitted lines still fail if an engine stops producing
+# them, and the OWED section is where the next gap gets declared. A ledger only
+# kept while it is non-empty is a ledger nobody starts again.
 #
 # Format: <engine>  <document>  <type>  <count>  <status>
 #
@@ -99,52 +111,19 @@ carve-js   256-table-cell-padding-must-be-a-space-17.crv          table_cell  2 
 carve-js   63-table-multi-line-cell-continuation.crv              table_cell  1  permitted
 carve-js   64-table-rowspan-with-multi-line-content.crv           table_cell  1  permitted
 
-# ---- OWED: carve-js ---------------------------------------------------------
+# ---- OWED --------------------------------------------------------------------
 #
-# An emptied definition description. The dd's only content is a link reference
-# definition, which §7 hoists to the document root and leaves the dd empty - but
-# the dd is not REASSEMBLED and its authored line `:  [r]: /u` is right there,
-# so an honest span exists. carve-php publishes [8,18], exactly that line.
-carve-js   227-a-definition-inside-a-definition-list-dd-is-collected-and-the-entry-keeps-no-trace.crv    definition_description  1  markup-carve/carve-js#813
-carve-js   227-a-definition-inside-a-definition-list-dd-is-collected-and-the-entry-keeps-no-trace-2.crv  definition_description  1  markup-carve/carve-js#813
-
-# A list item continued with a TAB. Four contiguous lines, no reassembly, and
-# the same document with a two-space continuation keeps every position in this
-# same engine - that control is the second example in the same corpus section.
-carve-js   259-a-tab-continues-a-list-item-just-as-two-spaces-do.crv  paragraph   1  markup-carve/carve-js#814
-carve-js   259-a-tab-continues-a-list-item-just-as-two-spaces-do.crv  soft_break  1  markup-carve/carve-js#814
-carve-js   259-a-tab-continues-a-list-item-just-as-two-spaces-do.crv  text        2  markup-carve/carve-js#814
-
-# ---- OWED: carve-rs ---------------------------------------------------------
+# EMPTY as of 2026-08-07, and deliberately kept as a section.
 #
-# The paragraph a CAPPED container degrades to, and its inlines. carve-js places
-# all eight, and its text spans pass the slice rule - so the spans are correct
-# rather than merely present.
-carve-rs   182-openers-past-the-nesting-cap-are-one-paragraph.crv  paragraph   1  markup-carve/carve-rs#716
-carve-rs   182-openers-past-the-nesting-cap-are-one-paragraph.crv  soft_break  3  markup-carve/carve-rs#716
-carve-rs   182-openers-past-the-nesting-cap-are-one-paragraph.crv  text        4  markup-carve/carve-rs#716
-
-# A figure over a REFERENCE image with a caption. carve-rs places the same
-# figure when the image is inline (`figure [0,18]`); only the reference form
-# loses it. carve-js and carve-php both publish [0,14], covering the image line
-# and the caption line together.
-carve-rs   207-a-reference-image-takes-a-caption.crv  figure  1  markup-carve/carve-rs#737
-
-# A footnote body whose continuation line is indented with a TAB. Not a
-# reassembly: the same construct with a space indent keeps all five positions in
-# this same engine, and carve-js and carve-php place them either way and agree
-# to the offset.
-carve-rs   224-a-tab-reaches-a-footnote-body-s-column-just-as-two-spaces-do.crv    paragraph   1  markup-carve/carve-rs#736
-carve-rs   224-a-tab-reaches-a-footnote-body-s-column-just-as-two-spaces-do.crv    text        1  markup-carve/carve-rs#736
-carve-rs   224-a-tab-reaches-a-footnote-body-s-column-just-as-two-spaces-do-2.crv  paragraph   1  markup-carve/carve-rs#736
-carve-rs   224-a-tab-reaches-a-footnote-body-s-column-just-as-two-spaces-do-2.crv  text        1  markup-carve/carve-rs#736
-carve-rs   224-a-tab-reaches-a-footnote-body-s-column-just-as-two-spaces-do-3.crv  footnote    1  markup-carve/carve-rs#736
-carve-rs   224-a-tab-reaches-a-footnote-body-s-column-just-as-two-spaces-do-3.crv  paragraph   1  markup-carve/carve-rs#736
-carve-rs   224-a-tab-reaches-a-footnote-body-s-column-just-as-two-spaces-do-3.crv  soft_break  1  markup-carve/carve-rs#736
-carve-rs   224-a-tab-reaches-a-footnote-body-s-column-just-as-two-spaces-do-3.crv  text        1  markup-carve/carve-rs#736
-
-# ---- OWED: carve-php --------------------------------------------------------
+# What used to be here, each deleted because `ast:check` reported it FIXED
+# against the engine's main and a direct probe of that engine agreed:
 #
-# The same capped-container site. carve-php places the paragraph and the soft
-# breaks there as of 876e312; only its text runs are left.
-carve-php  182-openers-past-the-nesting-cap-are-one-paragraph.crv  text  4  markup-carve/carve-php#965
+#   carve-js   227 x2 (definition_description)     markup-carve/carve-js#813
+#   carve-js   259 x3 (paragraph, soft_break, text) markup-carve/carve-js#814
+#   carve-rs   182 x3 (paragraph, soft_break, text) markup-carve/carve-rs#716
+#   carve-rs   207 x1 (figure)                      markup-carve/carve-rs#737
+#   carve-rs   224 x8 (over three fixtures)         markup-carve/carve-rs#736
+#   carve-php  182 x1 (text)                        markup-carve/carve-php#965
+#
+# All six issues are closed. A new gap goes here, one line per engine, document
+# and type, with the issue that tracks it - never `permitted`.

--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -25,12 +25,19 @@
 #   "*", so the one content-level rule passes for both. That is the trap this
 #   repo keeps re-finding: a rule that asserts a property the bug preserves.
 #
-# WHAT THIS FILE DOES NOT DECIDE. Whether a node's span covers the markup that
-# OPENS it - the list marker, the `>`, the `[^a]: ` - is markup-carve/carve#913,
-# needs-decision. Most of the EXTENT rows below are that question, and this file
-# records the disagreement without naming a side. That is worth doing before the
-# ruling: a count that moves means an engine changed its mind about a span, and
-# nothing else in this repo can see that happen.
+# WHAT THIS FILE DOES NOT DECIDE, AND WHAT IS NO LONGER OPEN. Whether a node's
+# span covers the markup that OPENS it - the list marker, the `>`, the `[^a]: `
+# - was markup-carve/carve#913, and it is RULED: docs/ast-json.md:108 states
+# that "a span begins at the markup that opens the construct", naming the two
+# exceptions (the inner half of a combined `/*x*/`, and a table cell, which runs
+# between the pipes). Most of the EXTENT rows below are that question, so each
+# of them is now an engine owing a fix rather than a convention nobody settled.
+#
+# This file still does not say WHICH engine owes it. That needs the source, and
+# the source-side rule is `checkOpeningMarkup` in scripts/spec/ast-positions.mjs,
+# which each engine runs against its own tree. What a row here records is that
+# the three do not agree, and what a COUNT records is an engine changing its
+# mind about a span - which nothing else in this repo can see happen.
 #
 # DECLARED rather than gated at zero, for the reason the value panel gives: in
 # this fleet a fix lands in one engine first, so the engine that is RIGHT is
@@ -47,51 +54,51 @@
 # PRESENCE and EXTENT are separate rows because they are different facts with
 # different owners. Presence is §4 and has a permitted category, declared per
 # engine and per document in resources/ast-position-waivers.txt; extent is the
-# open convention question and has none.
+# markup-inclusive rule above, and has none.
 #
 # Format: <type> (presence|extent)  <document-count>
 #
-# Measured 2026-08-06 over 716 documents (713 corpus plus 3 synthetic), at
-# carve 3a41f0e, carve-js 3d95e94, carve-rs 83ab9c1, carve-php 876e312.
-# 309 of those documents carry at least one span the three engines do not agree
-# on.
+# Measured 2026-08-07 over 833 documents (830 corpus plus 3 synthetic), at
+# carve 8ad86ee, carve-js 39b9223, carve-rs 0d560cc, carve-php d45e250.
+# 328 of those documents carry at least one span the three engines do not agree
+# on, over 16920 spans compared.
 
-# ---- EXTENT: the open convention question (markup-carve/carve#913) ----------
+# ---- EXTENT: PART 12 §4, markup-inclusive (markup-carve/carve#913) ----------
 
-list                    (extent)  127
-list_item               (extent)  73
-table_row               (extent)  65
-paragraph               (extent)  37
-footnote                (extent)  36
-definition_term         (extent)  21
-comment                 (extent)  18
-block_quote             (extent)  16
-definition_description  (extent)  14
-admonition              (extent)  12
-definition_list         (extent)  10
-heading                 (extent)  10
-code_block              (extent)  9
-hard_break              (extent)  6
+list                    (extent)  129
+table_row               (extent)  66
+list_item               (extent)  52
+paragraph               (extent)  47
+footnote                (extent)  40
+definition_term         (extent)  26
+definition_description  (extent)  21
+comment                 (extent)  11
+block_quote             (extent)  8
+hard_break              (extent)  7
+frontmatter             (extent)  4
 table                   (extent)  4
 table_cell              (extent)  4
-frontmatter             (extent)  3
-raw_block               (extent)  3
-div                     (extent)  2
-text                    (extent)  2
+admonition              (extent)  3
+definition_list         (extent)  3
+div                     (extent)  3
+text                    (extent)  3
 code                    (extent)  1
+heading                 (extent)  1
 insert                  (extent)  1
 literal_inline          (extent)  1
+soft_break              (extent)  1
 
 # ---- PRESENCE: one engine omits where the others place ---------------------
 #
 # Every row here is also declared per engine and per document, with the issue
 # tracking it, in resources/ast-position-waivers.txt. The two files disagree by
 # construction if one is updated without the other, which is deliberate.
+#
+# ONE ROW LEFT, and it is the permitted one: carve-js omits a table cell
+# continued on a `+` line, which docs/ast-json.md:113 and :427 exempt by name.
+# The six rows that stood here on 2026-08-06 - paragraph, text, soft_break,
+# definition_description, figure and footnote - all cleared when the engine
+# issues behind them landed, and the sibling file's OWED section emptied in the
+# same measurement.
 
 table_cell              (presence)  7
-paragraph               (presence)  5
-text                    (presence)  5
-soft_break              (presence)  3
-definition_description  (presence)  2
-figure                  (presence)  1
-footnote                (presence)  1

--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -26,3 +26,6 @@
 #
 # Format: <type.field>  <document-count>  <who diverges and where it is tracked>
 
+link.ref                  2  carve-php publishes the heading's RENDERED text where carve-js and carve-rs publish the authored label, so a collapsed `[`code()` heading][]` gives "code() heading" against "`code()` heading" - the three agree on href and rawRef, and §3a's "the derived label" reads both ways when the label carries inline markup (carve#962)
+text.value                1  carve-php's table caption keeps the trailing space its own HTML drops, so corpus 268-6 publishes "Cap " where carve-js and carve-rs publish "Cap" - invisible to the HTML gate, which all three pass (carve#963)
+

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -4349,18 +4349,15 @@ EOF = (* end of file *) ;
         to the block parser, and it is why the reference does not settle this
         one by being the reference.
 
-        NOT YET CORPUS-PINNED, and the reason is worth stating exactly. No
-        corpus document reaches the cap, which is why this went unnoticed:
-        every gate compares HTML over the corpus, so a path with no corpus
-        case is a path with no comparison.
-
-        What blocks the fixture is the EXECUTABLE SPEC, not the engines. The
-        corpus is rendered by scripts/spec, and it REFUSES past
-        MAX_NESTING_DEPTH rather than degrading -- so a case added today would
-        have to go in the refusal allowlist, where it is skipped and pins
-        nothing, which is worse than no case at all. Pinning this needs the
-        degrade path implemented in scripts/spec first. Engine drift is a
-        separate matter and has its own ledger now
+        NOW CORPUS-PINNED. This was unpinned for as long as the EXECUTABLE
+        SPEC refused past MAX_NESTING_DEPTH rather than degrading, because a
+        case added then would have gone in the refusal allowlist, where it is
+        skipped and pins nothing -- worse than no case at all. The degrade
+        path is implemented in scripts/spec now, so
+        tests/corpus/182-openers-past-the-nesting-cap-are-one-paragraph.crv
+        carries an HTML fixture, renders in the executable subset, and
+        REFUSED_ALLOW (scripts/spec/refused-allow.mjs) is empty. Engine drift
+        is a separate matter and has its own ledger
         (resources/engine-pin-drift.txt, carve#533).
 
         Recursive RENDER / RESOLVE /

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -519,8 +519,10 @@ function reportSpanDisagreements(present) {
     advice: [
       'Each line there is a node type the engines span differently, with the number of',
       'documents it shows up in. Update it in the commit that moves the number.',
-      'A row moving does NOT mean an engine is wrong: the extent convention is open',
-      '(markup-carve/carve#913). It means an engine changed its mind about a span.',
+      'A row moving does not say WHICH engine is wrong - this panel has the trees and',
+      'not the source - but the extent rule itself is settled: PART 12 §4 is',
+      'markup-inclusive (markup-carve/carve#913, docs/ast-json.md:108), and',
+      'checkOpeningMarkup in scripts/spec/ast-positions.mjs is what names a side.',
     ],
   })
   if (byKey.size > 0) {

--- a/scripts/spec/ast-spans.mjs
+++ b/scripts/spec/ast-spans.mjs
@@ -37,12 +37,17 @@
  * assert anything about what a span slices to. It compares the spans.
  *
  * WHAT IT DOES NOT DECIDE. Whether a node's span covers the markup that OPENS
- * it - the list marker, the `>`, the `[^a]: ` - is unruled: markup-carve/carve#913,
- * needs-decision. Most of what this panel reports is that question, and it
- * reports it as a DISAGREEMENT without naming a side, which is what can be said
- * truthfully today. A declared count that moves is still a signal even while
- * the convention is open: it means an engine changed its mind about a span, and
- * nothing else in this repo can see that happen.
+ * it - the list marker, the `>`, the `[^a]: ` - was markup-carve/carve#913, and
+ * it is RULED: docs/ast-json.md:108 states that a span begins at the markup
+ * that opens the construct. Most of what this panel reports is that question,
+ * so those rows are engines owing a fix rather than an open convention.
+ *
+ * What this module still does not do is say WHICH engine owes it, because that
+ * needs the source and this module only has the trees. It reports a
+ * DISAGREEMENT; `checkOpeningMarkup` in ./ast-positions.mjs is the rule that
+ * names a side, and each engine runs it against its own tree. A declared count
+ * that moves means an engine changed its mind about a span, and nothing else in
+ * this repo can see that happen.
  */
 
 import { POS_KEYS } from './ast-shape.mjs'
@@ -96,8 +101,8 @@ export function spanOf(node) {
  *
  * PRESENCE and EXTENT are separated because they are different facts with
  * different owners. Presence is PART 12 §4 and has a permitted category
- * (`resources/ast-position-waivers.txt` declares which); extent is the unruled
- * convention question and has none. Folding them into one row would let a
+ * (`resources/ast-position-waivers.txt` declares which); extent is §4's
+ * markup-inclusive rule and has none. Folding them into one row would let a
  * permitted omission and a wrong span share a number.
  *
  * Keyed by TYPE rather than by document for the reason `compareValues` gives:

--- a/tests/ast-values.test.mjs
+++ b/tests/ast-values.test.mjs
@@ -80,21 +80,19 @@ test('the shipped declaration parses', () => {
     readFileSync(resolve(root, 'resources/ast-value-divergence.txt'), 'utf8'),
   )
   // Every problem must be a FIXED - i.e. a real declared line - and never a
-  // MALFORMED one. The file is comment-only today, so this is currently the
-  // empty list; it is asserted this way so the test keeps meaning something
-  // once a line is added.
+  // MALFORMED one. The file carried no entries between carve#846 and
+  // 2026-08-07, when `link.ref` and `text.value` were declared (carve#962,
+  // carve#963), so this loop now runs over two problems rather than none - and
+  // that is the point of asserting it this way rather than counting.
   //
-  // A CONTROL, labelled rather than counted (carve#755). Coverage over the
-  // whole suite shows this line never executing, and blanking
-  // resources/ast-value-divergence.txt leaves the file exiting 0 - both true,
-  // and neither is a gap to fix. There is no participant floor to add here,
-  // because a declaration of zero divergences is the state the panel is trying
-  // to reach; a floor would be the inverse defect, a gate that only works while
-  // something is wrong. What proves the parser discriminates is the six tests
-  // above, each of which feeds it a literal line and reads the verdict.
-  // `tests/ast-spans.test.mjs` and `tests/ast-waivers.test.mjs` DO floor their
-  // declarations, and the difference is not an inconsistency: their ledgers are
-  // non-empty, so an emptied one there is loss rather than progress.
+  // NO FLOOR, and that is deliberate rather than an oversight: a declaration of
+  // zero divergences is the state the panel is trying to reach, so a floor
+  // would be the inverse defect, a gate that only works while something is
+  // wrong. What proves the parser discriminates is the six tests above, each of
+  // which feeds it a literal line and reads the verdict.
+  // `tests/ast-spans.test.mjs` floors its declaration, and the difference is
+  // not an inconsistency: that ledger records an open convention across two
+  // dozen node types, so an emptied one there is loss rather than progress.
   for (const p of problems) assert.match(p, /^FIXED/, p)
 })
 

--- a/tests/ast-waivers.test.mjs
+++ b/tests/ast-waivers.test.mjs
@@ -216,8 +216,23 @@ test('the shipped declaration parses and every outstanding line names an issue',
   assert.deepEqual(errors, [], errors.join('; '))
   assert.ok(declared.size > 0, 'the declaration is empty')
 
+  // NO FLOOR ON THE OWED HALF. This used to require at least one outstanding
+  // line, on the grounds that a split with an empty side is vacuous. That
+  // reasoning holds for the SPLIT and not for this file: what makes the split
+  // meaningful is that `parseWaivers` and `partitionFindings` treat the two
+  // statuses differently, which the eight synthetic tests above drive on
+  // hand-built input, each failing if its branch is removed. A floor here
+  // asserts something else entirely - that some engine currently owes a
+  // position - and on 2026-08-07 the last of those debts was paid
+  // (carve-js#813 and #814, carve-rs#716, #736 and #737, carve-php#965 all
+  // landed). A test that fails when the fleet becomes conformant is a test that
+  // has to be edited to accept good news, which is the wrong way round.
+  //
+  // What is still enforced below is the rule that outlives the emptiness: any
+  // line that IS outstanding names a fully qualified engine issue. That is the
+  // assertion a new declaration has to satisfy, and it is reachable the moment
+  // one is added.
   const owed = [...declared.values()].filter((d) => d.status !== 'permitted')
-  assert.ok(owed.length > 0, 'nothing is declared outstanding, which would make the split vacuous')
   for (const line of owed) {
     // FULLY QUALIFIED. A bare `#716` in this repo resolves to carve#716, not to
     // the engine issue it means, so it would link the wrong ticket.


### PR DESCRIPTION
`AST conformance` step 17 (`npm run ast:check`) has been red on `main`. Every finding it reported belonged to this repo's own declarations, not to an engine: three ledgers describing a fleet that had moved on.

## Re-measured, not taken on faith

The failing run's output was three engine merges old, so it was re-measured against the engines' current mains before a single line was deleted. At carve-js `39b9223`, carve-rs `0d560cc`, carve-php `d45e250`, over 833 documents (830 corpus plus 3 synthetic):

```
carve-js  (reference) 28 findings, 2 distinct (28 waived, 0 outstanding)
carve-rs              16 findings, 1 distinct (16 waived, 0 outstanding)
carve-php             16 findings, 1 distinct (16 waived, 0 outstanding)
carve-rb              39 findings (not reconciled: publishes carve-rs's tree)
BINDING PARITY: carve-rb's tree matches carve-rs on all 833 shared document(s).
```

That measurement disagreed with the brief this was picked up from in one place worth naming. The eight carve-rs lines tracking `markup-carve/carve-rs#736` were described as still live and needing to stay. They do not: `ast:check` reports all eight FIXED, and a direct probe of that binary places every node in all three `224-a-tab-reaches-a-footnote-body-s-column` fixtures, as it does in `207` and `182`:

```
224-a-tab-reaches-a-footnote-body-s-column-just-as-two-spaces-do-3   nodes 8   missing pos 0
207-a-reference-image-takes-a-caption                               nodes 4   missing pos 0
182-openers-past-the-nesting-cap-are-one-paragraph                  nodes 208 missing pos 0
```

The 16 findings carve-rs still reports are the nine PERMITTED `text` lines summing to 16. A different 16.

## What changed

**`resources/ast-position-waivers.txt` - the owed half is now empty.** Eighteen lines deleted, every one reported FIXED by the checker against that engine's own main, and all six issues behind them closed:

| engine | documents | issue |
| --- | --- | --- |
| carve-js | 227 x2, 259 x3 | `carve-js#813`, `carve-js#814` |
| carve-rs | 182 x3, 207, 224 x8 | `carve-rs#716`, `carve-rs#737`, `carve-rs#736` |
| carve-php | 182 | `carve-php#965` |

The OWED section stays as a section, with the deleted lines listed in a comment. A ledger only kept while it is non-empty is a ledger nobody starts again.

**`resources/ast-span-divergence.txt`** - seventeen counts corrected, six presence rows and two extent rows deleted as AGREED, one extent row (`soft_break`) added. The presence half is down to its single permitted row, carve-js omitting a `+`-continued table cell, which `docs/ast-json.md:113` and `:427` exempt by name. That is the same fact the sibling file's emptied OWED section records, arrived at independently, which is the cross-check those two files exist to provide.

**`resources/ast-value-divergence.txt`** - two rows added. Both are carve-php against the other two, both probed directly, and both filed first so the row can name where the work lives:

- `link.ref` on a collapsed reference to a heading. carve-php publishes the heading's rendered text where the other two publish the authored label, and §3a's "the derived label" reads both ways when the label carries inline markup. All three agree on `href` and `rawRef`. Filed as carve#962, which is a design call rather than a defect ruling.
- `text.value` in a table caption. carve-php keeps a trailing space its own HTML drops, so all three pass the corpus fixture and only the tree differs. Filed as carve#963.

**`tests/ast-waivers.test.mjs`** drops its floor on the owed half. The floor asserted that some engine currently owes a position, which is a fact about the fleet and not about the checker; the eight synthetic tests above it drive every direction of the split on hand-built input already. A test that has to be edited to accept good news is the wrong way round. The rule that outlives the emptiness, that an outstanding line names a fully qualified engine issue, is still enforced.

## Three stale statements corrected in passing

Each verified against the current tree rather than assumed:

- The span EXTENT convention was still called "unruled" and "needs-decision" in the span ledger, in `scripts/spec/ast-spans.mjs` and in the advice `ast-conformance.mjs` prints. carve#913 is closed and `docs/ast-json.md:108` rules it markup-inclusive. The checker was contradicting itself inside one output, printing "an engine spanning the content alone is the one that moves" six lines above "the extent convention is open". What is genuinely still open is only which engine owes a given row, because that panel holds the trees and not the source, and the corrected text says exactly that and points at `checkOpeningMarkup`.
- `resources/grammar.ebnf` called the nesting-cap degrade path NOT YET CORPUS-PINNED, on the stated grounds that the executable spec refuses past `MAX_NESTING_DEPTH`. It degrades now: corpus `182` carries an HTML fixture, and `REFUSED_ALLOW` in `scripts/spec/refused-allow.mjs` is the empty set.

## Scope

No grammar production changed and no corpus document was added or removed. The diff is the three `resources/*.txt` declaration ledgers, one comment block in `resources/grammar.ebnf`, two comment blocks in `scripts/`, and two test files whose assertions describe those ledgers. That is why this was done under the per-repo lock rather than an org-wide sweep lock, and why no engine checkout was driven: the engines were measured through fresh, session-private clones of their published mains.

## Step 19 is not addressed here

The other failing step, cross-engine render agreement, stands at 15 diffs and is left alone. It is cross-engine work and needs the sweep lock. `markup-carve/carve#961` should stay open for it.
