### PR TITLE
ci: run on the next branch as well as main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
   workflow_dispatch:
 
 # Every job here only reads the repo; nothing publishes or comments.


### PR DESCRIPTION
`pull_request.branches` filters on the BASE branch, so a pull request into `next` matched nothing and ran no workflow. GitHub reports such a PR as `CLEAN` because there are no required checks to fail, not because anything passed - which is how the 0.2 set came to look mergeable with no verification behind it.

`push` is widened too, so `next` stays covered after a merge.

carve-bench never had this hole: its trigger is a bare `pull_request:` with no branch filter.

Targeting `next` rather than `main` deliberately - that is where the gap is, and `main` is already covered by the existing filter. The change reaches `main` when the 0.2 line merges.