### PR TITLE
0.2: make two blank lines a hard list boundary

### DIFF
--- a/docs/examples/core.md
+++ b/docs/examples/core.md
@@ -994,6 +994,30 @@ lazy</li>
 
 :::
 
+Two or more consecutive blank lines are a hard list boundary. The compatible
+marker after the boundary opens a new sibling list; in ordinary LF source this
+means three newline bytes between the two item lines.
+
+::: compare
+
+```carve
+- apples
+
+
+- oranges
+```
+
+```html
+<ul>
+  <li>apples</li>
+</ul>
+<ul>
+  <li>oranges</li>
+</ul>
+```
+
+:::
+
 ## Task lists
 
 ::: compare

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>692 / 692</strong>
+    <strong>693 / 693</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>692 / 692</strong>
+    <strong>693 / 693</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>692 / 692</strong>
+    <strong>693 / 693</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,9 +36,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `692 / 692` | `0` | `0` | `3.01` |
-| JS | `8105210` | `692 / 692` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `692 / 692` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `693 / 693` | `0` | `0` | `3.01` |
+| JS | `8105210` | `693 / 693` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `693 / 693` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 
@@ -577,7 +577,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=692 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=693 targets=html,markdown,plain,carve,ansi
 rust: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=3.01
   mismatching documents: 0
 js: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=76.02
@@ -587,11 +587,11 @@ php: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=68.54
 cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=692 diffs=0 errors=0 fixtures=yes
-markdown: compared=692 diffs=0 errors=0 fixtures=1
-plain: compared=692 diffs=0 errors=0 fixtures=1
-carve: compared=692 diffs=0 errors=0 fixtures=13
-ansi: compared=692 diffs=0 errors=0 fixtures=none
+html: compared=693 diffs=0 errors=0 fixtures=yes
+markdown: compared=693 diffs=0 errors=0 fixtures=1
+plain: compared=693 diffs=0 errors=0 fixtures=1
+carve: compared=693 diffs=0 errors=0 fixtures=13
+ansi: compared=693 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 892 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 893 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,3 +24,4 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
+05-lists-22  The pinned 0.2 JS writer predates carve#1088's hard list boundary; remove when the next-branch pin advances.

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3477,6 +3477,11 @@ EOF = (* end of file *) ;
            * c
            * d
          `- a` followed by `- [x] b` is likewise two lists.
+         A run of TWO OR MORE blank lines is a hard list boundary: an item
+         marker after that run starts a new sibling list even when every N1
+         axis matches. One blank line remains the ordinary loose-list
+         separator. In the common LF spelling this distinction is three
+         newline bytes (`item\n\n\nitem`) versus two (`item\n\nitem`).
       N2 ORDERED DIALECT. A list's dialect (decimal / lower- or upper-alpha
          / lower- or upper-roman) and delimiter are fixed by its FIRST
          item; a later marker outside the dialect, or with the other
@@ -4006,6 +4011,9 @@ EOF = (* end of file *) ;
          (<li><p>text</p></li>). An item can hold more than one paragraph
          block and still be tight -- L2 and L6 below cover the ways that
          happens without a blank line ever appearing.
+         This definition applies to the ONE-blank-line separator. Two or more
+         blank lines invoke §11 N1's hard boundary and therefore separate two
+         lists instead of loosening one list.
       L1a THE ITEM'S FIRST BLOCK DOES NOT MATTER -- NORMATIVE. L1 asks
          whether the item holds a blank-line-separated second PARAGRAPH. It
          does not ask what the FIRST block was, and nothing here depends on

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -2064,6 +2064,7 @@ function collectItems(lines, i, list, state, ind, meas) {
     // A blank line was seen, and only invisible lines have followed it so far
     // (§17 L1b). The next PARAGRAPH closes the separation and loosens.
     let pendingSeparation = false
+    let hardListBoundary = false
     {
       const headText = head.text.trim()
       if (QUOTE.test(headText)) { if ((QUOTE.exec(headText)[1] ?? '').trim() !== '') startPara(); else closePara() }
@@ -2213,6 +2214,14 @@ function collectItems(lines, i, list, state, ind, meas) {
           continue
         }
         if (nm && nm.indent === baseIndent) {
+          // 0.2 hard boundary: one blank line is the ordinary loose-list
+          // separator; two or more blank lines end the list even when every
+          // N1 axis matches. `j - i` is the exact blank-line run length.
+          if (j - i >= 2 && sameAxes(list, nm)) {
+            hardListBoundary = true
+            i = j
+            break
+          }
           // blank line between ITEMS of this list -> loose (SS17 L1); a
           // following DIFFERENT list is a sibling and loosens nothing
           if (sameAxes(list, nm)) list.tight = false
@@ -2549,6 +2558,7 @@ function collectItems(lines, i, list, state, ind, meas) {
       list.tight = false
     }
     list.items.push(item)
+    if (hardListBoundary) return i
   }
   return i
 }

--- a/tests/corpus/05-lists-22.crv
+++ b/tests/corpus/05-lists-22.crv
@@ -1,0 +1,4 @@
+- apples
+
+
+- oranges

--- a/tests/corpus/05-lists-22.html
+++ b/tests/corpus/05-lists-22.html
@@ -1,0 +1,6 @@
+<ul>
+  <li>apples</li>
+</ul>
+<ul>
+  <li>oranges</li>
+</ul>

--- a/tests/separator-role-split.test.mjs
+++ b/tests/separator-role-split.test.mjs
@@ -1676,3 +1676,27 @@ test('the definition body dedent strips no further than column 3', () => {
       `strip leaves as text.\n  doc: ${JSON.stringify(doc)}`,
   )
 })
+
+const siblingLists = (source) => parse(source).blocks.filter((block) => block.t === 'list')
+const compactHtml = (source) => renderDoc(parse(source)).replace(/\s+/g, ' ').replace(/> </g, '><').trim()
+
+test('one blank line remains the loose-list separator', () => {
+  const parsed = siblingLists('1. a\n\n1. b\n')
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].items.length, 2)
+  assert.equal(parsed[0].tight, false)
+})
+
+test('two blank lines are a hard boundary between compatible lists', () => {
+  const source = '1. a\n\n\n1. b\n'
+  const parsed = siblingLists(source)
+  assert.equal(parsed.length, 2)
+  assert.deepEqual(parsed.map((list) => list.items.length), [1, 1])
+  assert.equal(compactHtml(source), '<ol><li>a</li></ol><ol><li>b</li></ol>')
+})
+
+test('the hard list boundary applies to bullets too', () => {
+  const source = '- a\n\n\n- b\n'
+  assert.equal(siblingLists(source).length, 2)
+  assert.equal(compactHtml(source), '<ul><li>a</li></ul><ul><li>b</li></ul>')
+})

--- a/tests/spec/05-lists.test
+++ b/tests/spec/05-lists.test
@@ -243,3 +243,17 @@ lazy</li>
   </li>
 </ol>
 ```
+
+```
+- apples
+
+
+- oranges
+.
+<ul>
+  <li>apples</li>
+</ul>
+<ul>
+  <li>oranges</li>
+</ul>
+```


### PR DESCRIPTION
Closes #1088 for the 0.2 line.

- keeps one blank line as the loose-list item separator
- makes two or more consecutive blank lines end a compatible list
- requires canonical writers to preserve two blank lines between adjacent compatible sibling lists
- adds executable oracle coverage and corpus fixture 05-lists-22

The prerequisite paragraph-interruption work from #315 is fully landed on `next`.