### PR TITLE
spec: beforeRender inherits a read-only context, not defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: `beforeRender` takes a read-only context, not the document alone.**
+  The hook runs before the render starts, so a hook that produces output of its
+  own had nothing to inherit and rendered with defaults: a table-of-contents
+  entry and the heading it was cloned from disagreed whenever a render option
+  (a `symbols` map, the raw-HTML policy) reached inline rendering. The context
+  carries the render options, the effective mode for the target format, and
+  whether the final target is HTML - the last so an extension emitting HTML in
+  the hook can skip its transform on the Markdown, plain-text and ANSI targets
+  and leave the source node for that renderer. It is READ-ONLY as a matter of
+  contract: the guards run after the hooks, so a hook handed live options could
+  clear the field a guard measures. The effective mode is `"interactive"` on
+  every non-HTML target whatever the caller passed, which §2.5 now says in place
+  of the claim that those renderers force `"static"` - no engine did that, and
+  the same section already said `renderStatic` is the HTML path only.
+
 - **PART 11 §6 no longer protects a fence's length.** The section named three
   author choices `fmt` must not respell, and its own argument backs two of them:
   a spelling is preserved because THE AST RECORDS IT, and `code_block` records

--- a/docs/extension-tutorial.md
+++ b/docs/extension-tutorial.md
@@ -75,7 +75,9 @@ interface CarveExtension {
   matchInline?: InlineMatcher          // parse stage: add inline syntax
   matchBlock?: BlockMatcher            // parse stage: add block syntax
   afterParse?(doc): Document           // transform the AST
-  beforeRender?(doc): Document         // transform before rendering
+  beforeRender?(doc, ctx): Document    // transform before rendering; `ctx` is
+                                       // read-only: options, effective mode,
+                                       // whether the target is HTML
   blockRenderers?: Record<string, …>   // render a block node type -> HTML
   inlineRenderers?: Record<string, …>  // render an inline node type -> HTML
   staticBlockRenderers?: …             // build-time (mode: "static") variants

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -194,9 +194,64 @@ An extension is a named unit contributing any subset of four things, run as:
 ### 2.2 Transforms
 
 - afterParse `(Document) -> Document` (collection/inspection)
-- beforeRender `(Document) -> Document` (mutation)
+- beforeRender `(Document, BeforeRenderContext) -> Document` (mutation)
 - Every extension's afterParse runs before any extension's beforeRender; within a
   phase, registration order.
+
+#### The beforeRender context
+
+`beforeRender` runs before the render starts, so a hook that produces output of
+its own has nothing to inherit: with the document alone in hand it renders with
+DEFAULTS. The table-of-contents extension is the case that shows it, because it
+builds its `<nav>` in exactly that hook - the entry and the heading it was cloned
+from disagree whenever a render option reaches inline rendering. Given
+
+```
+{#h}
+# :ok: h
+```
+
+and a symbols map of `ok` to `OK`, a hook rendering with defaults produces
+
+```html
+<nav class="toc">
+<ul>
+<li><a href="#h">:ok: h</a></li>
+</ul>
+</nav>
+<section id="h">
+  <h1>OK h</h1>
+</section>
+```
+
+The context is what the hook inherits instead. It carries:
+
+- **the render options** the conversion was called with, so a hook that renders
+  something renders it the way the caller asked;
+- **the effective mode** for the target format. It is `"interactive"` for the
+  Markdown, plain-text and ANSI renderers whatever the caller passed, because
+  static rendering is an HTML-only concern (§2.5): a caller reusing one set of
+  options across formats gets unchanged non-HTML output;
+- **whether the final target is HTML**. An extension that emits HTML in this hook
+  reads this to skip its transform on a non-HTML target and leave the source node
+  for that renderer to emit as source.
+
+The context is **READ-ONLY**, and that is part of the contract rather than an
+implementation detail. A hook must not be able to talk the renderer out of the
+caller's own hardening: the guard that reads an option runs after the hooks, so a
+hook handed the live options could clear the very field that guard measures.
+carve-rs met that shape from the other side - its `max_length` cap sat behind
+these hooks, and because the hook took the document by value a hook could empty
+the field the cap measured. An implementation therefore passes a value the hook
+cannot write back through: a frozen copy that is not the object the renderer is
+handed, or an immutable reference. Where a nested value is the caller's own
+object, read-only remains the contract even where the language cannot enforce it
+past the first level.
+
+The spelling is implementation-idiomatic (accessor methods in carve-rs and
+carve-php, readonly properties in carve-js); what an implementation MUST carry is
+the three items above. `afterParse` takes no context: it runs before rendering is
+a question at all.
 
 ### 2.3 Renderers
 
@@ -216,8 +271,11 @@ A render carries a **mode** - a render option, not document syntax:
 - `"interactive"` (default) - online HTML; extensions render their interactive
   form (live tabs, mermaid via a client script, KaTeX).
 - `"static"` - HTML for a medium that cannot interact or run client scripts
-  (print, PDF source, archival HTML). The Markdown, plain-text, and ANSI
-  renderers force `"static"` and the caller cannot override it.
+  (print, PDF source, archival HTML). The mode is an HTML concern: the Markdown,
+  plain-text and ANSI renderers ignore it, reaching the same end by flattening
+  (see the end of this section), so their output does not vary with it and the
+  effective mode a `beforeRender` context reports on those targets is
+  `"interactive"` whatever the caller passed (§2.2).
 
 `"print"`, `"email"`, and similar names are **reserved** for future named
 presets; an implementation MUST reject an unknown mode value rather than guess.

--- a/docs/graceful-degradation.md
+++ b/docs/graceful-degradation.md
@@ -143,8 +143,8 @@ The engine does **not** sniff the target. Degradation is set by a render
 **mode** - `"interactive"` (default) or `"static"` - plus the output format:
 
 - **Output format.** Markdown, plain text, and ANSI are inherently static and
-  force `"static"`; the label-caption rule and source-fallbacks apply
-  unconditionally there.
+  degrade unconditionally; the label-caption rule and source-fallbacks apply
+  there whatever mode the caller passed.
 - **Mode (HTML only).** `"interactive"` renders the live forms; `"static"`
   renders through each extension's `renderStatic` path (and the core caption
   floor for any unconsumed label). See the


