### PR TITLE
ci: gate the comparison twice, walk the corpus once

### DIFF
--- a/.github/workflows/ast-conformance.yml
+++ b/.github/workflows/ast-conformance.yml
@@ -100,9 +100,22 @@ jobs:
           repository: markup-carve/carve-rb
           path: carve-rb
 
+      # `bundler-cache: true` restores carve-rb's gems from the actions cache
+      # instead of resolving and building them from scratch, which was 54s of
+      # pure setup on every run. It needs `working-directory` because the
+      # Gemfile is in the carve-rb checkout, not in this repo.
+      #
+      # carve-rb commits no Gemfile.lock, so setup-ruby resolves once and keys
+      # the cache on the lock it generates. The `bundle install` in the build
+      # step below is kept deliberately: it costs about a second against a warm
+      # cache and it is what makes a cache miss, or a bundle path this action
+      # configures differently than expected, an ordinary slow run rather than a
+      # red job.
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: carve-rb
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -159,7 +172,13 @@ jobs:
           CARVE_JS_DIR: ${{ github.workspace }}/carve-js
           CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
           CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
-        run: npm run compare:impls -- --roundtrip --fail-on-diff
+        # `--report` makes this the ONLY pass over the corpus. The step below
+        # used to be a second full invocation of this same script, over the same
+        # corpus with the same three engines, purely to apply a different subset
+        # of the gate; `--roundtrip` is additive, so this run already computes
+        # the cross-engine and fixture counts it needs. It now writes them out
+        # and the step below gates them. See the note there.
+        run: npm run compare:impls -- --roundtrip --fail-on-diff --report=/tmp/compare-impls.json
 
       # EVERY render target, gated.
       #
@@ -185,13 +204,35 @@ jobs:
       # unresolved question teaches people to ignore the job, which is how both
       # of these checkers came to be unwired in the first place; gating on a
       # settled one is what keeps them settled.
+      #
+      # THIS STEP NO LONGER RE-RUNS THE COMPARISON. It used to be
+      # `compare:impls -- --fail-on-diff`, a second walk of the whole corpus
+      # with the same three engines, and at 669s it was 29% of this job. The
+      # step above already computed everything it needed: `--roundtrip` does not
+      # narrow the targets, the corpus or the comparison loop, it only adds a
+      # pass on top. What differed was the GATE - compare-impls hands each mode
+      # a different subset of the failing conditions and zeroes the other's
+      # counts - so the second invocation existed for its gate, not its work.
+      #
+      # Deleting it was therefore not an option: it carries the only gate on an
+      # engine disagreeing with a FIXTURE, the check whose comment in
+      # compare-impls records that it "could not fail the job" until it was
+      # added. So the run above writes its counts and this reads them. Both
+      # conditions still fail the job; the corpus is walked once.
+      #
+      # It stays a SEPARATE STEP rather than being folded into the one above
+      # because the verdict step at the end of this job reports failures by STEP
+      # NAME. One merged step would tell the tracking ticket that "conformance"
+      # broke without saying whether the formatter changed a document or the
+      # engines disagree about a render target, which is most of what makes that
+      # ticket worth reading.
+      #
+      # `if: always()`, for the reason the step above documents: this gate is
+      # independent of that one, and a round-trip failure must not skip it.
+      # A missing report is a failure here, not a pass - see the script.
       - name: Cross-engine render comparison (all targets)
         if: always()
-        env:
-          CARVE_JS_DIR: ${{ github.workspace }}/carve-js
-          CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
-          CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
-        run: npm run compare:impls -- --fail-on-diff
+        run: npm run compare:report -- /tmp/compare-impls.json
 
 
       # The grammar names engines and says what they do - "all impls support

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "corpus:build": "node scripts/generate-corpus.mjs",
     "compare:impls": "node scripts/compare-impls.mjs",
     "compare:counts": "node scripts/compare-impls.mjs --counts-only",
+    "compare:report": "node scripts/check-compare-report.mjs",
     "claims:check": "node scripts/engine-claims.mjs",
     "degradation:check": "node scripts/degradation-claims.mjs",
     "fmt:check": "node scripts/fmt-fixture-claims.mjs",

