### PR TITLE
docs: record the cycle, in the changelog and where an upgrader looks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A compact language attribute, `{:TAG}`** (carve#1114). `[Le Bon Usage]{:fr}`
+  is exact sugar for `{lang=fr}`, on inline spans and on block attribute lines
+  alike. The empty form `{:}` means the language is explicitly UNKNOWN and
+  desugars to `lang=""`, which stops inheritance where omitting the attribute
+  would keep it; it is distinct from the BCP 47 `und` and `zxx` tags. A tag is
+  ASCII-alphanumeric subtags of at most eight characters, hyphen-separated; a
+  malformed candidate leaves the whole block literal rather than half-parsing
+  it, and the sigil takes no padding, so `{: fr}` is the empty attribute plus a
+  separate boolean. `:tag` and `lang=tag` are ONE key: the last value wins at
+  the first position. This is an observable parsing change inside 0.1.x -
+  `[x]{:fr}` was literal before - accepted because the slot was unclaimed and
+  unassigned, after an audit of the organization and public `.crv` code search
+  found no literal use.
+
+- **The HTML import contract is specified** (carve#1098). Import is a migration
+  boundary, not an HTML serializer: an HTML5 parse, a documented policy, the
+  Carve AST, then the ordinary writer. Three modes (`safe`, `semantic`,
+  `roundtrip`), an ordered diagnostic list with portable codes for every lossy
+  decision, the required API surface per language plus `carve migrate --from
+  html`, the adapter names, a CSS policy that maps only explicit declarations,
+  and resource limits that fail with a typed error rather than a partial
+  document. Shared fixtures under `tests/html-import` define the portable
+  minimum.
+
+- **PART 12 §14: a caption may carry a structured short caption** (carve#1117).
+  A `figure` or `table` MAY carry `shortCaption`, an array of inline nodes, for
+  a target's list of figures or tables. Carve 0.1 source has no spelling for it,
+  so a parser never synthesizes one - it enters through an AST consumer or a
+  format bridge and survives encode/decode. HTML, plain and ANSI ignore it, the
+  canonical writer MUST omit it, and no processor may derive one by truncating
+  the full caption.
+
 ### Changed
 
 - **Semantic spans split by tier** (carve#1146). Core reserves three span
@@ -40,6 +74,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   occurrence document-wide, where `[HTML]{abbr="…"}` marks one. This is an observable HTML change for JS/Rust and for
   PHP without its former opt-in extension. AST, plain/ANSI, and canonical
   source behavior remain ordinary span behavior.
+
+- **PART 11 §6c: a value-less attribute is written as a boolean** (carve#1137).
+  The canonical writer contradicted itself over one construct: a boolean whose
+  key is `lang` contracted to the shortest dedicated form (`{:}`) while every
+  other boolean expanded to the longest (`{kbd=""}`). PART 11 §1 permitted both
+  and no clause chose. The writer now uses the DEDICATED production - the
+  language attribute for a `lang` key, the boolean attribute for a value-less
+  one - so `[Tab]{kbd}` formats back to `[Tab]{kbd}` rather than to a spelling
+  that says the value is an empty string where the tree says there is no value.
+
+- **A boolean and a key/value of the same name are one attribute**
+  (carve#1125). A boolean IS a key/value with an empty value, so it takes that
+  name's slot and the repeated key keeps the LAST value at the FIRST position,
+  like any repeated key. Emitting both would produce two HTML attributes with
+  one name.
+
+- **A structural attribute leads the author's own** (carve#1090). An attribute
+  an element derives from its own marker or destination - `<ol>`'s `type` and
+  `start`, a link's `href`, an image's `src` and `alt` - is part of the
+  element's shape rather than something added on top, so it is emitted BEFORE
+  the authored attributes, which then follow in source order; engine-minted
+  attributes come last. A structural CLASS still merges at the front of the
+  class slot. This matches reference djot on every shape measured.
+
+- **Footnote labels are matched exactly, and never cross a line**
+  (carve#1112). A label is a physical-line identifier: it may contain spaces
+  and tabs but not a source newline, and matching does not normalize
+  whitespace. A reference that spanned a newline used to resolve against a
+  definition it could not have been written as.
+
+- **An explicit `abbr` semantic attribute outranks automatic expansion**
+  (carve#1127). Inside such a span a resolved abbreviation contributes only its
+  visible text and renderers MUST NOT emit a nested `<abbr>`, so a
+  document-level `*[HTML]: …` definition no longer overrides
+  `[HTML]{abbr="Custom"}`.
+
+- **PART 10 §8b: the plain-text target preserves list depth** (carve#1084). A
+  nested item is indented two spaces per list ancestor. The target may discard
+  marker style and tight/loose layout, but flattening parent, child and
+  grandchild into siblings erases structure the reader has no other way to
+  recover - indentation is what plain text has.
+
+- **Bidi controls are stripped by presentation target** (carve#1082, #1083).
+  Canonical Carve preserves a Trojan-Source bidi override or isolate control
+  because it is the source; every presentation target strips it. `carve lint`
+  reports the source occurrence as `bidi-control-in-source`.
 
 ## [0.1.2] - 2026-08-10
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -111,6 +111,29 @@ This is the one break in RELEASED behavior rather than in a development window:
 `:kbd[x]` has rendered `<kbd>` in carve-js since its first release. The rewrite
 is mechanical - `:kbd[Tab]` becomes `[Tab]{kbd}`.
 
+**5. The language attribute claimed the `{:…}` slot**, which was unassigned and
+therefore literal:
+
+```carve
+[Le Bon Usage]{:fr}
+```
+
+```html
+<p>[Le Bon Usage]{:fr}</p>                        <!-- before -->
+<p><span lang="fr">Le Bon Usage</span></p>        <!-- after -->
+```
+
+The exception was taken deliberately and on evidence: attribute names cannot
+start with `:`, so nothing could collide, and an audit of the organization plus
+a public `.crv` code search found no literal use to break. A malformed tag
+(`{:en_US}`, `{:français}`) still leaves the block literal, so a typo looks like
+a typo rather than half-parsing.
+
+**6. The plain-text target stopped flattening nested lists.** Before, depth was
+erased and every item came out a sibling; now each list ancestor indents its
+item by two spaces (PART 10 §8b). A pipeline that parsed the plain output by
+column will see different columns.
+
 To find affected documents, search for the seven names used as attributes on a
 span, and for `:name[…]` with any of them. Where a value mattered, move it to an
 attribute that survives - a `title`, or a link if it was a URL.


### PR DESCRIPTION
> Stacked on markup-carve/carve#1150 - its commit is the parent here, and the base becomes `main` once that merges.

Fourteen commits since `0.1.2` changed `resources/grammar.ebnf`. **One** of them touched the CHANGELOG.

So the page a consumer reads to decide whether to upgrade described one change out of a dozen, and the page an author reads when their output moved named one behavior change out of three.

## The changelog gains what shipped

**Added** - the `{:TAG}` language attribute, the HTML import contract, PART 12 §14's structured short caption.

**Changed** - PART 11 §6c's boolean spelling in the writer, the boolean/key-value merge, structural attribute order, exact footnote labels that never cross a line, explicit `abbr` outranking automatic expansion, PART 10 §8b's plain-text list depth, bidi stripping by presentation target.

The test for belonging is whether an implementation has to follow it or a document's output moves. The corpus pins, CI jobs and test guards from the same window are deliberately absent - they are commit-message material, not release notes.

## Versioning names all three behavior changes

It said "one already has". Two more qualify:

```carve
[Le Bon Usage]{:fr}
```

```html
<p>[Le Bon Usage]{:fr}</p>                   <!-- before -->
<p><span lang="fr">Le Bon Usage</span></p>   <!-- after -->
```

and the plain-text target, which stopped flattening nested lists - depth used to be erased, so a pipeline reading that output by column now sees different columns.

An upgrader searching for what moved deserves all three in one list, with the `cite` case still called out as the one that loses content rather than changing shape.
