### PR TITLE
spec: caption attachment says the same thing in every place it is said

### DIFF
--- a/docs/edge-cases.md
+++ b/docs/edge-cases.md
@@ -546,8 +546,9 @@ Normative statement: `resources/grammar.ebnf` PART 9 §10. Verified by corpus
 
 **Rule (normative, grammar PART 2):** a heading **ends at the newline**.
 Nothing folds into it - the next line begins whatever block it begins, exactly
-as after any other closed block. A caption (`^ `) still attaches to it (§4),
-because attachment is not continuation.
+as after any other closed block. A `^ ` caption line is no exception: it does
+not fold in, and it does not attach either, because a heading is not one of
+§4's captionable hosts. It opens an ordinary paragraph.
 
 The heading id derives from that single line.
 

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -2086,7 +2086,7 @@ int main() {}
 
 ## Single-line headings
 
-A heading **ends at the newline**. Nothing folds into it: the next line begins whatever block it begins, exactly as after any other closed block. This diverges from djot deliberately — djot folds a following plain line into the heading, which is a silent corruption for anyone arriving from Markdown, and `divergence-from-djot` §7 already broke from djot on the mirror case. A caption (`^ …`) still attaches via §4, because attachment is not continuation. The heading id is built from the single line. (Setext underline headings remain intentionally excluded.)
+A heading **ends at the newline**. Nothing folds into it: the next line begins whatever block it begins, exactly as after any other closed block. This diverges from djot deliberately — djot folds a following plain line into the heading, which is a silent corruption for anyone arriving from Markdown, and `divergence-from-djot` §7 already broke from djot on the mirror case. A `^ …` caption line is no exception: it does not fold in, and it does not attach either, because a heading is not one of §4's captionable hosts - it opens an ordinary paragraph. The heading id is built from the single line. (Setext underline headings remain intentionally excluded.)
 
 ::: compare
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -442,8 +442,18 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
    newline inside the `h1`. A Djot document that wraps a heading therefore
    renders differently in Carve; `carve lint --from-djot` reports it.
 
-   A caption (`^ ` ...) still attaches to a heading (§4) -- attachment is not
-   continuation, and the caption is its own construct on its own line.
+   A `^ ` caption line is no exception: it does not fold in, and it does not
+   attach either, because a heading is NOT one of §4's captionable hosts. It
+   opens an ordinary paragraph of its own.
+
+     # H              -> <h1>H</h1> then <p>^ cap</p>
+     ^ cap
+
+   This sentence used to read "a caption still attaches to a heading (§4)",
+   citing as its authority the very clause whose enumeration omits a heading,
+   and no engine attaches one. A false claim carrying a true citation is worse
+   than a bare one: a reader who checks the reference finds the opposite and has
+   no way to tell which of the two is the language (carve#991).
 
    NO TRAILING ATTRIBUTES (djot-strict). A heading line carries NO trailing
    `{...}` attribute block: a `{...}` at the end of a heading line is ordinary
@@ -1037,11 +1047,18 @@ caption_continuation_line = inline_content, newline ;  (* a PLAIN line only *)
    caption text `cap\nmore`. The caption id (`#` placeholder) and cross-reference
    targeting use the full folded text. *)
 caption_slot = [blank_line], caption ;
