### PR TITLE
spec: fence length leaves the list of author choices fmt must not respell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **PART 11 §6 no longer protects a fence's length.** The section named three
+  author choices `fmt` must not respell, and its own argument backs two of them:
+  a spelling is preserved because THE AST RECORDS IT, and `code_block` records
+  no fence - neither its length nor its character. All three engines narrow a
+  four-backtick fence to three, and all three widen a fence to clear a run in
+  its content, so the round trip holds through both and the author's length is
+  load-bearing nowhere. The example is removed rather than implemented. The same
+  ruling answers the run-length question left open on the thematic break: the
+  marker field tracked at carve#976 carries the CHARACTER only, so `***` and
+  `*****` both come back as `***`.
+
 - **NORMATIVITY: the executable artifacts are derived checkers, and decide
   nothing.** `resources/carve-core.ohm` and `scripts/spec/*.mjs` execute what
   `resources/grammar.ebnf` states so a contradiction inside it becomes visible;

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -5584,9 +5584,36 @@ EOF = (* end of file *) ;
 
    6. WHAT IS NOT THE WRITER'S JOB. `fmt` does not re-wrap prose, reorder
       attributes, or respell a construct to a synonym (`*` vs `-` bullets,
-      fence length, ordered-list dialect). Those are the author's choices and
-      the AST records them; changing one would satisfy §1 while still
-      surprising the author.
+      ordered-list dialect). Those are the author's choices and the AST records
+      them; changing one would satisfy §1 while still surprising the author.
+
+      FENCE LENGTH WAS A THIRD EXAMPLE HERE AND IS NOT ONE (carve#1000). It is
+      removed rather than implemented, on this section's own second half: a
+      spelling is the author's to keep BECAUSE THE AST RECORDS IT, and
+      `code_block` records no fence at all (PART 12 §3). Neither the length of
+      the run nor the character it is made of survives the tree, so
+
+        ```js        all three publish the SAME node, and the writer
+        `````js      has nothing to reproduce
+        ~~~js
+
+      That is §6a's objection to the thematic break, reached one construct over:
+      a rule that cannot be applied leaves the question open rather than
+      answering it. The difference between the two is only that one was noticed.
+
+      THE WRITER COMPUTES THE WIDTH IT NEEDS, which is why removing the example
+      costs no document. A fence is widened to clear the longest fence-character
+      run in its content and narrowed when nothing requires the extra width, and
+      §1 holds through both: content carrying a three-backtick run keeps a
+      four-backtick opener, while plain content under a four-backtick opener
+      comes back as three. Measured in all three engines, and the narrowing row
+      is the one that matters -- it is the behavior this section forbade in
+      words and every engine performed, with the round trip intact through it.
+
+      So the mention was decorative. Had the writer instead relied on the
+      AUTHOR's length, removing it would have broken every document whose
+      content contains its own fence character, and the example would have been
+      load-bearing by accident rather than by design.
 
       NESTED BOLD ITALIC joins that list, and needed the AST to catch up before
       it could. `/*x*/` is a single production (`bold_italic`, PART 3) while
@@ -5632,6 +5659,14 @@ EOF = (* end of file *) ;
       carve#976. When the marker reaches the AST, §6 governs again and this
       clause is removed with the field that supersedes it -- so pinning `---`
       today forecloses nothing.
+
+      THE FIELD CARRIES THE MARKER CHARACTER, NOT THE RUN LENGTH (carve#1000).
+      `***` and `*****` are one spelling for this purpose, and both come back
+      as `***` -- the three-character width this clause already pins for `---`,
+      applied to whichever character the field names. The argument for
+      recording a length was §6's own mention of FENCE length, by analogy; that
+      mention has been removed as unimplemented, so the analogy points at
+      nothing and no construct's run length is recorded anywhere.
 
    6b. A FRONTMATTER OPENER IS WRITTEN `---yaml` -- NORMATIVE. The canonical
       writer spells the format token on the opening delimiter for EVERY


### PR DESCRIPTION
Closes #1000.

PART 11 section 6 named three spellings the canonical writer must not respell, and its own second half is the whole of the argument for all three: a spelling is the author's to keep BECAUSE THE AST RECORDS IT. The tree backs two of them.

- `list` carries `delim` and `bulletChar`, and says outright that a sibling list with a different marker is a different list.
- `code_block` carries `content`, `lang` and `header`, and nothing about the fence. A three, four and five backtick opener publish one node, and so does a tilde fence: neither the run's LENGTH nor its CHARACTER survives.

So section 6 could not be applied to fence length as written, which is section 6a's objection to the thematic break reached one construct over. The example is removed rather than implemented, per the ruling on the ticket.

## The precondition on the ruling, re-run

The signoff made the edit conditional on one thing: whether the writer relies on the AUTHOR's fence length or computes the width it needs. If it relies, the mention was load-bearing by accident and dropping it breaks every document whose content contains its own fence character.

It computes. The ticket measured this across carve-js, carve-php and carve-rs; re-run here through the carve-js revision this repo pins (`816c3a3`), comparing `carveToCarve` output and `carveToHtml` on both sides:

| content | author wrote | fmt opener | HTML equal |
|---|---|---|---|
| plain | 3 backticks | 3 backticks | yes |
| plain | 4 backticks | 3 backticks | yes |
| plain | 5 backticks | 3 backticks | yes |
| holds a 3-backtick run | 4 backticks | 4 backticks | yes |
| holds a 4-backtick run | 5 backticks | 5 backticks | yes |

The narrowing rows are the ones that matter: they are the behavior section 6 forbade in words and every engine performs, with the round trip intact through them.

## What this also settles, in section 6a

The run-length sub-question left open on #976 goes with it. The thematic-break marker field carries the CHARACTER only, so `***` and `*****` both come back as `***` - the three-character width section 6a already pins for `---`, applied to whichever character the field names. The argument for recording a length was section 6's mention of fence length by analogy, and the analogy now points at nothing. Recorded in section 6a so the implementer of #976 reads it where the field is described. That ticket stays open; only its sub-question is answered.

## Scope

Prose only: no production, no corpus document and no engine behavior moves. The clause inventory is unchanged - nothing added here carries a NORMATIVE heading.

Draft #291 also touches `resources/grammar.ebnf` and is a WARN rather than a block: it adds PART 9 §19 for file inclusion and shares no section with this edit, so it takes a rebase and not a decision.
