### PR TITLE
spec: pin that an uppercase LANG is a different key

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -16081,6 +16081,31 @@ Text
 
 :::
 
+An UPPERCASE key is a different key. Attribute names are case-sensitive
+(PART 11 §1), so `LANG` is an ordinary attribute that happens to spell a
+reserved name differently - the same way `{KBD}` is not the semantic span
+`{kbd}` (PART 9 §10). Only the exact lowercase `lang` is the language
+attribute's other spelling.
+
+::: compare
+
+```carve
+[a]{LANG=fr} [b]{lang=fr}
+```
+
+```html
+<p><span LANG="fr">a</span> <span lang="fr">b</span></p>
+```
+
+:::
+
+This pair is what the round-trip check needs to be able to fail. It compares
+`toHtml(fmt(x))` against `toHtml(x)` over every document, and a writer that
+folded the key case would rewrite `[a]{LANG=fr}` to `[a]{:fr}` and render
+`lang="fr"` where the source asked for `LANG="fr"`. Every other corpus
+document writes its attribute names in lower case, so the check could not
+see it (carve#1137).
+
 ## The language sigil takes no padding
 
 A space after `:` does not belong to the language attribute. The TAG is

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 936 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 937 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#992fbc901bc89dd047d257547d045413d6204bac",
+        "@markup-carve/carve": "github:markup-carve/carve-js#7d6a2bcfb417217c46f373b46eaec3c40fcd65d8",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.42.1",
@@ -985,8 +985,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#992fbc901bc89dd047d257547d045413d6204bac",
-      "integrity": "sha512-Kx2GYvITzPjTHcjqWF9tAcmEDlwTvCPJq8FNl54GP3mfmfGRpg82jQF2rsz68FfAaf3BG3Mf8h2H6HDqVF2rQQ==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#7d6a2bcfb417217c46f373b46eaec3c40fcd65d8",
+      "integrity": "sha512-zmq1Ex+YKQ865CR31mw8kvAn69zgY3KM/XTa910lUFiY2E0H6lfLQCpVSYyW/dF/N9GKWJbF/OmjYFMpQMKLmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#a59df0faabb879a23d0565b14873ccff80842b19",
+        "@markup-carve/carve": "github:markup-carve/carve-js#992fbc901bc89dd047d257547d045413d6204bac",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.42.1",
@@ -985,8 +985,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#a59df0faabb879a23d0565b14873ccff80842b19",
-      "integrity": "sha512-WEsWSqedAAVM8Y3upcIJbNsQDwAKcr7JkKS26kjfZR1IwtCwPPEPFgvvWRKxTINvVMpmeh2LGzwcvwRHWqNBkQ==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#992fbc901bc89dd047d257547d045413d6204bac",
+      "integrity": "sha512-Kx2GYvITzPjTHcjqWF9tAcmEDlwTvCPJq8FNl54GP3mfmfGRpg82jQF2rsz68FfAaf3BG3Mf8h2H6HDqVF2rQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#a59df0faabb879a23d0565b14873ccff80842b19",
+    "@markup-carve/carve": "github:markup-carve/carve-js#992fbc901bc89dd047d257547d045413d6204bac",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.42.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#992fbc901bc89dd047d257547d045413d6204bac",
+    "@markup-carve/carve": "github:markup-carve/carve-js#7d6a2bcfb417217c46f373b46eaec3c40fcd65d8",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.42.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,8 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-
-299-the-semantic-registry-holds-no-element-carve-already-spells-2  `code` and `mark` leave the semantic registry with this change (PART 9 §9), so `:code[…]` and `:mark[…]` take the generic `<span class="ext-NAME">` fallback. The pinned build still has both names in its registry and renders `<code>` and `<mark>`. Clears with the engine PRs and a pin bump.
-299-the-semantic-registry-holds-no-element-carve-already-spells-3  Same rule, the compact spelling: `[*b*]{code}` and `[*b*]{mark}` are ordinary boolean attributes now, where the pin still consumes both names into an element.
-45-inline-extensions-7  The registry line. `:code[x]` and `:mark[relevant]` are the two names of the nine that changed; the rest of the line is unaffected and pins that.
-45-inline-extensions-9  The combination line. `code` and `mark` drop out of the nesting and land on the outer span as leftover attributes, which is also what pins that the wrapper survives a NON-semantic name (`<span code="" mark="">` around the rest).

--- a/tests/corpus/296-a-language-attribute-and-lang-are-one-key-5.crv
+++ b/tests/corpus/296-a-language-attribute-and-lang-are-one-key-5.crv
@@ -1,0 +1,1 @@
+[a]{LANG=fr} [b]{lang=fr}

--- a/tests/corpus/296-a-language-attribute-and-lang-are-one-key-5.html
+++ b/tests/corpus/296-a-language-attribute-and-lang-are-one-key-5.html
@@ -1,0 +1,1 @@
+<p><span LANG="fr">a</span> <span lang="fr">b</span></p>

--- a/tests/spec/296-a-language-attribute-and-lang-are-one-key.test
+++ b/tests/spec/296-a-language-attribute-and-lang-are-one-key.test
@@ -25,3 +25,9 @@ Text
 .
 <p lang="de">Text</p>
 ```
+
+```
+[a]{LANG=fr} [b]{lang=fr}
+.
+<p><span LANG="fr">a</span> <span lang="fr">b</span></p>
+```


### PR DESCRIPTION
Fixes markup-carve/carve#1137.

## What was wrong

The canonical writer matched the `lang` key case-INSENSITIVELY when deciding to emit the `{:TAG}` shorthand, so `[x]{LANG=fr}` came back as `[x]{:fr}` - a different attribute NAME. PART 11 §1 requires `parse(fmt(x)) == parse(x)`, and the key changed, so it did not hold.

## The engines are already fixed

- **carve-js**: `992fbc9` (markup-carve/carve-js#1025), on `main`.
- **carve-php**: markup-carve/carve-php#1233, open.
- **carve-rs**: markup-carve/carve-rs#938, open.

Measured just now, js `992fbc9` and the php branch, byte-identical:

```
[x]{LANG=fr}  ->  fmt  [x]{LANG=fr}   html  <span LANG="fr">
[x]{lang=fr}  ->  fmt  [x]{:fr}       html  <span lang="fr">
[x]{Lang=fr}  ->  fmt  [x]{Lang=fr}   html  <span Lang="fr">
```

## What this PR adds: the input the check needed

`tests/corpus-fmt-roundtrip` already compares `toHtml(fmt(x))` against `toHtml(x)` over every corpus document - exactly the property that failed. Every corpus document wrote its attribute names in lower case, so no input could trip it. The check was real and passed for the same reason it always had.

The new example sits in the existing category 296, so nothing renumbers:

```carve
[a]{LANG=fr} [b]{lang=fr}
```

```html
<p><span LANG="fr">a</span> <span lang="fr">b</span></p>
```

**It fails on the old pinned build and passes on the new one.** Against `a59df0f` the suite reports two failures - `formatting never changes what a corpus document says` and `the oracle reads the engine's formatted output as the same document`. Against `992fbc9` both pass. That is the pin moving in this PR, which is what makes the document a proof rather than a decoration.

## The open question, answered by precedent rather than by ruling

The issue asks whether `{LANG=fr}` should be a language attribute at all. Case-sensitive is what the rest of the attribute layer already does, measured:

```
[x]{kbd}  ->  <p><kbd>x</kbd></p>
[x]{KBD}  ->  <p><span KBD="">x</span></p>
```

A reserved name spelled in another case is an ordinary attribute everywhere else, so `LANG` being ordinary is the consistent answer, not a new decision. The prose says so beside the example.

## Locking

Took the org-wide sweep lock: the change is inside `docs/examples/`, which is corpus source, and it moves the engine pin.