--- a/scripts/check-compare-report.mjs
+++ b/scripts/check-compare-report.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/*
+ * The cross-implementation half of the compare-impls gate, applied to a report
+ * file instead of to a second pass over the corpus.
+ *
+ * WHY THIS EXISTS. The `AST conformance` workflow ran compare-impls twice over
+ * the same corpus with the same three engines: once with `--roundtrip
+ * --fail-on-diff` and once with `--fail-on-diff`. That was 1214s + 669s, 83% of
+ * a 38-minute job, and the second invocation was almost all repeated work -
+ * `--roundtrip` is additive, so the first run already computed `crossImplDiffs`
+ * and every engine's fixture `mismatch` count.
+ *
+ * What was NOT shared was the gate. compare-impls hands each mode a different
+ * subset of the failing conditions: roundtrip mode gates round-trip diffs and
+ * the PART 11 §1 invariants, default mode gates cross-engine diffs and fixture
+ * mismatches, and each zeroes the other's counts. So deleting the second
+ * invocation would have deleted the only gate on an engine disagreeing with a
+ * FIXTURE - the check whose own comment in compare-impls records that it "could
+ * not fail the job" until it was added, which is the defect class carve#755
+ * catalogues. The saving had to come without dropping a condition.
+ *
+ * So: compute once, gate twice. The roundtrip run writes `--report=<file>` and
+ * gates its own half; this reads the file and gates the other half. All six
+ * conditions still fail the job, and the corpus is walked once.
+ *
+ * WHY IT STAYS A SEPARATE STEP. The workflow's verdict step reads back the
+ * names of the FAILING STEPS from the jobs API and files them into a tracking
+ * ticket. Collapsing the two steps into one would have made every failure
+ * report the same name, so the ticket would no longer say whether the formatter
+ * changed a document or the engines disagree about a render target. Keeping the
+ * step boundary keeps `Cross-engine render comparison (all targets)` in the
+ * ticket, and this script's own messages name the specific condition on top of
+ * that. The wall clock, not the signal, is what gets removed.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+
+import { COMPARISON_TARGETS } from './lib/corpus-targets.mjs'
+
+const path = process.argv[2]
+if (!path) {
+  console.error('Usage: node scripts/check-compare-report.mjs <report.json>')
+  process.exit(2)
+}
+
+/*
+ * A MISSING REPORT IS A FAILURE, not a pass.
+ *
+ * The step that writes this file runs first and can die before reaching the
+ * write - an engine that will not build, a missing fixture, a crash. If absence
+ * read as "nothing to report" this gate would go green precisely when the run
+ * it depends on fell over, which is the shape of check that cannot fail.
+ */
+if (!existsSync(path)) {
+  console.error(`No report at ${path}.`)
+  console.error(
+    'The step that produces it (compare:impls --roundtrip --fail-on-diff --report=...) did not ' +
+      'get far enough to write it, so nothing cross-implementation was checked. Read that step, ' +
+      'not this one.',
+  )
+  process.exit(1)
+}
+
+let report
+try {
+  report = JSON.parse(readFileSync(path, 'utf8'))
+} catch (err) {
+  console.error(`Could not parse ${path}: ${err.message}`)
+  process.exit(1)
+}
+
+if (report.schema !== 1) {
+  console.error(`Unknown report schema ${JSON.stringify(report.schema)} in ${path}; expected 1.`)
+  process.exit(1)
+}
+
+/*
+ * THE REPORT MUST COME FROM A FULL RUN.
+ *
+ * `--counts-only`, `--targets=` and `--limit=` all narrow what was compared,
+ * and a narrowed run writes a report whose zeros are perfectly true about a
+ * smaller question. Gating on one of those would quietly cover less than the
+ * invocation this replaced while still going green, so each narrowing is
+ * refused by name rather than averaged into a pass.
+ */
+const mode = report.mode ?? {}
+const narrowed = []
+if (mode.countsOnly) {
+  narrowed.push('--counts-only rendered one target instead of every comparison target')
+}
+if (mode.corpus !== 'core') {
+  narrowed.push(`the corpus was "${mode.corpus}", not "core"`)
+}
+if (mode.limit !== null && mode.limit !== undefined) {
+  narrowed.push(`--limit=${mode.limit} compared part of the corpus`)
+}
+const missingTargets = COMPARISON_TARGETS.filter((t) => !(mode.targets ?? []).includes(t))
+if (missingTargets.length > 0) {
+  narrowed.push(`target(s) not compared: ${missingTargets.join(', ')}`)
+}
+// Two engines is the floor for any cross-engine claim; with one, the diff count
+// is zero by construction. compare-impls already refuses this under
+// `--fail-on-diff`, and this refuses it again because the report is now read by
+// something that did not watch that run happen.
+if ((mode.engines ?? []).length < 2) {
+  narrowed.push(`only ${(mode.engines ?? []).length} engine(s) ran, so no comparison happened`)
+}
+if (narrowed.length > 0) {
+  console.error(`${path} was written by a run that compared less than this gate covers:`)
+  for (const reason of narrowed) console.error(`  - ${reason}`)
+  console.error('Re-run compare:impls over the full core corpus and every target.')
+  process.exit(1)
+}
+
+const crossImplDiffs = report.crossImplDiffs ?? 0
+const mismatches = report.mismatches ?? 0
+
+console.log(
+  `Read ${path}: ${mode.engines.join(', ')} over the ${mode.corpus} corpus, ` +
+    `targets ${mode.targets.join(', ')}.`,
+)
+
+if (crossImplDiffs > 0 || mismatches > 0) {
+  if (crossImplDiffs > 0) {
+    console.error(
+      `\n${crossImplDiffs} cross-implementation difference(s) - see the DIFF lines in the ` +
+        'compare step above.',
+    )
+  }
+  if (mismatches > 0) {
+    const by = Object.entries(report.mismatchedBy ?? {})
+      .filter(([, count]) => count > 0)
+      .map(([name, count]) => `${name}=${count}`)
+      .join(' ')
+    console.error(
+      `${mismatches} case(s) where an engine disagrees with the expected output` +
+        `${by ? ` (${by})` : ''} - see the per-engine mismatch counts in the compare step above.`,
+    )
+  }
+  process.exit(1)
+}
+
+console.log('No cross-implementation differences and no fixture mismatches.')

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -27,6 +27,27 @@ const roundtrip = args.has('--roundtrip')
 // disagreeing about a document's canonical form went unnoticed (carve#478).
 const failOnDiff = args.has('--fail-on-diff')
 
