### PR TITLE
docs: the compact semantic span, where the rest of the page still contradicts it

### DIFF
--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -194,6 +194,58 @@ A language tag never sets writing direction. Direction follows the script, and a
 
 A tag that is not structurally well formed leaves the whole block as literal text rather than half-parsing it - `{:en_US}`, `{:-en}` and `{:français}` all stay visible in the output. And the sigil takes no padding: `{: fr}` (with a space) is the empty language attribute plus a separate boolean `fr`, not a language tag.
 
+### Semantic spans: `{kbd}`, `{abbr="…"}`
+
+On an **inline span**, nine attribute names are consumed and become the HTML element of the same name: `abbr`, `time`, `code`, `mark`, `samp`, `var`, `kbd`, `cite`, `dfn`.
+
+```carve
+Press [Tab]{kbd} to indent.
+```
+
+```html
+<p>Press <kbd>Tab</kbd> to indent.</p>
+```
+
+Three of them keep what you wrote: an `abbr` or `dfn` value becomes `title`, a `time` value becomes `datetime`.
+
+```carve
+[HTML]{abbr="HyperText Markup Language"} is a markup language.
+```
+
+```html
+<p><abbr title="HyperText Markup Language">HTML</abbr> is a markup language.</p>
+```
+
+On the other six a value only picks the wrapper and is **not** written out, so `[x]{cite="https://example.org/dune"}` renders `<cite>x</cite>` and the URL reaches no output at all.
+
+Several at once nest in a **fixed** order - `abbr`, `time`, `code`, `mark`, `samp`, `var`, `kbd`, `cite`, `dfn`, innermost first - regardless of the order you typed them, so no document can come to depend on the spelling:
+
+```carve
+[CSS]{dfn abbr="Cascading Style Sheets"}
+```
+
+```html
+<p><dfn><abbr title="Cascading Style Sheets">CSS</abbr></dfn></p>
+```
+
+Anything left over - id, classes, other key/value pairs - stays on one outer `<span>`:
+
+```carve
+[x]{.shortcut kbd}
+```
+
+```html
+<p><span class="shortcut"><kbd>x</kbd></span></p>
+```
+
+Three things worth knowing:
+
+- **The `<span>` disappears only when every attribute was consumed.** `[x]{kbd}` is a bare `<kbd>x</kbd>`, but `[x]{kbd onclick="…"}` keeps the wrapper (`<span><kbd>x</kbd></span>`) even though hardening strips the handler: you wrote a non-semantic attribute, and that is counted before it is removed.
+- **The scope is exactly an ordinary span.** The same names on a code span, link, image or block-attribute line are ordinary attributes, so `` `c`{kbd} `` is `<code kbd="">c</code>`, not a `<kbd>`.
+- **Only HTML changes.** The AST keeps an ordinary span carrying the authored attributes, plain-text and terminal output render the content, and `carve fmt` writes the span back out with its attributes - a boolean as `name=""`, so `[Tab]{kbd}` formats to `[Tab]{kbd=""}`.
+
+The generic `:name[content]{attrs}` form (see [extensions](/extensions)) spells the same nine elements and is the only spelling for anything outside this registry.
+
 ## The one outlier: list items
 
 Every block takes its attributes on the preceding line and every inline takes them trailing - with a single exception: a list item's attribute block **abuts its marker**.
@@ -223,6 +275,8 @@ This is a Carve addition (djot cannot attribute list items at all) and is the **
 text [span]{.c}       ← inline: directly AFTER, no space
 
 [phrase]{:fr}         ← language: short for lang="fr"
