### PR TITLE
spec: the ext-NAME base class joins the author's class slot

### DIFF
--- a/docs/examples/extensions.md
+++ b/docs/examples/extensions.md
@@ -442,6 +442,38 @@ citation. `:abbr[text]{title="…"}` is independent of automatic abbreviation
 definitions. Names outside the fixed registry retain the readable generic
 fallback.
 
+On that fallback the structural `ext-NAME` class is not written ahead of
+everything: authored attributes keep their SOURCE order (PART 10 §1), and the
+base class merges into the class slot at the position the author put their own
+class. An id written before a class therefore stays before it.
+
+::: compare
+
+```carve
+:widget[x]{#i .c k=v}
+```
+
+```html
+<p><span id="i" class="ext-widget c" k="v">x</span></p>
+```
+
+:::
+
+With no class of their own there is no authored position to respect, so the
+base class leads.
+
+::: compare
+
+```carve
+:widget[x]{#i k=v}
+```
+
+```html
+<p><span class="ext-widget" id="i" k="v">x</span></p>
+```
+
+:::
+
 ## Symbols
 
 `:name:` is a symbol: a generic named inline placeholder with no built-in

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -17,15 +17,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>700 / 700</strong>
+    <strong>702 / 702</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>700 / 700</strong>
+    <strong>702 / 702</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>700 / 700</strong>
+    <strong>702 / 702</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -36,9 +36,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `700 / 700` | `0` | `0` | `3.01` |
-| JS | `8105210` | `700 / 700` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `700 / 700` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `702 / 702` | `0` | `0` | `3.01` |
+| JS | `8105210` | `702 / 702` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `702 / 702` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 
@@ -593,7 +593,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=700 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=702 targets=html,markdown,plain,carve,ansi
 rust: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=3.01
   mismatching documents: 0
 js: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=76.02

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 944 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 946 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/scripts/spec/render.mjs
+++ b/scripts/spec/render.mjs
@@ -406,8 +406,6 @@ const sem = g.createSemantics().addOperation('h', {
   extension(_c, name, _o, content, _cl, attrs) {
     const n = name.sourceString
     const inner = renderInline(content.sourceString, '[')
-    const extra = attrsOf(attrs).filter((a) => a[0] === 'class').map((a) => a[1])
-    const rest = attrsOf(attrs).filter((a) => a[0] !== 'class')
     // PART 10 §9: the fixed semantic registry renders its own element (attrs
     // apply to it); everything else is the generic ext-<name> span.
     // PART 9 §10: the `:name[…]` spelling has NO core handler at all. It is a
@@ -418,8 +416,19 @@ const sem = g.createSemantics().addOperation('h', {
     if (semantic.has(n)) {
       return `<${n}${renderAttrs(attrsOf(attrs))}>${inner}</${n}>`
     }
-    const cls = [`ext-${n}`, ...extra].join(' ')
-    return `<span class="${cls}"${renderAttrs(rest)}>${inner}</span>`
+    // The base class is a CLASS, not a prefix: it joins the author's class
+    // slot rather than being written ahead of everything. Splitting it out and
+    // emitting `class="..."` first reordered the author's attributes, so
+    // `:widget[x]{#i .c}` lost the id-before-class order PART 10 §1 requires
+    // (carve#1164). renderAttrs already merges every class into the FIRST
+    // class position, so inserting the base beside the author's first class
+    // puts it exactly there; with no class of their own it leads.
+    const list = attrsOf(attrs)
+    const firstClass = list.findIndex((a) => a[0] === 'class')
+    const merged = firstClass === -1
+      ? [['class', `ext-${n}`], ...list]
+      : [...list.slice(0, firstClass), ['class', `ext-${n}`], ...list.slice(firstClass)]
+    return `<span${renderAttrs(merged)}>${inner}</span>`
   },
   spComment(_sp, _pp, _rest) {
     return ''

--- a/tests/corpus/45-inline-extensions-12.crv
+++ b/tests/corpus/45-inline-extensions-12.crv
@@ -1,0 +1,1 @@
+:widget[x]{#i .c k=v}

--- a/tests/corpus/45-inline-extensions-12.html
+++ b/tests/corpus/45-inline-extensions-12.html
@@ -1,0 +1,1 @@
+<p><span id="i" class="ext-widget c" k="v">x</span></p>

--- a/tests/corpus/45-inline-extensions-13.crv
+++ b/tests/corpus/45-inline-extensions-13.crv
@@ -1,0 +1,1 @@
+:widget[x]{#i k=v}

--- a/tests/corpus/45-inline-extensions-13.html
+++ b/tests/corpus/45-inline-extensions-13.html
@@ -1,0 +1,1 @@
+<p><span class="ext-widget" id="i" k="v">x</span></p>

--- a/tests/spec/45-inline-extensions.test
+++ b/tests/spec/45-inline-extensions.test
@@ -71,3 +71,15 @@ Press [Ctrl+C]{kbd} to copy.
 .
 <p><abbr title="Custom">HTML</abbr></p>
 ```
+
+```
+:widget[x]{#i .c k=v}
+.
+<p><span id="i" class="ext-widget c" k="v">x</span></p>
+```
+
+```
+:widget[x]{#i k=v}
+.
+<p><span class="ext-widget" id="i" k="v">x</span></p>
+```


### PR DESCRIPTION
Part of markup-carve/carve#1164 - the corpus case and the oracle. The carve-rs engine fix is a separate PR.

## What was wrong

The generic `ext-NAME` fallback wrote `class="…"` ahead of everything, so a structural class reordered the author's attributes:

```
:widget[x]{#i .c k=v}
```

```html
<span class="ext-widget c" id="i" k="v">x</span>   <!-- oracle, carve-rs -->
<span id="i" class="ext-widget c" k="v">x</span>   <!-- carve-js -->
```

PART 10 §1 emits authored attributes in SOURCE order, and a mandatory base class belongs in the class slot, merged at the position of the FIRST class. `renderAttrs` in the oracle already implements exactly that for every other caller - the `extension` handler was the one place that split the class out and bypassed it.

## Two cases, because the rule has two halves

| source | result |
| --- | --- |
| `:widget[x]{#i .c k=v}` | `<span id="i" class="ext-widget c" k="v">` - merged at the author's class position |
| `:widget[x]{#i k=v}` | `<span class="ext-widget" id="i" k="v">` - no class of their own, so the base leads |

The second is what keeps this from being "the class always moves", and without it the category cannot tell the two halves apart.

## Why nothing caught it

The seven semantic names never took the fallback until markup-carve/carve#1162, and no corpus case combined `:name[…]` with an id BEFORE a class. So the oracle and two of three engines disagreed with carve-js in a way no check could see.

## Verification

`npm test` 1998 pass 0 fail. `engine:report --check` clean with no new drift: the pinned carve-js build reproduces both cases, since carve-js is the engine that was already right.

One correction worth recording: I first read case 12 as failing against the pinned build and declared drift for it. That reading came from a stale `node_modules` - after a clean install the pinned build produces the correct order, and the drift entry was wrong and is not in this PR.

## Locking

Took the org-wide sweep lock: the change is inside `docs/examples/`, which is corpus source, and it touches the oracle.
