### PR TITLE
ci: the scheduled conformance run files its own verdict, and PART 11 section 6a states its byte-0 exception

### DIFF
--- a/.github/workflows/ast-conformance.yml
+++ b/.github/workflows/ast-conformance.yml
@@ -22,6 +22,20 @@ on:
 
 permissions:
   contents: read
+  # The verdict step at the end of the job files what this run found. `issues`
+  # to open, update and close the tracking issue; `actions` to read back which
+  # of this job's own steps failed, so the report names them rather than
+  # sending a reader to hunt through a 40-minute log.
+  issues: write
+  actions: read
+
+# Two runs at once - the 04:00 schedule and a dispatch someone wanted NOW - would
+# reach the verdict step together and each find no open ticket, filing two. The
+# group serializes them; `cancel-in-progress: false` because a run that is 30
+# minutes into building four engines is worth finishing.
+concurrency:
+  group: ast-conformance
+  cancel-in-progress: false
 
 jobs:
   conformance:
@@ -262,3 +276,133 @@ jobs:
           php tests/gen-profile-fixtures.php > /tmp/profile-fixtures.regenerated.json
           diff -u tests/profile-fixtures.json /tmp/profile-fixtures.regenerated.json \
             || { echo "::error::tests/profile-fixtures.json no longer matches carve-php. Regenerate it (see the header of tests/gen-profile-fixtures.php) and re-check carve-js and carve-rs against the new file."; exit 1; }
