### PR TITLE
spec: the one-blank-line caption form is pinned on the four hosts that lacked it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `resources/engine-pin-drift.txt`; the two loose ones reproduce in the pinned
   build already, which is what makes them controls rather than coverage.
 
+- **PART 9 §4: the one-blank-line caption allowance is pinned on every host**
+  (carve#991). §4 gives one rule for all five captionable hosts - adjacent OR
+  exactly one blank line attaches - but the corpus held exactly ONE document
+  separating a host from its caption with a blank line, and it was a blockquote,
+  one of the three hosts whose production already ends in `[caption_slot]`. The
+  allowance was unpinned for the table, the fenced code block, the image
+  paragraph and display math, and for the last two it is PROSE rather than
+  structural, so nothing held it at all. A reader could have dropped the
+  blank-line form on four of five hosts and stayed green. New category
+  `281-a-caption-attaches-across-one-blank-line` pins the four, each preceded by
+  the same document with the blank line removed, which must render identically.
+  No behavior changes; every one of the eight is what the engines already do.
+
 - **PART 9 §17 L1a: a list item's first block does not decide loose or tight.**
   L1 asks whether the item holds a blank-line-separated second paragraph, not
   what its first block was. `- - a` followed by a blank line and `Body.` is

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -14406,3 +14406,235 @@ b</p>
 ```
 
 :::::
+
+## A caption attaches across one blank line
+
+PART 9 §4 gives one rule for all five captionable hosts: adjacent OR exactly one
+blank line attaches, two blank lines detach and leave the `^ ` line an ordinary
+paragraph. WHERE that rule is written down differs, and that is the whole reason
+this category exists. For the fenced code block, the block quote and the table it
+is STRUCTURAL - each production ends in `[caption_slot]`, and that slot's single
+optional `blank_line` IS the allowance. For the IMAGE PARAGRAPH and the
+STANDALONE DISPLAY-MATH BLOCK it is PROSE, because neither has a production to
+hang the slot on: both ARE a `paragraph`, and what distinguishes them is a
+condition on that paragraph's inline content (carve#991, carve#992).
+
+One rule, two spellings, and the corpus could tell them apart only for one host.
+Of the twenty documents carrying a `^ ` caption line, exactly ONE separated the
+host from its caption with a blank line - `55-blockquote-caption-after-a-blank-line`
+- and blockquote is one of the three hosts that has the slot. The allowance was
+unpinned for the other four, and for the two prose hosts it was unpinned
+structurally as well. A reader could have dropped the blank-line form on four of
+five hosts and stayed green.
+
+Four rows below pin it, one per remaining host. Each is preceded by the SAME
+document with the blank line taken out, which must render identically: that is
+the actual claim - not that a caption attaches, which is already pinned all over
+the corpus, but that these two spellings are ONE rule and produce one answer. The
+adjacent members are controls. They are unaffected by any mutation of the
+allowance, and they are here so a row cannot be satisfied by a reader that has
+stopped attaching captions altogether.
+
+### A table caption, adjacent
+
+The control for the row below. `09-tables` already pins this shape; it is
+repeated here so the pair reads as a pair and the two documents differ by exactly
+one line.
+
+::::: compare
+
+```carve
+|= Fruit |= Price |
+| Apple  | $1     |
+^ Fruit prices
+```
+
+```html
+<table>
+  <caption>Fruit prices</caption>
+  <thead><tr><th>Fruit</th><th>Price</th></tr></thead>
+  <tbody>
+    <tr><td>Apple</td><td>$1</td></tr>
+  </tbody>
+</table>
+```
+
+:::::
+
+### A table caption, after one blank line
+
+`table` ends in `[caption_slot]`, so this is the structural spelling. Byte for
+byte the same output as the row above.
+
+::::: compare
+
+```carve
+|= Fruit |= Price |
+| Apple  | $1     |
+
+^ Fruit prices
+```
+
+```html
+<table>
+  <caption>Fruit prices</caption>
+  <thead><tr><th>Fruit</th><th>Price</th></tr></thead>
+  <tbody>
+    <tr><td>Apple</td><td>$1</td></tr>
+  </tbody>
+</table>
+```
+
+:::::
+
+### A code block caption, adjacent
+
+The control. A captioned code block is a numbered LISTING (§4), and the
+`<figure>` wrapper is what carries the caption.
+
+::::: compare
+
+````carve
+```python
+def greet():
+    return 1
+```
+^ Listing: a greeting
+````
+
+```html
+<figure>
+  <pre><code class="language-python">def greet():
+    return 1
+</code></pre>
+  <figcaption>Listing: a greeting</figcaption>
+</figure>
+```
+
+:::::
+
+### A code block caption, after one blank line
+
+The second structural host. The blank line sits between the fence's CLOSER and
+the caption, which is the position `caption_slot`'s optional `blank_line`
+describes: `fenced_code_block` ends at a newline, so there is no competing
+optional for the blank to be consumed by.
+
+::::: compare
+
+````carve
+```python
+def greet():
+    return 1
+```
+
+^ Listing: a greeting
+````
+
+```html
+<figure>
+  <pre><code class="language-python">def greet():
+    return 1
+</code></pre>
+  <figcaption>Listing: a greeting</figcaption>
+</figure>
+```
+
+:::::
+
+### An image caption, adjacent
+
+The control. `08-image-with-caption` pins this shape too; the pair is repeated
+here for the same reason the table pair is.
+
+::::: compare
+
+```carve
+![Apollo 11](apollo.jpg)
+^ Figure 1: First moon landing
+```
+
+```html
+<figure>
+  <img src="apollo.jpg" alt="Apollo 11">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>
+```
+
+:::::
+
+### An image caption, after one blank line
+
+The first of the two PROSE hosts, and the one an author reaches for most often.
+There is no `image_paragraph` production and no slot: §4 is the rule, and PART 3
+says beside `image` that "there is no separate grammar production for the pair".
+
+So this row is the only thing that holds the allowance for this host. Nothing
+structural does.
+
+::::: compare
+
+```carve
+![Apollo 11](apollo.jpg)
+
+^ Figure 1: First moon landing
+```
+
+```html
+<figure>
+  <img src="apollo.jpg" alt="Apollo 11">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>
+```
+
+:::::
+
+### A display-math caption, adjacent
+
+The control. A captioned standalone display-math block is a numbered EQUATION
+(§4); the block must be solely the `$$`…`` span.
+
+::::: compare
+
+```carve
+$$`E = mc^2`
+^ Equation: mass-energy
+```
+
+```html
+<figure>
+  <p><span class="math display">\[E = mc^2\]</span></p>
+  <figcaption>Equation: mass-energy</figcaption>
+</figure>
+```
+
+:::::
+
+### A display-math caption, after one blank line
+
+The second PROSE host, and the same argument as the image paragraph: this block
+IS a `paragraph`, distinguished by a condition on its inline content, so no slot
+can be hung on it without making every paragraph captionable. §4 is the rule and
+this row is the pin.
+
+::::: compare
+
+```carve
+$$`E = mc^2`
+
+^ Equation: mass-energy
+```
+
+```html
+<figure>
+  <p><span class="math display">\[E = mc^2\]</span></p>
+  <figcaption>Equation: mass-energy</figcaption>
+</figure>
+```
+
+:::::
+
+Nothing here is new behavior. Every one of these eight documents is what
+carve-js already produced when the drift audit measured the five hosts across
+three separations, which is what makes them committable as a pin rather than a
+proposal.

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -68,7 +68,8 @@ Corpus added since this run: `254-colon-fence-separator-must-be-a-space`,
 `277-a-below-column-marker-after-a-comment-where-no-paragraph-is-open`,
 `278-a-list-marker-at-the-content-column-inside-an-open-fence`,
 `279-a-boundary-line-inside-an-open-fence-does-not-end-the-container`,
-`280-a-container-a-lazy-line-folded-into-is-still-open`.
+`280-a-container-a-lazy-line-folded-into-is-still-open`,
+`281-a-caption-attaches-across-one-blank-line`.
 
 Those categories landed on hosts that could not retake the run above, so its
 numbers describe the corpus WITHOUT them. The alternative was to edit the

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 848 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 856 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-2.crv
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-2.crv
@@ -1,0 +1,4 @@
+|= Fruit |= Price |
+| Apple  | $1     |
+
+^ Fruit prices

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-2.html
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-2.html
@@ -1,0 +1,7 @@
+<table>
+  <caption>Fruit prices</caption>
+  <thead><tr><th>Fruit</th><th>Price</th></tr></thead>
+  <tbody>
+    <tr><td>Apple</td><td>$1</td></tr>
+  </tbody>
+</table>

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-3.crv
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-3.crv
@@ -1,0 +1,5 @@
+```python
+def greet():
+    return 1
+```
+^ Listing: a greeting

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-3.html
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-3.html
@@ -1,0 +1,6 @@
+<figure>
+  <pre><code class="language-python">def greet():
+    return 1
+</code></pre>
+  <figcaption>Listing: a greeting</figcaption>
+</figure>

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-4.crv
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-4.crv
@@ -1,0 +1,6 @@
+```python
+def greet():
+    return 1
+```
+
+^ Listing: a greeting

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-4.html
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-4.html
@@ -1,0 +1,6 @@
+<figure>
+  <pre><code class="language-python">def greet():
+    return 1
+</code></pre>
+  <figcaption>Listing: a greeting</figcaption>
+</figure>

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-5.crv
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-5.crv
@@ -1,0 +1,2 @@
+![Apollo 11](apollo.jpg)
+^ Figure 1: First moon landing

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-5.html
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-5.html
@@ -1,0 +1,4 @@
+<figure>
+  <img src="apollo.jpg" alt="Apollo 11">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-6.crv
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-6.crv
@@ -1,0 +1,3 @@
+![Apollo 11](apollo.jpg)
+
+^ Figure 1: First moon landing

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-6.html
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-6.html
@@ -1,0 +1,4 @@
+<figure>
+  <img src="apollo.jpg" alt="Apollo 11">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-7.crv
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-7.crv
@@ -1,0 +1,2 @@
+$$`E = mc^2`
+^ Equation: mass-energy

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-7.html
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-7.html
@@ -1,0 +1,4 @@
+<figure>
+  <p><span class="math display">\[E = mc^2\]</span></p>
+  <figcaption>Equation: mass-energy</figcaption>
+</figure>

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-8.crv
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-8.crv
@@ -1,0 +1,3 @@
+$$`E = mc^2`
+
+^ Equation: mass-energy

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line-8.html
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line-8.html
@@ -1,0 +1,4 @@
+<figure>
+  <p><span class="math display">\[E = mc^2\]</span></p>
+  <figcaption>Equation: mass-energy</figcaption>
+</figure>

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line.crv
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line.crv
@@ -1,0 +1,3 @@
+|= Fruit |= Price |
+| Apple  | $1     |
+^ Fruit prices

--- a/tests/corpus/281-a-caption-attaches-across-one-blank-line.html
+++ b/tests/corpus/281-a-caption-attaches-across-one-blank-line.html
@@ -1,0 +1,7 @@
+<table>
+  <caption>Fruit prices</caption>
+  <thead><tr><th>Fruit</th><th>Price</th></tr></thead>
+  <tbody>
+    <tr><td>Apple</td><td>$1</td></tr>
+  </tbody>
+</table>

--- a/tests/spec/281-a-caption-attaches-across-one-blank-line.test
+++ b/tests/spec/281-a-caption-attaches-across-one-blank-line.test
@@ -1,0 +1,103 @@
+A caption attaches across one blank line
+
+```
+|= Fruit |= Price |
+| Apple  | $1     |
+^ Fruit prices
+.
+<table>
+  <caption>Fruit prices</caption>
+  <thead><tr><th>Fruit</th><th>Price</th></tr></thead>
+  <tbody>
+    <tr><td>Apple</td><td>$1</td></tr>
+  </tbody>
+</table>
+```
+
+```
+|= Fruit |= Price |
+| Apple  | $1     |
+
+^ Fruit prices
+.
+<table>
+  <caption>Fruit prices</caption>
+  <thead><tr><th>Fruit</th><th>Price</th></tr></thead>
+  <tbody>
+    <tr><td>Apple</td><td>$1</td></tr>
+  </tbody>
+</table>
+```
+
+````
+```python
+def greet():
+    return 1
+```
+^ Listing: a greeting
+.
+<figure>
+  <pre><code class="language-python">def greet():
+    return 1
+</code></pre>
+  <figcaption>Listing: a greeting</figcaption>
+</figure>
+````
+
+````
+```python
+def greet():
+    return 1
+```
+
+^ Listing: a greeting
+.
+<figure>
+  <pre><code class="language-python">def greet():
+    return 1
+</code></pre>
+  <figcaption>Listing: a greeting</figcaption>
+</figure>
+````
+
+```
+![Apollo 11](apollo.jpg)
+^ Figure 1: First moon landing
+.
+<figure>
+  <img src="apollo.jpg" alt="Apollo 11">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>
+```
+
+```
+![Apollo 11](apollo.jpg)
+
+^ Figure 1: First moon landing
+.
+<figure>
+  <img src="apollo.jpg" alt="Apollo 11">
+  <figcaption>Figure 1: First moon landing</figcaption>
+</figure>
+```
+
+```
+$$`E = mc^2`
+^ Equation: mass-energy
+.
+<figure>
+  <p><span class="math display">\[E = mc^2\]</span></p>
+  <figcaption>Equation: mass-energy</figcaption>
+</figure>
+```
+
+```
+$$`E = mc^2`
+
+^ Equation: mass-energy
+.
+<figure>
+  <p><span class="math display">\[E = mc^2\]</span></p>
+  <figcaption>Equation: mass-energy</figcaption>
+</figure>
+```


### PR DESCRIPTION
Item 3 of #991. The clause half landed as #992; item 4 is not touched here and the ticket stays open for it.

## What was unpinned

PART 9 §4 gives one rule for all five captionable hosts: adjacent OR exactly one blank line attaches, two blank lines detach. The corpus held **exactly one** document separating a host from its caption with a blank line, `55-blockquote-caption-after-a-blank-line`, and blockquote is one of the three hosts whose production already ends in `[caption_slot]`. So the one spelling the corpus could see was also the one the grammar could state.

For the image paragraph and the standalone display-math block the allowance is PROSE, not structural: neither has a production to hang the slot on, both ARE a `paragraph`, and §4 is the whole rule (#992 settled that and explained why the two structural alternatives fail). Those two were unpinned twice over.

## The rows

Eight documents, four pairs, in new category `281-a-caption-attaches-across-one-blank-line`. Each pinned row is preceded by the SAME document with the blank line removed.

| pair | host | spelling |
|---|---|---|
| `281-…-1` / `281-…-2` | table | adjacent / one blank line |
| `281-…-3` / `281-…-4` | fenced code block | adjacent / one blank line |
| `281-…-5` / `281-…-6` | image paragraph | adjacent / one blank line |
| `281-…-7` / `281-…-8` | standalone display math | adjacent / one blank line |

The claim is the IDENTITY, not that a caption attaches: twenty corpus documents already pin that. Each pair renders byte-identical output, verified before the rows were written.

## The mutation, measured before and after

The mutation the ticket names is removing the optional `blank_line` from `caption_slot`. In the executable spec that is the blank-skip at each of the four caption sites in `scripts/spec/layout.mjs`.

**Before these rows it broke exactly ONE document. After them it breaks FIVE**, which is the number the ticket asked for.

Per site, so no row rides on another:

| mutation, one site at a time | documents it kills |
|---|---|
| the `code_block` site | `281-…-4` |
| the `table` site | `281-…-2` |
| the `blockquote` site | `55-blockquote-caption-after-a-blank-line` |
| the shared image / display-math site | `281-…-6`, `281-…-8` |
| all four at once | all five above |

Before this PR, three of those four single-site mutations killed NOTHING. The image and display-math site is one site because both hosts are a `paragraph` distinguished by its inline content, which is exactly the reason #992 gave for not giving them a production.

## Controls, labelled as such

`281-…-1`, `281-…-3`, `281-…-5` and `281-…-7`, the four adjacent halves, are **controls**. No mutation of the allowance touches them; they are green before and after. They are in the PR so a row cannot be satisfied by a reader that stopped attaching captions altogether, and they make each pair differ by exactly one line.

Two of them, the table and the image, duplicate a shape `09-tables` and `08-image-with-caption` already pin. That is deliberate and is the cost of the pairs reading as pairs in one place; it is not additional coverage and is not counted as any.

## A gap this measured and did NOT close

While building the mutation table, one more mutation was run: widen the allowance from exactly one blank line to ANY number of blank lines. **It kills nothing, in all 856 documents.** The "two blank lines detach" half of §4 is pinned nowhere, for any of the five hosts, and still is after this PR.

That is outside item 3, which names the one-blank-line form only, so no row was added for it. Worth its own ticket.

## Corpus mechanics

Appended as a new category at the END of `docs/examples/edge-cases.md`, the only append-safe position, so `281` lands above the previous maximum and nothing renumbers. 848 pairs become 856. `npm run corpus:build` is idempotent and the diff is the eight new pairs plus one new `.test` file. **No existing golden moved.**

`docs/index.md` moves 848 to 856 because a test asserts the landing page quotes the real corpus size.

## Why the comparison page is declared rather than re-measured

Two tests assert `docs/implementation-comparison.md` quotes the real CORE corpus size, which these rows move from 675 to 683. The category is added to that page's "Corpus added since this run" list, which is the mechanism the page already has for exactly this.

The alternative was `npm run compare:counts`, which drives the three engine checkouts. That is a cross-engine step, it is not this repo's own gate, and another agent may be finishing `markup-carve/carve-rs#813` right now, so a reading taken from those checkouts could be fabricated. Editing the denominators by hand would publish a three-engine measurement nobody took. Declaring the lag is the accurate statement, and it is the same route the twenty-seven categories already on that list took.

## Gates

`npm test` 1854 pass / 0 fail / 1 skip. `npm run core:check` 856/856 conformant, 0 defects, 0 refused, 0 sentinel leaks. `npm run corpus:build` idempotent. `npm run engine:report -- --check` reproduces all eight new documents against the pinned build with no new drift declared, which is the self-contained evidence that these pin EXISTING behavior. The clause inventory is unchanged: no `-- NORMATIVE` heading is touched, `resources/grammar.ebnf` has no diff and `resources/normative-clauses.txt` has no diff.

**No cross-engine step was run or cited.** `compare:counts` and `compare:impls` were deliberately not run, for the reason given above.

## Drafts

`draft-check` reports WARN, not BLOCK, on two: draft `#291` (file inclusion) and draft `#444` (migration prep) both touch `docs/examples/edge-cases.md`, and `#444` also touches `docs/index.md`. Neither is about captions and neither touches `resources/grammar.ebnf` in a caption production. Expect a rebase on whichever lands first.

## What remains on the ticket

**Item 4 only**: measure carve-php and carve-rs on the same seven-host grid, three separations each. Not attempted here for the same reason it was deferred on the audit, and the ticket stays open for it.
