### PR TITLE
docs: make examples migration-clean Carve

### DIFF
--- a/docs/case-study/index.md
+++ b/docs/case-study/index.md
@@ -5,7 +5,7 @@ description: The original design research behind Carve - historical, not normati
 
 # Case Study
 
-::: info Historical document
+::: info "Historical document"
 This case study records the design research Carve grew out of: the landscape it
 came from, the principles that guided it, and the reasoning behind each syntax
 decision. It is **not the normative specification** and is not kept in lockstep

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -9,7 +9,7 @@ turning your content into a JavaScript program.
 > landscape (AsciiDoc, reStructuredText, Textile, and more), see
 > [Modern Markup Languages Comparison](./markup-languages).
 
-::: tip Legend
+::: tip "Legend"
 ✅ native &nbsp;·&nbsp; 🧩 plugin / extension needed &nbsp;·&nbsp; ⚠️ partial / convention &nbsp;·&nbsp; ❌ not available
 :::
 
@@ -96,7 +96,7 @@ for the detailed breakdown and caveats.
 - **MDX** - your docs *are* an app; you want to embed live React/JS components and accept that content runs code.
 - **Carve** - you write **cross-referenced, content-rich docs** (handbooks, specs, knowledge bases) and want batteries-included syntax, predictable output, and the same result across php / js / rs - without a build step that executes JavaScript.
 
-::: info Want the full reasoning?
+::: info "Want the full reasoning?"
 See [Technical Rationale](/technical-rationale) for the parser contract and
 [Divergence from Djot](/divergence-from-djot) for the specific design calls
 (case-preserving heading ids, content-required list markers, the `+` continuation marker).