+// Where to write this run's counts as JSON, so a SECOND gate can be applied to
+// them without re-running the comparison.
+//
+// The two gated conformance steps used to be two invocations of this script
+// over the same corpus with the same three engines: `--roundtrip --fail-on-diff`
+// and `--fail-on-diff`. Together they were 83% of the workflow's wall clock, and
+// the second one was almost entirely repeated work - `--roundtrip` does not
+// narrow `targets`, `pairs` or the comparison loop, so the roundtrip run already
+// computes `crossImplDiffs` and every engine's fixture `mismatch` count. It just
+// does not GATE them: the ternaries below hand each mode a different subset of
+// the failing conditions.
+//
+// So the fix is not to delete a run. Deleting the plain run would have dropped
+// the only gate on an engine disagreeing with a FIXTURE, which is the check
+// whose own comment records that it "could not fail the job" until it was added.
+// The fix is to compute once and gate twice: this run writes what it found, and
+// scripts/check-compare-report.mjs applies the cross-implementation half of the
+// gate to the file. Same six conditions, one pass over the corpus.
+const reportArg = process.argv.find((a) => a.startsWith('--report='))
+const reportPath = reportArg ? reportArg.slice('--report='.length) : null
+
 // The cheap half of the run. `tests/implementation-comparison-counts.test.mjs`
 // reads exactly two things off this output - `corpus_pairs=N` and each engine's
 // `pass=N/M` - and NEITHER is a timing: `grep avg_ms` over that test returns
