### PR TITLE
Compare locale smart quotes across all engines

### DIFF
--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -243,10 +243,7 @@ const PLAIN_EXTENSION_FEATURES = {
  * stamp ordering the second case turns on, so both are wired below instead
  * (carve#535).
  */
-const UNREACHABLE_REASONS = {
-  'smart-quotes-locale-de':
-    'carve-js has no quote-locale option; carve-php has the extension (carve#560)',
-}
+const UNREACHABLE_REASONS = {}
 
 // Cases that ask an engine for the author's source runs instead of the glyph.
 // One per target, because a manifest entry names one feature and one target -
@@ -297,6 +294,9 @@ const impls = [
           '--symbol', 'rocket=🚀', '--symbol', 'tada=🎉', '--symbol', '+1=👍', '--symbol', 'UPPER=⬆️',
           ...flags,
         ]
+      }
+      if (feature === 'smart-quotes-locale-de') {
+        return [...rustBaseCommand, '--quote-locale', 'de', ...flags]
       }
       // One flag, whichever target the case pins: the mode is a property of
       // the renderer, and every presentation renderer carries it.
@@ -349,6 +349,17 @@ const impls = [
               mentionUrl: '/users/{name}',
               tagUrl: '/topics/{name}',
             }));
+          `,
+        ]
+      }
+      if (feature === 'smart-quotes-locale-de') {
+        return [
+          'node', '--input-type=module', '-e',
+          `
+            import { readFileSync } from 'node:fs';
+            import { ${entry}, smartQuotes } from './dist/index.js';
+            const source = readFileSync(process.argv[1], 'utf8');
+            process.stdout.write(${entry}(source, { extensions: [smartQuotes({ locale: 'de' })] }));
           `,
         ]
       }

--- a/tests/optional-corpus.test.mjs
+++ b/tests/optional-corpus.test.mjs
@@ -95,9 +95,8 @@ const featureRunners = {
    * three expected files were being verified by nothing (carve#645 is the same
    * shape: a guard whose inputs are a fixed list only guards that list).
    *
-   * `smart-quotes-locale-de` stays skipped and is the reason a skip is worth
-   * having: the engine has no locale-quote option at all, so that pair really
-   * is describing something unimplemented.
+   * Locale quote selection is implementation configuration rather than Djot
+   * syntax, so the reference engine intentionally does not run that case.
    */
   'bare-url-autolink': (source, render) => render(source, { extensions: [autolink()] }),
   'smart-typography-off': (source, render) => render(source, { smartTypography: false }),
@@ -132,7 +131,7 @@ const featureRunners = {
  */
 const DECLARED_UNIMPLEMENTED = {
   'smart-quotes-locale-de':
-    'the reference engine has no quote-locale option at all; carve-php has the extension (carve#560)',
+    'locale quote selection is an implementation extension/configuration, not canonical Djot syntax',
 }
 
 /*


### PR DESCRIPTION
## Summary

- wire the German locale fixture to the new carve-js `smartQuotes()` extension and carve-rs `--quote-locale` option
- remove the obsolete single-engine exception
- keep the reference Djot runner skip explicit because locale selection is implementation configuration, not canonical Djot syntax

Depends on markup-carve/carve-js#996 and markup-carve/carve-rs#914. It should remain draft until both engine PRs land.

## Verification

Using both PR worktrees plus current carve-php, the optional comparison reports:

- `smart-quotes-locale-de (html): rust, js, php`
- zero cross-engine differences
- zero fixture mismatches
- all sampled optional cases reached at least two engines