### PR TITLE
test(ast): add shared source layout fixtures

### DIFF
--- a/docs/ast-source-layout.md
+++ b/docs/ast-source-layout.md
@@ -21,6 +21,11 @@ for every honestly positioned node. Optional facts cover markers, content
 columns, continuation style, blank lines, fences, attachments, and table
 spelling. Missing means unknown, never a guessed default.
 
+All producers consume the shared cases in
+[`resources/ast-source-layout-fixtures.json`](https://github.com/markup-carve/carve/blob/main/resources/ast-source-layout-fixtures.json).
+`exact` compares complete sidecars; `sourceFacts` pins encoding facts while AST
+position conformance independently tracks range agreement.
+
 Default parsing, AST JSON, CLI JSON, and rendering do not change. An AST decoder
 does not accept a sidecar as an AST, and a sidecar reader rejects versions it
 does not implement.

--- a/resources/ast-source-layout-fixtures.json
+++ b/resources/ast-source-layout-fixtures.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "exact": [{
+    "name": "ascii paragraph",
+    "source": "Hello",
+    "layout": {"version": 1, "encoding": "utf-8", "source": "Hello", "lineEndings": "none", "bom": false,
+      "nodes": [
+        {"path": "/children/0", "startByte": 0, "endByte": 5},
+        {"path": "/children/0/children/0", "startByte": 0, "endByte": 5}
+      ]}
+  }],
+  "sourceFacts": [
+    {"name": "utf8 bom and crlf", "source": "﻿- 😀\r\n", "lineEndings": "crlf", "bom": true},
+    {"name": "mixed endings", "source": "a\r\nb\nc\r", "lineEndings": "mixed", "bom": false},
+    {"name": "explicit continuation", "source": "- a\n+\n```sh\nx\n```\n", "lineEndings": "lf", "bom": false},
+    {"name": "marker-line fence", "source": "- ::: note\n  body\n  :::\n", "lineEndings": "lf", "bom": false},
+    {"name": "loose list", "source": "- a\n\n- b\n", "lineEndings": "lf", "bom": false},
+    {"name": "table padding and orphan span", "source": "| < | b |\n|---|---|\n", "lineEndings": "lf", "bom": false}
+  ]
+}

--- a/tests/ast-schema.test.mjs
+++ b/tests/ast-schema.test.mjs
@@ -54,6 +54,18 @@ test('source layout is a separate closed versioned sidecar', () => {
   assert.equal(validate({ type: 'document', children: [], srcByteLength: 0, sourceLayout: {} }), false)
 })
 
+test('shared source-layout fixtures validate', () => {
+  const layoutSchema = JSON.parse(readFileSync(resolve(root, 'resources/ast-source-layout-schema.json'), 'utf8'))
+  const validateLayout = new Ajv2020({ strict: true }).compile(layoutSchema)
+  const fixtures = JSON.parse(readFileSync(resolve(root, 'resources/ast-source-layout-fixtures.json'), 'utf8'))
+  for (const fixture of fixtures.exact) assert.equal(validateLayout(fixture.layout), true, fixture.name)
+  for (const fixture of fixtures.sourceFacts) {
+    const layout = { version: 1, encoding: 'utf-8', source: fixture.source,
+      lineEndings: fixture.lineEndings, bom: fixture.bom, nodes: [] }
+    assert.equal(validateLayout(layout), true, fixture.name)
+  }
+})
+
 /** The reference build: the package pin, or a checkout named by CARVE_JS_DIR. */
 const jsDir = process.env.CARVE_JS_DIR
 const lib = await import(jsDir ? resolve(jsDir, 'dist/index.js') : '@markup-carve/carve')


### PR DESCRIPTION
Adds the cross-engine fixture set for PART 12 §13. Exact cases compare complete sidecars; source-fact cases cover BOM, CRLF/mixed endings, continuations, marker-line fences, loose lists, and table span spelling.

Follow-up to #1032. BC breaks: 0.