### PR TITLE
Section 29 T5's DEL/C1 note is stale; the open half is the canonical writer

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -5076,12 +5076,20 @@ EOF = (* end of file *) ;
            are uniform here and the row's worry -- that carve-rs might be
            doing something else unseen -- did not hold. Assuming it was wrong
            would have been the error this row was written to prevent.
-         - DEL (U+007F) AND THE C1 CONTROLS are outside this section. A
-           security sweep found them already reaching Markdown output in
-           carve-js and carve-rs while carve-php refuses them, which is a
-           separate defect on its own ticket. This section is about C0, and
-           must not be read as saying the control-character story is
-           otherwise uniform across the targets.
+         - DEL (U+007F) AND THE C1 CONTROLS are outside this section, which
+           is about C0. The sweep that prompted this note found them reaching
+           Markdown output in carve-js and carve-rs while carve-php refused
+           them; that has since been fixed, and re-measuring finds all three
+           engines identical -- DEL, CSI (U+009B), OSC (U+009D) and U+0080 are
+           stripped on Markdown, plain text and ANSI alike. §25's NON-HTML
+           TARGETS requirement is met on those three.
+           WHAT IS STILL OPEN is the CANONICAL WRITER: all three engines let
+           every one of those characters through on the `carve` target. That
+           may be right -- a writer that drops content is lossy, and the
+           round-trip invariant is what that target answers to -- but §25 says
+           "non-HTML targets" without saying whether the canonical writer is
+           one, and the same question is open for §26's bidi overrides
+           (carve#1076). Deciding it once would settle both.
 *)
 
 


### PR DESCRIPTION
PART 9 section 29 T5's third item said DEL and the C1 controls were "already reaching Markdown output in carve-js and carve-rs while carve-php refuses them, which is a separate defect on its own ticket".

Re-measured: not true any more, and there is no open ticket for it either.

## All three engines are identical now

`a <CONTROL> b`, checking whether the character reaches the output:

| control | carve-js main | carve-rs main | carve-php 0.1.4 |
| --- | --- | --- | --- |
| DEL U+007F | stripped on md / plain / ansi | same | same |
| CSI U+009B | stripped on md / plain / ansi | same | same |
| OSC U+009D | stripped on md / plain / ansi | same | same |
| U+0080 | stripped on md / plain / ansi | same | same |

Section 25's NON-HTML TARGETS requirement is met on those three targets. Searching the tracker for the ticket the row points at turns up only closed ones, so a reader planning work from that sentence would go looking for a defect that was fixed and a ticket that does not exist. That is the rot this section exists to prevent, which is why the row is restated rather than left alone.

## What the re-measurement did turn up

The CANONICAL WRITER lets every one of those characters through, in all three engines:

```
carve target:  DEL REACHES   CSI REACHES   OSC REACHES   U+0080 REACHES
```

That may well be correct. A writer that drops content is lossy, and the round-trip invariant is what that target answers to. But section 25 says "non-HTML targets" without saying whether the canonical writer counts as one, and `markup-carve/carve#1076` has exactly the same question open for section 26's bidi overrides. Deciding it once settles both, so the row points there rather than opening a third thread.

## Scope

Prose only. No rule changes, no clause heading changes, `tests/normativity.test.mjs` passes 9 of 9. Nothing is decided here - the canonical-writer question is named and left to `carve#1076`.

Sweep lock, since it touches `resources/`.
