### PR TITLE
docs: three lint rules the engine emits and the page never listed

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -105,6 +105,9 @@ the command-line and editor behavior stay aligned.
 | `carve-version-unsupported` | a document declaring a Carve spec version the processor does not implement, so constructs added after that version render as something else without any error |
 | `unclosed-container-fence` | a `:::` opener with no matching closer; the container runs to end of input, which is legal (PART 9 §12) and rarely what was meant |
 | `fence-title-syntax` | text after a fence type word that is neither a quoted `"title"` nor a `[label]`, which makes the whole opener line plain text |
+| `footnote-labels-differ-only-in-whitespace` | two footnote definitions whose labels differ only in whitespace; labels are matched exactly, so they are two separate footnotes and a reader comparing them sees no reason why |
+| `semantic-attribute-value-ignored` | a non-empty value on `code`, `mark`, `samp`, `var`, `kbd` or `cite` in a compact semantic span; those six names select their wrapper and the value reaches no output at all, so `[Dune]{cite="https://example.org/dune"}` renders `<cite>Dune</cite>` and loses the URL (PART 9 §10) |
+| `semantic-attribute-outside-span` | one of the nine semantic names used where PART 9 §10 does not apply - a code span, link, image, block-attribute line or table cell - where it stays an ordinary attribute, so `` `c`{kbd} `` is `<code kbd="">` rather than a `<kbd>` |
 | `platform-mention-token` | an at-prefixed word in text the document publishes, which a host platform re-linkifies into a user mention; opt-in and off by default, see [platform autolink rules](#platform-autolink-rules) |
 | `platform-issue-reference` | a hash-number in text the document publishes, which a host platform re-linkifies into an issue reference; opt-in and off by default, see [platform autolink rules](#platform-autolink-rules) |
 

--- a/tests/lint-rule-table-claims.test.mjs
+++ b/tests/lint-rule-table-claims.test.mjs
@@ -80,7 +80,21 @@ const TRIGGERS = {
     source: 'See #123 for the discussion.\n',
     options: { platforms: ['github'] },
   },
+  'footnote-labels-differ-only-in-whitespace': 'see [^a b] and [^a  b]\n\n[^a b]: one\n\n[^a  b]: two\n',
+  'semantic-attribute-value-ignored': '[x]{cite="https://example.org/dune"}\n',
+  'semantic-attribute-outside-span': '`c`{kbd}\n',
 }
+
+/*
+ * A rule id the build carries but no trigger names.
+ *
+ * `collectPortableWhitespace` is retained behind an explicit `void` reference
+ * in carve-js and called from nowhere, so `portable-quote-marker-space` cannot
+ * be emitted by any input or option. It is listed here rather than silently
+ * skipped: the scan below would otherwise report it forever, and a reader has
+ * to be able to tell "no producer, known" from "no producer, nobody noticed".
+ */
+const UNPRODUCIBLE_IN_BUILD = new Set(['portable-quote-marker-space'])
 
 /** The rules this map calls with options, i.e. the ones that are not default-on. */
 const OPT_IN = Object.entries(TRIGGERS)
@@ -173,6 +187,68 @@ test('an opt-in rule reports nothing until it is asked for', () => {
     `rule(s) reported without being asked for: ${leaked.join(', ')}. ` +
       'docs/validation.md states a processor MUST NOT report these unless the ' +
       'caller names a platform.',
+  )
+})
+
+/*
+ * THE SCAN, because the comparison above cannot see a rule it was never told
+ * about.
+ *
+ * `emittedRules()` runs the TRIGGERS documents, so the set it produces is
+ * bounded by the rules already documented. A rule the engine gained with a
+ * condition no trigger document meets contributes nothing to it, and "every
+ * rule the engine emits is on the page" passes while the page is short. That
+ * is not hypothetical: at the pin this test was extended on, carve-js emitted
+ * `footnote-labels-differ-only-in-whitespace`,
+ * `semantic-attribute-value-ignored` and `semantic-attribute-outside-span`,
+ * the page listed none of the three, and every assertion above was green.
+ *
+ * So the ids are read out of the pinned build itself instead of being inferred
+ * from what this file already knows to ask for. That reads a build artifact,
+ * which is brittle by nature - the floor is what makes the brittleness loud: a
+ * bundler change that stops matching the pattern fails here rather than
+ * quietly turning the check into a statement about an empty list.
+ *
+ * THE PATTERN IS DELIBERATELY BROAD - every kebab-case string literal in the
+ * file, not the ids in one emission form. carve-js spells a rule id three ways
+ * today: `rule: 'x'` in a warning object, a positional `push(…, 'x', …)`, and
+ * an entry in a rule tuple. A pattern per form is a pattern per form somebody
+ * has to remember to add, which is the same blindness one level down; matching
+ * every kebab literal costs a `NOT_A_RULE` line the first time a non-rule
+ * kebab string appears, and that entry is visible where an unmatched form is
+ * not. Measured at the pin: 21 literals, all 21 of them rule ids, no noise.
+ */
+const NOT_A_RULE = new Set()
+
+function ruleIdsInBuild() {
+  const lintSource = readFileSync(
+    new URL('../node_modules/@markup-carve/carve/dist/lint.js', import.meta.url),
+    'utf8',
+  )
+  const literals = [...lintSource.matchAll(/['"]([a-z][a-z0-9]*(?:-[a-z0-9]+)+)['"]/g)].map((m) => m[1])
+
+  return [...new Set(literals)].filter((id) => !NOT_A_RULE.has(id)).sort()
+}
+
+test('the build was actually scanned', () => {
+  const found = ruleIdsInBuild()
+  assert.ok(
+    found.length >= 18,
+    `only ${found.length} rule id(s) found in the pinned build; the scan pattern no longer matches ` +
+      'how carve-js spells a rule id, so the check below is about an empty list.',
+  )
+})
+
+test('every rule id in the pinned build is on the page', () => {
+  const documented = documentedRules()
+  const missing = ruleIdsInBuild().filter(
+    (rule) => !documented.includes(rule) && !UNPRODUCIBLE_IN_BUILD.has(rule),
+  )
+  assert.deepEqual(
+    missing,
+    [],
+    `the pinned carve-js build carries rule id(s) docs/validation.md does not list: ${missing.join(', ')}. ` +
+      'A warning a user can read in their terminal and nowhere else is the contract this page exists to keep.',
   )
 })
 


### PR DESCRIPTION
`docs/validation.md` states that a rule id is spec surface: two engines reporting the same condition take the same id, and a CI filter, an editor suppression or a `# carve-lint-disable` comment is keyed on it. An id that fires in a terminal and appears nowhere on the page breaks that. `tests/lint-rule-table-claims.test.mjs` exists to catch it.

## It could not catch it

`emittedRules()` collects the ids produced by the TRIGGERS documents, and TRIGGERS is written from the page - so the set compared against the page is bounded by the page. A rule whose condition no trigger document meets contributes nothing, and "every rule the engine emits is on the page" stays green while the page is short.

At the current pin the page was short by three, all firing on ordinary input under default options:

| rule | trigger |
| --- | --- |
| `footnote-labels-differ-only-in-whitespace` | two definitions whose labels differ only in whitespace |
| `semantic-attribute-value-ignored` | `[Dune]{cite="https://example.org/dune"}` - the URL reaches no output |
| `semantic-attribute-outside-span` | `` `c`{kbd} `` - `<code kbd="">`, not a `<kbd>` |

Rows and trigger documents are added, so the existing checks now cover all three in both directions.

## The guard reads the build

The ids are extracted from the pinned build's `dist/lint.js` and compared against the page, independent of what the test already knows to ask for.

Load-bearing rather than decorative, measured: with the `semantic-attribute-value-ignored` row **and** its trigger entry removed, `every rule the engine emits is on the page` passes and `every rule id in the pinned build is on the page` fails. That is exactly the case the old check was blind to.

The pattern matches every kebab-case string literal instead of one emission form - carve-js spells a rule id three ways today (a `rule:` property, a positional push argument, a tuple entry), and a pattern per form is one more thing to remember, which is the same blindness one level down. Measured at the pin: 21 literals, all 21 of them rule ids, no noise. A floor of 18 makes a bundler change that stops matching fail loudly instead of turning the comparison into a statement about an empty list.

## One id is declared unproducible

`portable-quote-marker-space` is emitted by `collectPortableWhitespace`, which carve-js keeps behind an explicit `void` reference and calls from nowhere - it cannot fire for any input or option, so a row for it would be a promise with no producer. Naming it in the test keeps "no producer, known" distinguishable from "no producer, nobody noticed". Whether that collector comes back or goes away is a separate question; `docs/portable-whitespace.md` still documents `carve lint --portable` and a `portable-blank-line-before-block` rule that the engine no longer carries at all.
