### PR TITLE
spec: the value ledger declares nothing, because nothing diverges

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -496,7 +496,7 @@ A row may name an issue only where one of those still declares the debt.
 |---|---|---|
 | carve-js | §3a conformant on the resolved form: publishes `href`, `ref` and `rawRef` together | every block and inline placed, except the two categories §4 exempts: a coalesced `text` run, and a table cell continued on a `+` line |
 | carve-rs | §3a conformant on the resolved form: `ref` and `rawRef` survive resolution beside `href` | every block and inline placed, except the coalesced `text` runs §4 exempts |
-| carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries the resolution key in `ref` beside `rawRef`, the same label the other two publish | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the coalesced `text` runs §4 exempts |
+| carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries the resolution key in `ref` beside `rawRef`, the same label the other two publish on every corpus document | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the coalesced `text` runs §4 exempts |
 | carve-rb / carve-py / carve-go / carve-wasm | publish carve-rs's bytes | whatever carve-rs records |
 
 The gaps are listed rather than smoothed over on purpose: "six implementations"
@@ -540,15 +540,23 @@ answered and both closed.
 WHICH label `ref` carries when the label holds inline markup is now RULED, and
 the fleet already implements the ruling: given a collapsed reference whose label
 is `` `code()` heading ``, all three engines publish the heading's rendered
-text, `code() heading`. Measured on carve-js `5e3b723`, carve-rs `04f9284` and
-carve-php `9375df1`, each built from `main`.
+text, `code() heading`. Measured on carve-js `79175a5`, carve-rs `d855367` and
+carve-php `e2c3a97`, each built from a fresh clone of `main` on 2026-08-08.
 
