### PR TITLE
ci: provision downstream bump prerequisites

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -87,6 +87,10 @@ jobs:
           - repo: markup-carve/pandoc-carve
             submodule: spec
             lang: node
+            setup: |
+              curl -sSL -o /tmp/pandoc.deb https://github.com/jgm/pandoc/releases/download/3.5/pandoc-3.5-1-amd64.deb
+              sudo dpkg -i /tmp/pandoc.deb
+              pandoc --version | head -1
             test: npm ci && npm test
             allowlist: none - its conversion tests read the corpus directly
           - repo: markup-carve/carve-skill
@@ -94,6 +98,11 @@ jobs:
             lang: node
             test: npm ci && npm test
             allowlist: the drift guard in `test/` (the skill text has to state what the spec now says)
+          - repo: markup-carve/carve-lsp
+            submodule: tests/spec
+            lang: node
+            test: npm ci && npm run build && npm test
+            allowlist: none - its regression tests consume the pinned engine and spec fixtures
           # NOT here: markup-carve/intellij-carve, which also carries the spec
           # submodule. Its corpus snapshots run through Gradle with an IDE SDK
           # download, which does not fit this workflow's node/rust/php shape.
@@ -116,6 +125,13 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
+
+      # Some downstream suites need a host executable in addition to their
+      # language runtime. Keep that setup beside the matrix entry so a missing
+      # prerequisite cannot be misreported as corpus non-conformance.
+      - name: Set up downstream prerequisites
+        if: matrix.setup != ''
+        run: ${{ matrix.setup }}
 
       - name: Bump ${{ matrix.repo }}
         env:
@@ -478,7 +494,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Every repo with a spec submodule is bumped by this workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/bump-downstream-early-exit.test.mjs
+++ b/tests/bump-downstream-early-exit.test.mjs
@@ -437,3 +437,27 @@ test('a human bump PR that is already up to date is left open, not closed', () =
   )
   assert.equal(prStillOpen, true, 'the human PR was closed')
 })
+
+test('pandoc-carve installs its required host executable before conformance', () => {
+  const text = readFileSync(workflow, 'utf8')
+  const row = text.match(
+    /- repo: markup-carve\/pandoc-carve\n(?<body>[\s\S]*?)(?=\n\s+- repo:)/,
+  )
+  assert.ok(row, 'pandoc-carve is absent from the bump matrix')
+  assert.match(row.groups.body, /setup: \|[\s\S]*pandoc-3\.5-1-amd64\.deb/)
+  assert.match(row.groups.body, /pandoc --version/)
+  assert.match(
+    text,
+    /- name: Set up downstream prerequisites[\s\S]*if: matrix\.setup != ''[\s\S]*run: \$\{\{ matrix\.setup \}\}/,
+  )
+})
+
+test('carve-lsp is covered by the downstream bump matrix', () => {
+  const text = readFileSync(workflow, 'utf8')
+  const row = text.match(
+    /- repo: markup-carve\/carve-lsp\n(?<body>[\s\S]*?)(?=\n\s+# NOT here:)/,
+  )
+  assert.ok(row, 'carve-lsp is absent from the bump matrix')
+  assert.match(row.groups.body, /submodule: tests\/spec/)
+  assert.match(row.groups.body, /test: npm ci && npm run build && npm test/)
+})


### PR DESCRIPTION
Fixes #1056.

The downstream bump workflow now installs Pandoc 3.5 before running `pandoc-carve` conformance, so a missing host executable cannot masquerade as a corpus failure and force a healthy bump into draft.

It also adds `carve-lsp` to the bump matrix now that the repository carries `tests/spec`, resolving the live matrix-coverage failure. The matrix guard checkout is upgraded to `actions/checkout@v6`.

Regression assertions pin both matrix entries and the prerequisite execution step. The existing executable early-exit scenarios continue to pass (8/8 total).
