### PR TITLE
spec: what earns a clause, and what is recorded as unruled instead

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,6 +79,48 @@ believed.
 - **Never settle a cross-engine question by counting engines.** Three engines
   agreeing is evidence that a shape is unpinned, not that it is correct.
 
+## What earns a clause
+
+Every normative clause is paid for by three engines, the executable checkers,
+the corpus, and every satellite grammar that then has to classify the new
+category. That cost is worth paying for a rule an author can run into, and is
+pure overhead for one nobody can.
+
+So a new clause needs at least one of:
+
+- **An author-visible document.** Someone writing Carve by hand can plausibly
+  produce the shape, and the answer changes what they get.
+- **A visible rendering difference.** Two implementations produce different
+  output for that shape today, and a reader of the output could tell.
+
+Neither is a measurement of what implementations happen to do - "the three
+engines disagree" is what makes it a *question*, not what makes it worth
+answering. A shape that fails both tests is recorded as **unruled: engines may
+differ**, in the ticket and in the divergence list, and the productions are
+left alone.
+
+Recording it that way is a real outcome, not a deferral. It states that the
+project looked, found nothing an author or a reader can observe, and declined
+to spend the cost. A later ticket that finds an author-visible consequence
+reopens it with evidence attached, which is a stronger starting point than the
+original.
+
+Two worked examples, both from the same week:
+
+- **Earns a clause.** The inline attribute block's interior (carve#906):
+  `*x*{.a<TAB>.b}` is a shape a hand-writing author produces by pressing Tab,
+  three corpus documents already pinned an answer, and the two readings differ
+  visibly - attributes applied, or literal braces in the output.
+- **Does not, on its own.** A tab in a link-title slot (carve#907):
+  `[t](/u<TAB>"T")`. No corpus document pinned either answer in either
+  direction, and no rendered output differs, because every engine and every
+  writer normalizes the slot away. It is worth a clause only as part of the
+  positional rule it belongs to, not as a question of its own.
+
+The gate binds new clauses. It is not a reason to delete an existing one: a
+clause already carried by the corpus and the engines costs nothing further to
+keep, and removing it re-opens a settled question.
+
 ## Typical change order
 
 For a cross-cutting behavior change:

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -92,6 +92,13 @@
      a pinned engine rather than against the corpus, and reported nine
      grammar defects that were the pin being three weeks stale
      (tree-sitter-carve#160).
+   - WHAT EARNS A CLAUSE is a process rule rather than a language rule, so it
+     lives in .github/CONTRIBUTING.md and not here. In short: a new clause
+     needs an author-visible document or a visible rendering difference, and a
+     shape with neither is recorded as "unruled, engines may differ" instead
+     of costing three engines, the checkers, the corpus and every satellite
+     grammar a change. It binds new clauses only -- keeping an existing one is
+     free, removing one re-opens a settled question.
    ============================================================================ *)
 
 (* ============================================================================


### PR DESCRIPTION
Stacked on markup-carve/carve#966 - it extends the "What settles a question" section that PR adds. Review after it, or merge #966 first and this diff shrinks to its own commit.

## The gate

Every normative clause is paid for by three engines, the executable checkers, the corpus, and every satellite grammar that then has to classify the new category. Nothing states what makes that worth spending, so in practice the answer has been "a divergence was measured" - and a measured divergence is what makes a shape a *question*, not what makes it worth answering.

A new clause needs at least one of:

- **an author-visible document** - someone writing Carve by hand can plausibly produce the shape, and the answer changes what they get;
- **a visible rendering difference** - two implementations produce different output today, and a reader of the output could tell.

A shape with neither is recorded as **unruled: engines may differ**, and the productions are left alone. That is an outcome, not a deferral: it states that the project looked, found nothing an author or a reader can observe, and declined the cost. A later ticket that finds a consequence reopens it with evidence attached.

## Drawn on real cases

Both examples in CONTRIBUTING are from the same week.

| | shape | verdict |
|---|---|---|
| carve#906 | `*x*{.a<TAB>.b}` | **earns a clause** - an author produces it by pressing Tab, three corpus documents already pinned an answer, and the readings differ visibly (attributes applied, or literal braces in the output) |
| carve#907 | `[t](/u<TAB>"T")` | **does not, on its own** - nothing pinned either answer in either direction, and no rendered output differs, because every engine and every writer normalizes the slot away |

## Scope

Binds NEW clauses only. Keeping an existing clause costs nothing further, and removing one re-opens a settled question - stated explicitly so this cannot be read as licensing a deletion sweep.

It is a process rule, so it lives in `.github/CONTRIBUTING.md` with a pointer from the NORMATIVITY block, rather than becoming a clause itself. The inventory is unchanged at 115 clauses.