### PR TITLE
spec: a caret line does not end a paragraph it cannot caption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -493,6 +493,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `^ ` caption line does not end a paragraph it cannot caption**
+  (markup-carve/carve#1046, new §10 I7). A caret line is in neither §10 I1 nor
+  §10 I5, so it never interrupts an open paragraph on its own; §4 is what ends
+  one at a caret, and only for the five captionable hosts. The executable spec
+  ended the paragraph on EVERY caret line and opened a second one, where all
+  three engines fold the line in. Only the indented spelling was in the corpus,
+  where both readings agree, so the divergence stayed invisible until the
+  canonical writer stopped force-escaping a line-initial caret.
+
 - **Adjacent mergeable blocks in a tight attached run stay separate.** The
   canonical writer retains `+` from the first sequence boundary that would
   otherwise collapse two blocks, without changing isolated block openers.

--- a/docs/edge-cases.md
+++ b/docs/edge-cases.md
@@ -527,6 +527,8 @@ collected/consumed (an attribute line floats forward to the next block, §15).
 | `Text` / `` ``` `` / `code` | one paragraph | unterminated fence — no closer |
 | `Text` / `---` / `more` | paragraph + `<hr>` + paragraph | thematic break interrupts |
 | `Text` / `![a](u)` | one paragraph (inline image) | image excluded |
+| `Text` / `^ cap` | one paragraph | a caption line is not an interrupter (I7); §4 attaches only to a captionable host |
+| `![a](u)` / `^ cap` | `<figure>` | the paragraph IS the image, so §4 has a host and the caption attaches |
 | `See[^m].` / `[^m]: note` | paragraph + endnotes | invisible construct |
 | `# H` / `- item` | heading + sibling list | list marker ENDS the heading |
 | `# H` / `1. one` | heading + sibling list | list marker ENDS the heading (ordered too) |

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -15268,3 +15268,98 @@ header row becomes part of the first table's body.
 ```
 
 :::
+
+## A caret line does not end a paragraph it cannot caption
+
+PART 9 §10 I1 enumerates the lines that interrupt an open paragraph: a heading, a
+thematic break, a block quote, a valid table row, a guarded fence opener and a
+`:::` opener. I5 adds the invisible ones - a reference definition, a comment, a
+block-attribute line. A `^ ` caption line is in neither list, so it does not
+interrupt. What ends a paragraph at a caret is §4, and §4 reaches exactly five
+captionable hosts; for the two it spells in prose that means a paragraph whose
+WHOLE content is one image or one display-math span. Everywhere else the `^ `
+line is ordinary paragraph text and folds in, caret and all.
+
+`158-indented-image-and-caption-stay-literal` pins the INDENTED spelling, where
+both readings agree because an indented line opens no top-level block at all. The
+flush-left spelling was pinned nowhere, and the two readers in this repository
+answered it differently: every engine folded the line in, the executable spec
+ended the paragraph and opened a second one. Nothing failed while the canonical
+writer force-escaped a line-initial caret. When that escape came off, the writer
+was right and `oracle(fmt(x))` parted from `oracle(x)` on a document all three
+engines agreed about (carve#1046).
+
+A caret line after ordinary prose.
+
+::: compare
+
+```carve
+Text
+^ Figure 1: moon
+```
+
+```html
+<p>Text
+^ Figure 1: moon</p>
+```
+
+:::
+
+A caret line after a paragraph that merely CONTAINS an image. The image is not
+the whole paragraph, so no §4 host is present and the caret folds in behind it.
+
+::: compare
+
+```carve
+Text
+![Apollo](a.jpg)
+^ Figure 1: moon
+```
+
+```html
+<p>Text
+<img src="a.jpg" alt="Apollo">
+^ Figure 1: moon</p>
+```
+
+:::
+
+§10 I6 applies the relation to every open paragraph, including one inside a
+container, so a quoted caret line folds the same way.
+
+::: compare
+
+```carve
+> Text
+> ^ Figure 1: moon
+```
+
+```html
+<blockquote><p>Text
+^ Figure 1: moon</p></blockquote>
+```
+
+:::
+
+Control - when the paragraph IS the image, §4 attaches and the pair is a figure.
+`158-indented-image-and-caption-stay-literal-3` already pins this shape; it is
+repeated here because the rule above is only half a claim without it. The
+mutation that folds every caret line in leaves this row untouched, and a reader
+that stopped attaching captions altogether - the opposite defect - fails here
+and passes everything else in the section.
+
+::: compare
+
+```carve
+![Apollo](a.jpg)
+^ Figure 1: moon
+```
+
+```html
+<figure>
+  <img src="a.jpg" alt="Apollo">
+  <figcaption>Figure 1: moon</figcaption>
+</figure>
+```
+
+:::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>680 / 680</strong>
+    <strong>684 / 684</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>680 / 680</strong>
+    <strong>684 / 684</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>680 / 680</strong>
+    <strong>684 / 684</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,9 +36,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `680 / 680` | `0` | `0` | `3.01` |
-| JS | `8105210` | `680 / 680` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `680 / 680` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `684 / 684` | `0` | `0` | `3.01` |
+| JS | `8105210` | `684 / 684` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `684 / 684` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 
@@ -577,7 +577,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=680 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=684 targets=html,markdown,plain,carve,ansi
 rust: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=3.01
   mismatching documents: 0
 js: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=76.02
@@ -587,11 +587,11 @@ php: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=68.54
 cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=680 diffs=0 errors=0 fixtures=yes
-markdown: compared=680 diffs=0 errors=0 fixtures=1
-plain: compared=680 diffs=0 errors=0 fixtures=1
-carve: compared=680 diffs=0 errors=0 fixtures=13
-ansi: compared=680 diffs=0 errors=0 fixtures=none
+html: compared=684 diffs=0 errors=0 fixtures=yes
+markdown: compared=684 diffs=0 errors=0 fixtures=1
+plain: compared=684 diffs=0 errors=0 fixtures=1
+carve: compared=684 diffs=0 errors=0 fixtures=13
+ansi: compared=684 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 880 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 884 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1114,7 +1114,10 @@ caption_slot = [blank_line], caption ;
    display-math block -- attach the same caption under the same allowance, but
    there is no production to hang the slot on, so for them §4 is the whole
    rule. §4 says which, and why. A `^ ` line that follows neither a slot-
-   carrying host nor one of those two is ordinary inline/paragraph content.
+   carrying host nor one of those two is ordinary inline/paragraph content --
+   which, when a paragraph is OPEN above it, means it folds INTO that
+   paragraph rather than starting a second one. §10 I7 is that half, and it
+   is where the reading was left to inference for long enough to diverge.
    (Reading this note as "only a production attaches a caption" would make a
    captioned image a paragraph, which §4 denies and no engine does.) *)
 
@@ -3508,6 +3511,28 @@ EOF = (* end of file *) ;
          and every other line likewise begins its own block (PART 2,
          SINGLE-LINE HEADINGS). Djot folds a plain or same-`#` line in; this
          is the deliberate divergence, not a restatement of it.
+      I7 A CAPTION LINE DOES NOT INTERRUPT. A `^ ` line appears in neither
+         I1 nor I5. What ends a paragraph at a caret is §4, and §4 reaches
+         only the five captionable hosts; for the two it spells in prose that
+         is a paragraph whose WHOLE content is one image or one display-math
+         span, and there the caret line ends the paragraph and ATTACHES.
+         Anywhere else it folds in as ordinary paragraph text, caret and all:
+         "Text \n ^ cap" is one paragraph, and so is
+         "Text \n ![a](x.png) \n ^ cap", where the image is not the whole
+         paragraph and so there is no host to attach to.
+         NOT IN CONFLICT WITH THE CAPTION'S OWN RULE. A `^ ` line DOES end an
+         open CAPTION (PART 2, MULTI-LINE CAPTIONS, item 4) -- that is a rule
+         about a caption, stated separately from item 2's "a line that
+         interrupts a paragraph" precisely because a caret line is not one of
+         those. Item 4 would be redundant if it were.
+         WHY IT NEEDED WRITING DOWN. Only the INDENTED spelling was in the
+         corpus (158-indented-image-and-caption-stay-literal), where both
+         readings agree because an indented line opens no top-level block at
+         all. The executable spec ended the paragraph on EVERY caret line, all
+         three engines folded it in, and nothing failed until the canonical
+         writer stopped force-escaping a line-initial caret and `oracle(fmt(x))`
+         parted from `oracle(x)` (carve#1046). Pinned by corpus
+         286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption.
 
    11. LIST MARKER CHANGE STARTS A NEW LIST -- OPERATIONAL (governs `list`
       in PART 2). §10 decides FIRST whether marker lines establish a list

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -239,6 +239,18 @@ const ABBR_DEF = /^\*\[([A-Za-z0-9]+)\]: +(?![ \t]*$)([^ ].*)$/
 // than at each use: five places read this capture, and the rule was missing
 // from all five - one rule, one spelling.
 const CAPTION = /^\^ (.*?)[ \t]*$/
+// SS4's two PROSE-spelled captionable hosts: a paragraph whose WHOLE content is
+// one image (inline or reference form, trailing attribute block allowed), and
+// one whose whole content is a display-math span. The other three hosts have a
+// `[caption_slot]` production of their own. ONE spelling, read from two places -
+// the paragraph collector, which decides whether a `^ ` line ends the paragraph,
+// and the wrapper below it, which decides whether the caption attaches. Two
+// copies would let those two answers drift apart, and the collector's copy would
+// be the one nothing tested.
+const CAPTIONABLE_PARAGRAPH = /^(?:!\[[^\]]*\](?:\([^)]*\)|\[[^\]]*\])(?:\{[^}]*\})?|\$\$`.*`)$/
+function isCaptionableParagraph(para) {
+  return para.length === 1 && CAPTIONABLE_PARAGRAPH.test(para[0])
+}
 // The run after the marker is SPACES ONLY: `-\titem` is a paragraph in every
 // engine, so a tab here must not open a list (PART 9 SS11). Its width is the
 // item's content column for a non-task bullet.
