### PR TITLE
fix: a bump branch nobody has open is abandoned, not preserved

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -179,8 +179,29 @@ jobs:
             done <<< "$ahead"
           fi
 
+          # AND an open PR, which is what the heading above says and what the
+          # identity scan alone cannot tell. Commits stay ahead of `main` by
+          # AUTHOR no matter what became of their CONTENT, so once a bump PR is
+          # SQUASH-MERGED or closed its branch reads as human work forever: every
+          # later run takes the preserve path, merges `main` into a branch that
+          # already has the same content in a different shape, and aborts on the
+          # conflict. Nothing clears that but a human resetting the branch, and
+          # the abort's only reader-facing report is a comment on a PR that by
+          # definition is not open -- so it fails silently. It did, on
+          # tree-sitter-carve, for eight commits (carve#971).
+          #
+          # The two states are not the same. With a PR open somebody is working
+          # on the branch, refusing to force-push is right, and the comment
+          # reaches them. With no PR open the branch is abandoned: no reviewer,
+          # no comment target, and no route by which its commits reach `main`.
+          # Preserving it buys nothing and wedges every future bump.
+          open_pr="$(gh pr list --repo "$REPO" --head automation/bump-spec --state open --json number --jq '.[0].number // empty')"
+
           preserve=""
-          if [ "$foreign" -gt 0 ]; then
+          if [ "$foreign" -gt 0 ] && [ -z "$open_pr" ]; then
+            echo "automation/bump-spec on $REPO carries $foreign non-workflow commit(s) but has no open PR -> abandoned, recreating from main"
+          fi
+          if [ "$foreign" -gt 0 ] && [ -n "$open_pr" ]; then
             preserve=1
             echo "automation/bump-spec on $REPO carries $foreign non-workflow commit(s) -> preserving"
             # Need real history to merge: restore the full refspec and deepen.
@@ -195,10 +216,10 @@ jobs:
               conflict_msg="Bump aborted for \`$REPO\`: merging \`main\` into \`automation/bump-spec\` conflicts. The branch carries $foreign human commit(s), so this workflow will not force-push over them. Resolve the conflict on the branch, then re-run."
               echo "::error::$conflict_msg"
               echo "$conflict_msg" >> "$GITHUB_STEP_SUMMARY"
-              pr="$(gh pr list --repo "$REPO" --head automation/bump-spec --state open --json number --jq '.[0].number // empty')"
-              if [ -n "$pr" ]; then
-                gh pr comment "$pr" --repo "$REPO" --body "$conflict_msg" 2>/dev/null || true
-              fi
+              # `$open_pr` is non-empty here: it is what selected this path, so
+              # the comment always has somewhere to land. Before the gate above
+              # it did not, and this was the abort with no reader.
+              gh pr comment "$open_pr" --repo "$REPO" --body "$conflict_msg" 2>/dev/null || true
               exit 1
             fi
           else

--- a/tests/bump-downstream-early-exit.test.mjs
+++ b/tests/bump-downstream-early-exit.test.mjs
@@ -244,7 +244,7 @@ function fixtureRoot() {
   return '/tmp'
 }
 
