### PR TITLE
spec: define explicit abbreviation precedence

### DIFF
--- a/docs/examples/extensions.md
+++ b/docs/examples/extensions.md
@@ -401,6 +401,23 @@ Non-semantic attributes remain on one hardened outer span.
 
 :::
 
+An explicit `abbr` value takes precedence over automatic abbreviation
+definitions, avoiding invalid nested `<abbr>` markup.
+
+::: compare
+
+```carve
+*[HTML]: Hyper Text Markup Language
+
+[HTML]{abbr="Custom"}
+```
+
+```html
+<p><abbr title="Custom">HTML</abbr></p>
+```
+
+:::
+
 `:cite[text]` is a work title or source, not a bibliographic `[@key]`
 citation. `:abbr[text]{title="…"}` is independent of automatic abbreviation
 definitions. Names outside the fixed registry retain the readable generic

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>692 / 692</strong>
+    <strong>693 / 693</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>692 / 692</strong>
+    <strong>693 / 693</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>692 / 692</strong>
+    <strong>693 / 693</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,9 +36,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `692 / 692` | `0` | `0` | `3.01` |
-| JS | `8105210` | `692 / 692` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `692 / 692` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `693 / 693` | `0` | `0` | `3.01` |
+| JS | `8105210` | `693 / 693` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `693 / 693` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 
@@ -586,7 +586,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=692 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=693 targets=html,markdown,plain,carve,ansi
 rust: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=3.01
   mismatching documents: 0
 js: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=76.02
@@ -596,11 +596,11 @@ php: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=68.54
 cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=691 diffs=0 errors=0 fixtures=yes
-markdown: compared=691 diffs=0 errors=0 fixtures=1
-plain: compared=691 diffs=0 errors=0 fixtures=1
-carve: compared=691 diffs=0 errors=0 fixtures=13
-ansi: compared=691 diffs=0 errors=0 fixtures=none
+html: compared=692 diffs=0 errors=0 fixtures=yes
+markdown: compared=692 diffs=0 errors=0 fixtures=1
+plain: compared=692 diffs=0 errors=0 fixtures=1
+carve: compared=692 diffs=0 errors=0 fixtures=13
+ansi: compared=692 diffs=0 errors=0 fixtures=none
 target_agreement_note=html has an expected-output fixture per case; another target has one wherever a case added it (fixtures=N), and asserts engine agreement everywhere else.
 
 Extension capability matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 910 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 911 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -27,3 +27,4 @@
 45-inline-extensions-9  compact semantic span attributes await the downstream carve-js merge
 45-inline-extensions-10  compact semantic span nesting and hardening await the downstream carve-js merge
 97-boolean-attributes  kbd changed from a generic boolean span attribute to portable semantic sugar
+45-inline-extensions-11  explicit abbreviation precedence awaits the downstream carve-js merge

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -5514,6 +5514,12 @@ EOF = (* end of file *) ;
       independently nestable spelling and the only spelling for extension
       names outside this fixed registry.
 
+      An explicit `abbr` semantic attribute is authoritative over automatic
+      abbreviation expansion inside that span. A resolved `abbreviation` child
+      contributes only its visible abbreviation text there; renderers MUST NOT
+      emit a nested `<abbr>` element. Thus a document-level `*[HTML]: Long`
+      definition does not override `[HTML]{abbr="Custom"}`.
+
    ============================================================================
    PART 11: CANONICAL SOURCE WRITER (NORMATIVE)
    ============================================================================

--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -842,14 +842,17 @@ function applyAbbreviations(html, ctx) {
   // transform only text segments outside tags and outside code/pre
   const parts = html.split(/(<[^>]*>)/)
   let inCode = 0
+  let inAbbr = 0
   for (let i = 0; i < parts.length; i++) {
     const p = parts[i]
     if (p.startsWith('<')) {
       if (/^<(code|pre)[\s>]/.test(p)) inCode++
       else if (/^<\/(code|pre)>/.test(p)) inCode--
+      if (/^<abbr[\s>]/.test(p)) inAbbr++
+      else if (/^<\/abbr>/.test(p)) inAbbr--
       continue
     }
-    if (inCode > 0 || p === '') continue
+    if (inCode > 0 || inAbbr > 0 || p === '') continue
     let s = p
     for (const [term, expansion] of ctx.abbrDefs) {
       const re = new RegExp(`(^|[^\\p{L}\\p{N}])(${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})(?![\\p{L}\\p{N}])`, 'gu')

--- a/tests/corpus/45-inline-extensions-11.crv
+++ b/tests/corpus/45-inline-extensions-11.crv
@@ -1,0 +1,3 @@
+*[HTML]: Hyper Text Markup Language
+
+[HTML]{abbr="Custom"}

--- a/tests/corpus/45-inline-extensions-11.html
+++ b/tests/corpus/45-inline-extensions-11.html
@@ -1,0 +1,1 @@
+<p><abbr title="Custom">HTML</abbr></p>

--- a/tests/spec/45-inline-extensions.test
+++ b/tests/spec/45-inline-extensions.test
@@ -67,3 +67,11 @@ Press :kbd[Ctrl+C] to copy.
 <p><span id="copy" class="shortcut" data-key="copy"><kbd><strong>Ctrl</strong>+C</kbd></span>
 <span><kbd>x</kbd></span></p>
 ```
+
+```
+*[HTML]: Hyper Text Markup Language
+
+[HTML]{abbr="Custom"}
+.
+<p><abbr title="Custom">HTML</abbr></p>
+```


### PR DESCRIPTION
## Summary

- make an explicit `[text]{abbr="…"}` wrapper authoritative over automatic abbreviation expansion
- forbid nested automatic `<abbr>` output inside that explicit wrapper
- pin the interaction in the executable spec and shared corpus

## Why

The implementation work exposed that resolution could otherwise produce invalid nested `<abbr>` elements and obscure the explicitly authored title.

## Tests

- `npm run corpus:build`
- `node --test tests/corpus.test.mjs tests/normativity.test.mjs tests/examples.test.mjs`

Follow-up to #1126 and part of #1124.
