### PR TITLE
spec: permit thematic break markers in the AST

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -56,6 +56,11 @@ where that was.
 `children`. An implementation whose internals differ maps on the way out; it does
 not export its internals, and it does not invent a synonym.
 
+Author-choice fields preserve a spelling when it differs from the default.
+`list.bulletChar` records `*` while absence means `-`; likewise,
+`thematic_break.marker` records `*` or `_` while absence means `-`. A writer
+reproduces the recorded character and uses the default when the field is absent.
+
 **The tree is pre-resolve** (§3a). It records what the author wrote, not what the
 document resolves to. `[getting started][]` publishes a `link` carrying `ref` and
 the `rawRef` source whether or not anything defines the label. Both stages

--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -2764,6 +2764,14 @@
         "type": {
           "const": "thematic_break"
         },
+        "marker": {
+          "enum": [
+            "-",
+            "*",
+            "_"
+          ],
+          "description": "Thematic-break character AS AUTHORED (PART 11 section 6). Absent means the default `-`."
+        },
         "attrs": {
           "$ref": "#/$defs/attrs"
         },

--- a/tests/schema-fields-are-produced.test.mjs
+++ b/tests/schema-fields-are-produced.test.mjs
@@ -56,6 +56,11 @@ const OPT_IN_ONLY = {
   'citation_group.*': 'citations (Tier-2): the group wrapper and the integral `+` form',
 }
 
+/** Fields permitted by the schema before the corresponding engine rollout. */
+const ENGINE_ROLLOUT_PENDING = {
+  'thematic_break.marker': 'markup-carve/carve#976: engine support lands before the final pin bump',
+}
+
 /**
  * `attrs` and `pos` are shared `$ref`s every node may carry. They are not a
  * promise an individual type makes, and the corpus attaches attributes to about
@@ -162,7 +167,9 @@ test('every schema field is produced by a corpus document, or named as opt-in', 
     `schema walk found only ${declared.byType.size} types with fields`,
   )
 
-  const orphaned = orphanedPromises().filter((key) => !(key in OPT_IN_ONLY))
+  const orphaned = orphanedPromises().filter(
+    (key) => !(key in OPT_IN_ONLY) && !(key in ENGINE_ROLLOUT_PENDING),
+  )
 
   assert.deepEqual(
     orphaned,
@@ -188,6 +195,20 @@ test('every opt-in exemption is still needed', () => {
     [],
     `OPT_IN_ONLY names promise(s) the corpus now keeps: ${stale.join(', ')}. ` +
       'Remove the entry - the exemption is hiding a field that is covered.',
+  )
+})
+
+test('every pending engine-rollout exemption is still needed', () => {
+  const orphans = new Set(orphanedPromises())
+  const stale = Object.keys(ENGINE_ROLLOUT_PENDING)
+    .filter((key) => !orphans.has(key))
+    .sort()
+
+  assert.deepEqual(
+    stale,
+    [],
+    `ENGINE_ROLLOUT_PENDING names promise(s) the pinned engine now keeps: ${stale.join(', ')}. ` +
+      'Remove the entry - the engine rollout is complete.',
   )
 })
 


### PR DESCRIPTION
## Summary

- permits the optional `thematic_break.marker` AST field with `-`, `*`, and `_` values
- documents the author-choice field and its absent-means-hyphen default
- tracks the short engine rollout window with a self-expiring schema-field exemption

## Checks

- `npm test`
- `node --test tests/ast-schema.test.mjs tests/schema-fields-are-produced.test.mjs`

Closes markup-carve/carve#976 only after the engine and close-out stages land.
