### PR TITLE
Document the bidi source lint rule

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -90,6 +90,7 @@ the command-line and editor behavior stay aligned.
 
 | Rule | Catches |
 | ---- | ------- |
+| `bidi-control-in-source` | a Trojan-Source bidi override or isolate control (U+202A–U+202E, U+2066–U+2069) that canonical Carve preserves but every presentation target strips |
 | `duplicate-heading-id` | two headings producing the same id, either by slug collision or repeated explicit `{#id}` |
 | `broken-crossref` | a `</#id>` cross-reference with no matching heading or numbered caption id |
 | `unresolved-reference-link` | a `[text][label]` or `[text][]` reference link with no matching link definition; only the collapsed `[text][]` also falls back to the implicit heading target, so an explicit label that names no definition is unresolved even when a heading carries that text (PART 9R R1) |
@@ -253,7 +254,7 @@ The table above is carve-js. The other engines do not currently match it, and
 | implementation | `carve lint` | covers |
 |---|---|---|
 | carve-js | yes | the rules above, plus the Djot/Markdown migration checks |
-| carve-php | yes | Markdown-habit checks only (`markdown-strong-asterisks`, `markdown-strong-underscores`, `markdown-strikethrough`); none of the semantic rules above, and neither platform autolink rule |
+| carve-php | yes | `bidi-control-in-source` plus Markdown-habit checks (`markdown-strong-asterisks`, `markdown-strong-underscores`, `markdown-strikethrough`); none of the other semantic rules above, and neither platform autolink rule |
 | carve-rs | no | the binary has no `lint` command |
 
 The two platform autolink rules are carve-js only today. They are specified here

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#84609cb255a84443f6b253504668042fd5fc44a6",
+        "@markup-carve/carve": "github:markup-carve/carve-js#56735159d54a58ef91210c1577da1bfb6c0bf940",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.42.1",
@@ -984,8 +984,9 @@
       "license": "MIT"
     },
     "node_modules/@markup-carve/carve": {
-      "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#84609cb255a84443f6b253504668042fd5fc44a6",
+      "version": "0.1.3",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#56735159d54a58ef91210c1577da1bfb6c0bf940",
+      "integrity": "sha512-81K794t0ycFbNY2KjbCxe6qEe2Y5N/TGijrCpojt/uAEhE+JpWKiaUzTjKK7oP8AN58nX3XdUQOht5lcjDIs5g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#84609cb255a84443f6b253504668042fd5fc44a6",
+    "@markup-carve/carve": "github:markup-carve/carve-js#56735159d54a58ef91210c1577da1bfb6c0bf940",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.42.1",

--- a/tests/lint-rule-table-claims.test.mjs
+++ b/tests/lint-rule-table-claims.test.mjs
@@ -57,6 +57,7 @@ const page = readFileSync(resolve(root, 'docs/validation.md'), 'utf8')
  * opt-in options provokes its trigger either way.
  */
 const TRIGGERS = {
+  'bidi-control-in-source': 'a‮b\n',
   'duplicate-heading-id': '# A\n\n# A\n',
   'broken-crossref': 'see </#nope>\n',
   'unresolved-reference-link': 'see [text][nope]\n',


### PR DESCRIPTION
Follow-up to #1082 and markup-carve/carve-js#964.

Adds `bidi-control-in-source` to the validation contract, records PHP partial coverage, pins the JS implementation that emits it, and adds a live trigger so the bidirectional rule-table contract stays enforced.