### PR TITLE
The trailing-nbsp gate declaration comes off, and DECLARED is empty

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -37,7 +37,8 @@ implementation — except rows marked **✦**, which are opt-in extensions
 | `@user` `#tag` | mention / tag | social conventions |
 | `\*literal\*` | escape | backslash + any ASCII punctuation |
 | `--` `---` `...` `->` `(c)` | – — … → © | smart typography |
-| `\` at end of line | hard break | `\ ` (backslash-space) = no-break space |
+| `\` at end of line | hard break | `\ ` is a hard break here too — the trailing space is stripped before the escape is read |
+| `\ ` mid-line | no-break space | backslash-space; in the last column it is the hard break above |
 | `` `<br>`{=html} `` | raw inline | target-routed; Carve renderers emit only `=html`, others feed external writers ([why](/divergence-from-djot#_10-raw-passthrough-is-target-routed-and-the-pandoc-boundary)) |
 
 Bare delimiters work only at word boundaries; force one intraword with the brace form, e.g. `H{,2,}O`, `mc{^2^}`.

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -524,9 +524,10 @@ to remove it from a document; a failing document is forgiven only when removing
 that shape makes it satisfy both invariants, so a document that also fails for a
 second reason is reported rather than absorbed. Each entry carries a witness
 that must keep failing, so when the engine is fixed the gate goes red and the
-entry has to be deleted. Two entries are declared today: `carve#1027`, an
-escaped space as the last column of a line, and `carve#1030`, a ragged table
-written back rectangular. Both are live in all three engines.
+entry has to be deleted. **`DECLARED` is empty today**, so nothing is forgiven.
+The two entries it has carried both came off that way: `carve#1030`, a ragged
+table written back rectangular, and `carve#1027`, an escaped space as the last
+column of a line.
 
 The alphabet is the gate's reach, so extending it is how the gate grows rather
 than something to avoid. Both declared shapes were found by extending it, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#6bba82d0a71785365526d48fe524aef7a81a0fc4",
+        "@markup-carve/carve": "github:markup-carve/carve-js#02bd8fabc2af76c50c2a26b12735160580ccb653",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.42.1",
@@ -985,8 +985,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#6bba82d0a71785365526d48fe524aef7a81a0fc4",
-      "integrity": "sha512-6z/jWir+lLqsRHCGayWKSkJ5BuDM4riYxpMOXoC7dr2IqBNlkgSvElXKDbjSNHPEIXwBf0G7oRNZl6KkbD3mOw==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#02bd8fabc2af76c50c2a26b12735160580ccb653",
+      "integrity": "sha512-MFG8a8gWjf9sqw4H7/eZf7UGq3+Q+Z+oWN18OR0Nz8e7acXqmxnc4di38aKW97lzRVG0eYfZ6xo6hJvERorqkA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#6bba82d0a71785365526d48fe524aef7a81a0fc4",
+    "@markup-carve/carve": "github:markup-carve/carve-js#02bd8fabc2af76c50c2a26b12735160580ccb653",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.42.1",

--- a/scripts/property-check.mjs
+++ b/scripts/property-check.mjs
@@ -29,8 +29,9 @@
  * the repository that reaches the shapes carve#994 is about was both unexecuted
  * and, had it been executed, unable to fail. The header comment it used to carry
  * said "reporting only ... these invariants do not hold across the board today
