### PR TITLE
Pin lazy continuation into deep list-item paragraphs

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -2455,6 +2455,31 @@ Give the same fence its space and the contrast is exact. Written `::: note`, it 
 
 The same clause settles the neighboring shapes, which is how one knows it is the clause and not a special case, and each of them is a place an implementation could get the right answer here for the wrong reason. Indenting the lazy line to column 1 changes nothing, since it is still below the content column. The malformed fence may be the paragraph's FIRST line, written on the marker line itself (`- :::note`), and the item then opens with a paragraph that begins with fence-shaped text. Inside a block quote, `> tail` supplies the quote's prefix but not the item's indentation, which is the partial match S4 is written for. All three fold, for the one reason above; `tests/colon-fence-absorbed-in-an-item.test.mjs` pins them.
 
+The same rule reaches a list item's second paragraph. The blank before
+`spaced` makes the item loose, but it does not close the paragraph that
+`spaced` opens. The following flush-left line therefore folds into that
+innermost paragraph; paragraph depth does not create a special boundary.
+
+::: compare
+
+```carve
+1. item
+
+   spaced
+flush
+```
+
+```html
+<ol>
+  <li><p>item</p>
+    <p>spaced
+flush</p>
+  </li>
+</ol>
+```
+
+:::
+
 ## Compact list blocks
 
 A blank line is still required to start a block inside a list item, but it no longer makes the list *loose* when the indented content opens a block (sub-list, block quote, fenced code, fenced div, heading, table). The item stays **tight** — lead text inline, the block attached — so a checklist with notes or steps with code stay compact. (A Carve deviation: canonical djot renders these loose. Only the tight/loose rendering changes, not the block structure.)

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>692 / 692</strong>
+    <strong>693 / 693</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>692 / 692</strong>
+    <strong>693 / 693</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>692 / 692</strong>
+    <strong>693 / 693</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,9 +36,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `692 / 692` | `0` | `0` | `3.01` |
-| JS | `8105210` | `692 / 692` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `692 / 692` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `693 / 693` | `0` | `0` | `3.01` |
+| JS | `8105210` | `693 / 693` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `693 / 693` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 
@@ -577,7 +577,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=692 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=693 targets=html,markdown,plain,carve,ansi
 rust: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=3.01
   mismatching documents: 0
 js: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=76.02
@@ -587,11 +587,11 @@ php: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=68.54
 cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=692 diffs=0 errors=0 fixtures=yes
-markdown: compared=692 diffs=0 errors=0 fixtures=1
-plain: compared=692 diffs=0 errors=0 fixtures=1
-carve: compared=692 diffs=0 errors=0 fixtures=13
-ansi: compared=692 diffs=0 errors=0 fixtures=none
+html: compared=693 diffs=0 errors=0 fixtures=yes
+markdown: compared=693 diffs=0 errors=0 fixtures=1
+plain: compared=693 diffs=0 errors=0 fixtures=1
+carve: compared=693 diffs=0 errors=0 fixtures=13
+ansi: compared=693 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 892 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 893 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/tests/corpus/86-list-lazy-continuation-10.crv
+++ b/tests/corpus/86-list-lazy-continuation-10.crv
@@ -1,0 +1,4 @@
+1. item
+
+   spaced
+flush

--- a/tests/corpus/86-list-lazy-continuation-10.html
+++ b/tests/corpus/86-list-lazy-continuation-10.html
@@ -1,0 +1,6 @@
+<ol>
+  <li><p>item</p>
+    <p>spaced
+flush</p>
+  </li>
+</ol>

--- a/tests/spec/86-list-lazy-continuation.test
+++ b/tests/spec/86-list-lazy-continuation.test
@@ -134,3 +134,17 @@ body
 tail</li>
 </ul>
 ```
+
+```
+1. item
+
+   spaced
+flush
+.
+<ol>
+  <li><p>item</p>
+    <p>spaced
+flush</p>
+  </li>
+</ol>
+```


### PR DESCRIPTION
## Summary

- state explicitly that list lazy continuation reaches an item's innermost open paragraph at any depth
- add the missing second-paragraph corpus case
- update corpus counts for the new fixture

The case already passes in carve-js and carve-php. The matching carve-rs fix is tracked by markup-carve/carve-rs#890.

## Verification

- `npm run corpus:build`
- `npm test` — 1,921 passed, 1 intentional skip

Refs markup-carve/carve-rs#890.
