### PR TITLE
Section 29 T5's carve-rs measurement is discharged, and it conforms

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -5067,10 +5067,15 @@ EOF = (* end of file *) ;
            four. What it still does NOT claim is that EVERY reader agrees: a
            reader that reclassified these characters as whitespace would be a
            reason to revisit T2, and none measured so far does.
-         - CARVE-RS WAS NOT MEASURED on this behavior at all. The two
-           engines that agreed on the strip were carve-js and carve-php. The
-           first step of the carve-rs ticket is to MEASURE it, not to assume
-           it is wrong.
+         - CARVE-RS HAS NOW BEEN MEASURED, and it conforms. Driving both
+           U+000B and U+000C through the five positions T2 names, on each
+           target: carve-rs keeps them on HTML, Markdown and plain text and
+           strips them on ANSI -- T1, T2, T3 and T4 respectively, ten of ten
+           on each row. carve-js and carve-php were measured the same way at
+           the same time and agree with it on all four. So the three engines
+           are uniform here and the row's worry -- that carve-rs might be
+           doing something else unseen -- did not hold. Assuming it was wrong
+           would have been the error this row was written to prevent.
          - DEL (U+007F) AND THE C1 CONTROLS are outside this section. A
            security sweep found them already reaching Markdown output in
            carve-js and carve-rs while carve-php refuses them, which is a


### PR DESCRIPTION
PART 9 section 29 T5 recorded a second owed measurement: "CARVE-RS WAS NOT MEASURED on this behavior at all. The two engines that agreed on the strip were carve-js and carve-php. The first step of the carve-rs ticket is to MEASURE it, not to assume it is wrong."

Measured. It conforms.

## Result

carve-rs `6dab698`, built from a clean checkout with an isolated `CARGO_TARGET_DIR` so no stale binary could answer. Both U+000B and U+000C, through the five positions T2 names - inline, on a lone line between paragraphs, inside a code span, after a list marker, after an ATX hash:

| target | carve-rs | carve-js | carve-php | row |
| --- | --- | --- | --- | --- |
| html | keeps 10/10 | keeps 10/10 | keeps 10/10 | T1 |
| markdown | keeps 10/10 | keeps 10/10 | keeps 10/10 | T2 |
| plain | keeps 10/10 | keeps 10/10 | keeps 10/10 | T3 |
| ansi | strips 0/10 | strips 0/10 | strips 0/10 | T4 |

carve-js `cb63c48` and published carve-php `0.1.4` were driven through the same cases in the same session, so this is one measurement rather than three recollections.

## What it settles

The row's worry was that carve-rs might be doing something else unseen, and it said plainly that assuming it was wrong would be the error. It is not wrong - the three engines are uniform on all four rows. The row is rewritten to record that rather than deleted, since the fact that it was once unmeasured is part of why the section exists.

The remaining T5 item is untouched: DEL and the C1 controls are still outside this section and still on their own ticket.

## Scope

Prose only. No rule changes, no clause heading changes, `tests/normativity.test.mjs` passes 9 of 9. Nothing decided - the section asked for a measurement and this is the measurement.

Sweep lock, since it touches `resources/`.
