### PR TITLE
spec: declare the drift main is already carrying

### DIFF
--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -72,3 +72,21 @@
 89-block-attribute-lines-4  A header cell now carries `scope`; the pin emits none.
 98-table-span-marker-in-first-column  A header cell now carries `scope`; the pin emits none.
 99-table-cell-attributes  A header cell now carries `scope`; the pin emits none.
+
+# `:code[…]` and `:mark[…]` left the semantic registry (carve-js#1027): Carve
+# already spells both, so the extension form renders as the generic
+# `<span class="ext-NAME">` fallback rather than as `<code>` / `<mark>`. The pin
+# predates that and still emits the elements.
+45-inline-extensions-7  `:code` and `:mark` render as the generic ext-span; the pin emits <code> and <mark>.
+45-inline-extensions-9  As 45-inline-extensions-7.
+299-the-semantic-registry-holds-no-element-carve-already-spells-2  As 45-inline-extensions-7.
+299-the-semantic-registry-holds-no-element-carve-already-spells-3  As 45-inline-extensions-7.
+
+# PART 7 requires `space+` between two attributes (carve#1157). The pin accepts
+# an adjacent pair and the corpus refuses it. These three were declared under
+# their old numbers and the category was renumbered 299 -> 300 when
+# `299-the-semantic-registry-…` landed alongside it, which left the
+# declarations pointing at slugs that no longer exist.
+300-two-attributes-need-a-separator-between-them  `{.a.b}` is literal; the pin reads two classes.
+300-two-attributes-need-a-separator-between-them-2  `{.a#i}` is literal; the pin reads a class and an id.
+300-two-attributes-need-a-separator-between-them-3  `{#i.c}` is literal; the pin reads an id and a class.


### PR DESCRIPTION
`npm run engine:report -- --check` is red on `main` with seven undeclared slugs. CI runs it, so this is not latent.

## Two causes, one of them mine

**`:code` and `:mark` left the semantic registry** (markup-carve/carve-js#1027) - Carve already spells both, so the extension form renders as the generic `span.ext-NAME` fallback rather than as `<code>` / `<mark>`. The pin predates it and still emits the elements:

```
:code[*b*] :mark[*b*]
```

```html
<p><span class="ext-code"><strong>b</strong></span> <span class="ext-mark"><strong>b</strong></span></p>   <!-- corpus -->
<p><code><strong>b</strong></code> <mark><strong>b</strong></mark></p>                                       <!-- pin -->
```

Four documents. The window is normal; not declaring it is not.

**The separator category was renumbered under its own declarations.** markup-carve/carve#1157 appended `two-attributes-need-a-separator-between-them` as 299 and declared its three slugs under that number. `the-semantic-registry-holds-no-element-carve-already-spells` landed alongside it and took 299, so the separator category regenerated as **300** and the three declarations pointed at slugs that no longer exist.

That is the hazard `scripts/generate-corpus.mjs` warns about in its append-only guard - *"each engine allowlists categories by `NN-slug`"* - reached from a direction the guard does not cover. It is not a renumber inside one change; it is **two changes appending a category concurrently**, where whichever merges second is renumbered and every line naming its old number goes stale. The guard fires on the FILES. Nothing checks the declarations that reference them.

Worth a follow-up on its own: a check that every slug named in `resources/engine-pin-drift.txt` exists in `tests/corpus`. The file already fails in both directions for slugs that stop drifting; it does not fail for slugs that stop existing.

## Verification

Each of the seven was measured against the pinned build rather than assumed. `engine:report --check` now reports "Drift matches what is declared".

`npm test` is 1985 pass / 3 fail, and those three fail identically on `main` before this change - the writer round-trip pair and the `.fmt` fixture check, which are the §6c rollout's open window (markup-carve/carve#1152).