### PR TITLE
Standardize built-in semantic inline mappings

### DIFF
--- a/docs/examples/extensions.md
+++ b/docs/examples/extensions.md
@@ -247,6 +247,12 @@ Hey @alice, see #release-1.0.
 
 ## Inline extensions
 
+Nine names have a built-in, portable semantic HTML mapping: `abbr`, `cite`,
+`dfn`, `kbd`, `samp`, `var`, `time`, `code`, and `mark`. They remain ordinary
+`inline_extension` AST nodes; the mapping is renderer behavior, not an opt-in
+extension. Attributes land on the semantic element and use the same hardening
+as every other authored attribute.
+
 ::: compare
 
 ```carve
@@ -331,6 +337,39 @@ An authored `{.class}` on a generic inline extension merges into the single `cla
 ```
 
 :::
+
+::: compare
+
+```carve
+:abbr[HTML]{title="HyperText Markup Language"} :cite[The Book] :dfn[term]
+:samp[ready] :var[x] :time[noon]{datetime="12:00"} :code[x] :mark[relevant]
+```
+
+```html
+<p><abbr title="HyperText Markup Language">HTML</abbr> <cite>The Book</cite> <dfn>term</dfn>
+<samp>ready</samp> <var>x</var> <time datetime="12:00">noon</time> <code>x</code> <mark>relevant</mark></p>
+```
+
+:::
+
+The semantic element keeps nested inline content and authored attributes.
+
+::: compare
+
+```carve
+:kbd[*Ctrl*+C]{#copy .shortcut data-key="copy" onclick="alert(1)"}
+```
+
+```html
+<p><kbd id="copy" class="shortcut" data-key="copy"><strong>Ctrl</strong>+C</kbd></p>
+```
+
+:::
+
+`:cite[text]` is a work title or source, not a bibliographic `[@key]`
+citation. `:abbr[text]{title="…"}` is independent of automatic abbreviation
+definitions. Names outside the fixed registry retain the readable generic
+fallback.
 
 ## Symbols
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -53,7 +53,7 @@ PART 9 §19); Tier-2 / Tier-3 are off until enabled.
 | Mermaid / FencedRender, MathBlock, Glossary, Index, HeadingNumbers, CodeGroup | <Badge type="warning" text="extension" /> | off | — |
 | Bibliography (§6) — an **option on Citations**, not a separate registration: the host passes a CSL-JSON pool to the Citations extension | <Badge type="warning" text="extension" /> | off | — |
 | TableOfContents, HeadingPermalinks / LevelShift, ExternalLinks, Wikilinks, ColorSwatch, Lowercase/AsciiHeadingIds | <Badge type="warning" text="extension" /> | off | — |
-| SemanticSpan — **carve-php only** today; carve-js and carve-rs ship no such extension | <Badge type="warning" text="extension" /> | off | — |
+| SemanticSpan — **carve-php only** legacy attributes (`[x]{kbd}`); distinct from the built-in portable `:kbd[x]` semantic registry | <Badge type="warning" text="extension" /> | off | — |
 | [ImgFence](/svg-images) (sanitized SVG `img` fence — sandboxed by default) | <Badge type="warning" text="extension" /> | off | — |
 
 A `:name[…]` / `::: name` whose word has no registered handler renders via the
@@ -117,7 +117,9 @@ differs by processor. The narrative below details each tier.
   on each heading - and rewrite auto-filled `</#id>` cross-references to
   "Section 1.2 - Title"; opt-in, no new syntax; §9),
   HeadingLevelShift, ExternalLinks, DefaultAttributes, Wikilinks,
-  SemanticSpan (carve-php only),
+  PHP's legacy attribute-based SemanticSpan (the portable `:abbr[…]`,
+  `:cite[…]`, `:dfn[…]`, `:kbd[…]`, `:samp[…]`, `:var[…]`, `:time[…]`,
+  `:code[…]`, and `:mark[…]` mappings are built in and need no registration),
   ColorSwatch (inline `:color[value]` -> a validated color chip; carve-php,
   carve-js and carve-rs — see the [extension tutorial](./extension-tutorial)),
   and the opt-in heading-id transforms (LowercaseHeadingIds, AsciiHeadingIds).

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -74,7 +74,9 @@ Corpus added since this run: `254-colon-fence-separator-must-be-a-space`,
 `283-an-empty-footnote-body-is-written-with-the-empty-sentinel`,
 `289-a-structural-attribute-leads-the-author-s-own`,
 `290-adjacent-sibling-lists-survive-the-round-trip`,
