### PR TITLE
spec: the thematic-break marker records the character, not the run length

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -60,6 +60,9 @@ Author-choice fields preserve a spelling when it differs from the default.
 `list.bulletChar` records `*` while absence means `-`; likewise,
 `thematic_break.marker` records `*` or `_` while absence means `-`. A writer
 reproduces the recorded character and uses the default when the field is absent.
+The marker records the CHARACTER only: `***` and `*****` are one spelling, and
+no run length is recorded, on the same reasoning that took fence length off this
+list in carve#1000.
 
 **The tree is pre-resolve** (§3a). It records what the author wrote, not what the
 document resolves to. `[getting started][]` publishes a `link` carrying `ref` and

--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -2770,7 +2770,7 @@
             "*",
             "_"
           ],
-          "description": "Thematic-break character AS AUTHORED (PART 11 section 6). Absent means the default `-`."
+          "description": "Thematic-break marker character AS AUTHORED (PART 11 section 6). Absent means the default `-`. The CHARACTER only: `***` and `*****` are one spelling and no run length is recorded (carve#1000)."
         },
         "attrs": {
           "$ref": "#/$defs/attrs"


### PR DESCRIPTION
`thematic_break.marker` landed in `markup-carve/carve#1019` described as "Thematic-break character AS AUTHORED". That names what the field records and not what it discards, so a reader deciding whether a canonical writer must reproduce `*****` as five asterisks had nothing to go on.

The question is already settled. Run length left the list of author choices the writer preserves when fence length did, in `markup-carve/carve#1004`, on the argument that the AST records no run and every engine normalizes it. The enum here has only ever admitted single characters, so nothing about behavior changes; this states the consequence in the two places a reader looks.

Wording taken from the abandoned branch `spec/976-thematic-break-marker`, which had it right and which is being deleted now that its content is archived on `markup-carve/carve#1022`. Its schema hunk was superseded by `markup-carve/carve#1019` and its remaining work belongs to the engine rollout, so only this clarification is portable today.

Sweep lock taken rather than the per-repo one: `resources/ast-schema.json` is a spec resource, not markdown.
