### PR TITLE
Section 29 T5's owed pandoc measurement is discharged

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -5058,11 +5058,15 @@ EOF = (* end of file *) ;
 
       T5 WHAT THIS SECTION DOES NOT SETTLE, stated so its silence is not
          read as agreement:
-         - PANDOC WAS NOT MEASURED. It is not installed on the host this
-           ruling was made on, and it is among the readers the Markdown
-           target answers to. T2 therefore claims what four named readers
-           do, and does NOT claim that every reader agrees. Measuring pandoc
-           is owed.
+         - PANDOC HAS NOW BEEN MEASURED, and it agrees. pandoc 3.5 keeps
+           U+000B and U+000C in all five positions T2 names -- inline, on a
+           lone line between paragraphs, inside a code span, after a list
+           marker and after an ATX hash -- in its `commonmark`, `gfm` and
+           `markdown` readers alike, and `-<VT>item` opens no list in any of
+           them. T2's finding therefore rests on five readers rather than
+           four. What it still does NOT claim is that EVERY reader agrees: a
+           reader that reclassified these characters as whitespace would be a
+           reason to revisit T2, and none measured so far does.
          - CARVE-RS WAS NOT MEASURED on this behavior at all. The two
            engines that agreed on the strip were carve-js and carve-php. The
            first step of the carve-rs ticket is to MEASURE it, not to assume


### PR DESCRIPTION
PART 9 section 29 T5 recorded an owed measurement: "PANDOC WAS NOT MEASURED. It is not installed on the host this ruling was made on ... Measuring pandoc is owed." This discharges it.

## Measured

pandoc 3.5, U+000B and U+000C, in the five positions T2 names, across three readers:

```
pandoc -f commonmark   keeps both controls in all 5 positions: YES   VT after a bullet opens a list: no
pandoc -f gfm          keeps both controls in all 5 positions: YES   VT after a bullet opens a list: no
pandoc -f markdown     keeps both controls in all 5 positions: YES   VT after a bullet opens a list: no
```

The positions are the ones the row lists: inline, on a lone line between paragraphs, inside a code span, after a list marker, and after an ATX hash.

The sharpest case is the last column. T2's argument rests on `-<VT>item` opening no list, because it would open one if the reader treated the character as whitespace. It opens none in any of the three readers, so pandoc agrees with the four already measured and T2's finding now rests on five.

## What the row keeps

The rewrite does not delete T5's caution, because the part that still stands is the part that was always the point: it does not claim EVERY reader agrees. A reader that reclassified these characters as whitespace would be a reason to revisit T2, and none measured so far does.

The two other items in T5 are untouched and still owed - carve-rs is unmeasured on this behaviour, and DEL plus the C1 controls are outside the section.

## Scope

Prose only. No rule changes and no clause heading changes, so `tests/normativity.test.mjs` passes 9 of 9 unchanged. No engine or corpus behaviour is affected, and nothing here decides anything - the section asked for a measurement and this is the measurement.

Sweep lock, since it touches `resources/`.
