### PR TITLE
spec: the span counts and the waivers say what the engines now do

### DIFF
--- a/resources/ast-position-waivers.txt
+++ b/resources/ast-position-waivers.txt
@@ -55,24 +55,32 @@
 # because the node CANNOT be placed, not because nobody has placed it.
 #
 # Per ENGINE, per DOCUMENT and per TYPE, because `missing pos on "text"` is one
-# cause in `03-links-12` that §4 permits and a different cause in
-# `182-openers-past-the-nesting-cap-are-one-paragraph` that is an engine gap,
-# and a per-type line would name the first and hide the second - which is
-# exactly what the grouped report did.
+# cause in `237-a-continuation-row-carries-no-trailing-text` that §4 permits and
+# a different cause in `182-openers-past-the-nesting-cap-are-one-paragraph` that
+# is an engine gap, and a per-type line would name the first and hide the
+# second - which is exactly what the grouped report did.
 
 # ---- PERMITTED: a merged `text` run whose pieces are not adjacent ------------
 #
-# The §4 reassembly clause. An autolink unwrapped inside a link label
-# (03-links-12), the two halves of a table cell continued on a `+` line
-# (237, 249-4, 256-15/16/17, 63, 64), and line-block content rebuilt around the
-# indentation sentinel (41-line-blocks-9). All three engines omit; the clause
-# names the category, not the engine.
+# The §4 reassembly clause. The two halves of a table cell continued on a `+`
+# line (237, 249-4, 256-15/16/17, 63, 64), and line-block content rebuilt around
+# the indentation sentinel (41-line-blocks-9). All three engines omit; the
+# clause names the category, not the engine.
+#
+# `03-links-12` STOOD HERE and came off on 2026-08-08, one line per engine. It
+# was an autolink UNWRAPPED inside a link label: the label collapsed to a single
+# `text` run joined across the gap the autolink left, which is a value no offset
+# slices. §3a ended the unwrap - "a nested link and an autolink stay nodes"
+# (markup-carve/carve#967) - and all three engines now publish
+# `text > autolink > text` for `[pre <http://h> post](/u)`, each of the three
+# placed. Nothing is reassembled, so there is nothing for §4 to exempt, and a
+# waiver outliving its defect is a hole sized exactly to the old one
+# (markup-carve/carve#755).
 #
 # A CONTROL: these lines pin unchanged behavior, so no A/B over an engine can
 # fail on them. What is falsifiable is the declaration itself - see the three
 # directions above, each exercised in tests/ast-waivers.test.mjs.
 
-carve-js   03-links-12.crv                                        text  1  permitted
 carve-js   237-a-continuation-row-carries-no-trailing-text.crv    text  2  permitted
 carve-js   249-trailing-whitespace-after-a-block-marker-4.crv     text  2  permitted
 carve-js   256-table-cell-padding-must-be-a-space-15.crv          text  2  permitted
@@ -82,7 +90,6 @@ carve-js   41-line-blocks-9.crv                                   text  3  permi
 carve-js   63-table-multi-line-cell-continuation.crv              text  1  permitted
 carve-js   64-table-rowspan-with-multi-line-content.crv           text  1  permitted
 
-carve-rs   03-links-12.crv                                        text  1  permitted
 carve-rs   237-a-continuation-row-carries-no-trailing-text.crv    text  2  permitted
 carve-rs   249-trailing-whitespace-after-a-block-marker-4.crv     text  2  permitted
 carve-rs   256-table-cell-padding-must-be-a-space-15.crv          text  2  permitted
@@ -92,7 +99,6 @@ carve-rs   41-line-blocks-9.crv                                   text  3  permi
 carve-rs   63-table-multi-line-cell-continuation.crv              text  1  permitted
 carve-rs   64-table-rowspan-with-multi-line-content.crv           text  1  permitted
 
-carve-php  03-links-12.crv                                        text  1  permitted
 carve-php  237-a-continuation-row-carries-no-trailing-text.crv    text  2  permitted
 carve-php  249-trailing-whitespace-after-a-block-marker-4.crv     text  2  permitted
 carve-php  256-table-cell-padding-must-be-a-space-15.crv          text  2  permitted

--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -58,30 +58,49 @@
 #
 # Format: <type> (presence|extent)  <document-count>
 #
