### PR TITLE
chore: bump carve-js semantic span pin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#5f5ae4c7a58cfb44f2ad9a4246bd19903b24e064",
+        "@markup-carve/carve": "github:markup-carve/carve-js#d4b9f5b40e1497d964cfff7d0a0bf979fddc8155",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.42.1",
@@ -985,8 +985,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#5f5ae4c7a58cfb44f2ad9a4246bd19903b24e064",
-      "integrity": "sha512-tPvoW4D73BPhl0AKH7tM0mV2yE8dJ5/9d3+YctDc769D6eMSoI5ttWoxBmbw4fp30ldw+mdun2LaH5KeMY2Eug==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#d4b9f5b40e1497d964cfff7d0a0bf979fddc8155",
+      "integrity": "sha512-B5F1BkmrCNDZsxNHs4Og1X/f6m6xUvBJGhU4AGIbcvFiIkCWtTuhf4/pQd3c6YopHe7q0sDbEpGZ/qVYRjbpzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#5f5ae4c7a58cfb44f2ad9a4246bd19903b24e064",
+    "@markup-carve/carve": "github:markup-carve/carve-js#d4b9f5b40e1497d964cfff7d0a0bf979fddc8155",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.42.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,7 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-45-inline-extensions-9  compact semantic span attributes await the downstream carve-js merge
-45-inline-extensions-10  compact semantic span nesting and hardening await the downstream carve-js merge
-97-boolean-attributes  kbd changed from a generic boolean span attribute to portable semantic sugar
-45-inline-extensions-11  explicit abbreviation precedence awaits the downstream carve-js merge


### PR DESCRIPTION
## Summary

- pin the reference implementation to the merged compact semantic-span support
- remove the four temporary semantic-span drift exemptions

## Testing

- `npm test` (1954 passed, 1 skipped; the initial run exposed two comparison-count assertions caused by an uncommitted historical-note edit, which was removed)
- `node --test tests/implementation-comparison-counts.test.mjs tests/engine-pin-matches-the-lock.test.mjs tests/reference-build.test.mjs`
- `npm run core:check`
- `git diff --check`