### PR TITLE
spec: the span ledger counts the corpus it has, not the one it had

### DIFF
--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -84,11 +84,11 @@
 
 # ---- EXTENT: PART 12 §4, markup-inclusive (markup-carve/carve#913) ----------
 
-list                    (extent)  143
+list                    (extent)  145
 table_row               (extent)  74
 list_item               (extent)  55
 paragraph               (extent)  47
-footnote                (extent)  43
+footnote                (extent)  44
 definition_term         (extent)  27
 definition_description  (extent)  22
 comment                 (extent)  11


### PR DESCRIPTION
Clears the one failing step in `AST conformance` on main, reported by `markup-carve/carve#1051`.

Run `31308625594` failed `PART 12 conformance` on exactly this and nothing else:

```
THREE-WAY SPAN COMPARISON does not match resources/ast-span-divergence.txt:
  COUNT      list (extent) declares 143 document(s), measured 145
  COUNT      footnote (extent) declares 43 document(s), measured 44
```

Every engine is clean on substance in that same run - carve-js, carve-rs and carve-php each report `0 outstanding`, and carve-rb is not reconciled by design because it republishes carve-rs's tree.

## Why the numbers moved

The corpus grew from 883 to 891 documents since the ledger was last touched at `3ab36a9`. Eight documents arrived, and they account for both rows:

```
286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption (x4)   no list, no footnote
287-a-column-zero-definition-ends-an-open-list-item        (x4)   a list each; one carries footnote references
```

The caret cases contribute to neither row. The column-zero definition cases each carry a list and one carries footnotes, so `list` rises by 2 and `footnote` by 1 - a subset of what landed rather than the whole of it, which is what you would expect since not every list-bearing document spans differently.

## What this is not

No row is NEW, none AGREED, none fell. The ledger's own header lists all three as distinct failure modes, and this is only the third:

```
- a row that disagrees and is not listed  -> NEW, fails
- a listed row's DOCUMENT COUNT moves     -> COUNT, fails
- a listed row no longer disagrees        -> AGREED, delete the line, fails
```

A row that FELL would mean engines had converged and would want a sentence rather than a new number - that happened twice earlier and was written up rather than silently edited. Nothing here says an engine changed behavior.

## Scope

One file, two numbers. Rebased onto `403881d`, so it sits on top of the workflow change that walks the corpus once. No CHANGELOG entry: this is a spec-repo ledger, not consumer-visible.
