### PR TITLE
docs: name the 0.1.x behavior change, and stop documenting a lint rule that is gone

### DIFF
--- a/docs/portable-whitespace.md
+++ b/docs/portable-whitespace.md
@@ -12,11 +12,10 @@ forms, so following this page does not trade Markdown compatibility for Djot
 compatibility - it gives up neither.
 
 ::: tip
-These are advisory. They are reported only when you ask for them:
-
-```sh
-carve lint --portable doc.crv
-```
+These are advisory. Nothing reports them: the blank-line form is a portability
+convention rather than a defect, and the marker-space form became core syntax,
+where `carve lint` already reports a missing space as
+`blockquote-marker-without-space`.
 :::
 
 ## Leave a blank line before a block opener
@@ -55,7 +54,6 @@ A top-level list is the exception that needs nothing: a list marker does not
 interrupt a paragraph in Carve either, so `Some text` followed by `- a` is a
 single paragraph in both languages already.
 
-Reported as `portable-blank-line-before-block`.
 
 ## Put a space after every `>`
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -59,6 +59,47 @@ and nothing says so. The two fields do not compete - the frontmatter key is the
 author's intent, the trailing marker is what last processed the file - and a
 document carrying only the marker is still checked.
 
+### Behavior changes inside 0.1.x
+
+A `0.1.x` release may still change what an existing document renders to, and one
+already has. The compact semantic span gave nine attribute names a meaning they
+did not have before:
+
+`abbr`, `time`, `code`, `mark`, `samp`, `var`, `kbd`, `cite`, `dfn`
+
+On an ordinary `[content]{attrs}` span each is now consumed into its HTML element
+instead of reaching the output as an attribute
+([PART 9 §10](./blocks-and-attributes#semantic-spans-kbd-abbr)). A document that used one
+of those names as a plain marker attribute renders differently after upgrading.
+
+Eight of them change shape and keep their content:
+
+```carve
+[x]{time="2026-01-01"}
+```
+
+```html
+<span time="2026-01-01">x</span>   <!-- before -->
+<time datetime="2026-01-01">x</time>   <!-- after -->
+```
+
+**`cite` is the one to check.** It is a real HTML attribute - on `blockquote` and
+`q` - so `{cite="…"}` on a span was a reasonable thing to write, and its value now
+reaches no output at all:
+
+```carve
+[Dune]{cite="https://example.org/dune"}
+```
+
+```html
+<span cite="https://example.org/dune">Dune</span>   <!-- before -->
+<cite>Dune</cite>                                   <!-- after -->
+```
+
+To find affected documents, search for those nine names used as attributes on a
+span. Where the value mattered, move it to an attribute that survives - a `title`,
+or a link if it was a URL.
+
 ### Checking documents mechanically
 
 The marker is machine-readable, so this does not have to be done by eye. In


### PR DESCRIPTION
Two pages claimed things the build does not do. Closes markup-carve/carve#1141 and the docs half of markup-carve/carve#1142.

## Versioning said nothing about the one behavior change 0.1.x has already made

The compact semantic span gave nine attribute names a meaning they did not have, so a document that used one as a plain marker attribute renders differently after an upgrade - and `docs/versioning.md`, the page an author consults about exactly that, was silent.

`cite` is the case worth naming, because it is a real HTML attribute on `blockquote` and `q`, so `{cite="…"}` on a span was a reasonable thing to write:

```carve
[Dune]{cite="https://example.org/dune"}
```

```html
<span cite="https://example.org/dune">Dune</span>   <!-- before -->
<cite>Dune</cite>                                   <!-- after -->
```

The value now reaches no output at all. The other eight change shape and keep their content.

Why the lint rule proposed under markup-carve/carve#1131 does not cover this: it reports the loss for someone writing that attribute TODAY. It cannot tell an upgrading author that last week's document renders differently. Different questions, and only one of them had an answer.

This is option 2 from markup-carve/carve#1141. Option 3 - a version-delta check family - is a separate question about whether that category exists at all, and is not decided here.

## Portable whitespace documented a command and a rule that do not exist

`carve lint --portable` is a deprecated option in carve-js and `portable-blank-line-before-block` appears in no engine's source, so the page pointed at a diagnostic no reader could produce.

Taking the option markup-carve/carve#1142 argues for: the marker-space half became core syntax and `carve lint` already reports a missing space as `blockquote-marker-without-space`, which is documented and does fire; the blank-line half is a portability convention rather than a defect. The prose about the portable forms themselves is unchanged and still true - only the claim that something reports them is gone.

The engine half of #1142 - deleting the dead `collectPortableWhitespace` collector and the `UNPRODUCIBLE_IN_BUILD` entry that points at it - follows separately, since it touches carve-js.

## Verification

`npm test` 1979 pass 0 fail, and `npm run docs:build` completes, which is what checks the new cross-page anchor resolves.