### PR TITLE
spec: standardize compact semantic spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Compact semantic span attributes are portable core syntax** (carve#1124).
+  `[Ctrl]{kbd}`, `[HTML]{abbr="…"}`, and combinations such as
+  `[CSS]{dfn abbr="…"}` now share one normative HTML mapping across PHP,
+  JavaScript, and Rust. The fixed registry is `abbr`, `time`, `code`, `mark`,
+  `samp`, `var`, `kbd`, `cite`, and `dfn`; non-semantic attributes remain on a
+  hardened outer span. This is an observable HTML change for JS/Rust and for
+  PHP without its former opt-in extension. AST, plain/ANSI, and canonical
+  source behavior remain ordinary span behavior.
+
 ## [0.1.2] - 2026-08-10
 
 ### Changed

--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -3258,9 +3258,9 @@ Check if (x < 5) holds, and 3<4 too.
 ## Boolean attributes
 
 A bare word in a `{…}` block (no `#` / `.` / `=`) is a value-less (boolean)
-attribute, rendered `name=""`. It works in any attribute position and mixes
-with id / class / key=value. A carve extension beyond canonical djot, matching
-djot-php.
+attribute, normally rendered `name=""`. It works in any attribute position and
+mixes with id / class / key=value. The nine semantic span names are the core
+exception: on `[content]{attrs}` they select their semantic wrapper.
 
 ::: compare
 
@@ -3269,7 +3269,7 @@ Press [Tab]{kbd} to indent.
 ```
 
 ```html
-<p>Press <span kbd="">Tab</span> to indent.</p>
+<p>Press <kbd>Tab</kbd> to indent.</p>
 ```
 
 :::

--- a/docs/examples/extensions.md
+++ b/docs/examples/extensions.md
@@ -366,6 +366,41 @@ The semantic element keeps nested inline content and authored attributes.
 
 :::
 
+For semantic spans, the same registry is available as compact attribute sugar.
+This is especially useful when several semantic wrappers belong to one label.
+`abbr`, `dfn`, and `time` values map to `title`, `title`, and `datetime`; the
+fixed nesting order preserves the established PHP spelling.
+
+::: compare
+
+```carve
+[CSS]{dfn abbr="Cascading Style Sheets"}
+[Noon]{time="12:00"} [x]{code mark samp var kbd cite}
+```
+
+```html
+<p><dfn><abbr title="Cascading Style Sheets">CSS</abbr></dfn>
+<time datetime="12:00">Noon</time> <cite><kbd><var><samp><mark><code>x</code></mark></samp></var></kbd></cite></p>
+```
+
+:::
+
+Non-semantic attributes remain on one hardened outer span.
+
+::: compare
+
+```carve
+[*Ctrl*+C]{#copy .shortcut kbd data-key="copy" onclick="alert(1)"}
+[x]{kbd onclick="alert(1)"}
+```
+
+```html
+<p><span id="copy" class="shortcut" data-key="copy"><kbd><strong>Ctrl</strong>+C</kbd></span>
+<span><kbd>x</kbd></span></p>
+```
+
+:::
+
 `:cite[text]` is a work title or source, not a bibliographic `[@key]`
 citation. `:abbr[text]{title="…"}` is independent of automatic abbreviation
 definitions. Names outside the fixed registry retain the readable generic

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -53,7 +53,7 @@ PART 9 §19); Tier-2 / Tier-3 are off until enabled.
 | Mermaid / FencedRender, MathBlock, Glossary, Index, HeadingNumbers, CodeGroup | <Badge type="warning" text="extension" /> | off | — |
 | Bibliography (§6) — an **option on Citations**, not a separate registration: the host passes a CSL-JSON pool to the Citations extension | <Badge type="warning" text="extension" /> | off | — |
 | TableOfContents, HeadingPermalinks / LevelShift, ExternalLinks, Wikilinks, ColorSwatch, Lowercase/AsciiHeadingIds | <Badge type="warning" text="extension" /> | off | — |
-| SemanticSpan — **carve-php only** legacy attributes (`[x]{kbd}`); distinct from the built-in portable `:kbd[x]` semantic registry | <Badge type="warning" text="extension" /> | off | — |
+| Semantic spans — compact portable attributes (`[x]{kbd}`, `[HTML]{abbr="…"}`); PHP's former opt-in extension is now a compatibility shim | <Badge type="tip" text="core" /> | on | no |
 | [ImgFence](/svg-images) (sanitized SVG `img` fence — sandboxed by default) | <Badge type="warning" text="extension" /> | off | — |
 
 A `:name[…]` / `::: name` whose word has no registered handler renders via the

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>694 / 694</strong>
+    <strong>692 / 692</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>694 / 694</strong>
+    <strong>692 / 692</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>694 / 694</strong>
+    <strong>692 / 692</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,9 +36,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `694 / 694` | `0` | `0` | `3.01` |
-| JS | `8105210` | `694 / 694` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `694 / 694` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `692 / 692` | `0` | `0` | `3.01` |
+| JS | `8105210` | `692 / 692` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `692 / 692` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 
@@ -77,7 +77,10 @@ Corpus added since this run: `254-colon-fence-separator-must-be-a-space`,
 `291-a-fence-keeps-the-blank-line-at-the-end-of-its-content`,
 `292-a-boolean-and-a-key-value-of-the-same-name-are-one-attribute`,
 `45-inline-extensions-7`,
-`45-inline-extensions-8`.
+`45-inline-extensions-8`,
+`45-inline-extensions-9`,
+`45-inline-extensions-10`; `97-boolean-attributes` changed its expected HTML
+under the same semantic-span rule.
 
 Those categories landed on hosts that could not retake the run above, so its
 numbers describe the corpus WITHOUT them. The alternative was to edit the
@@ -583,7 +586,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=694 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=692 targets=html,markdown,plain,carve,ansi
 rust: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=3.01
   mismatching documents: 0
 js: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=76.02
@@ -593,11 +596,11 @@ php: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=68.54
 cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=693 diffs=0 errors=0 fixtures=yes
-markdown: compared=693 diffs=0 errors=0 fixtures=1
-plain: compared=693 diffs=0 errors=0 fixtures=1
-carve: compared=693 diffs=0 errors=0 fixtures=13
-ansi: compared=693 diffs=0 errors=0 fixtures=none
+html: compared=691 diffs=0 errors=0 fixtures=yes
+markdown: compared=691 diffs=0 errors=0 fixtures=1
+plain: compared=691 diffs=0 errors=0 fixtures=1
+carve: compared=691 diffs=0 errors=0 fixtures=13
+ansi: compared=691 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 908 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 910 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,3 +24,6 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
+45-inline-extensions-9  compact semantic span attributes await the downstream carve-js merge
+45-inline-extensions-10  compact semantic span nesting and hardening await the downstream carve-js merge
+97-boolean-attributes  kbd changed from a generic boolean span attribute to portable semantic sugar

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -5492,6 +5492,28 @@ EOF = (* end of file *) ;
       coincide. Accessible ruby is NOT in this registry: it requires structured
       base/annotation children rather than a single inline container.
 
+   10. COMPACT SEMANTIC SPANS. On an ordinary `[content]{attrs}` span, the
+      boolean or key/value attributes `abbr`, `time`, `code`, `mark`, `samp`,
+      `var`, `kbd`, `cite`, and `dfn` are reserved HTML rendering sugar. Each
+      present name is consumed as an attribute and wraps the rendered inline
+      content in its same-named HTML element. A non-empty `abbr`, `dfn`, or
+      `time` value becomes `title`, `title`, or `datetime`, respectively;
+      values on the other names only select their wrapper.
+
+      Multiple semantic attributes nest in this fixed INNER-TO-OUTER order:
+      `abbr`, `time`, `code`, `mark`, `samp`, `var`, `kbd`, `cite`, `dfn`.
+      This order is independent of author attribute order. Any id, class, or
+      other key/value attributes remain on one outer `<span>` and pass through
+      §1-2 plus PART 9 §25 attribute hardening. If no semantic attribute is
+      present, the ordinary `<span>` rendering is unchanged.
+
+      This rule changes only HTML rendering. The AST remains an ordinary
+      `span` carrying the authored attributes. Plain and ANSI targets render
+      its inline content, and the canonical Carve writer preserves
+      `[content]{attrs}`. The `:name[content]` form in §9 remains the generic,
+      independently nestable spelling and the only spelling for extension
+      names outside this fixed registry.
+
    ============================================================================
    PART 11: CANONICAL SOURCE WRITER (NORMATIVE)
    ============================================================================

--- a/scripts/spec/render.mjs
+++ b/scripts/spec/render.mjs
@@ -193,6 +193,34 @@ export function renderAttrs(list) {
   return parts.join('')
 }
 
+// PART 10 §10: compact semantic-span attributes are an HTML rendering sugar
+// over the ordinary `span` node.  Keep PHP's established relative order and
+// outer span for non-semantic attributes; the authored attribute list remains
+// untouched in the AST and source targets.
+const SEMANTIC_SPAN_ORDER = ['abbr', 'time', 'code', 'mark', 'samp', 'var', 'kbd', 'cite', 'dfn']
+function renderSemanticSpan(text, list) {
+  const semantic = new Map()
+  const rest = []
+  for (const attr of list) {
+    const name = attr[0] === 'bool' || attr[0] === 'kv' ? attr[1] : null
+    if (name && SEMANTIC_SPAN_ORDER.includes(name)) semantic.set(name, attr[0] === 'kv' ? attr[2] : '')
+    else rest.push(attr)
+  }
+  if (semantic.size === 0) return `<span${renderAttrs(list)}>${text}</span>`
+
+  let html = text
+  for (const name of SEMANTIC_SPAN_ORDER) {
+    if (!semantic.has(name)) continue
+    const value = semantic.get(name)
+    const mapped = value !== '' && name === 'abbr' ? ` title="${escapeAttr(value)}"`
+      : value !== '' && name === 'dfn' ? ` title="${escapeAttr(value)}"`
+        : value !== '' && name === 'time' ? ` datetime="${escapeAttr(value)}"`
+          : ''
+    html = `<${name}${mapped}>${html}</${name}>`
+  }
+  return rest.length === 0 ? html : `<span${renderAttrs(rest)}>${html}</span>`
+}
+
 const sem = g.createSemantics().addOperation('h', {
   inlines(items) {
     // The bare single-char emphasis delimiters are NOT resolved by the PEG.
@@ -453,7 +481,7 @@ sem.addOperation('applyTail(text, source)', {
   },
   attrs(_o, _s1, _first, _s2, _rest, _s3, _c) {
     const { text } = this.args
-    return `<span${renderAttrs(this.parseAttrs())}>${text}</span>`
+    return renderSemanticSpan(text, this.parseAttrs())
   },
   emptyAttrs(_o, _sp, _c) {
     const { text } = this.args

--- a/tests/corpus/45-inline-extensions-10.crv
+++ b/tests/corpus/45-inline-extensions-10.crv
@@ -1,0 +1,2 @@
+[*Ctrl*+C]{#copy .shortcut kbd data-key="copy" onclick="alert(1)"}
+[x]{kbd onclick="alert(1)"}

--- a/tests/corpus/45-inline-extensions-10.html
+++ b/tests/corpus/45-inline-extensions-10.html
@@ -1,0 +1,2 @@
+<p><span id="copy" class="shortcut" data-key="copy"><kbd><strong>Ctrl</strong>+C</kbd></span>
+<span><kbd>x</kbd></span></p>

--- a/tests/corpus/45-inline-extensions-9.crv
+++ b/tests/corpus/45-inline-extensions-9.crv
@@ -1,0 +1,2 @@
+[CSS]{dfn abbr="Cascading Style Sheets"}
+[Noon]{time="12:00"} [x]{code mark samp var kbd cite}

--- a/tests/corpus/45-inline-extensions-9.html
+++ b/tests/corpus/45-inline-extensions-9.html
@@ -1,0 +1,2 @@
+<p><dfn><abbr title="Cascading Style Sheets">CSS</abbr></dfn>
+<time datetime="12:00">Noon</time> <cite><kbd><var><samp><mark><code>x</code></mark></samp></var></kbd></cite></p>

--- a/tests/corpus/97-boolean-attributes.html
+++ b/tests/corpus/97-boolean-attributes.html
@@ -1,1 +1,1 @@
-<p>Press <span kbd="">Tab</span> to indent.</p>
+<p>Press <kbd>Tab</kbd> to indent.</p>

--- a/tests/extension-catalog-claims.test.mjs
+++ b/tests/extension-catalog-claims.test.mjs
@@ -6,10 +6,9 @@
  * register, and nothing measured it. Two entries were wrong when this was
  * written, in different ways:
  *
- *   - `SemanticSpan` sat in the Tier-3 row with no qualifier. It exists in
- *     carve-php alone - carve-js and carve-rs have no mention of it in `src` at
- *     all - and the very same row annotates ColorSwatch with all three engine
- *     names, so the omission read as "available everywhere".
+ *   - `SemanticSpan` once sat in the Tier-3 row with no qualifier while it was
+ *     PHP-only. It has since become core syntax and correctly left the opt-in
+ *     rows, so it needs no export exception here.
  *   - `Bibliography` sat in the same row as though it were a registration. It is
  *     an OPTION on the Citations extension (`bibliography?: CslEntry[]`), so a
  *     reader looking for a `bibliography` export finds nothing.
@@ -36,7 +35,6 @@ const page = readFileSync(resolve(root, 'docs/extensions.md'), 'utf8')
  * the export, the entry has to go, so this cannot quietly outlive its reason.
  */
 const NOT_A_REFERENCE_EXPORT = {
-  SemanticSpan: 'carve-php only',
   Bibliography: 'option on Citations',
 }
 

--- a/tests/spec/45-inline-extensions.test
+++ b/tests/spec/45-inline-extensions.test
@@ -51,3 +51,19 @@ Press :kbd[Ctrl+C] to copy.
 .
 <p><kbd id="copy" class="shortcut" data-key="copy"><strong>Ctrl</strong>+C</kbd></p>
 ```
+
+```
+[CSS]{dfn abbr="Cascading Style Sheets"}
+[Noon]{time="12:00"} [x]{code mark samp var kbd cite}
+.
+<p><dfn><abbr title="Cascading Style Sheets">CSS</abbr></dfn>
+<time datetime="12:00">Noon</time> <cite><kbd><var><samp><mark><code>x</code></mark></samp></var></kbd></cite></p>
+```
+
+```
+[*Ctrl*+C]{#copy .shortcut kbd data-key="copy" onclick="alert(1)"}
+[x]{kbd onclick="alert(1)"}
+.
+<p><span id="copy" class="shortcut" data-key="copy"><kbd><strong>Ctrl</strong>+C</kbd></span>
+<span><kbd>x</kbd></span></p>
+```

--- a/tests/spec/97-boolean-attributes.test
+++ b/tests/spec/97-boolean-attributes.test
@@ -3,7 +3,7 @@ Boolean attributes
 ```
 Press [Tab]{kbd} to indent.
 .
-<p>Press <span kbd="">Tab</span> to indent.</p>
+<p>Press <kbd>Tab</kbd> to indent.</p>
 ```
 
 ```


### PR DESCRIPTION
## Summary

- standardize compact semantic span attributes such as `[Ctrl]{kbd}` and `[HTML]{abbr="…"}`
- define the fixed registry, value mappings, deterministic combination order, and outer-span attribute behavior
- keep the AST and non-HTML renderers on ordinary span semantics
- add shared corpus coverage for all nine names, combinations, nested markup, and hostile-attribute hardening
- reclassify PHP's former opt-in-only behavior as portable core syntax

## Compatibility

This intentionally changes HTML for recognized attributes in engines that previously rendered them as ordinary span attributes. The source and AST remain valid and unchanged; the new HTML is the semantic meaning of the existing compact spelling.

## Tests

- `npm run corpus:build`
- `node --test tests/corpus.test.mjs tests/normativity.test.mjs tests/examples.test.mjs tests/implementation-comparison-counts.test.mjs tests/extension-catalog-claims.test.mjs`

Tracks #1124; close after all implementation PRs land.
