### PR TITLE
docs: clarify semantic boolean spans

### DIFF
--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -151,7 +151,7 @@ The same `{…}` block is used in both positions:
 - `#id` - element id (one per element)
 - `.class` - add a class (repeatable)
 - `key=value` / `key="value"` - arbitrary attribute; quote when the value has spaces
-- `boolean` - a bare word (no `#`/`.`/`=`) becomes a value-less attribute, rendered `name=""` (e.g. `[Tab]{kbd}` → `<span kbd="">Tab</span>`)
+- `boolean` - a bare word (no `#`/`.`/`=`) becomes a value-less attribute, rendered `name=""` (e.g. `{.note open}` adds `open=""`). Registered semantic names on inline spans instead select their HTML element (e.g. `[Tab]{kbd}` → `<kbd>Tab</kbd>`).
 
 ## The one outlier: list items
 


### PR DESCRIPTION
## Summary

- clarify that ordinary bare attributes still render as empty-valued attributes
- document that registered inline semantic names such as `kbd` select their semantic HTML element

## Testing

- `git diff --check`