### PR TITLE
ci: upgrade setup-node action to v6

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -113,7 +113,7 @@ jobs:
       # own CI), so the bump can decide draft-vs-ready.
       - name: Set up Node
         if: matrix.lang == 'node'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
       - name: Set up Rust


### PR DESCRIPTION
Updates the downstream bump workflow to `actions/setup-node@v6`.

The live verification run for #1065 passed every matrix job but showed GitHub's Node 20 action-runtime deprecation annotation on each Node downstream. This removes that warning and aligns the setup action with the checkout v6 upgrade already on `main`.

The workflow YAML parses cleanly and all eight executable bump-workflow regression scenarios pass.