-# Measured 2026-08-07 over 833 documents (830 corpus plus 3 synthetic), at
-# carve 8ad86ee, carve-js 39b9223, carve-rs 0d560cc, carve-php d45e250.
-# 328 of those documents carry at least one span the three engines do not agree
-# on, over 16920 spans compared.
+# Measured 2026-08-08 over 883 documents (880 corpus plus 3 synthetic), at
+# carve 02a947c, carve-js e35cfcb, carve-rs fa4d3f7, carve-php 177989a.
+# 353 of those documents carry at least one span the three engines do not agree
+# on, over 18069 spans compared.
+#
+# TEN counts moved since the 2026-08-07 measurement above and the ROW SET did
+# not: no row is new and none agreed, so this is the same set of disagreements
+# over a corpus 50 documents larger.
+#
+# EIGHT of the ten rose, which 50 new documents account for. TWO FELL -
+# block_quote 8 to 7 and text 3 to 2 - and corpus growth cannot lower a count,
+# since each document is judged on its own. Neither is corpus churn either: no
+# corpus document has been deleted or renamed since those numbers were written,
+# and the one that was MODIFIED does not account for either row - swapping its
+# earlier content back in leaves both rows exactly where they are. So one
+# document per row that used to disagree now agrees, which is an engine moving
+# onto the other two. Not carve-js: rebuilt at the commit before its most recent
+# behavior change, the block_quote row measures the same 7 over this corpus.
+#
+# WHICH document left is not recoverable here, and that is this file's design
+# rather than an omission - it records counts precisely so it does not churn on
+# every corpus insertion (see the header above). A count falling is the signal;
+# the engine's own history is where the reason lives.
 
 # ---- EXTENT: PART 12 §4, markup-inclusive (markup-carve/carve#913) ----------
 
-list                    (extent)  129
-table_row               (extent)  66
-list_item               (extent)  52
+list                    (extent)  143
+table_row               (extent)  74
+list_item               (extent)  55
 paragraph               (extent)  47
-footnote                (extent)  40
-definition_term         (extent)  26
-definition_description  (extent)  21
+footnote                (extent)  43
+definition_term         (extent)  27
+definition_description  (extent)  22
 comment                 (extent)  11
-block_quote             (extent)  8
+block_quote             (extent)  7
 hard_break              (extent)  7
+admonition              (extent)  4
+div                     (extent)  4
 frontmatter             (extent)  4
 table                   (extent)  4
 table_cell              (extent)  4
-admonition              (extent)  3
 definition_list         (extent)  3
-div                     (extent)  3
-text                    (extent)  3
+text                    (extent)  2
 code                    (extent)  1
 heading                 (extent)  1
 insert                  (extent)  1


### PR DESCRIPTION
Clears the remaining two causes in the `PART 12 conformance` step of
`AST conformance` (markup-carve/carve#1023). The third, `link.ref`, was an
engine defect and landed as markup-carve/carve-php#1114.

## Ten span counts

The ROW SET did not change - no row is new, none agreed - so this is the same 23
disagreements measured over a corpus 50 documents larger, 883 against 833.

Eight rose, which the new documents account for. Two FELL, and those are worth a
sentence rather than a silent edit:

```
block_quote (extent)  8 -> 7
text        (extent)  3 -> 2
```

Corpus growth cannot lower a count, since each document is judged on its own,
and neither is corpus churn: nothing has been deleted or renamed since those
numbers were written, and the one document that WAS modified accounts for
neither row - swapping its earlier content back in and re-running leaves both
rows at 7 and 2. So one document per row that used to disagree now agrees, which
is an engine moving onto the other two. Not carve-js: rebuilt at the commit
before its most recent behavior change, the block_quote row measures the same 7
over this corpus.

Which document left is not recoverable from this file, and that is its design
rather than a gap - it keeps counts precisely so it does not churn on every
corpus insertion.

## Three waivers the run reports FIXED

`03-links-12`, one line per engine. The finding they cover was an autolink
UNWRAPPED inside a link label: the label collapsed into a single `text` run
joined across the gap the autolink left, a value no offset slices, which is the
PART 12 section 4 reassembly case.

Section 3a ended the unwrap - "a nested link and an autolink stay nodes",
markup-carve/carve#967 - and all three engines now publish the label as three
placed nodes.

Input:

```
[pre <http://h> post](/u)
```

carve-js, carve-rs and carve-php each give `text > autolink > text`, with a
position on every one. Nothing is reassembled, so there is nothing for section 4
to exempt. A waiver that outlives its defect is a hole sized exactly to the old
one (markup-carve/carve#755), which is the same reasoning that took the gate
declarations off tonight. The two prose references to that document are
repointed rather than left dangling.

## Still red after this

`Cross-engine render comparison (all targets)` is a SEPARATE step of the same
job and fails independently, so markup-carve/carve#1023 does not close on this
PR. It reports 12 cross-implementation differences, 9 on the markdown target and
3 on carve, over documents added between 2026-07-17 and 2026-08-08 - a standing
backlog rather than tonight's drift, and the same step failed on the 2026-08-07
runs. Filed separately with its measurement rather than widened into this PR.