--- a/docs/dismissed-syntax.md
+++ b/docs/dismissed-syntax.md
@@ -28,6 +28,7 @@ Visit "Google"(https://google.com "Search engine") today.
 
 ---
 
+{#link-syntax-arrow}
 ## Link Syntax: `[text -> url]` (arrow)
 
 **Proposed:**
@@ -47,6 +48,7 @@ Visit [Google -> https://google.com] for search.
 
 ---
 
+{#link-syntax-wiki}
 ## Link Syntax: `[[url | text]]` (wiki-style)
 
 **Proposed (wiki-style):**

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -176,7 +176,7 @@ used `+` as a bullet (most don't).
 output is learnable in seconds and memorable after weeks away - the "ten-second
 rule." It is a source-compatibility break with Djot, but a small, teachable one.
 
-::: warning One delimiter flips meaning
+::: warning "One delimiter flips meaning"
 `~text~` is **subscript** in Djot but **strikethrough** in Carve (the tilde looks
 like a line through text). Carve writes subscript as the braced `{,text,}` only.
 This is the one inline delimiter whose meaning differs between the two
@@ -370,7 +370,7 @@ Carve's `` `x`{=format} `` byte-identically and routes it correctly per writer:
 | `latex` | `{=latex}` | html, typst, markdown |
 | `typst` | `{=typst}` | html, latex, markdown |
 
-::: warning Do not pipe a whole Carve document through pandoc
+::: warning "Do not pipe a whole Carve document through pandoc"
 Only the raw-passthrough construct is byte-shared. A full Carve document is **not**
 valid Djot: pandoc's Djot reader reads `/italic/` as literal text and remaps
 `_underline_` to `<em>` (Djot emphasis). Carve's visual-mnemonic emphasis

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -3647,7 +3647,8 @@ are always on and identical across implementations.
 A `javascript:` link destination is rejected, leaving an empty `href` (the link
 text is preserved):
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 [click here](javascript:stealCookies)
@@ -3661,7 +3662,8 @@ text is preserved):
 
 An autolink with a dangerous scheme is blanked the same way:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 <vbscript:msgbox>
@@ -3678,7 +3680,8 @@ The denylist also covers OS protocol-handler and command-execution schemes
 launch a binary or open a macro-bearing document. A Windows document handler
 such as `ms-office:` is blanked, even when it embeds an inner URL:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 [a](ms-office:ofe|u|http://evil/x.docm)
@@ -3692,7 +3695,8 @@ such as `ms-office:` is blanked, even when it embeds an inner URL:
 
 The Follina-class `ms-msdt:` handler is blanked:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 [b](ms-msdt:/id)
@@ -3706,7 +3710,8 @@ The Follina-class `ms-msdt:` handler is blanked:
 
 The `shell:` scheme (and an `ms-msdt:` autolink) are blanked the same way:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 [c](shell:Startup)
@@ -3724,7 +3729,8 @@ The `shell:` scheme (and an `ms-msdt:` autolink) are blanked the same way:
 Ordinary web and contact schemes remain allowed -- only the dangerous classes
 are neutralized. An `https:` link and a `tel:` link are kept intact:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 [d](https://ok.com)
@@ -3742,7 +3748,8 @@ are neutralized. An `https:` link and a `tel:` link are kept intact:
 An image whose source uses a dangerous scheme keeps its `alt` but drops the
 `src` value:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 ![logo](javascript:stealCookies)
@@ -3756,7 +3763,8 @@ An image whose source uses a dangerous scheme keeps its `alt` but drops the
 
 An event-handler attribute (any `on*` name) is dropped entirely:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 A [danger]{onclick="steal()"} span.
@@ -3771,7 +3779,8 @@ A [danger]{onclick="steal()"} span.
 A `style` value containing a CSS `expression(` (or `url(`, `@import`,
 `behavior:`, `-moz-binding`) is blanked, keeping the harmless `style` slot:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 A [danger]{style="x:expression(steal())"} span.
@@ -3785,7 +3794,8 @@ A [danger]{style="x:expression(steal())"} span.
 
 The `srcdoc` and `formaction` attribute names are dropped:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 A [danger]{srcdoc="<script>"} span.
@@ -3800,7 +3810,8 @@ A [danger]{srcdoc="<script>"} span.
 An attribute-block `href`/`src` override cannot reintroduce a dangerous scheme;
 the safe destination is kept and the override is ignored:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 [safe](https://example.com){href="javascript:steal"}
@@ -4322,7 +4333,8 @@ target.
 <!-- The carve body holds a precomposed e-acute (U+00E9). -->
 A precomposed `é` (U+00E9) yields id `Café`:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 # Café
@@ -4340,7 +4352,8 @@ A precomposed `é` (U+00E9) yields id `Café`:
 A decomposed `e` + U+0301 yields the SAME id `Café` (NFC), while the rendered
 heading text keeps the author's decomposed sequence:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 # Café
@@ -4358,7 +4371,8 @@ heading text keeps the author's decomposed sequence:
 A heading containing U+202E and U+200B yields an id with NEITHER (`ABC`); the
 rendered text drops the bidi-override but keeps the zero-width space:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 # A‮B​C
@@ -4381,7 +4395,8 @@ to the raw control downstream, so it is removed rather than escaped.
 <!-- The carve body holds a, RIGHT-TO-LEFT OVERRIDE (U+202E), b. -->
 In paragraph text the control is stripped:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 a‮b
@@ -4396,7 +4411,8 @@ a‮b
 <!-- The carve body holds a code span: a, RIGHT-TO-LEFT OVERRIDE (U+202E), b. -->
 In a code span the control is stripped too (not entity-encoded):
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 `a‮b`
@@ -4418,7 +4434,8 @@ SPACE (U+202F) -- before matching the scheme (PART 9 §25), so an obfuscated
 A reference destination prefixed by U+202F then `javascript:` is rejected,
 leaving an empty `href`:
 
-::: compare no-render
+{.no-render}
+::: compare
 
 ```carve
 [click][a]

--- a/docs/extension-tutorial.md
+++ b/docs/extension-tutorial.md
@@ -54,7 +54,7 @@ url: https://example.com
 and gets a scannable QR for each - a link to open, a network to join, a text to
 send, a contact to save. Same extension, different payload convention (Step 1).
 
-::: tip Tier
+::: tip "Tier"
 Everything here is [Tier-3](./extensions#_1-feature-taxonomy): an app extension,
 off by default, never part of the conformance corpus. It changes nothing about
 core Carve - it only claims the `qr` info word on fenced code blocks, which core
@@ -123,7 +123,7 @@ hyphenated, not a second word: `` ```qr wifi `` is, per the grammar's
 info word disqualifies the fence), so the type has to be part of the single
 `language_info` token — and `-` is a valid token character.
 
-::: tip Authors never escape
+::: tip "Authors never escape"
 WiFi / MeCard / vCard treat `\ ; , :` (and `"` for WiFi) as **structural**, but
 that is the *builder's* problem, not the author's. The author always writes the
 plain value — `password: pa;ss`, `org: ACME, Inc` — and `buildQrPayload`

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -6,7 +6,7 @@ authority for Tier-1 output; the optional Tier-2 corpus
 This document defines the feature taxonomy and the extension mechanism every
 implementation realizes.
 
-::: tip Hands-on
+::: tip "Hands-on"
 For a worked, end-to-end walkthrough of building a Tier-3 extension (a `qr`
 fenced block, in both carve-js and carve-php), see
 [Writing an extension: a QR-code case study](./extension-tutorial).

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -21,7 +21,7 @@ Or skim the **[Cheat Sheet](/cheatsheet)** — the whole syntax fits on one page
 
 There are three reference engines. All of them turn a Carve string into HTML and pass the shared Tier-1 corpus.
 
-::: tip Published packages
+::: tip "Published packages"
 The three reference engines are published: npm [`@markup-carve/carve`](https://www.npmjs.com/package/@markup-carve/carve), Packagist [`markup-carve/carve-php`](https://packagist.org/packages/markup-carve/carve-php), and crates.io [`carve-lang`](https://crates.io/crates/carve-lang). The install commands below use them.
 :::
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -17,7 +17,7 @@ This is the canonical formal specification of Carve. It is **layered**, and each
 | PART 11 | Canonical source writer (`carve fmt`): round-trip invariants and the escaping rule | Invariants over `parse`/`fmt` + a decision procedure |
 | PART 12 | AST serialization: the JSON shape a parsed document exchanges as | Reference-implementation field names + a round-trip invariant |
 
-::: info Why layers instead of one grammar?
+::: info "Why layers instead of one grammar?"
 Light markup languages are provably not context-free: fence-length matching is a counting constraint, indentation is 2D, and reference resolution needs a whole-document symbol table. No single EBNF can express Carve (or Djot, or CommonMark). What CAN be done - and what this file does - is state every rule in *some* exact formalism, so nothing normative rests on English prose.
 :::
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 ---
+title: Carve
 layout: home
 
 hero:

--- a/docs/migrate-from-markdown.md
+++ b/docs/migrate-from-markdown.md
@@ -7,7 +7,7 @@ description: A task-oriented guide for Markdown and GFM authors switching to Car
 
 This guide is for authors who already know CommonMark or GitHub-Flavored Markdown (GFM) and want to rewrite documents in Carve. It focuses on what to change, not on why Carve differs from Markdown - for the design rationale see [Carve vs Markdown/Djot/MDX](/comparison).
 
-::: tip Automated conversion
+::: tip "Automated conversion"
 There is no `migrate` CLI command; the Markdown converter is a library API. In carve-js call `markdownToCarve` (exported from `@markup-carve/carve`); in carve-php use `MarkupCarve\Carve\Converter\MarkdownToCarve`:
 
 ```js
@@ -71,7 +71,7 @@ _underline_
 
 :::
 
-::: warning Emphasis is the most common migration error
+::: warning "Emphasis is the most common migration error"
 The auto-converter rewrites emphasis for you, but watch for cases where your Markdown used `_` for italics - in Carve `_underline_` renders as `<u>`, not `<em>`.
 :::
 
@@ -280,7 +280,7 @@ const html = carveToHtml(source, { allowRawHtml: false })
 
 The equivalent switch exists per engine (carve-rs `Options::with_raw_html(false)`, etc.). See [Security](/security) for the full model.
 
-::: warning Trust boundary
+::: warning "Trust boundary"
 Bare tags are safe (literal) regardless. The setting above only governs the explicit ```` ```=html ```` / `{=html}` passthrough - leave it disabled for user-generated content.
 :::
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -307,21 +307,21 @@ reversed in the browser.
 | **Carve** | ~1 MB (budget-capped, then degrades to plain text) | < 1 s |
 | typical Markdown parser | unbounded, or a ReDoS hang | seconds → DoS |
 
-::: warning One thing you must still configure
+::: warning "One thing you must still configure"
 **Raw HTML is on by default.** ` ```=html ` blocks and `` `…`{=html} `` inline
 raw are emitted verbatim unless you disable raw passthrough (or run a safe
 mode). For untrusted input, turn raw HTML off - the URL, attribute, and DoS
 defenses above are always on, but raw passthrough is the one switch you own.
 :::
 
-::: tip Prefer the `img` fence over raw `=html` for SVG
+::: tip "Prefer the `img` fence over raw `=html` for SVG"
 To put SVG on the page without the raw-HTML passthrough, use the
 [`img` fence](/svg-images). It sanitizes the SVG and, by default, emits a
 browser-sandboxed `data:image/svg+xml` `<img>` - safe for untrusted input.
 Themeable inline `<svg>` is an opt-in the host enables only for trusted content.
 :::
 
-::: tip Defense in depth still applies
+::: tip "Defense in depth still applies"
 Carve's URL/CSS hardening is a **denylist** of known-dangerous constructs, not a
 full allowlist sanitizer. For genuinely hostile input that may carry arbitrary
 attributes, keep running the rendered HTML through a DOM sanitizer (e.g.
@@ -352,7 +352,7 @@ auto-detection, so a bare tag is never live markup. The only way to emit raw
 HTML is the **explicit** `` ```=html `` construct, which you disable for
 untrusted input.
 
-::: tip Two things this CVE also reminds you of
+::: tip "Two things this CVE also reminds you of"
 Even with Carve's inert output, a *preview* application still owns its sandbox:
 render into an `iframe[sandbox]` with no same-origin / no localhost access and a
 Content-Security-Policy. And keep raw-HTML passthrough off for untrusted files.
@@ -375,7 +375,7 @@ always-on scheme denylist blanks these to `href=""`:
 So `[open](ms-office:ofe|u|http://evil/x.docm)` becomes `<a href="">open</a>` —
 the OS handler is never reachable.
 
-::: warning A denylist is a moving target
+::: warning "A denylist is a moving target"
 Blocking the *known* command-execution schemes closes the documented class, but
 new OS handlers appear. If your application turns link clicks into OS-handler
 invocations (a desktop preview, an editor), enable the scheme **allowlist**


### PR DESCRIPTION
Reapplies the useful parts of the stale `docs/quote-admonition-titles` branch onto current main:

- quote every prose admonition title so examples use valid Carve opener syntax
- add explicit heading ids where migration-sensitive links rely on them
- keep the newer wording added since the old branch diverged

Tested: `npm test` (1878 passed).