### PR TITLE
spec: withdraw the two semantic-span .fmt fixtures for the rollout too

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -6090,8 +6090,9 @@ EOF = (* end of file *) ;
       the value is an empty STRING, where the tree says the attribute has no
       value at all.
 
-      THE `.fmt` FIXTURE FOR `297-the-language-sigil-takes-no-padding` IS
-      WITHDRAWN, not updated, and comes back with the pin bump. Those fixtures
+      THREE `.fmt` FIXTURES ARE WITHDRAWN, not updated, and come back with the
+      pin bump: `297-the-language-sigil-takes-no-padding`,
+      `97-boolean-attributes` and `45-inline-extensions-9`. Those fixtures
       are read THROUGH the pinned build by
       `tests/corpus-fmt-roundtrip.test.mjs`, and by the engines through their
       own `spec` submodule, so a fixture carrying the NEW bytes fails in both

--- a/tests/corpus/45-inline-extensions-9.fmt
+++ b/tests/corpus/45-inline-extensions-9.fmt
@@ -1,2 +1,0 @@
-[CSS]{dfn="" abbr="Cascading Style Sheets"}
-[Noon]{time=12:00} [x]{code="" mark="" samp="" var="" kbd="" cite=""}

--- a/tests/corpus/97-boolean-attributes.fmt
+++ b/tests/corpus/97-boolean-attributes.fmt
@@ -1,1 +1,0 @@
-Press [Tab]{kbd=""} to indent.


### PR DESCRIPTION
markup-carve/carve#1143 withdrew `297-the-language-sigil-takes-no-padding.fmt` because no spelling of it is green on both sides of the PART 11 §6c writer change. It named one file. The two sidecars markup-carve/carve#1138 added have the same shape and were missed:

```
97-boolean-attributes.fmt     Press [Tab]{kbd=""} to indent.
45-inline-extensions-9.fmt    [CSS]{dfn="" abbr="Cascading Style Sheets"}
                              [Noon]{time=12:00} [x]{code="" mark="" samp="" var="" kbd="" cite=""}
```

Both are read through each engine's `spec` submodule, so they are red the moment a writer ships §6c.

Not reasoned about - measured. With §6c implemented in carve-js, those two files fail `corpus-canonical-form` and `corpus-render-fixtures`, the same two suites the padding fixture had already been pulled out of:

```
FAIL  the pinned canonical form > is what fmt produces for 45-inline-extensions-9
FAIL  the pinned canonical form > is what fmt produces for 97-boolean-attributes
FAIL  spec corpus non-HTML render fixtures > fmt: 45-inline-extensions-9
FAIL  spec corpus non-HTML render fixtures > fmt: 97-boolean-attributes
```

The `.txt` sidecars beside them are untouched: plain text renders content, not attributes, so they are unaffected by the spelling.

All three `.fmt` files come back in the pin bump, with the bare spelling, once every writer emits it. §6c's own note now names all three instead of one.

`npm test` 1979 pass 0 fail.