-`291-a-fence-keeps-the-blank-line-at-the-end-of-its-content`.
+`291-a-fence-keeps-the-blank-line-at-the-end-of-its-content`,
+`45-inline-extensions-7`,
+`45-inline-extensions-8`.
 
 Those categories landed on hosts that could not retake the run above, so its
 numbers describe the corpus WITHOUT them. The alternative was to edit the

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 903 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 905 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2416,8 +2416,9 @@ citation_definition = '[@', citation_key, "]:", space, [attributes], inline_cont
 extension_inline = ':', extension_name, '[', extension_content, ']', [attributes] ;
 extension_name = identifier ;
 (* `identifier` already permits a leading `_`, so `_` is a valid extension
-   name: `:_[x]` -> `<span class="ext-_">x</span>` (an unrecognized name
-   falls back to a generic `<span class="ext-NAME">`). It MUST start with a
+   name: `:_[x]` -> `<span class="ext-_">x</span>` (a name outside the
+   built-in semantic registry in PART 10 §9 falls back to a generic
+   `<span class="ext-NAME">`). It MUST start with a
    letter or `_`, so a digit-first name is NOT an extension: `:1[x]` stays
    literal text, while `:a1[x]` (digit only after the first letter) is valid.
    On a GENERIC extension an authored `{.class}` MERGES into the single
@@ -5465,6 +5466,31 @@ EOF = (* end of file *) ;
       when no URL template is configured; a configured template links to them. The footnote
       backlink glyph is `↩` (§16). Math wraps content in `\(…\)` /
       `\[…\]` inside `<span class="math inline|display">` (§18).
+
+   9. BUILT-IN SEMANTIC INLINE EXTENSIONS. The following extension names render
+      as their same-named HTML element: `abbr`, `cite`, `dfn`, `kbd`, `samp`,
+      `var`, `time`, `code`, and `mark`. Thus `:kbd[x]` is `<kbd>x</kbd>` and
+      `:abbr[HTML]{title="HyperText Markup Language"}` is
+      `<abbr title="HyperText Markup Language">HTML</abbr>`.
+
+      These are renderer mappings over the ordinary `inline_extension` node;
+      they introduce no new syntax or AST node type and require no opt-in
+      extension registration. Authored id, classes and key/value attributes
+      land on the semantic element in the normal author order and pass through
+      §1-2 plus PART 9 §25 attribute hardening.
+      An implementation MUST NOT turn
+      an arbitrary extension name into an HTML tag. Every name outside this
+      fixed registry retains the generic `<span class="ext-NAME">` fallback.
+
+      Plain and ANSI targets render only the extension's inline content. The
+      canonical Carve writer preserves `:name[content]{attrs}`. `:cite[text]`
+      denotes a work title or source and is unrelated to a bibliographic
+      `[@key]` citation. `:abbr[text]{title="…"}` is an explicitly authored
+      semantic wrapper and neither declares nor changes automatic abbreviation
+      definitions. `:code` and `:mark` remain extension spellings distinct from
+      the ordinary code-span and highlight syntaxes even though their HTML tags
+      coincide. Accessible ruby is NOT in this registry: it requires structured
+      base/annotation children rather than a single inline container.
 
    ============================================================================
    PART 11: CANONICAL SOURCE WRITER (NORMATIVE)

--- a/scripts/spec/render.mjs
+++ b/scripts/spec/render.mjs
@@ -349,11 +349,11 @@ const sem = g.createSemantics().addOperation('h', {
     const inner = renderInline(content.sourceString, '[')
     const extra = attrsOf(attrs).filter((a) => a[0] === 'class').map((a) => a[1])
     const rest = attrsOf(attrs).filter((a) => a[0] !== 'class')
-    // the kbd extension renders its own element (attrs apply to it);
-    // everything else is the generic ext-<name> span
-    if (n === 'kbd') {
-      const cls = extra.length ? ` class="${escapeAttr(extra.join(' '))}"` : ''
-      return `<kbd${cls}${renderAttrs(rest)}>${inner}</kbd>`
+    // PART 10 §9: the fixed semantic registry renders its own element (attrs
+    // apply to it); everything else is the generic ext-<name> span.
+    const semantic = new Set(['abbr', 'cite', 'dfn', 'kbd', 'samp', 'var', 'time', 'code', 'mark'])
+    if (semantic.has(n)) {
+      return `<${n}${renderAttrs(attrsOf(attrs))}>${inner}</${n}>`
     }
     const cls = [`ext-${n}`, ...extra].join(' ')
     return `<span class="${cls}"${renderAttrs(rest)}>${inner}</span>`

--- a/tests/corpus/45-inline-extensions-7.crv
+++ b/tests/corpus/45-inline-extensions-7.crv
@@ -1,0 +1,2 @@
+:abbr[HTML]{title="HyperText Markup Language"} :cite[The Book] :dfn[term]
+:samp[ready] :var[x] :time[noon]{datetime="12:00"} :code[x] :mark[relevant]

--- a/tests/corpus/45-inline-extensions-7.html
+++ b/tests/corpus/45-inline-extensions-7.html
@@ -1,0 +1,2 @@
+<p><abbr title="HyperText Markup Language">HTML</abbr> <cite>The Book</cite> <dfn>term</dfn>
+<samp>ready</samp> <var>x</var> <time datetime="12:00">noon</time> <code>x</code> <mark>relevant</mark></p>

--- a/tests/corpus/45-inline-extensions-8.crv
+++ b/tests/corpus/45-inline-extensions-8.crv
@@ -1,0 +1,1 @@
+:kbd[*Ctrl*+C]{#copy .shortcut data-key="copy" onclick="alert(1)"}

--- a/tests/corpus/45-inline-extensions-8.html
+++ b/tests/corpus/45-inline-extensions-8.html
@@ -1,0 +1,1 @@
+<p><kbd id="copy" class="shortcut" data-key="copy"><strong>Ctrl</strong>+C</kbd></p>

--- a/tests/spec/45-inline-extensions.test
+++ b/tests/spec/45-inline-extensions.test
@@ -37,3 +37,17 @@ Press :kbd[Ctrl+C] to copy.
 .
 <p><span class="ext-foo cls">a</span></p>
 ```
+
+```
+:abbr[HTML]{title="HyperText Markup Language"} :cite[The Book] :dfn[term]
+:samp[ready] :var[x] :time[noon]{datetime="12:00"} :code[x] :mark[relevant]
+.
+<p><abbr title="HyperText Markup Language">HTML</abbr> <cite>The Book</cite> <dfn>term</dfn>
+<samp>ready</samp> <var>x</var> <time datetime="12:00">noon</time> <code>x</code> <mark>relevant</mark></p>
+```
+
+```
+:kbd[*Ctrl*+C]{#copy .shortcut data-key="copy" onclick="alert(1)"}
+.
+<p><kbd id="copy" class="shortcut" data-key="copy"><strong>Ctrl</strong>+C</kbd></p>
+```


### PR DESCRIPTION
## Summary

- define the fixed nine-name semantic inline HTML registry
- keep the canonical AST and source spelling as ordinary inline extensions
- pin mappings, nested content, attributes, and hostile-attribute hardening in the shared corpus
- distinguish semantic `:cite`/`:abbr` wrappers from citations and abbreviation definitions
- correct the legacy PHP `SemanticSpanExtension` documentation

## Tests

- `npm run corpus:build`
- `node --test tests/corpus.test.mjs tests/normativity.test.mjs tests/extension-catalog-claims.test.mjs tests/corpus-render-fixture-inventory.test.mjs`

Tracks #1116; close after downstream parity PRs land.