@@ -1140,6 +1161,55 @@ console.log(
 
 if (bench) {
   console.log('\nBenchmark note: timings include process startup and are useful for CLI-level smoke comparison only.')
+}
+
+// Written BEFORE the gate below, and unconditionally, because the gate exits.
+// A report that only appears on success would leave the second gate with
+// nothing to read on exactly the runs that matter, and a missing report is
+// indistinguishable from a clean one to anything downstream - so the reader
+// treats absence as failure and this writer makes sure absence means the run
+// died before reaching here.
+//
+// The MODE goes in the file, not just the counts. `--counts-only` and
+// `--targets=` narrow what was compared, and a narrowed run produces a report
+// whose zeros are true but answer a smaller question. The reader refuses those
+// rather than passing on them, so the second gate cannot silently come to cover
+// less than the invocation it replaced.
+if (reportPath) {
+  writeFileSync(
+    reportPath,
+    `${JSON.stringify(
+      {
+        schema: 1,
+        mode: {
+          roundtrip,
+          countsOnly,
+          corpus: corpusName,
+          limit: limit === Infinity ? null : limit,
+          targets: activeTargets,
+          engines: active.map((impl) => impl.name),
+        },
+        // The cross-implementation half of the gate: engines disagreeing with
+        // each other, and engines disagreeing with a fixture.
+        crossImplDiffs,
+        mismatches: active.reduce((total, impl) => total + stats[impl.name].mismatch, 0),
+        mismatchedBy: Object.fromEntries(
+          active.map((impl) => [impl.name, stats[impl.name].mismatch]),
+        ),
+        // The round-trip half, recorded so the file is a full account of the run
+        // rather than only the part the reader gates on.
+        roundtripDiffs,
+        semanticFailures,
+        idempotenceFailures,
+        crossReadFailures,
+        staleUnreachable,
+        undocumentedUnreachable: undocumentedUnreachable.map((u) => u.feature),
+      },
+      null,
+      2,
+    )}\n`,
+  )
+  console.log(`\nWrote ${reportPath}.`)
 }
 
 // The gate. In roundtrip mode a diff means an engine's formatter changed what a


### PR DESCRIPTION
Refs markup-carve/carve#1052.

`AST conformance` takes about 38 minutes and 83% of it is two invocations of
compare-impls over the same corpus with the same three engines: 1214s for
`--roundtrip --fail-on-diff` and 669s for `--fail-on-diff`.

`--roundtrip` is additive. It does not narrow `targets`, `pairs` or the
comparison loop, so the roundtrip run already computes `crossImplDiffs` and
every engine's fixture `mismatch` count. The second invocation repeats all of
that work to apply a different GATE, because compare-impls hands each mode a
different subset of the failing conditions and zeroes the other's counts.

### Why the step is not simply deleted

The plain run carries the only gate on an engine disagreeing with a FIXTURE,
and that check's own comment in compare-impls records that it "could not fail
the job" until it was added. Deleting the step would have bought eleven minutes
by reopening the defect class this repo keeps finding. Roundtrip mode zeroes
`mismatches` outright, so nothing else would have caught it.

### What this does instead

Compute once, gate twice. The roundtrip run takes `--report=<file>` and writes
every count it found. `scripts/check-compare-report.mjs` reads the file and
applies the cross-implementation half of the gate. All six conditions still
fail the job; the corpus is walked once.

The reader refuses rather than passes when it cannot do its job:

- a MISSING report is a failure, because the writing step runs first and can
  die before reaching the write, and absence would otherwise be
  indistinguishable from a clean run
- a report from a run narrowed by `--counts-only`, `--targets=`, `--limit=`, a
  non-core corpus or a single engine is refused BY NAME, so this gate cannot
  silently come to cover less than the invocation it replaced

The write happens before the gate and unconditionally, so a run that exits 1 on
its own half still leaves the other half checkable.

### Why it stays two steps

The verdict step reports failures by STEP NAME into the tracking issue. One
merged step would say "conformance" broke without saying whether the formatter
changed a document or the engines disagree about a render target, which is most
of what makes that report worth reading. Both step names are unchanged, so the
verdict step needs no change and loses no specificity.

### Also

`ruby/setup-ruby` gets `bundler-cache: true` against the carve-rb checkout, 54s
of pure setup per run. The `bundle install` in the build step is kept so a cache
miss is a slow run rather than a red job.

Not done, deliberately: no sharding (the engines must be built in one workspace
for cross-engine comparison), no corpus trimming, and `property:check
--count=20000` is untouched at 5s.

### Note on the gate

`main` is currently red on `PART 12 conformance`, which is tracked separately in
markup-carve/carve#1051 and is not from this branch.