- * (carve#359)". carve#359 is closed. What remains failing is one shape, named in
- * DECLARED below, and naming it is what lets everything else gate.
+ * (carve#359)". carve#359 is closed, and so is every shape that was named in
+ * DECLARED below to let the rest of the sweep gate while it waited. DECLARED is
+ * empty now, so nothing is forgiven.
  */
 
 import { execFileSync } from 'node:child_process'
@@ -109,12 +110,29 @@ export function untilStable(rewrite, src) {
 /*
  * SHAPES THE WRITER IS KNOWN TO BREAK TODAY.
  *
+ * EMPTY, AND THAT IS THE DESIGNED END STATE. Every entry that has stood here so
+ * far was removed by the change that fixed its shape, because the audit below
+ * makes a stale entry fail the run: a waiver cannot outlive its defect.
+ * `trailing-nbsp` (markup-carve/carve#1027) was the last of them, and the sweep
+ * now gates PART 11 section 1 with nothing forgiven.
+ *
  * The point of a declaration rather than a lowered bar: a generated sweep that
  * simply reported "38 failures" tells a reader nothing about whether the number
  * grew for a new reason, and a sweep whose alphabet was trimmed until it came
  * back clean would report nothing at all. So each known cause is named once,
  * with the ticket that owns it and a mechanical way to remove it from a
  * document, and EVERYTHING ELSE FAILS THE JOB.
+ *
+ * The shape of an entry, for whoever adds the next one:
+ *
+ *   {
+ *     id: 'short-name',
+ *     ticket: 'markup-carve/carve#N',
+ *     what: 'the shape, and why it is declared rather than fixed',
+ *     witness: 'the smallest document carrying it',
+ *     control: 'a document that does NOT carry it',
+ *     without: (src) => untilStable(rewrite, src),
+ *   }
  *
  * `without` must delete the shape and nothing else. A failing document is
  * attributed to an entry only when removing that entry's shape makes the
@@ -131,25 +149,7 @@ export function untilStable(rewrite, src) {
  *   - its `without` must leave `control` untouched, so an over-broad rewrite
  *     that quietly repairs unrelated documents cannot pass for an explanation.
  */
-export const DECLARED = [
-  {
-    id: 'trailing-nbsp',
-    ticket: 'markup-carve/carve#1027',
-    what:
-      'an escaped space (a backslash followed by a space) as the last column of a ' +
-      'line. All three writers emit the same bytes and all three drop the space; ' +
-      'the bare backslash left behind re-parses as a hard line break. carve-rs and ' +
-      'carve-php read the source that way to begin with, so only carve-js - the ' +
-      'engine this sweep runs through - violates section 1 on it. The parse ' +
-      'divergence underneath is unruled, which is why this is declared rather ' +
-      'than fixed.',
-    witness: 'x \\ \n',
-    control: '# head\n\np 10\\ kg /i/\n',
-    // Only a backslash-space at end of line, and not one whose backslash is
-    // itself escaped - `\\ ` is a literal backslash followed by a real space.
-    without: (src) => untilStable((s) => s.replace(/(^|[^\\])\\ +$/gm, '$1'), src),
-  },
-]
+export const DECLARED = []
 
 /**
  * Both PART 11 invariants over one document.

--- a/tests/property-check-attribution.test.mjs
+++ b/tests/property-check-attribution.test.mjs
@@ -1,13 +1,16 @@
 /*
  * The gate's own machinery, driven on hand-built inputs.
  *
- * scripts/property-check.mjs gates PART 11 section 1 over generated documents,
- * and it does so while ONE shape is still failing (carve#1027). Everything
- * therefore turns on the attribution: a failing document is forgiven only when
- * removing a declared shape makes it satisfy both invariants, and is reported
- * otherwise. An attribution that is too generous turns the gate back into the
- * report it used to be, silently, and the generated documents are the wrong
- * place to notice that - they are regenerated per run and nobody reads them.
+ * scripts/property-check.mjs gates PART 11 section 1 over generated documents.
+ * `DECLARED` is EMPTY today - carve#1027 was the last shape in it - so nothing
+ * is forgiven, and everything below is exercised against a STUB writer with its
+ * own declaration rather than against the shipped list. That is deliberate: the
+ * machinery has to keep working for the next entry, and a test that could only
+ * run while a real waiver existed would have died with the waiver, leaving the
+ * attribution unguarded exactly when someone adds the next one. An attribution
+ * that is too generous turns the gate back into the report it used to be,
+ * silently, and the generated documents are the wrong place to notice that -
+ * they are regenerated per run and nobody reads them.
  *
  * So each direction below is exercised against a stub writer whose behavior is
  * chosen, not observed. Every assertion fails if its branch is removed:


### PR DESCRIPTION
Closes markup-carve/carve#1027.

The engine half landed first, in markup-carve/carve-js#933: an escaped space in the last column of a line is a hard break there now, matching carve-rs and carve-php. This is the other half.

## The declaration goes red, so it goes

`DECLARED` in `scripts/property-check.mjs` named this shape with a witness that must keep failing. Bumping the pin to the carve-js commit that carries the fix turns that witness green, and the audit reports it:

```
DECLARATION trailing-nbsp is stale: its witness "x \\ \n" now satisfies both
invariants. The engine fixed it (markup-carve/carve#1027); delete the entry so
the shape is gated like every other.
```

That is the design working, so the pin bump and the deletion are one change: the sweep never runs with a stale waiver in it.

`DECLARED` is empty as a result, and the sweep gates PART 11 section 1 with nothing forgiven. The comment block above it keeps the shape of an entry for whoever adds the next one, and `tests/property-check-attribution.test.mjs` goes on exercising the machinery against its own stub declaration rather than against the shipped list. That was already how it was written and it is worth keeping: a test that could only run while a real waiver existed would have died with the waiver, leaving the attribution unguarded exactly when the next entry appears.

## Documents corrected

- `docs/cheatsheet.md` said a backslash-space is a no-break space, with nothing about the one place it is not. It now names both readings and says which column decides.
- `docs/implementation-comparison.md` still described two declared entries.

## No corpus document, deliberately

The rule is that an editor may strip the trailing space without changing the meaning. A fixture whose whole subject is an invisible trailing space inside a Markdown source file is therefore the fixture most likely to be normalized away and go on passing while testing nothing - the exact failure this repository keeps finding elsewhere. The generated sweep reaches the shape instead: the alphabet already carries the escaped space, line ends are where the generator puts it, and with `DECLARED` empty nothing about it is forgiven.

## No CHANGELOG entry

Nothing normative moved. The direction was decided by MARKER REQUIRES CONTENT in `resources/grammar.ebnf`, which was already on the page and already stated its own generality past the markers it names. What changed here is a gate declaration, a pin and two documents. The behavior change has its entry in carve-js.
