### PR TITLE
release: prepare 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-08-10
+
 ### Changed
 
 - **A column-zero link or footnote definition closes an open list item**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carve-docs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "carve-docs",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "chart.js": "^4.5.1",
         "mermaid": "^11.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carve-docs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "description": "Documentation site for Carve, a post-Markdown markup language",


### PR DESCRIPTION
## Summary

- bump the spec/docs package metadata from 0.1.1 to 0.1.2
- cut the accumulated Unreleased changelog as 0.1.2 dated 2026-08-10
- leave a fresh empty Unreleased section for subsequent work

This is the required final preparation before publishing the existing coordinated 0.1.2 draft release. It intentionally excludes the draft migration-clean examples and transclusion work.

Validated with the complete spec suite: 1,918 tests, 1,917 passed, one intentional skip, zero failures. The package metadata and lockfile agree. After this PR lands, `scripts/pre-tag-check.sh 0.1.2` is the final tag gate.