-function runScenario({ humanCommit, branchAfterBump = false, botExtraFile = false }) {
+function runScenario({ humanCommit, branchAfterBump = false, botExtraFile = false, openPr = true }) {
   const root = mkdtempSync(join(fixtureRoot(), 'carve-bump-'))
   const carve = buildCarveRemote(root)
   const downstreamBare = buildDownstream(root, carve, { humanCommit, branchAfterBump, botExtraFile })
@@ -253,7 +253,7 @@ function runScenario({ humanCommit, branchAfterBump = false, botExtraFile = fals
   const log = join(root, 'gh.log')
   const prState = join(root, 'pr-open.txt')
   writeFileSync(log, '')
-  writeFileSync(prState, '723\n')
+  writeFileSync(prState, openPr ? '723\n' : '')
   writeGhStub(binDir, { downstreamBare, log, prState })
   writeFileSync(
     join(binDir, 'compare.txt'),
@@ -382,6 +382,36 @@ test('a bot branch that also changes files outside the submodule is left open', 
  * whose branch already contains main: the merge is a no-op, so the exit falls
  * through to the guard itself.
  */
+/*
+ * Human commits ahead of `main` are not by themselves live work. A commit stays
+ * ahead by AUTHOR whatever became of its CONTENT, so a squash-merged or closed
+ * bump PR leaves its branch reading as human work forever - and the preserve
+ * path then merges `main` into a branch holding the same content in a different
+ * shape, and aborts on the conflict, on every run, until a human resets it. It
+ * did that on tree-sitter-carve for eight commits (carve#971), and reported it
+ * only by commenting on a PR that was not open.
+ *
+ * With no open PR the branch has no reviewer and no route to `main`, so the
+ * normal recreate-from-main path is the right one. `humanCommit` is what makes
+ * this scenario prove something: without the open-PR gate it takes the preserve
+ * path, which is the wedge.
+ */
+test('a branch with human commits but no open PR is abandoned, not preserved', () => {
+  const { status, output, calls } = runScenario({ humanCommit: true, openPr: false })
+
+  assert.equal(status, 0, `the skip path should exit 0\n${output}`)
+  assert.match(
+    output,
+    /carries 1 non-workflow commit\(s\) but has no open PR -> abandoned, recreating from main/,
+    `the branch was not recognised as abandoned\n${output}`,
+  )
+  assert.doesNotMatch(
+    output,
+    /-> preserving/,
+    `the preserve path ran for a branch nobody has open - this is the wedge in carve#971\ngh calls:\n${calls}\noutput:\n${output}`,
+  )
+})
+
 test('a human bump PR that is already up to date is left open, not closed', () => {
   const { status, output, calls, prStillOpen } = runScenario({
     humanCommit: true,


### PR DESCRIPTION
Closes #971.

The `Bump downstream corpora` workflow failed on `main` for eight commits, always
on the `markup-carve/tree-sitter-carve` leg and always the same way: it merged
`main` into that repo's `automation/bump-spec`, and the merge conflicted.

## What the guard actually checks

The preserve path states its scope in the heading above it:

```
# ---- Never clobber human work on an open bump PR ----------------
```

The code never checks the open part. It asks
`compare/main...automation/bump-spec` who wrote the commits ahead of `main` and
calls the branch live if any identity is not the bot's.

A commit stays ahead of `main` by AUTHOR whatever became of its CONTENT. So once
a bump PR is squash-merged or closed, its branch reads as human work forever:
every later run takes the preserve path, merges `main` into a branch that already
holds the same content in a different shape, and aborts on the conflict. Nothing
clears that but a human resetting the branch.

That is what tree-sitter-carve was in. Its PR markup-carve/tree-sitter-carve#153
was cut from `automation/bump-spec`, was superseded by
markup-carve/tree-sitter-carve#161 and was closed, leaving four human commits
stranded on the branch.

## Why nobody was on it

The abort reports the conflict three times, and only the third has a human
reader:

```
pr="$(gh pr list --repo "$REPO" --head automation/bump-spec --state open ...)"
if [ -n "$pr" ]; then
  gh pr comment "$pr" --repo "$REPO" --body "$conflict_msg" 2>/dev/null || true
fi
```

There was no open PR, so the guard skipped and the failure never left the Actions
tab. The state that produces the wedge is exactly the state that silences the
report of it.

## The change

The two states are not the same:

- **PR open** - somebody is working on the branch. Refusing to force-push is
  right, and the comment reaches them.
- **No PR open** - the branch is abandoned. No reviewer, no comment target, no
  route by which its commits reach `main`. Preserving it buys nothing and wedges
  every future bump.

So the preserve path now requires an open bump PR as well as a non-bot commit,
which is what its heading always claimed. With none open the branch takes the
normal recreate-from-`main` path. The abort's comment is no longer guarded,
because the state that selected the path guarantees a target.

The new scenario carries a human commit and no open PR, and it is load-bearing:
with the gate reverted it takes the preserve path, which is the wedge. The four
existing scenarios all run with a PR open and are unaffected.

## The conflict itself was not a disagreement

Worth recording for whoever hits this path next. Neither conflicting entry was a
real content difference. The submodule pointer is overwritten on the next line
anyway, and `package-lock.json` differed by one field:

```
-      "resolved": "git+https://github.com/markup-carve/carve-js.git#39b922385e84a2a05ab12fab60d23af37147df7b",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#39b922385e84a2a05ab12fab60d23af37147df7b",
```

Same package, same pinned commit, different URL scheme, because a local
`npm install` under a git `insteadOf` rewrite records `git+ssh://` where CI
records `git+https://`. A lockfile that flips on whose machine generated it will
keep producing conflicts on this path whenever it is reached.

## The stranded branch

Being cleared separately. Five of its six commits are superseded by
markup-carve/tree-sitter-carve#161 - established by building both parsers and
running a 31-document differential over every construct they touch, not from
`ahead_by`. The sixth is preserved as
markup-carve/tree-sitter-carve#162 before the branch is reset.

## What this narrows, deliberately

The gate trades away one case: a human who pushes to `automation/bump-spec`
without opening a PR now gets recreated over, where before the branch would have
been preserved and a PR opened for it.

I do not think that case can be recovered cheaply, and it is worth saying why
rather than leaving it implied. The obvious refinement - preserve when NO PR has
ever existed for the branch, and treat only closed-or-merged as abandoned - does
almost nothing, because this workflow opens a PR on every bump, so any repo it
has run against already has closed bump PRs in its history. The refinement would
answer "abandoned" for exactly the same branches.

The residual risk seems small: `automation/bump-spec` is a workflow-owned branch
that the normal path force-pushes by design, so pushing work there without
opening a PR is already outside the contract. The case the gate protects, by
contrast, is the one that has actually happened and that nothing else recovers
from.