### PR TITLE
spec: two blank lines detach a caption, on every host that takes one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same document with the blank line removed, which must render identically.
   No behavior changes; every one of the eight is what the engines already do.
 
+- **PART 9 §4: where the caption allowance STOPS is pinned on every host**
+  (carve#997). The clause has two halves - at most one blank line attaches, and
+  anything wider does not - and only the first was held by a document. Widening
+  `caption_slot` from `[blank_line], caption` to `{blank_line}, caption`, so that
+  any number of blank lines attaches, broke NOTHING in 856 documents: every
+  captioned document in the corpus had zero or one blank line, so not one of them
+  could tell "at most one" apart from "any number". New category
+  `282-two-blank-lines-detach-a-caption`, ten documents in five pairs, one pair
+  per captionable host. Each two-blank-line row pins the host UNCAPTIONED and the
+  `^ ` line as an ordinary paragraph, and is preceded by the same document with
+  one blank line, which attaches; without that control a row would be equally
+  satisfied by a reader that stopped attaching captions across a blank line at
+  all. The widening now breaks five documents where it broke none. No behavior
+  changes; carve-js, carve-php and carve-rs produce all ten of these outputs
+  today.
+
 - **PART 9 §17 L1a: a list item's first block does not decide loose or tight.**
   L1 asks whether the item holds a blank-line-separated second paragraph, not
   what its first block was. `- - a` followed by a blank line and `Body.` is

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -14638,3 +14638,291 @@ Nothing here is new behavior. Every one of these eight documents is what
 carve-js already produced when the drift audit measured the five hosts across
 three separations, which is what makes them committable as a pin rather than a
 proposal.
+
+## Two blank lines detach a caption
+
+PART 9 §4 states the caption allowance in two halves: adjacent or exactly ONE
+blank line attaches, and anything wider does not. `caption_slot`'s single
+optional `blank_line` IS that allowance, and the word that carries the second
+half is `[...]` rather than `{...}` - one blank line at most, not a run.
+
+The first half is pinned. `281-a-caption-attaches-across-one-blank-line` put a
+one-blank-line document on every host, and removing the optional `blank_line`
+from `caption_slot` now breaks five documents where it broke one before.
+
+The second half was pinned nowhere, for any host. Widening `caption_slot` to
+
+```
+caption_slot = {blank_line}, caption ;
+```
+
+so that ANY number of blank lines attaches broke NOTHING in 856 documents. Every
+captioned document in the corpus had zero or one blank line between the host and
+the `^ ` line, so not one of them could tell "at most one" apart from "any
+number". A reader that attached a caption across three blank lines, or ten,
+satisfied every document and every gate in this repository (carve#997).
+
+That is the same shape as the control recorded at
+`279-a-boundary-line-inside-an-open-fence-does-not-end-the-container-6`: a
+document that passes for a reason unrelated to the rule it looks like it covers.
+
+Five rows below pin the second half, one per captionable host. Each is preceded
+by the SAME document with one blank line instead of two, which must attach. That
+pairing is the point rather than decoration: a row that only proves detachment at
+two blank lines is equally satisfied by a reader that stopped attaching captions
+across a blank line at all, which is the opposite defect. The one-blank-line
+members are CONTROLS - the widening mutation does not touch them, and the
+complementary mutation touches only them.
+
+What detachment looks like is worth stating once, because it is the same on all
+five hosts: the host renders UNCAPTIONED - a bare `<table>`, `<pre>`,
+`<blockquote>`, `<img>` or math paragraph with no `<figure>` around it - and the
+`^ ` line becomes an ordinary paragraph whose text begins with a literal caret.
+Nothing is dropped and nothing is an error; the two blocks simply stop being one.
+
+### A table caption, after one blank line
+
+The control for the row below. `table` ends in `[caption_slot]`, so the
+attachment here is structural.
+
+::::: compare
+
+```carve
+|= City |= People |
+| Oslo  | 700k   |
+
+^ Table: city sizes
+```
+
+```html
+<table>
+  <caption>Table: city sizes</caption>
+  <thead><tr><th>City</th><th>People</th></tr></thead>
+  <tbody>
+    <tr><td>Oslo</td><td>700k</td></tr>
+  </tbody>
+</table>
+```
+
+:::::
+
+### A table caption, after two blank lines
+
+One line more than the control. The table keeps its rows and loses its
+`<caption>`; the `^ ` line is a paragraph.
+
+::::: compare
+
+```carve
+|= City |= People |
+| Oslo  | 700k   |
+
+
+^ Table: city sizes
+```
+
+```html
+<table>
+  <thead><tr><th>City</th><th>People</th></tr></thead>
+  <tbody>
+    <tr><td>Oslo</td><td>700k</td></tr>
+  </tbody>
+</table>
+<p>^ Table: city sizes</p>
+```
+
+:::::
+
+### A code block caption, after one blank line
+
+The control. A captioned code block is a numbered LISTING (§4) and the `<figure>`
+wrapper is what carries the caption.
+
+::::: compare
+
+````carve
+```lua
+local n = 1
+```
+
+^ Listing: a local
+````
+
+```html
+<figure>
+  <pre><code class="language-lua">local n = 1
+</code></pre>
+  <figcaption>Listing: a local</figcaption>
+</figure>
+```
+
+:::::
+
+### A code block caption, after two blank lines
+
+The `<figure>` goes with the attachment. What is left is the plain `<pre>` a
+fenced block renders on its own, and a paragraph.
+
+::::: compare
+
+````carve
+```lua
+local n = 1
+```
+
+
+^ Listing: a local
+````
+
+```html
+<pre><code class="language-lua">local n = 1
+</code></pre>
+<p>^ Listing: a local</p>
+```
+
+:::::
+
+### A blockquote caption, after one blank line
+
+The control. This is the host the corpus could already see: `blockquote` ends in
+`[caption_slot]` and `55-blockquote-caption-after-a-blank-line` has pinned the
+one-blank-line form since long before this category existed.
+
+::::: compare
+
+```carve
+> the cited line
+
+^ Source: the cited work
+```
+
+```html
+<figure>
+  <blockquote><p>the cited line</p></blockquote>
+  <figcaption>Source: the cited work</figcaption>
+</figure>
+```
+
+:::::
+
+### A blockquote caption, after two blank lines
+
+Detached, the quote is an ordinary `<blockquote>` with no `<figure>` and no
+`<figcaption>`.
+
+::::: compare
+
+```carve
+> the cited line
+
+
+^ Source: the cited work
+```
+
+```html
+<blockquote><p>the cited line</p></blockquote>
+<p>^ Source: the cited work</p>
+```
+
+:::::
+
+### An image caption, after one blank line
+
+The control, and the first of the two PROSE hosts. There is no `image_paragraph`
+production and no slot to widen or narrow: the block IS a `paragraph`, and what
+makes it captionable is a condition on its inline content (carve#992). §4 is the
+whole rule, so a corpus row is the only thing that can hold either half of it.
+
+::::: compare
+
+```carve
+![Ganymede](ganymede.jpg)
+
+^ Figure: the largest moon
+```
+
+```html
+<figure>
+  <img src="ganymede.jpg" alt="Ganymede">
+  <figcaption>Figure: the largest moon</figcaption>
+</figure>
+```
+
+:::::
+
+### An image caption, after two blank lines
+
+Without the caption there is no `<figure>`, and an image-only paragraph renders
+as the bare `<img>` at block level.
+
+::::: compare
+
+```carve
+![Ganymede](ganymede.jpg)
+
+
+^ Figure: the largest moon
+```
+
+```html
+<img src="ganymede.jpg" alt="Ganymede">
+<p>^ Figure: the largest moon</p>
+```
+
+:::::
+
+### A display-math caption, after one blank line
+
+The control, and the second PROSE host. A captioned standalone display-math block
+is a numbered EQUATION (§4); the block must be solely the `$$`-prefixed span.
+
+::::: compare
+
+```carve
+$$`a + b = c`
+
+^ Equation: the sum
+```
+
+```html
+<figure>
+  <p><span class="math display">\[a + b = c\]</span></p>
+  <figcaption>Equation: the sum</figcaption>
+</figure>
+```
+
+:::::
+
+### A display-math caption, after two blank lines
+
+Detached, the math block is the ordinary paragraph it always was, and the caption
+is a second one.
+
+::::: compare
+
+```carve
+$$`a + b = c`
+
+
+^ Equation: the sum
+```
+
+```html
+<p><span class="math display">\[a + b = c\]</span></p>
+<p>^ Equation: the sum</p>
+```
+
+:::::
+
+None of this is new behavior. All ten documents were measured against carve-js,
+carve-php and carve-rs before they were written down, and all three produce these
+bytes on all ten, so the category pins existing behavior rather than proposing
+any.
+
+One thing the rows do not prove, and should not be read as proving: the five
+hosts are five SPELLINGS of the rule, not five independent implementations of it.
+The image paragraph and the display-math block share one decision site in the
+executable spec, because both are the same `paragraph` with a different condition
+on their content. Both rows still belong - a change to either condition would
+move one and not the other - but a mutation of the shared site kills them
+together, and the five-host count is a count of hosts, not of code paths.

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -69,7 +69,8 @@ Corpus added since this run: `254-colon-fence-separator-must-be-a-space`,
 `278-a-list-marker-at-the-content-column-inside-an-open-fence`,
 `279-a-boundary-line-inside-an-open-fence-does-not-end-the-container`,
 `280-a-container-a-lazy-line-folded-into-is-still-open`,
-`281-a-caption-attaches-across-one-blank-line`.
+`281-a-caption-attaches-across-one-blank-line`,
+`282-two-blank-lines-detach-a-caption`.
 
 Those categories landed on hosts that could not retake the run above, so its
 numbers describe the corpus WITHOUT them. The alternative was to edit the

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 856 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 866 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-10.crv
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-10.crv
@@ -1,0 +1,4 @@
+$$`a + b = c`
+
+
+^ Equation: the sum

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-10.html
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-10.html
@@ -1,0 +1,2 @@
+<p><span class="math display">\[a + b = c\]</span></p>
+<p>^ Equation: the sum</p>

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-2.crv
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-2.crv
@@ -1,0 +1,5 @@
+|= City |= People |
+| Oslo  | 700k   |
+
+
+^ Table: city sizes

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-2.html
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-2.html
@@ -1,0 +1,7 @@
+<table>
+  <thead><tr><th>City</th><th>People</th></tr></thead>
+  <tbody>
+    <tr><td>Oslo</td><td>700k</td></tr>
+  </tbody>
+</table>
+<p>^ Table: city sizes</p>

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-3.crv
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-3.crv
@@ -1,0 +1,5 @@
+```lua
+local n = 1
+```
+
+^ Listing: a local

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-3.html
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-3.html
@@ -1,0 +1,5 @@
+<figure>
+  <pre><code class="language-lua">local n = 1
+</code></pre>
+  <figcaption>Listing: a local</figcaption>
+</figure>

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-4.crv
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-4.crv
@@ -1,0 +1,6 @@
+```lua
+local n = 1
+```
+
+
+^ Listing: a local

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-4.html
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-4.html
@@ -1,0 +1,3 @@
+<pre><code class="language-lua">local n = 1
+</code></pre>
+<p>^ Listing: a local</p>

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-5.crv
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-5.crv
@@ -1,0 +1,3 @@
+> the cited line
+
+^ Source: the cited work

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-5.html
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-5.html
@@ -1,0 +1,4 @@
+<figure>
+  <blockquote><p>the cited line</p></blockquote>
+  <figcaption>Source: the cited work</figcaption>
+</figure>

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-6.crv
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-6.crv
@@ -1,0 +1,4 @@
+> the cited line
+
+
+^ Source: the cited work

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-6.html
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-6.html
@@ -1,0 +1,2 @@
+<blockquote><p>the cited line</p></blockquote>
+<p>^ Source: the cited work</p>

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-7.crv
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-7.crv
@@ -1,0 +1,3 @@
+![Ganymede](ganymede.jpg)
+
+^ Figure: the largest moon

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-7.html
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-7.html
@@ -1,0 +1,4 @@
+<figure>
+  <img src="ganymede.jpg" alt="Ganymede">
+  <figcaption>Figure: the largest moon</figcaption>
+</figure>

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-8.crv
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-8.crv
@@ -1,0 +1,4 @@
+![Ganymede](ganymede.jpg)
+
+
+^ Figure: the largest moon

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-8.html
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-8.html
@@ -1,0 +1,2 @@
+<img src="ganymede.jpg" alt="Ganymede">
+<p>^ Figure: the largest moon</p>

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-9.crv
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-9.crv
@@ -1,0 +1,3 @@
+$$`a + b = c`
+
+^ Equation: the sum

--- a/tests/corpus/282-two-blank-lines-detach-a-caption-9.html
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption-9.html
@@ -1,0 +1,4 @@
+<figure>
+  <p><span class="math display">\[a + b = c\]</span></p>
+  <figcaption>Equation: the sum</figcaption>
+</figure>

--- a/tests/corpus/282-two-blank-lines-detach-a-caption.crv
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption.crv
@@ -1,0 +1,4 @@
+|= City |= People |
+| Oslo  | 700k   |
+
+^ Table: city sizes

--- a/tests/corpus/282-two-blank-lines-detach-a-caption.html
+++ b/tests/corpus/282-two-blank-lines-detach-a-caption.html
@@ -1,0 +1,7 @@
+<table>
+  <caption>Table: city sizes</caption>
+  <thead><tr><th>City</th><th>People</th></tr></thead>
+  <tbody>
+    <tr><td>Oslo</td><td>700k</td></tr>
+  </tbody>
+</table>

--- a/tests/spec/282-two-blank-lines-detach-a-caption.test
+++ b/tests/spec/282-two-blank-lines-detach-a-caption.test
@@ -1,0 +1,122 @@
+Two blank lines detach a caption
+
+```
+|= City |= People |
+| Oslo  | 700k   |
+
+^ Table: city sizes
+.
+<table>
+  <caption>Table: city sizes</caption>
+  <thead><tr><th>City</th><th>People</th></tr></thead>
+  <tbody>
+    <tr><td>Oslo</td><td>700k</td></tr>
+  </tbody>
+</table>
+```
+
+```
+|= City |= People |
+| Oslo  | 700k   |
+
+
+^ Table: city sizes
+.
+<table>
+  <thead><tr><th>City</th><th>People</th></tr></thead>
+  <tbody>
+    <tr><td>Oslo</td><td>700k</td></tr>
+  </tbody>
+</table>
+<p>^ Table: city sizes</p>
+```
+
+````
+```lua
+local n = 1
+```
+
+^ Listing: a local
+.
+<figure>
+  <pre><code class="language-lua">local n = 1
+</code></pre>
+  <figcaption>Listing: a local</figcaption>
+</figure>
+````
+
+````
+```lua
+local n = 1
+```
+
+
+^ Listing: a local
+.
+<pre><code class="language-lua">local n = 1
+</code></pre>
+<p>^ Listing: a local</p>
+````
+
+```
+> the cited line
+
+^ Source: the cited work
+.
+<figure>
+  <blockquote><p>the cited line</p></blockquote>
+  <figcaption>Source: the cited work</figcaption>
+</figure>
+```
+
+```
+> the cited line
+
+
+^ Source: the cited work
+.
+<blockquote><p>the cited line</p></blockquote>
+<p>^ Source: the cited work</p>
+```
+
+```
+![Ganymede](ganymede.jpg)
+
+^ Figure: the largest moon
+.
+<figure>
+  <img src="ganymede.jpg" alt="Ganymede">
+  <figcaption>Figure: the largest moon</figcaption>
+</figure>
+```
+
+```
+![Ganymede](ganymede.jpg)
+
+
+^ Figure: the largest moon
+.
+<img src="ganymede.jpg" alt="Ganymede">
+<p>^ Figure: the largest moon</p>
+```
+
+```
+$$`a + b = c`
+
+^ Equation: the sum
+.
+<figure>
+  <p><span class="math display">\[a + b = c\]</span></p>
+  <figcaption>Equation: the sum</figcaption>
+</figure>
+```
+
+```
+$$`a + b = c`
+
+
+^ Equation: the sum
+.
+<p><span class="math display">\[a + b = c\]</span></p>
+<p>^ Equation: the sum</p>
+```


### PR DESCRIPTION
PART 9 section 4 states the caption allowance in two halves: at most ONE blank line attaches, and anything wider does not. Only the first half was held by a document.

## The gap

Widening `caption_slot` from

```
caption_slot = [blank_line], caption ;
```

to

```
caption_slot = {blank_line}, caption ;
```

so that ANY number of blank lines attaches, broke **nothing** in 856 documents. Every captioned document in the corpus carried zero or one blank line between the host and the `^ ` line, so not one of them could tell "at most one" apart from "any number". An engine that attached a caption across three blank lines, or ten, satisfied every document and every gate in this repository.

Same shape as the control already recorded at `279-a-boundary-line-inside-an-open-fence-does-not-end-the-container-6`: a document that passes for a reason unrelated to the rule it looks like it covers.

## The rows

New category `282-two-blank-lines-detach-a-caption`. Ten documents, five pairs, one pair per captionable host: table, fenced code block, blockquote, image paragraph, standalone display math.

Each **two-blank-line** row pins the host UNCAPTIONED and the `^ ` line as an ordinary paragraph:

```
> the cited line


^ Source: the cited work
```

```html
<blockquote><p>the cited line</p></blockquote>
<p>^ Source: the cited work</p>
```

Each is preceded by the SAME document with **one** blank line, which attaches:

```
> the cited line

^ Source: the cited work
```

```html
<figure>
  <blockquote><p>the cited line</p></blockquote>
  <figcaption>Source: the cited work</figcaption>
</figure>
```

Those five one-blank-line members are CONTROLS and the pairing is not decoration. Without them a row is equally satisfied by a reader that stopped attaching captions across a blank line at all, which is the opposite defect.

## Acceptance

The mutation the ticket names, run on this branch:

| mutation | before | after | documents it breaks after |
|---|---|---|---|
| widen to `{blank_line}` | 0 | 5 | the five two-blank-line rows, one per host |
| remove the optional `blank_line` | 5 | 10 | the five it already broke, plus this category's five controls |

The widening breaks one row per host, which is what the ticket asked for. The complementary mutation goes from five to ten and never touches a two-blank-line row, which is the pairing doing its job.

## The five-host count is a count of hosts, not of code paths

Worth saying rather than leaving to be inferred. The image paragraph and the standalone display-math block share ONE decision site in the executable spec, because both are the same `paragraph` under a different condition on their inline content. A mutation of that site kills both rows together. Both rows still belong, since a change to either condition would move one and not the other, but nobody should read "five hosts" as five independent implementations. The prose in the category says so too.

## Measured on all three engines first

carve-js at the pinned build, carve-php at `967535d` and carve-rs at `a52aa10` were each run against all ten documents before the rows were written. All three produce these bytes on all ten, so the category pins existing behavior rather than proposing any. `a52aa10` is carve-rs's own "a caption attaches across at most one blank line" fix, which is the landing this ticket was waiting on.

## Notes

- No unrelated golden moved. Regenerating the corpus touches only this category.
- Corpus numbering is append-only, so the category lands at 282 and nothing renumbers.
- The category is declared under "Corpus added since this run" on the comparison page rather than that page's denominators being edited by hand, for the reason that section already gives.
- Two known drafts overlap `docs/examples/edge-cases.md` and are WARN rather than BLOCK: draft `carve#291` (file inclusion) and draft `carve#444` (migration prep, marked do-not-merge). Neither touches captions or `caption_slot`; both will want a rebase whenever they land, which is already true of every corpus category added since they were opened.

Closes #997