-(* FORMAL adjacency (PART 9 §4, now structural): a caption attaches to the
-   immediately preceding captionable block, with AT MOST ONE blank line
-   between them -- the optional blank_line in caption_slot is the whole
-   allowance. Host productions reference caption_slot; a `^ ` line anywhere
-   else is ordinary inline/paragraph content. *)
+(* FORMAL adjacency (PART 9 §4): a caption attaches to the immediately
+   preceding captionable block, with AT MOST ONE blank line between them --
+   the optional blank_line in caption_slot is the whole allowance.
+
+   THREE OF THE FIVE HOSTS REFERENCE THIS SLOT: `code_block`, `blockquote` and
+   `table`. §4's other two -- the image paragraph and the standalone
+   display-math block -- attach the same caption under the same allowance, but
+   there is no production to hang the slot on, so for them §4 is the whole
+   rule. §4 says which, and why. A `^ ` line that follows neither a slot-
+   carrying host nor one of those two is ordinary inline/paragraph content.
+   (Reading this note as "only a production attaches a caption" would make a
+   captioned image a paragraph, which §4 denies and no engine does.) *)
 
 (* CAPTION NUMBER PLACEHOLDER -- NORMATIVE.
    The FIRST bare `#` in a caption's TOP-LEVEL inline_content is a number
@@ -3052,14 +3069,42 @@ EOF = (* end of file *) ;
         `//x//` and `__x__` (corpus 74-doubled-emphasis-delimiters). The
         braced-only `^`/`,` are not bare, so `^^x^^` is likewise literal.
 
-   4. CAPTION PLACEMENT -- FORMALIZED (caption_slot in PART 2). A `^ `
-      caption attaches via the [caption_slot] slot of the captionable
-      hosts: an image paragraph, a blockquote, a table, a fenced code block
+   4. CAPTION PLACEMENT -- ONE RULE, TWO SPELLINGS (caption_slot in PART 2).
+      A `^ ` caption attaches to exactly five captionable hosts: an image
+      paragraph, a blockquote, a table, a fenced code block
       (a captioned code block is a numbered LISTING), or a standalone
       display-math block (a numbered EQUATION; the block must be solely the
-      `$$`…`` span). caption_slot's single optional blank_line IS the
-      "one blank line allowed between block and caption" rule -- structural
-      now, not prose.
+      `$$`…`` span). The allowance is the same for all five: adjacent OR exactly
+      one blank line attaches, two blank lines detach and leave the `^ ` line
+      an ordinary paragraph.
+
+      WHERE THAT ALLOWANCE IS WRITTEN DOWN differs, and saying so is the point
+      of this paragraph. For THREE hosts it is STRUCTURAL -- `code_block`,
+      `blockquote` and `table` each end in `[caption_slot]` (PART 2), and
+      caption_slot's single optional blank_line IS the rule. For the IMAGE
+      PARAGRAPH and the STANDALONE DISPLAY-MATH BLOCK it is PROSE: this
+      clause is the rule, and PART 3 already says so beside `image` ("there
+      is no separate grammar production for the pair").
+
+      NOT AN OVERSIGHT. Neither of those two has a production to hang the slot
+      on. Both ARE a `paragraph` (PART 2), and what distinguishes them -- a
+      paragraph whose whole content is one image, a paragraph that is solely
+      the display-math span -- is a condition on that paragraph's inline
+      content, the same not-context-free class as PART 7's cell_content ("may
+      not contain an unescaped `|`") and §15's block_attributes. Two ways to
+      formalize it fail on inspection: hanging `[caption_slot]` on `paragraph`
+      itself would make EVERY paragraph captionable, which this enumeration
+      denies and no engine does; and a separate image / math paragraph
+      production would duplicate `paragraph` ambiguously AND inherit its
+      trailing `[blank_line]`, so the one blank line the slot exists to
+      account for could be consumed by either optional -- structural in
+      spelling and undecided in fact.
+
+      One rule, two spellings, not two rules. An engine implements this
+      clause; it does not implement three productions and then guess at the
+      remaining two hosts. This paragraph used to end "structural now, not
+      prose", which was true of three hosts out of five and read as true of
+      all five (carve#991).
 
    5. TABLE MODEL -- OPERATIONAL SEMANTICS (cell split, row validity,
       header cells, span walk, continuation rows, delimiter row, row


### PR DESCRIPTION
Caption attachment was stated in a dozen places across this repo and they did not
agree. Nothing here changes behavior: every statement below was checked against
what the engines already do, and the correction always moved the sentence, never
the language.

## What was wrong

**A heading was named as a captionable host, citing the clause that omits it.**
`resources/grammar.ebnf:445` said "a caption still attaches to a heading (section
4) - attachment is not continuation". PART 9 section 4 enumerates five hosts and a
heading is not one of them. A false claim carrying a true-looking citation is
worse than a bare one: a reader who follows the reference finds the opposite and
has no way to tell which of the two is the language.

The sentence was answering a real question, though. The clause around it is about
a heading ending at its newline and nothing folding in, and a reader does need to
know what a following `^ ` line does. So the true half is kept and the answer
corrected: the line does not fold in, and it does not attach either, because a
heading is not a captionable host. It opens an ordinary paragraph.

**The same claim was stated twice more, outside the grammar.** `docs/edge-cases.md`
section 18 and `docs/examples/edge-cases.md`'s single-line-headings section each
carried their own copy, each citing section 4 the same way. Both are corrected in
the same PR. Neither the audit nor the grammar sweep found these, because both
looked only at `resources/grammar.ebnf`; they turned up in review.

**"Structural now, not prose" was true of three hosts out of five.** `caption_slot`
is referenced by `code_block`, `blockquote` and `table`. The image paragraph and
the standalone display-math block have no production to hang the slot on, which
PART 3 already says beside `image` ("there is no separate grammar production for
the pair"). Read literally, the note beside `caption_slot` also said that a `^ `
line outside a slot-carrying production is ordinary content, which would make a
captioned image a paragraph.

## Which route change 2 took, and why the other was wrong

The ticket offered two routes: give the image paragraph and the display-math block
a real `[caption_slot]`, or amend the sentence to say which hosts are structural
and which are prose. **This PR takes the second route**, and writes the reason for
it into the clause so the next reader does not have to rediscover it.

Adding productions is wrong here for three separate reasons, each checkable in the
file:

1. **There is nothing to hang the slot on, and the missing thing is not
   context-free.** Both hosts *are* a `paragraph` (`grammar.ebnf:1403`). What
   distinguishes them - a paragraph whose whole content is one image, a paragraph
   that is solely the display-math span - is a condition on that paragraph's inline
   content. That is the same class the file already flags twice as inexpressible:
   PART 7's `cell_content` ("may not contain an unescaped `|` ... the exception is
   not expressible context-free") and section 15's `block_attributes` ("NOT
   context-free").
2. **Hanging `[caption_slot]` on `paragraph` itself would make every paragraph
   captionable.** Section 4's enumeration denies that, and no engine does it.
3. **A separate image / math paragraph production would be ambiguous in exactly the
   place the slot exists to disambiguate.** It would duplicate `paragraph`, and it
   would inherit its trailing `[blank_line]` - while `caption_slot` *begins* with
   `[blank_line]`. The one blank line the slot exists to account for could then be
   consumed by either optional. The three hosts that do carry the slot have no such
   problem: `blockquote_line`, `table_row` and `fenced_code_block` all end at a
   `newline`, not at an optional blank line. Structural in spelling, undecided in
   fact, is worse than prose that is right.

The executable oracle already works this way, which is the corroboration rather
than the argument: `scripts/spec/layout.mjs` attaches a caption to the three slot
hosts structurally, and reaches the image and math hosts by testing whether a
one-line paragraph is *solely* an image or *solely* a `$$` span - and for a
reference image it cannot even decide in that pass, deferring to a post-pass once
the definitions are known. That is not a shape a production expresses.

So the clause now says: one rule, two spellings, not two rules. The allowance is
identical for all five hosts (adjacent or exactly one blank line attaches, two
blank lines detach); for three of them it is written in a production, for two of
them this clause is where it is written, and the clause says why. The section 4
heading also loses its `-- FORMALIZED` marker, which announced a formalization
that reached three hosts out of five.

## How many statements there actually are

The audit counted from one read of the grammar and named three productions. A full
sweep of `resources/grammar.ebnf` classified into productions, citations and
restatements finds **18 statements bearing on caption attachment**: 4 productions
(the three hosts plus `caption_slot` itself), 2 normative sentences (the host
enumeration and the blank-line allowance), 1 citation, and 11 restatements. Two of
those the audit did not name are worth calling out
because they are load-bearing rather than decorative:

- `grammar.ebnf:4121` independently restates the display-math host from PART 9
  section 18.
- `grammar.ebnf:5457` restates the image host from the `fmt` writer's side ("an
  image followed by a caret line stays a paragraph instead of being promoted to a
  figure"), which is why the caret is an unconditional escape.

Adding the two prose copies in `docs/` brings the repo total to 20.

The sweep also looked for a seventh host that neither the audit nor section 4
names - a list, a list item, a div or admonition, a footnote, a raw block, an
include, a definition list, a figure fence, an img fence, a thematic break, a
generic paragraph. There is none. The near misses are all negative or output-side
statements: `grammar.ebnf:1027` names a div, a thematic break and a comment as
things that *end* a caption, not hosts that receive one; `grammar.ebnf:4140` and
`:4953` name figure/table/listing/equation as *rendered kinds*, not input hosts;
`grammar.ebnf:6690`'s "reference image's caption" is the image host under a
different image spelling.

## Scope

No corpus document moves and no engine changes; `docs/` edits are prose beside the
fenced examples, not the examples themselves. This is a spec-internal consistency
fix.

The ticket stays **open**. Two of its four items are deliberately not in this PR:

- **Item 3 (four corpus rows pinning the one-blank-line form).** Those rows pin
  behavior that already holds, so an A/B on them cannot fail. They need a named
  mutation to justify them - removing the optional `blank_line` from
  `caption_slot` - together with a statement of which documents that mutation
  breaks. Today it breaks exactly one (`55-blockquote-caption-after-a-blank-line`),
  which is precisely why the rows are wanted and also why adding them casually
  would be adding four checks that cannot fail. Separate work, with its own care.
- **Item 4 (measure carve-php and carve-rs on the seven-host grid).** Both
  checkouts are under edit by the fence-boundary work, so any reading taken now
  would be fabricated. That half stays owed and stays stated as owed.

Draft overlap: draft #291 (file inclusion) touches `resources/grammar.ebnf` and
`docs/examples/edge-cases.md`, and draft #444 (migration prep) touches
`docs/examples/edge-cases.md`. Both are WARN, not BLOCK - no topic overlap with
captions, no link to this ticket. Expect a rebase on whichever lands first.

## Lock discipline on this PR, stated because it is a deviation

The org sweep lock was held continuously by another run for the whole session and never came free, so this branch was prepared without it and is being pushed without it.

The hazard that lock exists to prevent is a fabricated cross-engine diff produced by reading an engine checkout while another run is editing it. **No cross-engine step was run for this PR and none is cited.** Every gate quoted above is self-contained to this repository: `npm test`, `npm run corpus:build` (byte-identical), `npm run core:check`, and the clause inventory. The host grid was measured against this repository's own pinned `@markup-carve/carve` devDependency, which no other run touches.

carve-php and carve-rs remain unmeasured on caption attachment, and that half stays owed rather than being reported as done.