@@ -1729,7 +1741,22 @@ function parseBlocksImpl(lines, state, top, inItem = false, seeded = undefined) 
       for (const [re, what] of REFUSERS) {
         if (re.test(lines[i])) throw new Refuse(`${what} interrupting a paragraph`)
       }
-      if (para.length > 0 && CAPTION.test(lines[i])) break // a caption ends the block (SS4); an orphan `^ ` line is literal text
+      // SS4, NOT SS10. A `^ ` line ends an open paragraph only where SS4 has
+      // something to attach it to: a paragraph whose WHOLE content is one image
+      // or one display-math span, the two hosts SS4 spells in prose. SS10's
+      // interruption relation does not list a caption line at all - neither I1's
+      // visible openers nor I5's invisible constructs - so anywhere else the
+      // line is ordinary paragraph text and FOLDS IN, caret and all, which is
+      // what all three engines do.
+      //
+      // This used to break on every caption line. The paragraph then ended and
+      // the caret line opened a second one, and only the indented spelling was
+      // in the corpus (158-indented-image-and-caption-stay-literal), where both
+      // readings agree because an indented line opens nothing. The flush-left
+      // form went unpinned until the canonical writer stopped force-escaping a
+      // line-initial caret and `oracle(fmt(x))` parted from `oracle(x)` on a
+      // document every engine agreed about (carve#1046).
+      if (isCaptionableParagraph(para) && CAPTION.test(lines[i])) break
       if (lines[i][0] === '{' && tryAttrLine(lines, i)) break // SS15 A1 / SS10 I5
       if (ind(i).rest.startsWith('%%')) break // SS10 I5 (comment line or fence)
       if (inItem && para.length > 0 && matchMarkerAt(ind(i))) break // SS24 C3
