### PR TITLE
docs: a collapsed reference's ref is the resolution key, said in as many words

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -99,6 +99,28 @@ For the collapsed form `[getting started][]`, `ref` is the **derived** label
 (`getting started`) - the label the reference resolves by. `rawRef` holds the
 authored spelling, so the empty brackets are not lost.
 
+Where the label carries inline markup the two readings of "derived" part, and
+**`ref` is the resolution key** - the string the reference matched on, not the
+label as authored. Given
+
+```
+# `code()` heading
+
+[`code()` heading][]
+```
+
+the reference publishes:
+
+```json
+{ "type": "link", "href": "#code-heading", "ref": "code() heading", "rawRef": "[`code()` heading][]" }
+```
+
+The authored label is recoverable from `rawRef` by stripping its brackets; the
+key is recoverable from nothing, because `href` holds the SLUG
+(`#code-heading`), a different string from the key. So `ref` carrying the key
+adds information, where carrying the authored label would only repeat `rawRef`.
+Ruled at [carve#962](https://github.com/markup-carve/carve/issues/962).
+
 **Type identifiers come from the [profiles vocabulary](/profiles)** (§1-2), and
 are `snake_case` always. The AST carries a few types a profile cannot deny -
 `document`, `smart_punctuation`, `literal_inline`, `tag`, `abbreviation_def` -
@@ -474,7 +496,7 @@ A row may name an issue only where one of those still declares the debt.
 |---|---|---|
 | carve-js | §3a conformant on the resolved form: publishes `href`, `ref` and `rawRef` together | every block and inline placed, except the two categories §4 exempts: a coalesced `text` run, and a table cell continued on a `+` line |
 | carve-rs | §3a conformant on the resolved form: `ref` and `rawRef` survive resolution beside `href` | every block and inline placed, except the coalesced `text` runs §4 exempts |
-| carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries a derived label in `ref` beside `rawRef`, the same label the other two publish - what remains open is which label it SHOULD be, a design question rather than a divergence ([carve#962](https://github.com/markup-carve/carve/issues/962)) | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the coalesced `text` runs §4 exempts |
+| carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries the resolution key in `ref` beside `rawRef`, the same label the other two publish | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the coalesced `text` runs §4 exempts |
 | carve-rb / carve-py / carve-go / carve-wasm | publish carve-rs's bytes | whatever carve-rs records |
 
 The gaps are listed rather than smoothed over on purpose: "six implementations"
@@ -515,11 +537,18 @@ to carry as open: whether the serialized tree is pre- or post-resolve (carve#481
 and carve-rs and carve-php flattening an unresolved reference (carve#486), both
 answered and both closed.
 
-What is NOT settled is WHICH label `ref` SHOULD carry when the label holds
-inline markup. The fleet is unanimous on it: given a collapsed reference whose
-label is `` `code()` heading ``, all three engines publish the heading's
-rendered text, `code() heading`. Measured on carve-js `5e3b723`, carve-rs
-`04f9284` and carve-php `9375df1`, each built from `main`.
+WHICH label `ref` carries when the label holds inline markup is now RULED, and
+the fleet already implements the ruling: given a collapsed reference whose label
+is `` `code()` heading ``, all three engines publish the heading's rendered
+text, `code() heading`. Measured on carve-js `5e3b723`, carve-rs `04f9284` and
+carve-php `9375df1`, each built from `main`.
+
+`resources/ast-value-divergence.txt` still declares `link.ref` as a divergence,
+in the pre-merge terms this paragraph used to use. That file is filled in by
+`npm run ast:check` driving three BUILT satellites, and it has not been re-run
+since js and rs moved. The ruling asks no engine to change, so what that line
+owes is a re-measurement rather than a fix - and until it is re-run, the SHAs
+above are the measured side and the ledger is the older claim.
 
 **This paragraph said the opposite until 2026-08-08**, recording carve-php as
 publishing the rendered text where the other two published the authored label.
@@ -529,12 +558,13 @@ written from the stale text then reasoned carve-php was the defective engine and
 filed against it, which would have made it the sole outlier and undone two
 merges.
 
-So what remains open is a design question rather than a divergence, and it is
-tracked at [carve#962](https://github.com/markup-carve/carve/issues/962): §3a's
-"the derived label" reads both ways, `rawRef` already holds the authored
-spelling, and if `ref` moved to the authored spelling too then the resolution key
-would be nowhere in the tree - `href` holds the SLUG (`#code-heading`), which is
-a different string from the key (`code() heading`).
+So it was a design question rather than a divergence, and it is ruled at
+[carve#962](https://github.com/markup-carve/carve/issues/962): `ref` carries the
+RESOLUTION KEY, and §3a above now says so instead of leaving "the derived label"
+to be read both ways. What decided it is that the authored label is recoverable
+from `rawRef` by stripping its brackets while the key is recoverable from
+nothing - `href` holds the SLUG (`#code-heading`), which is a different string
+from the key (`code() heading`).
 
 An earlier version of this paragraph recorded something different again - none
 publishing `rawRef`, carve-php publishing `ref: ""` - and the rows above


### PR DESCRIPTION
## The ambiguity

PART 12 section 3a says, for the collapsed form, that `ref` is "the **derived**
label - the label the reference resolves by". That sentence is true and it reads
two ways in exactly one case: when the label carries inline markup, "derived" can
mean *derived from the empty brackets* (the source text between `[` and `]`,
backticks intact) or *the string resolution actually matched on*. Every example
the clause gives has a plain label, where the two coincide, which is why it went
unstated long enough for three engines to be read as disagreeing about it.

## The ruling

`ref` is the RESOLUTION KEY. The page now says so, with the worked example that
separates the two readings:

```
# `code()` heading

[`code()` heading][]
```

```json
{ "type": "link", "href": "#code-heading", "ref": "code() heading", "rawRef": "[`code()` heading][]" }
```

and with the argument that decides it: the authored label is recoverable from
`rawRef` by stripping its brackets, while the resolution key is recoverable from
nothing, because `href` holds the SLUG (`#code-heading`), a different string from
the key (`code() heading`). So `ref` carrying the key adds information, where
carrying the authored label would only repeat `rawRef`.

No engine moves. All three already publish the key.

## Two other passages on the same page needed correcting

Both called the question open, which was accurate when written and is not now.

- The carve-php conformance row said "what remains open is which label it SHOULD
  be" and cited the ticket. Per that table's own contract a row states measured
  state and the history goes in the prose below it, so the row now names what the
  engine publishes and drops the citation.
- The paragraph under the section-3a transcript block said "what is NOT settled is
  WHICH label". It records the ruling instead. The re-measurement with its engine
  SHAs and the stale-claim warning above it are kept intact.

Neither implied the authored reading, so nothing on the page contradicted the
ruling; what they contradicted was the fact that it had been made.

## One thing stated rather than fixed

`resources/ast-value-divergence.txt` still declares `link.ref` as a divergence in
the pre-merge terms, describing carve-php as the outlier. That file is filled in
by `npm run ast:check` driving three BUILT satellites, and has not been re-run
since `markup-carve/carve-js#875` and `markup-carve/carve-rs#799` moved js and rs
onto the key. The ruling asks no engine to change, so what that line owes is a
re-measurement, not a fix, and deleting it drives engine checkouts. The page now
says this in place, so the contradiction is dated rather than silent.

## Lock

This took the PER-REPO lock `markup-carve.carve`, not `markup-carve.sweep`. The
change touches only `docs/ast-json.md`, a `*.md` file outside `docs/examples/`,
so it moves no corpus document and drives no engine checkout. Three other agents
are contending for the sweep lock and this had no reason to join that queue.

## Drafts

`draft-check` is CLEAR. Draft `markup-carve/carve#444`
(`docs/quote-admonition-titles`) is the docs-overlapping draft worth naming: it
touches ten pages under `docs/`, none of them `docs/ast-json.md`, so there is no
file overlap and no topic overlap with the collapsed-reference clause.

Closes #962
