### PR TITLE
spec: the AST table's satellite rows are checked here, not handed off

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -452,10 +452,11 @@ suffix in document order, so `# Notes` twice gives `Notes` and then `Notes-2`,
 and deriving the second one means having replayed every heading before it. A
 consumer holding only the tree - a table of contents, an LSP go-to-definition, a
 cross-document index - cannot do that, so the id rides in `heading.attrs.id`
-beside an authored `{#id}` rather than being left to be guessed. carve-js
-publishes it today; carve-rs and carve-php do not, a divergence declared in
-`resources/ast-value-divergence.txt` until each lands a producer
-([carve#750](https://github.com/markup-carve/carve/issues/750)).
+beside an authored `{#id}` rather than being left to be guessed. All three
+engines publish it today. It was the largest entry the value declaration ever
+carried - 45 documents, carve-js alone against the other two - and it was
+deleted when carve-rs landed the last producer
+([carve#750](https://github.com/markup-carve/carve/issues/750) is closed).
 
 ## Conformance status
 
@@ -463,11 +464,17 @@ Run `node scripts/ast-conformance.mjs` in this repo against sibling checkouts of
 the engines. It reports two things a schema cannot: nodes with no position, and
 spans that do not cover the text they claim.
 
+The rows below are MEASURED state, so they are reconciled rather than trusted.
+`tests/ast-json-claims.test.mjs` measures the carve-js row against the pinned
+engine, and holds every row to the two ledgers that run's satellites fill in -
+`resources/ast-position-waivers.txt` and `resources/ast-value-divergence.txt`.
+A row may name an issue only where one of those still declares the debt.
+
 | engine | shape | positions |
 |---|---|---|
-| carve-js | §3a conformant on the resolved form: publishes `href`, `ref` and `rawRef` together | blocks and inlines, except reassembled regions (table cells, line-block content) |
-| carve-rs | §3a conformant on the resolved form: `ref` and `rawRef` survive resolution beside `href` (the open half of [carve#481](https://github.com/markup-carve/carve/issues/481), now measured) | blocks and most inlines; reconstructed regions are unplaced, as are the paragraphs a capped container degrades to ([carve#672](https://github.com/markup-carve/carve/issues/672)) |
-| carve-php | §3a conformant on both forms measured here: an unresolved reference is a `link` node (closing the shape [carve#486](https://github.com/markup-carve/carve/issues/486) reported), and the collapsed form carries the derived label in `ref` beside `rawRef`; two field-name divergences left: the root carries `abbreviations`, and `inline_extension` publishes `extensionType`/`children` ([carve-php#510](https://github.com/markup-carve/carve-php/issues/510)) | recorded behind a parse option, enabled whenever it serializes |
+| carve-js | §3a conformant on the resolved form: publishes `href`, `ref` and `rawRef` together | every block and inline placed, except the two categories §4 exempts: a coalesced `text` run, and a table cell continued on a `+` line |
+| carve-rs | §3a conformant on the resolved form: `ref` and `rawRef` survive resolution beside `href` | every block and inline placed, except the coalesced `text` runs §4 exempts |
+| carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries a derived label in `ref` beside `rawRef` - though WHICH label diverges once the label carries inline markup ([carve#962](https://github.com/markup-carve/carve/issues/962)) | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the coalesced `text` runs §4 exempts |
 | carve-rb / carve-py / carve-go / carve-wasm | publish carve-rs's bytes | whatever carve-rs records |
 
 The gaps are listed rather than smoothed over on purpose: "six implementations"
@@ -480,12 +487,19 @@ column, and the test is whether a true span EXISTS rather than whether one was
 written down.
 
 The definition-list entry this paragraph used to name is fixed: carve-rs places
-`definition_term` and `definition_description` today, checked over every
-corpus document that contains one. What the same measurement does turn up is a
-different gap - carve-rs and carve-php leave the paragraphs a CAPPED container
-degrades to unplaced (`182-openers-past-the-nesting-cap-are-one-paragraph`),
-where carve-js places them against real offsets, so the reassembly exemption does
-not reach them ([carve#672](https://github.com/markup-carve/carve/issues/672)).
+`definition_term` and `definition_description` today, checked over every corpus
+document that contains one. So is the gap that replaced it. Re-measured over 833
+documents on 2026-08-07, the OWED half of `resources/ast-position-waivers.txt`
+is EMPTY: the paragraphs a capped container degrades to are placed in all three
+engines now, and so is everything else that stood in that column a day earlier.
+Every position finding left is `permitted` under §4.
+
+That is also how the carve-rs row went wrong. It named the capped-container gap
+for two days after the gap closed and the declaration behind it was deleted,
+because the one-engine test above declared that row out of scope and handed it to
+a script that never reads this page
+([carve#965](https://github.com/markup-carve/carve/issues/965)). A row citing an
+issue no ledger still declares is now a failing test rather than a sentence.
 
 The §3a entries were measured, on `See [getting started][] here.` with the label
 defined. All three engines now publish the whole triple - `href`, `ref` and
@@ -496,7 +510,17 @@ defined. All three engines now publish the whole triple - `href`, `ref` and
     carve-php  {"href":"/start","ref":"getting started","rawRef":"[getting started][]"}
 
 The unresolved form agrees too: `See [missing][] here.` is a `link` node in all
-three, not flattened text.
+three, not flattened text. Between them those two lines close what the rows used
+to carry as open: whether the serialized tree is pre- or post-resolve (carve#481)
+and carve-rs and carve-php flattening an unresolved reference (carve#486), both
+answered and both closed.
+
+What is NOT settled is WHICH label `ref` carries when the label holds inline
+markup. Given a collapsed reference whose label is `` `code()` heading ``,
+carve-php publishes the heading's rendered text where the other two publish the
+authored label, and §3a's "the derived label" reads both ways. That one is
+declared in `resources/ast-value-divergence.txt`, which is why the carve-php row
+may cite it.
 
 An earlier version of this paragraph recorded the opposite - none publishing
 `rawRef`, carve-php publishing `ref: ""` - and the rows above described the

--- a/resources/ast-position-waivers.txt
+++ b/resources/ast-position-waivers.txt
@@ -2,16 +2,22 @@
 # populations it used to print as one number.
 #
 # PART 12 §4 exempts a node the producer REASSEMBLED - its value is not a slice
-# of the source at any offset, so no honest span exists. docs/ast-json.md:113
-# and :148-153 name those cases verbatim, and docs/ast-json.md:427 names
-# carve-js as the engine that omits a continued cell's position. Those lines are
-# `permitted` below and there is nothing to fix in any engine, ever.
+# of the source at any offset, so no honest span exists. docs/ast-json.md names
+# those cases verbatim - "A table cell continued on a `+` line, the hard break a
+# line block makes" - and its conformance table's carve-js row names carve-js as
+# the engine that omits a continued cell's position. Those lines are `permitted`
+# below and there is nothing to fix in any engine, ever.
 #
-# Everything else is OWED. docs/ast-json.md:116-117 narrows the exemption to
-# "nodes that *cannot* be placed, not nodes that have not been placed yet", and
-# the conformance section at docs/ast-json.md:438 states the test as "whether a
-# true span EXISTS rather than whether one was written down". Each of those
-# lines carries the issue tracking it.
+# Everything else is OWED. docs/ast-json.md narrows the exemption to "covers
+# nodes that *cannot* be placed, not nodes that have not been placed yet", and
+# its conformance section states the test as "whether a true span EXISTS rather
+# than whether one was written down". Each of those lines carries the issue
+# tracking it.
+#
+# Cited by PHRASE, not by line: every line number this header used to carry had
+# drifted (carve#965), and the phrases are pinned in
+# scripts/spec/ast-page-anchors.mjs so a reworded clause fails a test instead of
+# quietly sending a reader to the wrong paragraph.
 #
 # Printed as one number the two were indistinguishable, so the total moved
 # whenever the CORPUS grew and nobody could tell which half moved. Measured over
@@ -56,7 +62,7 @@
 
 # ---- PERMITTED: a merged `text` run whose pieces are not adjacent ------------
 #
-# docs/ast-json.md:148-153. An autolink unwrapped inside a link label
+# The §4 reassembly clause. An autolink unwrapped inside a link label
 # (03-links-12), the two halves of a table cell continued on a `+` line
 # (237, 249-4, 256-15/16/17, 63, 64), and line-block content rebuilt around the
 # indentation sentinel (41-line-blocks-9). All three engines omit; the clause
@@ -98,8 +104,8 @@ carve-php  64-table-rowspan-with-multi-line-content.crv           text  1  permi
 
 # ---- PERMITTED: a table cell continued on a `+` line -------------------------
 #
-# docs/ast-json.md:113 names the construct and docs/ast-json.md:427 already
-# names carve-js as the engine that omits it. carve-rs and carve-php place
+# docs/ast-json.md names the construct in the §4 clause, and its conformance
+# table's carve-js row names the engine. carve-rs and carve-php place
 # these, which is permitted too - §4 exempts, it does not forbid. Also a
 # CONTROL.
 

--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -27,7 +27,7 @@
 #
 # WHAT THIS FILE DOES NOT DECIDE, AND WHAT IS NO LONGER OPEN. Whether a node's
 # span covers the markup that OPENS it - the list marker, the `>`, the `[^a]: `
-# - was markup-carve/carve#913, and it is RULED: docs/ast-json.md:108 states
+# - was markup-carve/carve#913, and it is RULED: docs/ast-json.md states
 # that "a span begins at the markup that opens the construct", naming the two
 # exceptions (the inner half of a combined `/*x*/`, and a table cell, which runs
 # between the pipes). Most of the EXTENT rows below are that question, so each
@@ -95,7 +95,8 @@ soft_break              (extent)  1
 # construction if one is updated without the other, which is deliberate.
 #
 # ONE ROW LEFT, and it is the permitted one: carve-js omits a table cell
-# continued on a `+` line, which docs/ast-json.md:113 and :427 exempt by name.
+# continued on a `+` line, which docs/ast-json.md's §4 clause and its
+# conformance table exempt by name.
 # The six rows that stood here on 2026-08-06 - paragraph, text, soft_break,
 # definition_description, figure and footnote - all cleared when the engine
 # issues behind them landed, and the sibling file's OWED section emptied in the

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -521,7 +521,8 @@ function reportSpanDisagreements(present) {
       'documents it shows up in. Update it in the commit that moves the number.',
       'A row moving does not say WHICH engine is wrong - this panel has the trees and',
       'not the source - but the extent rule itself is settled: PART 12 §4 is',
-      'markup-inclusive (markup-carve/carve#913, docs/ast-json.md:108), and',
+      'markup-inclusive (markup-carve/carve#913; docs/ast-json.md: a span "begins at the',
+      'markup that opens the construct"), and',
       'checkOpeningMarkup in scripts/spec/ast-positions.mjs is what names a side.',
     ],
   })
@@ -1555,10 +1556,10 @@ declarationDrift.push({
   problems: waiverProblems,
   advice: [
     'Each line there is one engine, one document and one node type, with a count and',
-    'either "permitted" (PART 12 §4 exempts a REASSEMBLED node - see docs/ast-json.md',
-    'lines 113 and 148-153) or the issue tracking the gap. Update it in the commit',
-    'that moves the number, and never widen a line to "permitted" to quiet a run:',
-    'docs/ast-json.md:116-117 narrows the exemption to nodes that CANNOT be placed.',
+    'either "permitted" (PART 12 §4 exempts a REASSEMBLED node - see the §4 clause on',
+    'docs/ast-json.md) or the issue tracking the gap. Update it in the commit that',
+    'moves the number, and never widen a line to "permitted" to quiet a run: that page',
+    'narrows the exemption to nodes that CANNOT be placed, not nodes nobody has placed.',
   ],
 })
 

--- a/scripts/spec/ast-json-table.mjs
+++ b/scripts/spec/ast-json-table.mjs
@@ -1,0 +1,139 @@
+/*
+ * The conformance table on docs/ast-json.md, parsed.
+ *
+ * That table is a MEASUREMENT written down in prose - one row per engine, a
+ * shape column and a positions column - and measured state rots. It has been
+ * found wrong four times: carve#673 (a definition-list gap carve-rs had fixed),
+ * carve#674 (the §3a rows, wrong in the opposite direction), a §7 row describing
+ * a node no engine produces, and carve#965, which is why this file exists.
+ *
+ * `tests/ast-json-claims.test.mjs` measured the carve-js row against the pinned
+ * engine and declared the other two rows out of scope, on the stated grounds
+ * that `scripts/ast-conformance.mjs` measured them nightly. It does not. It
+ * never opens the page - every mention of the filename in scripts/ is a pointer
+ * inside a comment or an advice string. So two of the three rows were handed to
+ * a checker that never took the job, and the carve-rs row rotted in exactly the
+ * direction the one-engine test was written to catch.
+ *
+ * WHAT THIS COMPARES A ROW TO. Not a live satellite: this repo has one engine,
+ * the `@markup-carve/carve` pin, and a checker that needs three checkouts to run
+ * is a checker that does not run. It compares each row to the LEDGERS this repo
+ * already commits and already gates:
+ *
+ *   resources/ast-position-waivers.txt - per engine, per document, per node
+ *   type, every position finding, each either `permitted` (§4 exempts it) or an
+ *   issue that owes a fix. `npm run ast:check` reconciles it against the three
+ *   engines and fails in three directions, including the FIXED direction that
+ *   deletes a stale line.
+ *
+ *   resources/ast-value-divergence.txt - the fields the three publish different
+ *   values for, with the issue tracking each.
+ *
+ * Those files ARE the recorded measurement of the satellites, refreshed by the
+ * run that drives them. A row that contradicts one of them is a row describing
+ * a state the fleet has left. Per carve#966 this module is not the authority on
+ * what the page should say: it reports where the page and the committed ledger
+ * disagree, and the ledger is the one that was measured.
+ */
+
+/** A markdown table row split on unescaped pipes, outer cells dropped. */
+const cellsOf = (line) =>
+  line
+    .split('|')
+    .slice(1, -1)
+    .map((cell) => cell.trim())
+
+const SEPARATOR = /^\|[\s:|-]+\|$/
+
+/**
+ * The `## Conformance status` table.
+ *
+ * Located by its header row rather than by offset, and an absent or reshaped
+ * table is an error rather than an empty result - a parser that returns zero
+ * rows for a table it failed to find turns every row assertion below into a
+ * check that cannot fail, which is the family of defect this file is part of.
+ */
+export function parseConformanceTable(page) {
+  const lines = page.split('\n')
+  const header = lines.findIndex((line) => line.trim() === '| engine | shape | positions |')
+  if (header === -1) {
+    throw new Error(
+      'docs/ast-json.md has no `| engine | shape | positions |` header; the conformance table ' +
+        'was renamed or reshaped, and every row check below is measuring nothing until this is updated',
+    )
+  }
+  if (!SEPARATOR.test(lines[header + 1].trim())) {
+    throw new Error(`docs/ast-json.md:${header + 2} is not a table separator; the table shape changed`)
+  }
+
+  const rows = []
+  for (let i = header + 2; i < lines.length; i += 1) {
+    const line = lines[i].trim()
+    if (!line.startsWith('|')) break
+    const cells = cellsOf(line)
+    if (cells.length !== 3) {
+      throw new Error(`docs/ast-json.md:${i + 1} has ${cells.length} cells, expected 3 (engine, shape, positions)`)
+    }
+    const [engineCell, shape, positions] = cells
+    rows.push({
+      lineNo: i + 1,
+      engineCell,
+      engines: engineCell.split('/').map((name) => name.trim()),
+      shape,
+      positions,
+    })
+  }
+  if (rows.length === 0) throw new Error('the conformance table has a header and no rows')
+
+  return rows
+}
+
+/**
+ * Every issue a piece of text cites, as `owner/repo#N`.
+ *
+ * All three spellings in play: a markdown link to the issue URL, the fully
+ * qualified `markup-carve/carve-rs#716` a ledger status uses, and the bare
+ * `carve-php#510` the prose uses. Normalized to one, so a row cannot dodge the
+ * check by changing how it writes the same reference.
+ */
+export function citedIssues(text) {
+  const found = new Set()
+  for (const m of text.matchAll(/https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)/g)) {
+    found.add(`${m[1]}/${m[2]}#${m[3]}`)
+  }
+  for (const m of text.matchAll(/([\w.-]+)\/([\w.-]+)#(\d+)/g)) {
+    found.add(`${m[1]}/${m[2]}#${m[3]}`)
+  }
+  for (const m of text.matchAll(/(?<![\w/-])(carve(?:-[a-z]+)?)#(\d+)/g)) {
+    found.add(`markup-carve/${m[1]}#${m[2]}`)
+  }
+
+  return found
+}
+
+/** A ledger's declaration lines - its comments carry the history, not the debt. */
+export const declarationLines = (text) =>
+  text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#'))
+
+/**
+ * The issues this repo currently DECLARES as open engine debt.
+ *
+ * Declaration lines only. A ledger's comment block narrates what was deleted
+ * and when - `carve-rs#716`, `carve-php#965` and four others are named there as
+ * closed - and reading the comments would let a row cite an issue precisely
+ * because the debt behind it was retired. That is the failure this whole file
+ * is about, so the set is built from the live lines.
+ */
+export function declaredDebt({ waivers, values }) {
+  const found = new Set()
+  for (const line of declarationLines(waivers)) {
+    const status = line.split(/\s+/)[4]
+    if (status && status !== 'permitted') for (const issue of citedIssues(status)) found.add(issue)
+  }
+  for (const line of declarationLines(values)) for (const issue of citedIssues(line)) found.add(issue)
+
+  return found
+}

--- a/scripts/spec/ast-page-anchors.mjs
+++ b/scripts/spec/ast-page-anchors.mjs
@@ -1,0 +1,56 @@
+/*
+ * The sentences of docs/ast-json.md that other files CITE, quoted rather than
+ * numbered.
+ *
+ * Every module that leans on a clause from that page used to point at it by
+ * line: `docs/ast-json.md:116-117`, `:148-153`, `:427`, `:438`, `:108`. The page
+ * grows, so all five drifted, and markup-carve/carve#965 tabulated the damage.
+ * The correction that issue proposed - re-number them - was itself out of date
+ * by the time it was written: it put the narrowing clause at 131 when the clause
+ * is at 142, and reported `:113` as still landing on the §4 exception when 113
+ * is the codepoint sentence. A line number cannot be maintained by hand against
+ * a living page, and a citation nobody can check is the miniature of the defect
+ * that issue is about.
+ *
+ * So a citation names a PHRASE. The phrase is checked - tests/ast-json-claims
+ * asserts each of these occurs exactly once on the page - which means rewording
+ * the clause fails until the citation is updated, and moving the paragraph costs
+ * nothing. That is the opposite of the line-number trade.
+ *
+ * Matching collapses runs of whitespace on both sides, so an anchor may be
+ * written on one line even where the page wraps it. Keep the backticks and the
+ * asterisks: they are what makes several of these unique.
+ */
+export const PAGE_ANCHORS = {
+  /** §4 is markup-inclusive. Cited by the span panel and its advice string. */
+  markupInclusive: 'begins at the markup that opens the construct',
+
+  /** §4's exemption for a node the producer reassembled. */
+  reassembledExemption: '**may omit `pos` and is conformant doing so**',
+
+  /** The reassembled cases, named one by one. */
+  reassembledCases: 'A table cell continued on a `+` line, the hard break a line block makes',
+
+  /** The exemption is for what CANNOT be placed, not for what has not been. */
+  exemptionIsNarrow: 'covers nodes that *cannot* be placed, not nodes that have not been placed yet',
+
+  /** The conformance test: a true span EXISTS, not a span was written down. */
+  spanMustExist: 'whether a true span EXISTS rather than whether one was written down',
+}
+
+/** Whitespace-insensitive, so an anchor survives the page rewrapping a line. */
+export const flatten = (text) => text.replace(/\s+/g, ' ')
+
+/** How many times an anchor occurs in the page. Exactly one is the contract. */
+export function countAnchor(page, phrase) {
+  const haystack = flatten(page)
+  const needle = flatten(phrase)
+  let found = 0
+  let at = haystack.indexOf(needle)
+  while (at !== -1) {
+    found += 1
+    at = haystack.indexOf(needle, at + 1)
+  }
+
+  return found
+}

--- a/scripts/spec/ast-spans.mjs
+++ b/scripts/spec/ast-spans.mjs
@@ -38,8 +38,8 @@
  *
  * WHAT IT DOES NOT DECIDE. Whether a node's span covers the markup that OPENS
  * it - the list marker, the `>`, the `[^a]: ` - was markup-carve/carve#913, and
- * it is RULED: docs/ast-json.md:108 states that a span begins at the markup
- * that opens the construct. Most of what this panel reports is that question,
+ * it is RULED: docs/ast-json.md states that a span "begins at the markup that
+ * opens the construct". Most of what this panel reports is that question,
  * so those rows are engines owing a fix rather than an open convention.
  *
  * What this module still does not do is say WHICH engine owes it, because that

--- a/scripts/spec/ast-waivers.mjs
+++ b/scripts/spec/ast-waivers.mjs
@@ -7,15 +7,21 @@
  *   PERMITTED. PART 12 §4 exempts a node the producer REASSEMBLED - a table
  *   cell continued on a `+` line, a `text` run coalesced across a gap - because
  *   its value is not a slice of the source at any offset, so no honest span
- *   exists. docs/ast-json.md:113 and :148-153 name those cases verbatim, and
- *   docs/ast-json.md:427 already names carve-js as the engine that omits a
+ *   exists. docs/ast-json.md names those cases verbatim - the clause is "A table
+ *   cell continued on a `+` line, the hard break a line block makes" - and its
+ *   conformance table's carve-js row names carve-js as the engine that omits a
  *   continued cell's position. Nothing to fix, in any engine, ever.
  *
- *   OWED. Everything else in that column. docs/ast-json.md:116-117 narrows the
- *   exemption to "nodes that *cannot* be placed, not nodes that have not been
- *   placed yet", and the conformance section at docs/ast-json.md:438 states the
- *   test as "whether a true span EXISTS rather than whether one was written
- *   down". Each of these is an engine defect with an issue.
+ *   OWED. Everything else in that column. docs/ast-json.md narrows the exemption
+ *   to "covers nodes that *cannot* be placed, not nodes that have not been
+ *   placed yet", and its conformance section states the test as "whether a true
+ *   span EXISTS rather than whether one was written down". Each of these is an
+ *   engine defect with an issue.
+ *
+ * Those clauses are cited by PHRASE and not by line, and the phrases are pinned
+ * in scripts/spec/ast-page-anchors.mjs: the line numbers that used to stand here
+ * had all drifted by the time carve#965 tabulated them, and the numbers that
+ * issue proposed as the correction were stale before it was filed.
  *
  * Printed as one number, the two were indistinguishable, so the count moved
  * whenever the corpus grew and nobody could tell which half moved. Declaring

--- a/tests/ast-json-claims.test.mjs
+++ b/tests/ast-json-claims.test.mjs
@@ -20,9 +20,35 @@
  * checked. Both together mean the row and the engine cannot drift apart
  * quietly - which is the only failure mode this page has ever had.
  *
- * The carve-rs and carve-php rows are out of scope here: this suite has one
- * engine, the `@markup-carve/carve` pin. Those rows are measured by
- * `scripts/ast-conformance.mjs`, which runs the satellites nightly.
+ * THE SATELLITE ROWS ARE IN SCOPE TOO, and the note that said otherwise is why
+ * this file needed a second pass. It read: "those rows are measured by
+ * `scripts/ast-conformance.mjs`, which runs the satellites nightly". That script
+ * does not open this page and never did - every mention of the filename in
+ * scripts/ is a pointer inside a comment or an advice string. So two of the three
+ * rows were handed to a checker that never took the job, and the carve-rs row
+ * then rotted in exactly the direction this file was written to catch, naming
+ * carve#672 as a live gap for two days after it closed (carve#965).
+ *
+ * What the satellite rows are measured against is not a live checkout - this
+ * suite has one engine, and a check needing three built satellites is a check
+ * that does not run where most changes are written. They are measured against
+ * the two ledgers this repo commits, which `npm run ast:check` fills in BY
+ * driving those satellites:
+ *
+ *   resources/ast-position-waivers.txt - every position finding, per engine, per
+ *   document, per node type, each either `permitted` under §4 or an issue owing
+ *   a fix;
+ *   resources/ast-value-divergence.txt - the fields the three publish different
+ *   VALUES for, with the issue tracking each.
+ *
+ * Per carve#966 these checks are not the authority on what the page should say.
+ * They report where the page and a committed ledger disagree, and the ledger is
+ * the side that was measured.
+ *
+ * WHAT THEY DO NOT COVER, said out loud so the next reader is not handed a job
+ * nobody took: a shape claim about FIELD NAMES. No ledger here records one - the
+ * schema panel gates those at zero against a live checkout - so such a claim
+ * cannot be checked from this repo, and the carve-php row no longer makes one.
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
@@ -40,10 +66,18 @@ import {
   toAstJson,
 } from '@markup-carve/carve'
 
+import { citedIssues, declaredDebt, parseConformanceTable } from '../scripts/spec/ast-json-table.mjs'
+import { PAGE_ANCHORS, countAnchor, flatten } from '../scripts/spec/ast-page-anchors.mjs'
+import { RECONCILED_ENGINES, parseWaivers } from '../scripts/spec/ast-waivers.mjs'
+
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const page = readFileSync(resolve(root, 'docs/ast-json.md'), 'utf8')
+const waiverText = readFileSync(resolve(root, 'resources/ast-position-waivers.txt'), 'utf8')
+const valueText = readFileSync(resolve(root, 'resources/ast-value-divergence.txt'), 'utf8')
 
-const jsRow = page.split('\n').find((line) => line.startsWith('| carve-js |'))
+const rows = parseConformanceTable(page)
+const rowFor = (engine) => rows.find((row) => row.engines.length === 1 && row.engines[0] === engine)
+const jsRow = rowFor('carve-js')?.shape
 
 const nodesOfType = (doc, type) => {
   const found = []
@@ -176,6 +210,7 @@ test('the markup targets blank it, which is why the tree may keep it', () => {
     ['html', carveToHtml],
     ['markdown', carveToMarkdown],
     ['plain', carveToPlainText],
+    ['ansi', carveToAnsi],
   ]) {
     const out = render(source)
     assert.ok(
@@ -194,8 +229,11 @@ test('the markup targets blank it, which is why the tree may keep it', () => {
  * (carve#773).
  *
  * The gated record that the PIN was behind the fix has been deleted, because the
- * pin has caught up - which is what that gate was for. The four-target
- * assertion above covers ansi like the rest.
+ * pin has caught up - which is what that gate was for. The loop above says it
+ * covers "the four targets" and listed three: `carveToAnsi` was imported and
+ * never called, so the terminal target section 25 names explicitly was asserted
+ * by nothing. Same family as the header note this file was fixed for, one scope
+ * smaller, and now `ansi` is in the loop.
  */
 test('feeding the tree back through the engine applies the denylist', () => {
   // The page tells a consumer this is the escape hatch: hand the tree back to a
@@ -220,4 +258,200 @@ test('the page still tells a consumer both halves', () => {
     /javascript:alert\(1\)/,
     'docs/ast-json.md no longer shows what an unsanitized destination looks like',
   )
+})
+
+/*
+ * ---------------------------------------------------------------------------
+ * THE WHOLE TABLE, RECONCILED AGAINST THE LEDGERS.
+ *
+ * See the header for why these are here rather than "somebody else's problem".
+ * Each one is stated so that it can fail while the page is CORRECT - a guard
+ * that only works while a row is already wrong stops working the moment the row
+ * is fixed, which is the state this PR reaches (carve#955).
+ * ---------------------------------------------------------------------------
+ */
+
+/** The declaration lines that OWE a fix, per engine. `permitted` is not debt. */
+const owedByEngine = () => {
+  const { declared, errors } = parseWaivers(waiverText)
+  assert.deepEqual(errors, [], `resources/ast-position-waivers.txt did not parse: ${errors.join('; ')}`)
+  const owed = new Map()
+  for (const line of declared.values()) {
+    if (line.status === 'permitted') continue
+    if (!owed.has(line.engine)) owed.set(line.engine, [])
+    owed.get(line.engine).push(line)
+  }
+
+  return owed
+}
+
+/** The permitted node types the ledger records, per engine. */
+const permittedByEngine = () => {
+  const { declared } = parseWaivers(waiverText)
+  const permitted = new Map()
+  for (const line of declared.values()) {
+    if (line.status !== 'permitted') continue
+    if (!permitted.has(line.engine)) permitted.set(line.engine, new Set())
+    permitted.get(line.engine).add(line.type)
+  }
+
+  return permitted
+}
+
+/*
+ * How a positions cell spells a permitted category.
+ *
+ * A ledger type with no entry here fails rather than defaulting to "covered":
+ * a new permitted category is a new sentence the page owes, and a map that
+ * silently skips what it does not know is the same shape as the scope note this
+ * file was fixed for.
+ */
+const PERMITTED_PHRASE = {
+  text: 'coalesced `text` run',
+  table_cell: 'table cell',
+}
+
+test('every engine the position ledger names has a row, and every reconciled engine its own', () => {
+  const named = new Set()
+  for (const row of rows) for (const engine of row.engines) named.add(engine)
+
+  for (const engine of permittedByEngine().keys()) {
+    assert.ok(
+      named.has(engine),
+      `resources/ast-position-waivers.txt declares ${engine} and the conformance table has no row for it`,
+    )
+  }
+  for (const engine of RECONCILED_ENGINES) {
+    assert.ok(rowFor(engine), `${engine} is reconciled by ast:check but shares a row, or has none`)
+  }
+})
+
+test('a row names an issue only where a ledger still declares the debt', () => {
+  // THE ROT ITSELF. The carve-rs row named carve#672 for two days after the
+  // issue closed and its declaration line was deleted, and the carve-php row
+  // named carve-php#510 for six days after that issue closed on a full-corpus
+  // re-measurement. Both were readable as current state by anyone who did not
+  // go and check the issue.
+  const debt = declaredDebt({ waivers: waiverText, values: valueText })
+  for (const row of rows) {
+    for (const cell of [row.shape, row.positions]) {
+      for (const issue of citedIssues(cell)) {
+        assert.ok(
+          debt.has(issue),
+          `docs/ast-json.md:${row.lineNo} (${row.engineCell}) cites ${issue}, which neither ` +
+            'resources/ast-position-waivers.txt nor resources/ast-value-divergence.txt still ' +
+            'declares. A conformance row states measured state; the history goes in the prose below it.',
+        )
+      }
+    }
+  }
+})
+
+test('a declared position gap is named in its own engine row', () => {
+  // The other direction: a ledger may not owe something the table does not show.
+  // Vacuous today because the OWED half is empty, and NOT a control - adding one
+  // owed line to the ledger fails this without touching the page.
+  const debt = owedByEngine()
+  for (const [engine, lines] of debt) {
+    const row = rowFor(engine)
+    assert.ok(row, `${engine} owes ${lines.length} position finding(s) and has no row of its own`)
+    const cited = citedIssues(row.positions)
+    for (const line of lines) {
+      assert.ok(
+        cited.has(line.status),
+        `resources/ast-position-waivers.txt owes ${line.status} for ${engine} ` +
+          `(${line.document}, ${line.type}) and docs/ast-json.md:${row.lineNo} does not name it`,
+      )
+    }
+  }
+})
+
+test('a positions cell names exactly the permitted categories its ledger records', () => {
+  const permitted = permittedByEngine()
+  for (const engine of RECONCILED_ENGINES) {
+    const row = rowFor(engine)
+    const types = permitted.get(engine) ?? new Set()
+    const cell = flatten(row.positions)
+    for (const [type, phrase] of Object.entries(PERMITTED_PHRASE)) {
+      const named = cell.includes(phrase)
+      if (types.has(type)) {
+        assert.ok(
+          named,
+          `resources/ast-position-waivers.txt permits ${type} for ${engine} and ` +
+            `docs/ast-json.md:${row.lineNo} does not say so (expected the phrase "${phrase}")`,
+        )
+      } else {
+        assert.ok(
+          !named,
+          `docs/ast-json.md:${row.lineNo} tells a reader ${engine} omits a ${type} position, ` +
+            'and no line in resources/ast-position-waivers.txt records one',
+        )
+      }
+    }
+    for (const type of types) {
+      assert.ok(
+        type in PERMITTED_PHRASE,
+        `resources/ast-position-waivers.txt permits "${type}" for ${engine} and nothing here ` +
+          'knows how the page spells it - add it to PERMITTED_PHRASE and to the row',
+      )
+    }
+  }
+})
+
+test('an engine claiming §3a conformance has the measurement printed below the table', () => {
+  // The transcript block under the table is the recorded §3a measurement for all
+  // three. A row may not claim conformance the page cannot show.
+  for (const row of rows) {
+    if (!/§3a conformant/.test(row.shape)) continue
+    for (const engine of row.engines) {
+      const line = page
+        .split('\n')
+        .find((candidate) => candidate.trim().startsWith(`${engine}   `) || candidate.trim().startsWith(`${engine}  {`))
+      assert.ok(line, `docs/ast-json.md:${row.lineNo} claims §3a conformance for ${engine} with no measured line`)
+      for (const field of ['"href"', '"ref"', '"rawRef"']) {
+        assert.ok(
+          line.includes(field),
+          `the §3a transcript for ${engine} does not publish ${field}, and its row claims the whole triple`,
+        )
+      }
+    }
+  }
+})
+
+test('a paragraph citing the value ledger names only fields it still declares', () => {
+  // How the heading-id paragraph went stale: it said `heading.attrs.id` was "a
+  // divergence declared in resources/ast-value-divergence.txt", six weeks after
+  // carve-rs landed the last producer and the line was deleted. A page that
+  // points at a declaration has to point at one that is there.
+  const declaredFields = new Set(
+    valueText
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line !== '' && !line.startsWith('#'))
+      .map((line) => line.split(/\s+/)[0]),
+  )
+  for (const paragraph of page.split('\n\n')) {
+    if (!paragraph.includes('resources/ast-value-divergence.txt')) continue
+    for (const m of paragraph.matchAll(/`([a-z_]+(?:\.[a-z_]+)+)`/gi)) {
+      assert.ok(
+        declaredFields.has(m[1]),
+        `docs/ast-json.md points at resources/ast-value-divergence.txt for \`${m[1]}\`, ` +
+          'which that file no longer declares',
+      )
+    }
+  }
+})
+
+test('every clause another file cites still occurs exactly once on the page', () => {
+  // The line numbers these replaced had ALL drifted, and the correction carve#965
+  // proposed was itself stale on arrival: it put the narrowing clause at 131 when
+  // it was at 142. A phrase moves with its paragraph; a line number does not.
+  for (const [name, phrase] of Object.entries(PAGE_ANCHORS)) {
+    assert.equal(
+      countAnchor(page, phrase),
+      1,
+      `scripts/spec/ast-page-anchors.mjs cites "${name}" as "${phrase}", which docs/ast-json.md ` +
+        'no longer contains exactly once - reword the citation or restore the clause',
+    )
+  }
 })


### PR DESCRIPTION
Closes markup-carve/carve#965.

`tests/ast-json-claims.test.mjs` exists because the per-engine table on
`docs/ast-json.md` quotes MEASURED engine state, and measured state rots. Its
header then scoped two thirds of the job out:

> The carve-rs and carve-php rows are out of scope here: this suite has one
> engine, the `markup-carve/carve` npm pin. Those rows are measured by
> `scripts/ast-conformance.mjs`, which runs the satellites nightly.

**Confirmed false.** That script never opens the page. Every hit for the
filename in `scripts/` is a pointer inside a comment or an advice string, never a
read:

```
$ grep -rn "readFileSync" scripts/ast-conformance.mjs
scripts/ast-conformance.mjs:81:   resources/ast-schema.json
scripts/ast-conformance.mjs:397:  VALUE_DIVERGENCE_FILE
scripts/ast-conformance.mjs:513:  SPAN_DIVERGENCE_FILE
scripts/ast-conformance.mjs:547:  POSITION_WAIVER_FILE
scripts/ast-conformance.mjs:776:  package.json
scripts/ast-conformance.mjs:831:  the corpus
```

So two of three rows were handed to a checker that never took the job, the shape
markup-carve/carve#755 catalogs.

## What the re-measurement found

Measured against what this repo already holds: the pinned engine for carve-js,
and the committed ledgers `resources/ast-position-waivers.txt` and
`resources/ast-value-divergence.txt` for the satellites, since those files are
the recorded output of the run that drives them.

| row / claim | state | measured against |
| --- | --- | --- |
| carve-js shape (§3a triple) | correct | the pinned engine, live |
| carve-js positions | correct, understated: it named table cells and line-block content, and the ledger also permits a coalesced `text` run | position ledger |
| carve-rs shape (§3a) | correct | §3a transcript on the page |
| **carve-rs positions** | **WRONG.** Named the capped-container gap as live, citing markup-carve/carve#672, which closed 2026-08-05; its declaration lines were deleted the day after, and the OWED half of the ledger is now empty in all three engines | position ledger |
| **carve-php shape** | **WRONG.** Claimed "two field-name divergences left", citing markup-carve/carve-php#510, which closed 2026-08-01 on a full-corpus re-measurement reporting no schema finding; and said nothing about the one §3a divergence that IS declared | value ledger, closed issue |
| carve-php positions | correct, understated the same way as carve-js | position ledger |
| derived-engine row | correct | not reconciled by design, per `notReconciledBecause` |
| **heading-id paragraph** | **WRONG.** Still said carve-rs and carve-php publish no generated id, "a divergence declared in `resources/ast-value-divergence.txt`", six weeks after that line was deleted for no longer diverging | value ledger |

Parked, and said out loud rather than left as a false scope note: the carve-php
shape claim about FIELD NAMES cannot be measured from this repo at all. No ledger
here records field-name divergence - the schema panel gates it at zero against a
live checkout - so the row no longer makes such a claim, and the test header says
why.

## The check

One checker, reading the page and comparing every row to a measurement. Six
assertions, each stated so it can fail while the page is CORRECT
(markup-carve/carve#955), not only while a row is already wrong:

- every engine the position ledger names has a row, and each reconciled engine
  has one of its own;
- **a row names an issue only where a ledger still declares that debt** - the rot
  itself, in one line;
- a declared position gap is named in its own engine's row. Vacuous today because
  the OWED half is empty, and not a control: adding one owed line to the ledger
  fails it with the page untouched;
- a positions cell names exactly the permitted categories the ledger records for
  that engine, both directions, and a permitted type the phrase map does not know
  fails rather than defaulting to covered;
- an engine claiming §3a conformance has the measurement printed below the table;
- a paragraph pointing at the value ledger names only fields it still declares.

Per markup-carve/carve#966 none of this is the authority on what the page should
say. It reports where the page and a committed ledger disagree, and the ledger is
the side that was measured.

## The line-number citations are gone, not renumbered

Five clauses were cited by line from four files and every one had drifted.
Renumbering is the obvious fix and it is not a fix: the corrected numbers filed
with the ticket were already stale, putting the narrowing clause at 131 when it
is at 142, and reporting 113 as landing on the §4 exception when 113 is the
codepoint sentence. For the record, the current lines are 142, 136-142, 475 and
479 - and they will be wrong again next week, which is the point.

A citation now names a PHRASE, the phrases are pinned in
`scripts/spec/ast-page-anchors.mjs`, and a test requires each to occur on the
page exactly once. Rewording a clause fails until the citation follows; moving a
paragraph costs nothing.

## One smaller instance of the same family

The denylist loop says it covers "the four targets" and listed three.
`carveToAnsi` was imported and never called, so the terminal target PART 9 §25
names explicitly was asserted by nothing. It is in the loop now, and the pin
passes.