@@ -1759,10 +1786,7 @@ function parseBlocksImpl(lines, state, top, inItem = false, seeded = undefined) 
       // text under a reference image while all three engines built the
       // figure - and nothing caught it, because every captioned-image case
       // in the corpus uses the inline form.
-      if (
-        para.length === 1 &&
-        (/^!\[[^\]]*\](\([^)]*\)|\[[^\]]*\])(\{[^}]*\})?$/.test(para[0]) || /^\$\$`.*`$/.test(para[0]))
-      ) {
+      if (isCaptionableParagraph(para)) {
         pnode.caption = cap[1]
         // A reference image is captionable ONLY IF IT RESOLVES, and the
         // definition may sit below it - so the decision cannot be made

--- a/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-2.crv
+++ b/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-2.crv
@@ -1,0 +1,3 @@
+Text
+![Apollo](a.jpg)
+^ Figure 1: moon

--- a/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-2.html
+++ b/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-2.html
@@ -1,0 +1,3 @@
+<p>Text
+<img src="a.jpg" alt="Apollo">
+^ Figure 1: moon</p>

--- a/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-3.crv
+++ b/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-3.crv
@@ -1,0 +1,2 @@
+> Text
+> ^ Figure 1: moon

--- a/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-3.html
+++ b/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-3.html
@@ -1,0 +1,2 @@
+<blockquote><p>Text
+^ Figure 1: moon</p></blockquote>

--- a/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-4.crv
+++ b/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-4.crv
@@ -1,0 +1,2 @@
+![Apollo](a.jpg)
+^ Figure 1: moon

--- a/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-4.html
+++ b/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-4.html
@@ -1,0 +1,4 @@
+<figure>
+  <img src="a.jpg" alt="Apollo">
+  <figcaption>Figure 1: moon</figcaption>
+</figure>

--- a/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption.crv
+++ b/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption.crv
@@ -1,0 +1,2 @@
+Text
+^ Figure 1: moon

--- a/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption.html
+++ b/tests/corpus/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption.html
@@ -1,0 +1,2 @@
+<p>Text
+^ Figure 1: moon</p>

--- a/tests/spec/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption.test
+++ b/tests/spec/286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption.test
@@ -1,0 +1,37 @@
+A caret line does not end a paragraph it cannot caption
+
+```
+Text
+^ Figure 1: moon
+.
+<p>Text
+^ Figure 1: moon</p>
+```
+
+```
+Text
+![Apollo](a.jpg)
+^ Figure 1: moon
+.
+<p>Text
+<img src="a.jpg" alt="Apollo">
+^ Figure 1: moon</p>
+```
+
+```
+> Text
+> ^ Figure 1: moon
+.
+<blockquote><p>Text
+^ Figure 1: moon</p></blockquote>
+```
+
+```
+![Apollo](a.jpg)
+^ Figure 1: moon
+.
+<figure>
+  <img src="a.jpg" alt="Apollo">
+  <figcaption>Figure 1: moon</figcaption>
+</figure>
+```


### PR DESCRIPTION
Closes markup-carve/carve#1046.

## What was red

`AST conformance` on main failed one step, `PART 11 formatter round trip`, in
both the 01:32Z dispatch and the 04:54Z scheduled run. Same step, same document,
both times:

```
CROSS-READ oracle(fmt(x)) != oracle(x) [rust] 158-indented-image-and-caption-stay-literal-2
CROSS-READ oracle(fmt(x)) != oracle(x) [js]   158-indented-image-and-caption-stay-literal-2
CROSS-READ oracle(fmt(x)) != oracle(x) [php]  158-indented-image-and-caption-stay-literal-2
roundtrip_compared=880 roundtrip_diffs=0 semantic_failures=0 idempotence_failures=0 cross_read_failures=3
```

The Markdown delimiter-row work the run was dispatched for is not involved. It
touches the Markdown writer, and this check never renders Markdown.

## The document, and why every engine passed it

Source:

```
 {.gallery}
 ![Apollo](a.jpg)
 ^ Figure 1: moon
```

All three engines write it as:

```
\{\.gallery\}
![Apollo](a.jpg)
^ Figure 1: moon
```

and read that back as one paragraph, so `to_html(fmt(x)) == to_html(x)` holds in
each of them and nothing in an engine repo fails. The oracle reads the same
bytes as two:

```html
<p>{.gallery}
<img src="a.jpg" alt="Apollo"></p>
<p>^ Figure 1: moon</p>
```

So the disagreement is about PARSING, and it predates this week. The canonical
writer used to force-escape a line-initial caret; when that escape came off, the
writer stopped hiding a divergence it had been covering. Reduced to its smallest
form, with no indentation and no attribute line in sight:

```
Text
^ cap
```

carve-rs, carve-js and carve-php all give `<p>Text\n^ cap</p>`; the executable
spec gave `<p>Text</p><p>^ cap</p>`.

## Which reader is right

Decided by clause, not by counting engines.

PART 9 section 10 states paragraph interruption as an enumeration: I1 lists the
visible openers (heading, thematic break, block quote, valid table row, guarded
fence opener, `:::` opener) and I5 the invisible constructs (reference
definition, comment, block-attribute line). A `^ ` caption line is in neither.
What ends a paragraph at a caret is section 4, and section 4 reaches exactly
five captionable hosts; for the two it spells in prose that means a paragraph
whose WHOLE content is one image or one display-math span. Everywhere else the
line is ordinary paragraph text and folds in.

PART 2 already said the same thing in the caption_slot note, one sentence short
of settling it: "A `^ ` line that follows neither a slot-carrying host nor one
of those two is ordinary inline/paragraph content." The missing half is what
"ordinary paragraph content" does when a paragraph is already open above it.

The caption's own clause agrees by construction. Item 4 of MULTI-LINE CAPTIONS
says a further `^ ` line ends an open CAPTION, and it is stated separately from
item 2, which is defined as "a line that INTERRUPTS a paragraph". Item 4 is
redundant unless a caret line is not one of those.

So the engines are right and the oracle was wrong. No engine changes here, which
also means no cross-engine divergence can be manufactured by this PR: the render
comparison scores engines against each other and never runs the oracle.

## The change

- `scripts/spec/layout.mjs`: the paragraph collector broke on EVERY caret line
  and let the wrapper below it decide attachment afterwards. It now breaks only
  where section 4 has a host, and both places read one
  `isCaptionableParagraph` helper rather than two copies of the same regex, so
  the collector's answer cannot drift from the wrapper's.
- `resources/grammar.ebnf`: new section 10 I7 writes the reading down, plus the
  missing half-sentence in the caption_slot note. No new NORMATIVE heading, so
  `resources/normative-clauses.txt` is unchanged.
- `docs/examples/edge-cases.md`: corpus 286 pins the flush-left form on prose,
  on a paragraph that merely contains an image, and inside a block quote, plus
  the image-plus-caption control that keeps the rule honest in the other
  direction.
- Quoted corpus counts follow the four new pairs.

## Evidence

With the corpus case in place and the oracle untouched:

```
not ok 919 - 286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption
  + actual - expected
  + '<p>Text</p>\n<p>^ Figure 1: moon</p>'
  - '<p>Text\n^ Figure 1: moon</p>'
not ok 920 - 286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-2
not ok 921 - 286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption-3
# tests 1907
# pass 1903
# fail 3
```

With the fix: 1907 tests, 0 fail, and the local five-target sweep with all three
engines built from their current mains reports `cross_read_failures=0`.

## One thing deliberately left alone

A second, independent oracle divergence sits next to this one and is NOT touched
here, because it is a different question with a different answer:

```
- item
^ cap
```

Every engine ends the list and renders `^ cap` as its own paragraph; the oracle
folds the caret line into the item. That is section 24 C3 (what continues an
open list item), not section 10, and it behaves identically with and without
this change, so it is pre-existing and unrelated. No corpus document reaches the
shape, and nothing in the conformance job is red on it.