### PR DESCRIPTION
Implements the ruling on markup-carve/carve#1007: `beforeRender` receives the
document AND a read-only context, and the clause names the context rather than an
options parameter.

## What the clause now says

Section 2.2 spells the hook `(Document, BeforeRenderContext) -> Document` and
states what the context carries:

- the render options the conversion was called with;
- the EFFECTIVE mode for the target format, which is `"interactive"` for the
  Markdown, plain-text and ANSI renderers whatever the caller passed;
- whether the final target is HTML.

The last one is why this shape rather than a bare options parameter. An
extension that emits HTML in the hook reads it to skip its transform on a
non-HTML target and leave the source node for that renderer to emit as source.
carve-rs built that accessor because it met the case; an options parameter has
nothing to say about it, which is the question the ticket already listed as open.

READ-ONLY is stated as contract rather than left to each engine. The guard that
reads an option runs after the hooks, so a hook handed the live options could
clear the very field that guard measures. carve-rs met the same shape from the
other side: its `max_length` cap sat behind these hooks, and because the hook
took the document by value a hook could empty the field the cap measured.

## Two consequential edits, because the clause has to be consistent

Section 2.5's bullet claimed the Markdown, plain-text and ANSI renderers force
`"static"`. No engine does that, and the end of that same section already says
`renderStatic` is the HTML path only and those renderers reach the same end by
flattening. Measured on `main` builds:

| engine | what a non-HTML target does with the mode |
| --- | --- |
| carve-rs | forces `Mode::Interactive`, documented as HTML-only |
| carve-php | `getRenderMode()` returns `INTERACTIVE` for a non-HTML renderer |
| carve-js | the mode is read by the HTML renderer only |

The bullet now says what is measured, which is also what the new clause needs.
`docs/graceful-degradation.md` repeated the same phrasing for the same fact and
now says those targets degrade unconditionally. Neither edit moves engine
behavior; both remove a claim that contradicted the page they sit on.

The extension tutorial's carve-js binding gains the parameter it was missing.

## Not in this PR

The clause describes a shape carve-rs already has and the other two engines are
moving to. The engine PRs are carve-js and carve-php; carve-rs needs no change.
A spec-side check that measures the reference engine's hook shape is not possible
yet, because the reference engine is pinned by SHA and the carve-js change is not
in that pin.
