### PR TITLE
docs: stop calling the examples page's core features extensions

### DIFF
--- a/docs/examples/extensions.md
+++ b/docs/examples/extensions.md
@@ -1,11 +1,26 @@
 ---
 title: "Examples: Extensions"
-description: Tier-2/3 extension features, side by side with the HTML they produce.
+description: Admonitions, abbreviations, mentions, symbols, cross-references and the extension syntax, side by side with the HTML they produce.
 ---
 
 # Extensions examples
 
-Features provided by extensions on top of the core language: admonitions, abbreviations, mentions and tags, inline extensions, symbols, and cross-reference numbering.
+Admonitions, abbreviations, mentions and tags, the extension syntax, symbols, and
+numbered cross-references, plus one genuine extension: diagrams.
+
+**Most of what is on this page is core, not an extension.** Everything down to
+and including [Numbered cross-references](#numbered-cross-references) is
+default-on core syntax per the
+[feature-tier table](/extensions#feature-tiers-quick-reference). `@mention`,
+`#tag` and `:symbol:` parsing are core too, and are the only ones on this page a
+processor may turn off (grammar PART 9 §19). The nine semantic names under
+[Inline extensions](#inline-extensions) are renderer behavior rather than an
+opt-in extension, and so is the compact `[x]{kbd}` spelling. Only
+[Diagrams and charts](#diagrams-and-charts) is an extension in the tier sense.
+
+The page keeps its name because a corpus category's number is its position among
+these example sections, so moving one renumbers every category after it and
+invalidates the per-implementation lists that cite them.
 
 ## Admonitions
 


### PR DESCRIPTION
Fixes the framing reported for <https://markup-carve.github.io/carve/examples/extensions#abbreviations>.

## What was wrong

The page opened with:

> Features provided by extensions on top of the core language: admonitions, abbreviations, mentions and tags, inline extensions, symbols, and cross-reference numbering.

Every item in that list is **core** per the normative feature-tier table in `docs/extensions.md`:

| Section on the page | Tier per the table |
| --- | --- |
| Admonitions | core, default on, not disableable |
| Abbreviations | core, default on, not disableable |
| Mentions and tags | core, default on; §19 lets a processor disable |
| Inline extensions | the SYNTAX is core; only the handlers are Tier-2/3 |
| Symbols | core, default on; §19 lets a processor disable |
| Numbered cross-references | core, default on, not disableable |
| Diagrams and charts | extension, off by default |

Only the last one is an extension in the tier sense. The frontmatter description said "Tier-2/3 extension features", which was wrong for six of seven sections.

The nine semantic names under Inline extensions are renderer behavior rather than an opt-in extension, and the compact `[x]{kbd}` spelling is core too, with PHP's former opt-in extension now a compatibility shim.

## Prose only, deliberately

The sections stay where they are and keep their order. A corpus category's number is its POSITION among the example sections, so moving Abbreviations into `core.md` renumbers every category after it and invalidates the per-implementation lists that cite `NN-slug`. `generate-corpus.mjs` says so in its own comments and reports moves for exactly this reason.

`npm run corpus:build` produces no diff from this change. That constraint is now written on the page, so the next reader does not have to rediscover why the file keeps its name.

## Locking

Took the org-wide sweep lock rather than the per-repo one: the change is inside `docs/examples/`, which is corpus source.

## Note

`claims:check` could not run here - it requires all three engine checkouts and found none. It refuses rather than reporting a clean run over nothing, so no claim is being made about it. `npm test` (1979 passing) and `docs:build` are green; the build validates the two internal anchors this adds.
