### PR TITLE
spec: carve-core.ohm is derived, and the files stop calling each other normative

### DIFF
--- a/resources/carve-core.ohm
+++ b/resources/carve-core.ohm
@@ -9,6 +9,15 @@ CarveCore {
   // conformance corpus in CI fashion: a corpus input that this grammar
   // matches must render to the corpus HTML byte-for-byte.
   //
+  // PRECEDENCE. This file is DERIVED and resources/grammar.ebnf is normative;
+  // where the two disagree, the production wins and this file is the defect.
+  // See the NORMATIVITY block at the top of that file. Historically both were
+  // described as "the two normative files", which is what let a disagreement
+  // sit unresolved with each one deferring to the other (carve#912) - there
+  // was no rule saying which was the language. There is now, and the
+  // conformance direction is one-way: core:check asks whether this grammar
+  // reproduces the committed corpus, never whether the corpus matches it.
+  //
   // SCOPE (Core). This file owns the INLINE layer and the leaf blocks of
   // the executable spec. Blocks: ATX headings, thematic breaks, paragraphs,
   // fenced code. Inline: the seven bare emphasis delimiters (/ * _ ~ ^ = ,)
@@ -88,9 +97,9 @@ CarveCore {
   // The slot before the info string is PADDING and takes `space`, matching
   // `fenced_code_block = code_fence_open, [space], [code_fence_info]` in
   // resources/grammar.ebnf. It said `spaceChar*` until carve#907, and
-  // `spaceChar` is a space OR A TAB - so the two normative files disagreed at
-  // this one production while every prose clause said a tab is syntax only in
-  // a line's leading indentation run (PART 7).
+  // `spaceChar` is a space OR A TAB - so this file disagreed with the
+  // production it implements at this one point, while every prose clause said
+  // a tab is syntax only in a line's leading indentation run (PART 7).
   //
   // The caveat this comment used to carry - THIS RULE IS NOT EXECUTED - was
   // true and is not any more. scripts/spec/render.mjs still matches only
@@ -309,7 +318,7 @@ CarveCore {
   // run (PART 7, MARKER SEPARATORS AND PADDING SLOTS; carve#901 correcting
   // carve#878). This file briefly read `" " | "\t"` to match the widened
   // production (carve#888); the production has since narrowed back, and the
-  // two normative files in `resources/` agree again. `destChar` already
+  // two files in `resources/` agree again. `destChar` already
   // excludes both space and tab, so the destination still ends at either.
   //
   // The three engines accept a tab here and now diverge from the production;
@@ -438,9 +447,9 @@ CarveCore {
   //
   // That was LATENT rather than wrong output: scripts/spec/layout.mjs bails
   // on a blank line before this rule is reached, so no document could show
-  // it. A contradiction between the two normative files is worth removing
-  // anyway - the next reader of either file has no way to tell which one is
-  // the language. tests/block-attribute-line-breaks.test.mjs drives this
+  // it. A contradiction between this file and the production it implements is
+  // worth removing anyway - a reader who hits one has to know which is the
+  // language, and at the time nothing said (it does now: the production). tests/block-attribute-line-breaks.test.mjs drives this
   // rule directly so the narrowing is observable rather than another
   // unevaluated edit (carve#755, carve#916).
   blockAttrs = "{" battrPad attrItem (battrSep attrItem)* battrPad "}"

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2572,8 +2572,8 @@ attribute_list = attribute, {space+, attribute} ;
    five positions; only hand-written source does.
 
    Two neighbouring questions are explicitly NOT decided here and have
-   their own tickets: a NEWLINE inside a quoted value, where the two
-   normative files split and the engines are 2-1 (carve#888), and
+   their own tickets: a NEWLINE inside a quoted value, where this file and
+   carve-core.ohm split and the engines are 2-1 (carve#888), and
    carve-php capping a block-attribute block at one line break where the
    other two engines and the oracle accept N. *)
 (* RENDER ORDER -- NORMATIVE: attributes are emitted in the order they
@@ -2785,8 +2785,11 @@ digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' ;
    THE FOUR ARE NARROW BY RULING, not by accident (carve#912). carve-js,
    carve-php, carve-rs AND the executable spec all accepted a run at all
    four, so this was not an engine divergence: four artifacts agreed with
-   each other and disagreed with the written cardinality, and both normative
-   files carried a comment deferring the question to the other. The
+   each other and disagreed with the written cardinality, and this file and
+   carve-core.ohm each carried a comment deferring the question to the other.
+   That deadlock is what precedence exists to break -- see NORMATIVITY: the
+   production is the language and the ohm file is derived, so a split of this
+   shape now has an answer before anyone measures anything. The
    productions were held right and the four artifacts narrow. The cost is
    recorded so it is not re-litigated: every document with two spaces at one
    of those slots reparses.


### PR DESCRIPTION
Stacked on markup-carve/carve#966 and markup-carve/carve#968.

#966 settled that the executable artifacts are derived checkers. Five comments across `resources/` still describe `grammar.ebnf` and `carve-core.ohm` as **"the two normative files"** - and that phrasing is not cosmetic. It is what let a disagreement sit unresolved with each file deferring to the other.

## The case that shows the cost

carve#912. Four artifacts - carve-js, carve-php, carve-rs and the executable spec - accepted a whitespace *run* at four slots the production spells `space`. So it was never an engine divergence: the written cardinality disagreed with everything that ran. And **both files carried a comment handing the question to the other one**, because nothing said which was the language.

## Changes

- `carve-core.ohm` gains a **PRECEDENCE** paragraph in its ROLE block: it is derived, `grammar.ebnf` is normative, and where the two disagree the production wins and the ohm file is the defect. The conformance direction is stated one-way - `core:check` asks whether the ohm grammar reproduces the committed corpus, never whether the corpus matches the ohm grammar.
- Four narrative comments (the code fence's padding slot, the destination slot, the block-attribute rule, the quoted-value newline) now say "this file and the production it implements". The history they record is unchanged; only the claim about who decides is.
- `grammar.ebnf`'s carve#912 note names the deadlock as the thing precedence exists to break, so the next reader meets the resolution rather than just the symptom.

## Scope

Prose only. No production, no corpus document and no engine behavior moves. Clause inventory unchanged at 115.