### PR TITLE
Document the footnote-label divergence from Djot

### DIFF
--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -776,6 +776,69 @@ carries that where a `<div>` does not. RENDERER SPECIALIZATION rather than a
 source or AST break: the same source produces the same tree shape, and only the
 element it renders to differs.
 
+## 21. Footnote labels are matched exactly
+
+**Djot:** a footnote label is normalized before lookup, so runs of whitespace
+collapse and the ends are trimmed. Every reference below binds to the same
+definition.
+
+**Carve:** the label runs to the closing `]` and is matched exactly. Whitespace
+is not normalized, the ends are part of the identifier, and a reference may not
+contain a newline at all - so only a reference written the way the definition
+was written binds.
+
+Definition:
+
+```
+[^a b]: foo
+```
+
+References, measured against djot.js 0.3.2:
+
+```
+[^a b]      Djot: binds    Carve: binds
+[^a  b]     Djot: binds    Carve: literal text
+[^a<TAB>b]  Djot: binds    Carve: literal text
+[^ a b ]    Djot: binds    Carve: literal text
+```
+
+A reference may not contain a newline in Carve, so a wrapped one is literal:
+
+```
+see[^two
+words].
+
+[^two words]: foo
+```
+
+renders
+
+```html
+<p>see[^two
+words].</p>
+```
+
+Released Djot agrees on that one: djot.js 0.3.2 also leaves it literal, so this
+half is not a divergence today. It is becoming one - jgm/djot.js#146 rules the
+two sides asymmetric, letting a reference wrap and folding the newline away in
+normalization, and djot-php#269 follows that upstream. Carve's answer stays no:
+a definition marker is one line, and without normalization a wrapped reference
+would be an identifier no definition can bind.
+
+**Why.** A label is an identifier, and normalization makes two visibly different
+identifiers the same key: `[^a b]` and `[^a  b]` are one footnote in Djot,
+which is a difference an author can see in their source but not in their
+output. Matching the bytes keeps the source the authority, and it is the same
+ruling the link-reference labels take.
+
+The cost is real and worth stating: a long label cannot be wrapped. Djot buys
+that ability with normalization; Carve does not, and a reference broken across
+lines stays literal text rather than binding. `carve portability` reports the
+difference on a document that relies on either behavior.
+
+A SOURCE break: the bytes decide, and nothing is silently dropped - an
+unmatched reference stays visible as the text the author typed.
+
 ## What Carve adds on top (not breaks)
 
 An unterminated `%%%` degrades to a line comment rather than opening an opaque

--- a/tests/divergence-claims.test.mjs
+++ b/tests/divergence-claims.test.mjs
@@ -48,6 +48,15 @@ const normalize = (html) => html.replace(/\s+/g, ' ').trim()
  * nest it, which is the claim, but they pretty-print the nesting differently
  * (`<blockquote><p>` against `<blockquote> <p>`), and this file compares
  * whitespace-squashed HTML.
+ *
+ * Section 21 (footnote labels) is absent for the same kind of reason, and it is
+ * worth spelling out because the entry LOOKS testable here. Any input carrying
+ * a resolved footnote already differs between the two engines: the backlink
+ * glyph is `↩` in Carve and `↩︎` (with a variation selector) in Djot. So
+ * `differs: true` passes for every footnote input whether or not the label
+ * matched, which is a check that cannot fail - the exact shape this file
+ * exists to avoid. The binding behavior is pinned by the corpus instead
+ * (22-footnotes-6 for the wrapped reference).
  */
 const CLAIMS = [
   { section: '1', input: '# Getting Started\n', differs: false, note: 'the emitted id is deliberately Djot-shaped - the divergence is in RESOLUTION, not the slug' },


### PR DESCRIPTION
`docs/divergence-from-djot.md` mentioned footnotes only for the inline `^[…]` addition, so the difference an author actually trips over was absent: **Djot normalizes a footnote label before lookup; Carve matches it exactly.**

Measured against djot.js 0.3.2, definition `[^a b]: foo`:

| reference | Djot | Carve |
|---|---|---|
| `[^a b]` | binds | binds |
| `[^a  b]` | binds | literal |
| `[^a<TAB>b]` | binds | literal |
| `[^ a b ]` | binds | literal |

The entry states the cost, not just the rule: exact matching means a long label cannot be wrapped. Normalization buys that; Carve gives it up. An author deserves to read that in the same paragraph.

**The newline half is written as agreement, not divergence.** Released djot.js leaves a wrapped reference literal exactly as Carve does - I measured it. It is [jgm/djot.js#146](https://github.com/jgm/djot.js/issues/146) that makes the two sides asymmetric upstream, with [php-collective/djot-php#269](https://github.com/php-collective/djot-php/pull/269) following, and that is when it becomes a difference. Claiming it today would be exactly the stale entry `tests/divergence-claims.test.mjs` exists to catch.

**No claim case for section 21**, and the comment block says why: any input with a resolved footnote already differs between the engines, because the backlink glyph is `↩` in Carve and `↩︎` (variation selector) in Djot. So `differs: true` would pass whether or not the label matched - a check that cannot fail, which is the shape that file is written to avoid. The behavior is corpus-pinned instead (`22-footnotes-6`).

Context: this came out of reviewing markup-carve/carve-js#1012, which brings carve-js onto the exact-match rule. carve-php and carve-rs were already there, so all three engines agree once it lands.

No CHANGELOG entry: documentation of an existing normative rule, no behavior change.

`npm test`: 1956 pass, 0 fail.