-`resources/ast-value-divergence.txt` still declares `link.ref` as a divergence,
-in the pre-merge terms this paragraph used to use. That file is filled in by
-`npm run ast:check` driving three BUILT satellites, and it has not been re-run
-since js and rs moved. The ruling asks no engine to change, so what that line
-owes is a re-measurement rather than a fix - and until it is re-run, the SHAs
-above are the measured side and the ledger is the older claim.
+`resources/ast-value-divergence.txt` declared that disagreement until the same
+day, in the pre-merge terms this paragraph used to use. It was re-measured on
+those three builds - a full `npm run ast:check` over 870 samples - and the
+declaration is now EMPTY: no field the three publish differs anywhere in the
+corpus, so both lines were deleted rather than reworded. The caption line that
+sat beside it went the same way, fixed under
+[carve#963](https://github.com/markup-carve/carve/issues/963).
+
+An empty declaration is a statement about the corpus, which is the only thing
+the run measures. Four collapsed-reference labels the corpus does not hold - one
+carrying `/emphasis/`, one an escape, one a nested link, one a symbol shortcode
+- do still split carve-php from the other two, and they split the HTML with it,
+so they are owed a fixture rather than a declaration
+([carve#1011](https://github.com/markup-carve/carve/issues/1011)).
 
 **This paragraph said the opposite until 2026-08-08**, recording carve-php as
 publishing the rendered text where the other two published the authored label.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#816c3a310a412c1072150f3189456d4c2d78ff39",
+        "@markup-carve/carve": "github:markup-carve/carve-js#79175a53595a5faa04891708f275e4f01603ccd1",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.42.1",
@@ -985,8 +985,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#816c3a310a412c1072150f3189456d4c2d78ff39",
-      "integrity": "sha512-WoICyXhupBpdnZ3m13wsStPjglMA6vOja9RzIuJfnKghhZ7CBuKfg53bLBanTwvYZ/MCnOxN8A5lpug2KMp0Ow==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#79175a53595a5faa04891708f275e4f01603ccd1",
+      "integrity": "sha512-dL9e5yzv5qq+ZEdZ1Yw51tFt9JoL5AEBpJLywDU3G6J4FYLUiUaIIqOHI70Pif6H+PPhR4EkhQNn/AC/zZkQVQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#816c3a310a412c1072150f3189456d4c2d78ff39",
+    "@markup-carve/carve": "github:markup-carve/carve-js#79175a53595a5faa04891708f275e4f01603ccd1",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.42.1",

--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -25,7 +25,28 @@
 # one field behaving one way everywhere it appears.
 #
 # Format: <type.field>  <document-count>  <who diverges and where it is tracked>
-
-link.ref                  2  carve-php publishes the heading's RENDERED text where carve-js and carve-rs publish the authored label, so a collapsed `[`code()` heading][]` gives "code() heading" against "`code()` heading" - the three agree on href and rawRef, and §3a's "the derived label" reads both ways when the label carries inline markup (carve#962)
-text.value                1  carve-php's table caption keeps the trailing space its own HTML drops, so corpus 268-6 publishes "Cap " where carve-js and carve-rs publish "Cap" - invisible to the HTML gate, which all three pass (carve#963)
+#
+# EMPTY, and re-measured rather than assumed. Both lines this file carried until
+# 2026-08-08 were deleted on a full run of `npm run ast:check` over 870 samples
+# against carve-js 79175a5, carve-rs d855367 and carve-php e2c3a97, each built
+# from a fresh clone of main:
+#
+#   link.ref    declared 2 documents, measured 0. The engines had disagreed
+#               about which label a collapsed reference publishes; ruled at
+#               carve#962 and implemented by all three.
+#   text.value  declared 1 document, measured 0. carve-php kept the trailing
+#               space on a caption line; fixed under carve#963.
+#
+# WHAT AN EMPTY FILE DOES NOT MEAN. It says the three agree on every scalar in
+# 870 documents, and the corpus is what it can say. A shape the corpus does not
+# hold is a shape this file has never measured - so deleting a line is evidence
+# about the corpus, not a certificate about the engines.
+#
+# Measured off-corpus while emptying it: in a collapsed reference whose label
+# holds `/emphasis/`, a `\_` escape, a `:symbol:` shortcode or a nested link,
+# carve-php derives a different resolution key from carve-js and carve-rs. That
+# does NOT belong here. This file is for divergences the HTML gate cannot see,
+# and those four shapes change the HTML too - carve-php leaves the reference
+# unresolved, or slugs the heading differently - so they are ordinary corpus
+# conformance, owed a fixture rather than a line (markup-carve/carve#1011).
 

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,13 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-
-278-a-list-marker-at-the-content-column-inside-an-open-fence  PART 9 §24 S1/S2: a list marker at an item's content column inside an open fence is code text. The pin reads the marker instead and opens a nested list (markup-carve/carve-php#1007, carve#974).
-278-a-list-marker-at-the-content-column-inside-an-open-fence-2  The same rule with the fence opened after a blank line inside the item, which the pin collects through a different loop and gets wrong the same way.
-279-a-boundary-line-inside-an-open-fence-does-not-end-the-container  PART 9 §17 L3 attaches ONE BLOCK and a fenced block ends at its closer, so a definition line inside a `+`-attached open code fence is verbatim text. The pin ends the note body there, leaves the fence unterminated and prints the trailing text as the document's FIRST block (markup-carve/carve-js#884).
-279-a-boundary-line-inside-an-open-fence-does-not-end-the-container-2  The same fence with a blank line in it, which the pin ends the attached block on for the same reason.
-279-a-boundary-line-inside-an-open-fence-does-not-end-the-container-3  The same blank line in a definition list's body, which the pin collects through a different loop and gets wrong the same way.
-279-a-boundary-line-inside-an-open-fence-does-not-end-the-container-5  PART 9 §10 I2: a list marker at a colon fence body's own column folds into the open paragraph. The pin closes the div there, opens a real list and leaves a stray empty div behind.
-279-a-boundary-line-inside-an-open-fence-does-not-end-the-container-7  The same blank line in a block a `+` attaches to a LIST ITEM, the largest severing group of the class and a fourth collector again. The pin ends the attached block at the blank, so the closing fence is never consumed and the stray run opens an empty inline code element at document level (markup-carve/carve-js#884).
-279-a-boundary-line-inside-an-open-fence-does-not-end-the-container-8  PART 9 §17 L1 and §28: a blank line inside an item's INDENTED comment fence is verbatim and invisible, so the item holds no second paragraph and stays tight. The pin loosens it, wrapping `x` in a paragraph because of a line that renders nothing (markup-carve/carve#985).
-279-a-boundary-line-inside-an-open-fence-does-not-end-the-container-10  The same blank inside an item's indented COLON fence. The blank separates two paragraphs of the DIV, not of the item, so the item stays tight; the pin hands it to the item's looseness scan instead.

--- a/tests/ast-json-claims.test.mjs
+++ b/tests/ast-json-claims.test.mjs
@@ -63,6 +63,9 @@ import {
   fromAstJson,
   parse,
   renderHtml,
+  // Aliased: `resolve` is already taken here by node:path, and the two are one
+  // letter apart in a file that uses both on adjacent lines.
+  resolve as resolveReferences,
   toAstJson,
 } from '@markup-carve/carve'
 
@@ -113,6 +116,46 @@ test('a resolved reference publishes href, ref and rawRef - and the row says so'
     jsRow,
     /§3a conformant on the resolved form/,
     'the engine publishes the whole §3a triple; the carve-js row no longer says so',
+  )
+})
+
+/*
+ * §3a's RULING, measured against the pin rather than described.
+ *
+ * "`ref` is the resolution key" was ruled at carve#962 and written onto the page
+ * with three engine SHAs beside it, and nothing here read `ref` on a label that
+ * holds inline markup - the one shape where the key and the authored label are
+ * different strings. So the pin could sit 368 commits behind the ruling, publish
+ * the authored label, and every assertion on this page stay green: the same
+ * "no case can fail" shape one layer up from the ledger it cites (carve#1003).
+ *
+ * RESOLVED, not parse-only. A heading anchor is not a link reference
+ * definition, so `resolve()` is where the reference finds it; `treeOf` above
+ * stops short of that and reports `href: ""` with the authored label in `ref`
+ * on BOTH sides of the ruling, which would have made this test pass against the
+ * build it was written to catch.
+ */
+test('ref carries the resolution key, not the authored label, when the label holds markup', () => {
+  const tree = toAstJson(resolveReferences(parse('# `code()` heading\n\n[`code()` heading][]\n')))
+  const [link] = nodesOfType(tree, 'link')
+  assert.ok(link, 'no link node for a collapsed reference to a heading')
+  assert.equal(link.href, '#code-heading')
+  assert.equal(
+    link.ref,
+    'code() heading',
+    'the pinned build publishes the authored label where §3a rules the key - the pin predates carve#962',
+  )
+  assert.equal(link.rawRef, '[`code()` heading][]')
+
+  // The page states the ruling with this exact pair; a build that moved off it
+  // must not leave the sentence standing.
+  assert.ok(
+    page.includes('**`ref` is the resolution key**'),
+    'docs/ast-json.md no longer states the §3a ruling this measures',
+  )
+  assert.ok(
+    page.includes('"ref": "code() heading"'),
+    'the §3a example on docs/ast-json.md no longer publishes the key this measures',
   )
 })
 


### PR DESCRIPTION
Closes markup-carve/carve#1003.

`resources/ast-value-divergence.txt` declared two divergences. A full
`npm run ast:check` over 870 samples measures both at zero documents, so both
lines are gone, and so is `resources/engine-pin-drift.txt`, which the pin bump
below caught up on.

Re-measured on fresh clones of `main`, each built in its own throwaway
checkout, because the ticket's own figures were taken three engine revisions
ago:

```
carve-js   79175a5   (ticket measured c245eed)
carve-rs   d855367   (ticket measured 39e6968)
carve-php  e2c3a97   (ticket measured ebd9386)
```

```
THREE-WAY VALUE COMPARISON: the engines publish the same values everywhere.

THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:
  FIXED      link.ref no longer diverges - delete its line
  FIXED      text.value no longer diverges - delete its line
```

## The deletion is load-bearing

An empty ledger only helps if the panel goes red when the behavior returns, so
both entries were re-broken in a throwaway carve-php clone and the run repeated.

The caption entry, by dropping the fix for
[carve#963](https://github.com/markup-carve/carve/issues/963) out of
`src/Parser/BlockParser.php`:

```php
// foreach ($captionLines as $captionIndex => $captionLine) {
//     $captionLines[$captionIndex] = rtrim($captionLine, " \t");
// }
```

The key entry, by making `src/Parser/InlineParser.php` derive no key from a
collapsed label, which is what every engine did before
[carve#962](https://github.com/markup-carve/carve/issues/962) was ruled:

```php
$plain = $ref;   // was: preg_replace('/[_*~^+={}`\[\]]/', '', $ref)
```

Both come back named, and the second mutation drags a third field with it:

```
THREE-WAY VALUE COMPARISON: 3 field(s) disagree, across 3 document(s)
     2 doc(s)  link.href
        carve-js="#code-heading"  carve-rs="#code-heading"  carve-php=""
     2 doc(s)  link.ref
        carve-js="code() heading"  carve-rs="code() heading"  carve-php="`code()` heading"
     1 doc(s)  text.value
        carve-js="Cap"  carve-rs="Cap"  carve-php="Cap "

THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:
  NEW        text.value diverges in 1 document(s) and is not declared
  NEW        link.href diverges in 2 document(s) and is not declared
  NEW        link.ref diverges in 2 document(s) and is not declared
```

The `link.href` row is the mutation's own side effect, not a third deletion:
a key nothing matches leaves the reference unresolved. It is listed because the
panel named it and a report that quietly drops a row it did not predict is the
habit this ticket is about.

## What the ticket's single sample missed

The ticket measured one document per entry. Measuring more label shapes found
that a collapsed reference does still split carve-php from the other two, on
four shapes no corpus document holds: a label carrying `/emphasis/`, an escape,
a nested link, or a symbol shortcode. On the first three carve-php does not
resolve the reference at all.

That is not what this ledger records. It is for fields the engines publish
different values for while the HTML agrees, and all four shapes change the HTML
too, so they are ordinary corpus conformance owed a fixture. Filed as
[carve#1011](https://github.com/markup-carve/carve/issues/1011); the ledger's
header now carries the same warning, so an empty file is not read as a
certificate about the engines when it is a statement about the corpus.

## The pin

The carve-js pin moves from `816c3a3` to `79175a5`. It changes an outcome twice
over.

All nine slugs in `resources/engine-pin-drift.txt` reproduce on the new build,
so that declaration empties too, and `npm run engine:report -- --check` renders
867 of 867 corpus pairs identically through the pin.

And the pin sat 35 commits behind a ruling this repo's own page states - the
ticket says 368, the compare API says 35 - with nothing red, because no test
read a reference's key on a label carrying markup: the one shape where the key
and the authored label are different strings. That test exists now. It runs on
the RESOLVED tree, because a heading anchor is not a link reference definition,
and the parse-only helper beside it reports the authored label on both sides of
the ruling.

Held against the old pin in a scratch checkout of this same branch, it fails on
exactly that assertion, which is what makes the bump an outcome rather than a
line:

```
not ok 3 - ref carries the resolution key, not the authored label, when the label holds markup
    the pinned build publishes the authored label where §3a rules the key
    + actual - expected
    + '`code()` heading'
    - 'code() heading'
```

## Left alone deliberately

The same run reports drift in two OTHER declarations, both from engines moving
rather than from anything here: nine count rows and one new presence row in
`resources/ast-span-divergence.txt`, and a footnote position finding neither
carve-rs nor carve-php declares in `resources/ast-position-waivers.txt`. Those
are separate ledgers with separate rulings behind them, and folding them into a
deletion PR would bury the one claim this change is making.