+
+      # THE READER. Everything above reports into a job nobody is obliged to
+      # open. This workflow runs on a SCHEDULE, so no pull request gate can see
+      # it go red, `main` shows green push CI while it is failing, and for weeks
+      # nothing looked (carve#961). That is the check-with-no-reader family
+      # catalogued in carve#755: the check exists, runs, and reports, and no one
+      # consumes the result. A second check reporting into the same void would
+      # be the defect rather than the fix, so what this step adds is a CONSUMER.
+      #
+      # The run files its own verdict where this project's backlog already
+      # looks: one tracking issue, opened by the first red run, kept current by
+      # every later one, and CLOSED by the first green run. An open issue is
+      # what the org-wide sweep enumerates and what a human sees on the issue
+      # list, so a red schedule now costs someone a ticket instead of nothing.
+      #
+      # Closing it by hand does not mute it. The lookup below matches OPEN
+      # issues only, so the next red run opens a fresh one; the only way to stop
+      # the reports is to make the run green. Nor does it accumulate: a red run
+      # with an open ticket edits that ticket rather than filing another.
+      #
+      # It carries no label on purpose - `hold` and `needs-decision` are the two
+      # labels this org's automation reads as "do not touch", and an alert that
+      # lands pre-silenced is no alert.
+      #
+      # THE TICKET IS SCOPED TO THE REF. `workflow_dispatch` can be aimed at any
+      # branch, so without the scope a green dispatch from a feature branch would
+      # CLOSE a ticket about `main` - silencing the alarm by testing something
+      # else, which is this issue's own failure mode wearing a different hat.
+      # A branch keeps its own ticket, and it self-closes the same way.
+      #
+      # This step FAILS if it cannot file. A reporter that swallows its own
+      # errors is exactly the defect it exists to fix, so a missing permission
+      # or a rate limit turns the job red rather than passing quietly.
+      - name: File the verdict where someone reads it
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          JOB_STATUS: ${{ job.status }}
+          HEAD_SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          TITLE="AST conformance is failing on $REF_NAME"
+          MARKER="<!-- ast-conformance-verdict ref=$REF_NAME -->"
+
+          # Which steps failed, read back from the run itself. A hand-kept list
+          # of step ids would go stale the first time a step is added, and a
+          # step this report forgot to name is a step whose failure is invisible
+          # again.
+          failed="$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate \
+            --jq '.jobs[].steps[] | select(.conclusion == "failure") | "- `" + .name + "`"')"
+
+          # Matched on the marker in the body rather than on the title, so
+          # renaming the issue does not fork it into two, and listed rather than
+          # searched, because the search index lags behind a fresh issue by
+          # enough to file a duplicate.
+          open_issues="$(gh api "repos/$REPO/issues?state=open&per_page=100" --paginate \
+            | jq -r --arg m "$MARKER" \
+                '.[] | select(.pull_request == null) | select((.body // "") | contains($m)) | .number')"
+          issue="${open_issues%%$'\n'*}"
+
+          if [ "$JOB_STATUS" = "success" ]; then
+            echo "AST conformance is green on $HEAD_SHA."
+            if [ -n "$issue" ]; then
+              gh issue comment "$issue" --repo "$REPO" --body \
+                "Green again: run $RUN_URL on \`$HEAD_SHA\`. Closing. The next red run opens a fresh ticket rather than reopening this one, so a closed ticket always means the last run passed."
+              gh issue close "$issue" --repo "$REPO"
+              echo "Closed #$issue."
+            fi
+            echo "AST conformance green on \`$HEAD_SHA\`. Nothing filed." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "$MARKER"
+            echo
+            echo "\`AST conformance\` is failing on \`$REF_NAME\`. This workflow builds four"
+            echo "engines and runs on a daily schedule, so no pull request gate sees it and"
+            echo "the branch shows green push CI while this is red."
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| run | $RUN_URL |"
+            echo "| commit | \`$HEAD_SHA\` |"
+            echo "| ref | \`$REF_NAME\` |"
+            echo "| trigger | \`$EVENT_NAME\` |"
+            echo
+            echo "### Failing steps"
+            echo
+            if [ -n "$failed" ]; then
+              printf '%s\n' "$failed"
+            else
+              echo "- (none reported; the job did not complete - see the run)"
+            fi
+            echo
+            echo "### Before acting on this"
+            echo
+            echo "The counts in the run are a snapshot. Four engines merge into their own"
+            echo "\`main\` through the day and this workflow runs once at 04:00 UTC, so a"
+            echo "figure read here can be hours and a dozen merges old. Re-dispatch"
+            echo "(\`gh workflow run ast-conformance.yml -R $REPO\`) and quote the run id you"
+            echo "measured, rather than rerunning this one - a rerun overwrites the evidence."
+            echo
+            echo "This ticket is filed and maintained by the workflow. It is EDITED by each"
+            echo "later red run and CLOSED by the first green one. Closing it by hand does"
+            echo "not silence it: the next red run files a new one."
+          } > /tmp/ast-conformance-verdict.md
+
+          if [ -n "$issue" ]; then
+            gh issue edit "$issue" --repo "$REPO" --body-file /tmp/ast-conformance-verdict.md
+            echo "Updated #$issue."
+            url="$(gh issue view "$issue" --repo "$REPO" --json url --jq .url)"
+          else
+            url="$(gh issue create --repo "$REPO" --title "$TITLE" \
+              --body-file /tmp/ast-conformance-verdict.md)"
+            echo "Filed $url."
+          fi
+
+          {
+            echo "## AST conformance is red"
+            echo
+            echo "Filed at $url"
+            echo
+            printf '%s\n' "${failed:-- (no step reported a failure)}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -5690,6 +5690,49 @@ EOF = (* end of file *) ;
       emits a thematic break as three hyphens whatever the author wrote, so
       `***` and `___` both come back as `---`.
 
+      EXCEPT WHERE `---` WOULD OPEN FRONTMATTER. A `---` line at byte 0 of the
+      EMITTED document is the frontmatter opener, not a break. Spelling this
+      clause's form there can manufacture a block the document does not have,
+      and everything down to whatever closes it is swallowed with it: a
+      document of `***`, a blank line and `---` renders two breaks, and written
+      by the literal reading of this clause it renders NOTHING -- with any
+      paragraph standing between them lost too. Where that would happen the
+      writer spells the break `***` instead, and that deviation is §1a's --
+      §1's invariant outranks a per-construct rule, and this is the case §1a
+      was reached for.
+      It is CONFORMANT. It is not a divergence from this section, and an
+      implementation that has it is not to be corrected back.
+
+      THE CONDITION IS THE WHOLE EMITTED DOCUMENT, NOT ITS FIRST LINE. An
+      opener needs a closer, so three hyphens at byte 0 open nothing unless a
+      later line closes them -- `***` alone, and `***` above a paragraph, are
+      both written `---` with no exception at all. The document that survives
+      and the document that is destroyed are IDENTICAL on line 1 and differ
+      several lines down, which is why the check this clause most invites, a
+      pattern match on the first line, answers a different question than the
+      one asked. What an implementation owes is §1a's test: read the emitted
+      bytes with its own parser.
+
+      WHICH break moves is not pinned, because more than one departure
+      restores §1 and §1a already says to take the smallest. Usually it is the
+      break at byte 0. Where the writer itself PROMOTED something else there --
+      hoisting a definition below the body can leave a paragraph at the head --
+      the text at byte 0 is not the writer's to respell, and the departure
+      available is to respell the CLOSER instead. What IS pinned is the
+      spelling a moved break takes, `***`, for the reason this clause exists at
+      all: a construct left with two admissible spellings normalizes two ways,
+      and an exception is no more exempt from that than the rule is.
+
+      STATED HERE RATHER THAN LEFT TO §1a. §1a makes the deviation conformant
+      wherever it is reached, and this clause would still read as though no
+      deviation were permitted. A clause that reads unconditionally is applied
+      unconditionally: an engine that has this right invites a later reader to
+      file it as a defect against this section and revert it, which has cost
+      one engine a ticket already (carve-rs#732). When the marker reaches the
+      AST (carve#976) the writer reproduces what the author wrote, no leading
+      `---` is manufactured from anything, and this exception is removed with
+      the clause it qualifies.
+
       This is where §6 runs out, and it runs out for the reason §6 itself
       gives. §6 leaves a spelling alone because "those are the author's
       choices AND THE AST RECORDS THEM", and the second half is the whole of


### PR DESCRIPTION
Two halves of `markup-carve/carve#961`, and neither is a finding.

The ticket's own framing is the important one: the `AST conformance` workflow had been red on `main` for weeks and nothing noticed, "not by a gate - every tick asked only is this pull request green". A daily scheduled job that clones and builds four engines is the right cadence for a cross-repo drift check, and it is also invisible to every gate this project runs. The check existed, ran, and reported, and nothing consumed the result.

## 1. The reader: the run files its own verdict

`.github/workflows/ast-conformance.yml` gains a final step that turns the run's outcome into a tracking issue.

- **One issue**, matched on a marker in its body rather than on its title, so a later red run EDITS it instead of filing a second.
- **Closed by the first green run**, with a comment naming the run that cleared it. A closed ticket therefore means the last run passed, not that somebody tidied up.
- **Closing it by hand does not mute it.** The lookup matches OPEN issues only, so the next red run files a fresh one. The only way to stop the reports is to make the run green.
- **The failing steps are read back from the run's own API**, not from a hand-kept list of step ids. Such a list goes stale the first time a step is added, and would then hide exactly the failure it forgot to name.
- **No label.** `hold` and `needs-decision` are the two labels this org's automation reads as "do not touch", and an alert that lands pre-silenced is no alert.
- **The step fails if it cannot file.** A reporter that swallows its own errors is the defect it exists to fix.
- **The ticket is scoped to the ref.** `workflow_dispatch` can be aimed at any branch, so a shared marker would let a green dispatch from a feature branch CLOSE a ticket about `main` - silencing the alarm by testing something else, which is this ticket's own failure mode wearing a different hat. A branch keeps its own ticket and it self-closes the same way.
- **`concurrency`** comes with it: the 04:00 schedule and a dispatch someone wanted now would otherwise reach the verdict step together, each find no open ticket, and file two.

### Why an issue, and not the other two options

A **badge or a digest line** has no reader who is obliged to look, which is the state being fixed rather than a fix for it.

A **cheap per-pull-request subset** was the more tempting one, and it does not exist. What this job measures is four engines' current `main` against this repository's three declaration ledgers; there is no subset of that a gate can run without the builds, and the recurring failure here has been a ledger going stale against engines that moved, which is precisely the part no local check can see. Gating unrelated pull requests on a cross-repo question also teaches people to ignore the job, which this workflow's own comments record as how both of its checkers came to be unwired in the first place.

An open issue is what the org-wide sweep enumerates and what a human sees on the issue list. It is a consumer that already exists.

## 2. The ruled clause: PART 11 section 6a states its byte-0 exception

The signoff on the ticket. Section 6a says the writer emits a thematic break as three hyphens "whatever the author wrote" and states no exception. There is one, and it is not optional: a `---` line at byte 0 of the EMITTED document is the frontmatter opener. A document of `***`, a blank line and `---` renders two rules; written by the literal reading of the clause it renders nothing, with any paragraph between them lost too.

Section 1a (markup-carve/carve#1005) already makes that deviation conformant in general terms, and says in its own pull request body that stating the exception in 6a is this ticket's. What 1a cannot do is stop 6a from reading as though no deviation were permitted, and that is the concrete harm: markup-carve/carve-rs#732 was filed against an engine that had the deviation right.

The clause now states four things:

- the exception and its trigger, and that the deviation is section 1a's rather than a divergence from this section;
- that the condition is the WHOLE emitted document, not its first line. An opener needs a closer, so `***` alone and `***` above a paragraph are both written `---` with no exception at all. The surviving document and the destroyed one are identical on line 1 and differ several lines down, so a pattern match on the first line answers a different question;
- that WHICH break moves is not pinned, because more than one departure restores the invariant and section 1a already says to take the smallest. Usually it is the break at byte 0; where the writer promoted a paragraph there by hoisting a definition below the body, the head is not the writer's to respell and the closer moves instead;
- that the spelling a moved break takes IS pinned, at `***`, on this clause's own argument: a construct left with two admissible spellings normalizes two ways, and an exception is no more exempt from that than the rule is.

Prose only. No production moves, no corpus document moves, and `resources/normative-clauses.txt` is unchanged at 132 clauses, because this qualifies an existing clause rather than adding one.

## Scope and locks

Took the org-wide sweep lock `markup-carve.sweep`, not the per-repo one: the change touches `resources/grammar.ebnf`, which is outside the workflows-and-markdown case the per-repo lock covers.

No closing keyword. This lands the ticket's structural half and its ruled clause; the findings half is a separate matter and the ticket's own record is that it stays open until the render-comparison rows are gone.

No CHANGELOG entry: nothing under a shipped source directory changes behavior, and a workflow is not a consumer-visible surface.

Draft `291` (file inclusion, PART 9 section 19) also touches `resources/grammar.ebnf` and is a WARN rather than a block: it shares no section with this edit, so it takes a rebase and not a decision.
