### PR TITLE
Carry single-line footnote labels into next

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -1018,6 +1018,9 @@ renders as
 ```
 
 **Rules** (PART 9 §16):
+- A label is a non-empty physical-line identifier. It may contain spaces and
+  tabs, matched exactly, but never a source newline; `[^two` then `words]` is
+  literal text rather than a reference.
 - Definitions may appear anywhere (order-independent); the first
   definition for a label wins. A body is the def line plus any indented
   continuation lines (parsed as blocks).

--- a/docs/examples/core.md
+++ b/docs/examples/core.md
@@ -2487,6 +2487,13 @@ A `[^label]` reference is numbered by document order; its `[^label]: …`
 definition renders in an endnotes section with a backlink, using djot's
 `doc-noteref` / `doc-endnotes` / `doc-backlink` roles.
 
+The label is a non-empty physical-line identifier. Spaces and tabs are allowed
+and matched exactly, but a source newline ends the opportunity to form the
+reference: an editor's visual wrapping is harmless, while an inserted hard
+line break leaves the bracketed source literal. A definition marker likewise
+occupies one physical line, so there is no multiline identifier that only one
+side could produce.
+
 ::: compare
 
 ```carve
@@ -2590,6 +2597,27 @@ See[^m] and again[^m].
     </li>
   </ol>
 </section>
+```
+
+:::
+
+::: compare
+
+```carve
+Wrapped[^two
+words].
+
+[^two words]: This definition is not referenced.
+
+[^broken
+label]: This is not a definition.
+```
+
+```html
+<p>Wrapped[^two
+words].</p>
+<p>[^broken
+label]: This is not a definition.</p>
 ```
 
 :::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>693 / 693</strong>
+    <strong>694 / 694</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>693 / 693</strong>
+    <strong>694 / 694</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>693 / 693</strong>
+    <strong>694 / 694</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,9 +36,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `693 / 693` | `0` | `0` | `3.01` |
-| JS | `8105210` | `693 / 693` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `693 / 693` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `694 / 694` | `0` | `0` | `3.01` |
+| JS | `8105210` | `694 / 694` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `694 / 694` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 
@@ -577,7 +577,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=693 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=694 targets=html,markdown,plain,carve,ansi
 rust: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=3.01
   mismatching documents: 0
 js: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=76.02

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 893 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 894 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/carve-core.ohm
+++ b/resources/carve-core.ohm
@@ -233,6 +233,8 @@ CarveCore {
 
   // --- Footnotes (PART 3; a bare `^` is literal, so `^[` is unambiguous) --
   footnoteRef = "[^" fnLabel "]" attrs?
+  // A physical-line identifier: spaces and tabs are data, newlines are not.
+  // This mirrors the one-line definition marker and grammar.ebnf §16.
   fnLabel    = (~"]" ~newline any)+
   inlineNote = "^[" brContent* "]" attrs?
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2270,7 +2270,11 @@ highlight_content = (inline_element | text_run | literal_special)+ ;
    see docs/dismissed-syntax.md. *)
 footnote = reference_footnote | inline_footnote ;
 reference_footnote = "[^", footnote_label, ']' ;
-footnote_label = {character - ']'}+ ;
+(* A label is a physical-line identifier. It may contain spaces and tabs, but
+   never a source newline: a definition marker occupies one line, and admitting
+   a newline only on the reference side would create an identifier no valid
+   definition can bind. Matching is exact; whitespace is not normalized. *)
+footnote_label = {character - ']' - newline}+ ;
 inline_footnote = "^[", inline_content, ']' ;
 (* the closing `]` is the balanced, escape- and code-span-aware close
    (PART 9 §16); footnote recognition is DISABLED inside the content *)

--- a/tests/corpus/22-footnotes-6.crv
+++ b/tests/corpus/22-footnotes-6.crv
@@ -1,0 +1,7 @@
+Wrapped[^two
+words].
+
+[^two words]: This definition is not referenced.
+
+[^broken
+label]: This is not a definition.

--- a/tests/corpus/22-footnotes-6.fmt
+++ b/tests/corpus/22-footnotes-6.fmt
@@ -1,0 +1,7 @@
+Wrapped[^two
+words].
+
+[^broken
+label]: This is not a definition.
+
+[^two words]: This definition is not referenced.

--- a/tests/corpus/22-footnotes-6.html
+++ b/tests/corpus/22-footnotes-6.html
@@ -1,0 +1,4 @@
+<p>Wrapped[^two
+words].</p>
+<p>[^broken
+label]: This is not a definition.</p>

--- a/tests/spec/22-footnotes.test
+++ b/tests/spec/22-footnotes.test
@@ -65,3 +65,18 @@ See[^m] and again[^m].
   </ol>
 </section>
 ```
+
+```
+Wrapped[^two
+words].
+
+[^two words]: This definition is not referenced.
+
+[^broken
+label]: This is not a definition.
+.
+<p>Wrapped[^two
+words].</p>
+<p>[^broken
+label]: This is not a definition.</p>
+```


### PR DESCRIPTION
## Summary

- carry the single-line footnote-label rule from `main` into `next`
- retain `next`'s independent corpus count while adding the new regression fixture
- keep the normative grammar, informative EBNF, docs, and generated corpus synchronized

## Verification

- clean cherry-pick of the merged behavior from #1112, with the `next` corpus count resolved from 893 to 894
- `git diff --check`

The local worktree did not have its Node dependencies installed; full conformance is delegated to this branch's CI.