+
+[Tab]{kbd}            ← semantic span: <kbd>Tab</kbd>
 
 -{#item} list item    ← list item: abuts the marker (no space!)
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -164,6 +164,8 @@ continues on the next line.
 ```carve
 {#id .class key=value}        (attach to the preceding/following element)
 {:fr}  {:de-CH}  {:}          (language: short for lang="fr"; {:} = unknown)
+[Tab]{kbd}                    (semantic span: <kbd>Tab</kbd>; also abbr, time,
+[HTML]{abbr="HyperText …"}     code, mark, samp, var, cite, dfn)
 
 *[HTML]: HyperText Markup Language   (abbreviation definition)
 

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -864,10 +864,16 @@ as more than restyled Djot:
   is a spelling of decimal-dot, not a dialect, so it mixes with `1.` in one
   list; only `.` may drop its value, since a leading `) ` collides with prose
   parentheticals far more often (grammar, ordered_marker).
-- **Boolean attributes** - a bare word in `{…}` (`[Tab]{kbd}`, `{.note open}`)
-  is a value-less attribute rendered `name=""`. Canonical djot rejects bare
-  words (the whole block stays literal); carve accepts them, following djot-php
-  (grammar §14).
+- **Boolean attributes** - a bare word in `{…}` (`[text]{featured}`,
+  `{.note open}`) is a value-less attribute rendered `name=""`. Canonical djot
+  rejects bare words (the whole block stays literal); carve accepts them,
+  following djot-php (grammar §14). The nine semantic names below are consumed
+  instead of rendered.
+- **Compact semantic spans** - `abbr`, `time`, `code`, `mark`, `samp`, `var`,
+  `kbd`, `cite` and `dfn` on an ordinary span select an HTML element rather than
+  an attribute, so `[Tab]{kbd}` is `<kbd>Tab</kbd>`; `abbr`, `dfn` and `time`
+  values become `title`, `title` and `datetime`. Djot has no equivalent: there
+  the same span is `<span kbd="">` (PART 9 §10).
 - **Target-aware rendering** - one parsed document, multiple renderers (HTML,
   ANSI, Markdown, plain text) behind a single extension contract.
 

--- a/docs/migrate-from-markdown.md
+++ b/docs/migrate-from-markdown.md
@@ -44,6 +44,7 @@ The table below covers the constructs you use most often. Items marked **same** 
 | Tables | GFM pipe tables with a `\|---\|` row | `\|=` header cells | **Changed** - see below (GFM delimiter row also accepted) |
 | Footnotes | `[^label]` + `[^label]: text` (GFM ext.) | same | Plus inline `^[...]` |
 | Raw HTML | Inline and block, on by default | Bare tags are literal; explicit `=html` passthrough only | See below |
+| Keys, abbreviations, dates | raw `<kbd>`, `<abbr title="…">`, `<time datetime="…">` | `[Tab]{kbd}`, `[HTML]{abbr="…"}`, `[today]{time="…"}` | Carve adds this - raw HTML is off, so the nine semantic names (`abbr`, `time`, `code`, `mark`, `samp`, `var`, `kbd`, `cite`, `dfn`) are how you reach those elements |
 
 ## Emphasis: the most important change
 

--- a/docs/native-features-analysis.md
+++ b/docs/native-features-analysis.md
@@ -45,7 +45,7 @@ Grammar references point at `resources/grammar.ebnf`.
 |---------|-----------------|-------------|--------|
 | **Captions** | `^ caption` after block | `^ caption` | ✅ In grammar (caption rule; image/blockquote/table placement). |
 | **Abbreviations** | `*[ABBR]: expansion` | `*[ABBR]: expansion` | ✅ In grammar (PART 5: Abbreviations). |
-| **Semantic spans** | `[text]{.kbd}` → `<kbd>` | `:kbd[text]` | ✅ Via `:type[content]` extension syntax (4.20). |
+| **Semantic spans** | `[text]{.kbd}` → `<kbd>` | `[text]{kbd}` or `:kbd[text]` | ✅ Both spellings are core (PART 9 §9 and §10). Nine names: `abbr`, `time`, `code`, `mark`, `samp`, `var`, `kbd`, `cite`, `dfn`. |
 | **Autolinks** | `<url>` / `<email>` | Angle-bracket autolinks only | ✅ In spec (4.3). Bare URLs are *not* auto-linked (djot-aligned). |
 | **Inline footnotes** | `[content]{.fn}` | `^[content]` | ✅ Tier-1 core, in grammar (§16). A carve addition (not in djot); pandoc-style `^[content]`, numbered into the shared endnotes. |
 | **Table alignment** | `:--`, `--:`, `:--:` | `\|=<` / `\|=>` / `\|=~` markers | ✅ In spec (4.8). |

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3954,13 +3954,20 @@ EOF = (* end of file *) ;
           digit-first identifiers / `class="123"`; see jgm/djot issue 399.)
           A digit/`-`/`_` AFTER the first character is valid (`{.a1}`).
       BOOLEAN (value-less) ATTRIBUTES -- NORMATIVE. A bare identifier with no
-      value (`[text]{kbd}`, `{.note open}`, `{disabled}` on a block line) is a
-      boolean attribute, rendered `name=""`. It is matched after the
+      value (`[text]{featured}`, `{.note open}`, `{disabled}` on a block line)
+      is a boolean attribute, rendered `name=""`. It is matched after the
       `key_value_attribute` form (so `k=v` stays a key/value) and mixes freely
       with id/class/key=value in source order; multiple are allowed; a
       digit-first bare word is not a valid name (the block stays literal, as for
       any digit-first identifier). All impls support it (a carve extension
       beyond canonical djot, matching djot-php; corpus 97-boolean-attributes).
+      THE NINE NAMES OF PART 9 §10 ARE THE EXCEPTION TO `name=""`: on an
+      ordinary span, `abbr`, `time`, `code`, `mark`, `samp`, `var`, `kbd`,
+      `cite` and `dfn` are consumed into an HTML element instead of reaching
+      the output as an attribute, so `[Tab]{kbd}` is `<kbd>Tab</kbd>` and not
+      `<span kbd="">Tab</span>`. They are boolean attributes everywhere else,
+      including in the AST and in the canonical writer, which spells the same
+      span `[Tab]{kbd=""}`.
       A COLON is not an `identifier` character, so a colon-bearing name is
       unrecognized in every form -- `{xml:lang="en"}`, `{.sm:hover}`, `{#a:b}`
       and a bare `{a:b}` all leave the run literal, in every engine (corpus

--- a/tests/corpus/45-inline-extensions-9.fmt
+++ b/tests/corpus/45-inline-extensions-9.fmt
@@ -1,0 +1,2 @@
+[CSS]{dfn="" abbr="Cascading Style Sheets"}
+[Noon]{time=12:00} [x]{code="" mark="" samp="" var="" kbd="" cite=""}

--- a/tests/corpus/45-inline-extensions-9.txt
+++ b/tests/corpus/45-inline-extensions-9.txt
@@ -1,0 +1,1 @@
+CSS Noon x

--- a/tests/corpus/97-boolean-attributes.fmt
+++ b/tests/corpus/97-boolean-attributes.fmt
@@ -1,0 +1,1 @@
+Press [Tab]{kbd=""} to indent.

--- a/tests/corpus/97-boolean-attributes.txt
+++ b/tests/corpus/97-boolean-attributes.txt
@@ -1,0 +1,1 @@
+Press Tab to indent.


### PR DESCRIPTION
The compact semantic span shipped with a normative clause and HTML fixtures. Three consequences of it stayed behind.

## The boolean-attribute clause still teaches the old output

`resources/grammar.ebnf` (BOOLEAN ATTRIBUTES, PART 4) and `docs/divergence-from-djot.md` both illustrate "a bare word rendered `name=\"\"`" with the one bare word that is now consumed instead:

```
Press [Tab]{kbd} to indent.
```

```html
<p>Press <kbd>Tab</kbd> to indent.</p>
```

The same edit was made to `docs/blocks-and-attributes.md` in a previous PR and these two were missed. The example moves to a name outside the registry, both places point at the nine names, and the djot page gains the divergence as an entry of its own - `<span kbd="">` really is what Djot renders there.

## The non-HTML targets were prose only

PART 9 §10 states the AST keeps an ordinary span, that plain and terminal output render the content, and that the writer spells a consumed boolean `name=""`. No `.fmt`, `.txt`, `.md` or `.ansi` fixture existed beside any semantic-span case, so an engine whose writer dropped the attribute, or whose plain renderer leaked it, would pass every gate.

Four sidecars now pin it:

| fixture | pins |
| --- | --- |
| `97-boolean-attributes.fmt` | `Press [Tab]{kbd=""} to indent.` - the writer keeps the consumed attribute and spells the boolean |
| `97-boolean-attributes.txt` | `Press Tab to indent.` - plain renders the content, not the wrapper |
| `45-inline-extensions-9.fmt` | value forms plus a six-name combination survive the round trip |
| `45-inline-extensions-9.txt` | the whole registry renders as its content in plain text |

Verified byte-for-byte in all three engines before being written down, not only in the pinned build: carve-js `a59df0fa`, carve-php `520ea41`, carve-rs `410845c` produce every one of these four files exactly.

## Authors had nowhere to learn it

The feature reached the extension catalog and one sentence of the attribute list. `docs/blocks-and-attributes.md` gains a section mirroring the language-attribute section beside it: the registry, which three names keep their value and which six discard it, the fixed nesting order, what remains on the outer span, and the three things that are easy to get wrong - the wrapper survives a stripped attribute, the rule is scoped to an ordinary span (`` `c`{kbd} `` is `<code kbd="">`), and only HTML changes. The cheatsheet and the Markdown migration table get the entry, since a Markdown author reaching for `<kbd>` has no raw HTML to reach for here.

Every HTML example on those pages is the pinned engine's actual output, compared byte for byte.
