### PR TITLE
spec: an abbreviation expands inside an inline container

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -16471,3 +16471,97 @@ a < b and a <b> c and x > y
 ```
 
 :::
+
+## An abbreviation expands inside an inline container
+
+PART 9R R3 matches a term in RENDERED TEXT at word boundaries. The container the
+text sits in does not change that: an ordinary span, a compact semantic span and
+the `:name[…]` extension form all expand, exactly as emphasis and a link do.
+
+The corpus had one case here - the explicit-`abbr` row, which every engine agreed
+on - so every neighbouring row was unpinned, and two engines kept opposite
+defects for months with no red test: carve-rs dropped the expansion inside a
+span, carve-js dropped it inside `:name[…]` (markup-carve/carve#1151).
+
+::: compare
+
+```carve
+*[HTML]: Long Form
+
+The [HTML]{.x} key.
+```
+
+```html
+<p>The <span class="x"><abbr title="Long Form">HTML</abbr></span> key.</p>
+```
+
+:::
+
+A compact semantic span is the same question, and PART 9 §10 made this spelling a
+documented feature - so a dropped expansion here is silent loss inside a
+construct the docs teach.
+
+::: compare
+
+```carve
+*[HTML]: Long Form
+
+The [HTML]{kbd} key.
+```
+
+```html
+<p>The <kbd><abbr title="Long Form">HTML</abbr></kbd> key.</p>
+```
+
+:::
+
+The `:name[…]` form takes the generic fallback in a core render, and the term
+still expands inside it.
+
+::: compare
+
+```carve
+*[HTML]: Long Form
+
+The :kbd[HTML] key.
+```
+
+```html
+<p>The <span class="ext-kbd"><abbr title="Long Form">HTML</abbr></span> key.</p>
+```
+
+:::
+
+The controls: emphasis and a link already agreed across engines, and they pin
+that the containers above are not special-cased in one direction.
+
+::: compare
+
+```carve
+*[HTML]: Long Form
+
+Both *HTML* and [HTML](/u) expand.
+```
+
+```html
+<p>Both <strong><abbr title="Long Form">HTML</abbr></strong> and <a href="/u"><abbr title="Long Form">HTML</abbr></a> expand.</p>
+```
+
+:::
+
+An explicit `abbr` attribute is the one exception (markup-carve/carve#1127): the
+authored expansion wins and the definition does not apply on top of it.
+
+::: compare
+
+```carve
+*[HTML]: Long Form
+
+The [HTML]{abbr="Custom"} key.
+```
+
+```html
+<p>The <abbr title="Custom">HTML</abbr> key.</p>
+```
+
+:::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -89,7 +89,8 @@ Corpus added since this run: `254-colon-fence-separator-must-be-a-space`,
 `45-inline-extensions-10`; `97-boolean-attributes` changed its expected HTML
 under the same semantic-span rule,
 `302-a-math-span-s-base-class-keeps-the-class-slot-in-place`,
-`304-an-angle-bracket-is-escaped-only-where-it-opens-markup`.
+`304-an-angle-bracket-is-escaped-only-where-it-opens-markup`,
+`305-an-abbreviation-expands-inside-an-inline-container`.
 
 Those categories landed on hosts that could not retake the run above, so its
 numbers describe the corpus WITHOUT them. The alternative was to edit the

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 952 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 957 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -86,3 +86,9 @@
 07-blockquote-with-attribution  A captioned quote renders `<blockquote><footer>`; the pin renders `<figure><figcaption>`.
 55-blockquote-caption-after-a-blank-line  A captioned quote renders `<blockquote><footer>`; the pin renders `<figure><figcaption>`.
 282-two-blank-lines-detach-a-caption-5  A captioned quote renders `<blockquote><footer>`; the pin renders `<figure><figcaption>`.
+
+# PART 9R R3: a term expands in rendered text at word boundaries, whatever
+# container the text sits in. The pinned carve-js build drops the expansion
+# inside the `:name[…]` extension form specifically (carve#1151); it is correct
+# on every other row of the same case. Clears with the engine fix and a pin bump.
+305-an-abbreviation-expands-inside-an-inline-container-3  The pin drops an abbreviation expansion inside `:name[…]`.

--- a/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-2.crv
+++ b/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-2.crv
@@ -1,0 +1,3 @@
+*[HTML]: Long Form
+
+The [HTML]{kbd} key.

--- a/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-2.html
+++ b/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-2.html
@@ -1,0 +1,1 @@
+<p>The <kbd><abbr title="Long Form">HTML</abbr></kbd> key.</p>

--- a/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-3.crv
+++ b/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-3.crv
@@ -1,0 +1,3 @@
+*[HTML]: Long Form
+
+The :kbd[HTML] key.

--- a/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-3.html
+++ b/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-3.html
@@ -1,0 +1,1 @@
+<p>The <span class="ext-kbd"><abbr title="Long Form">HTML</abbr></span> key.</p>

--- a/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-4.crv
+++ b/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-4.crv
@@ -1,0 +1,3 @@
+*[HTML]: Long Form
+
+Both *HTML* and [HTML](/u) expand.

--- a/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-4.html
+++ b/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-4.html
@@ -1,0 +1,1 @@
+<p>Both <strong><abbr title="Long Form">HTML</abbr></strong> and <a href="/u"><abbr title="Long Form">HTML</abbr></a> expand.</p>

--- a/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-5.crv
+++ b/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-5.crv
@@ -1,0 +1,3 @@
+*[HTML]: Long Form
+
+The [HTML]{abbr="Custom"} key.

--- a/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-5.html
+++ b/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container-5.html
@@ -1,0 +1,1 @@
+<p>The <abbr title="Custom">HTML</abbr> key.</p>

--- a/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container.crv
+++ b/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container.crv
@@ -1,0 +1,3 @@
+*[HTML]: Long Form
+
+The [HTML]{.x} key.

--- a/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container.html
+++ b/tests/corpus/305-an-abbreviation-expands-inside-an-inline-container.html
@@ -1,0 +1,1 @@
+<p>The <span class="x"><abbr title="Long Form">HTML</abbr></span> key.</p>

--- a/tests/spec/305-an-abbreviation-expands-inside-an-inline-container.test
+++ b/tests/spec/305-an-abbreviation-expands-inside-an-inline-container.test
@@ -1,0 +1,41 @@
+An abbreviation expands inside an inline container
+
+```
+*[HTML]: Long Form
+
+The [HTML]{.x} key.
+.
+<p>The <span class="x"><abbr title="Long Form">HTML</abbr></span> key.</p>
+```
+
+```
+*[HTML]: Long Form
+
+The [HTML]{kbd} key.
+.
+<p>The <kbd><abbr title="Long Form">HTML</abbr></kbd> key.</p>
+```
+
+```
+*[HTML]: Long Form
+
+The :kbd[HTML] key.
+.
+<p>The <span class="ext-kbd"><abbr title="Long Form">HTML</abbr></span> key.</p>
+```
+
+```
+*[HTML]: Long Form
+
+Both *HTML* and [HTML](/u) expand.
+.
+<p>Both <strong><abbr title="Long Form">HTML</abbr></strong> and <a href="/u"><abbr title="Long Form">HTML</abbr></a> expand.</p>
+```
+
+```
+*[HTML]: Long Form
+
+The [HTML]{abbr="Custom"} key.
+.
+<p>The <abbr title="Custom">HTML</abbr> key.</p>
+```


### PR DESCRIPTION
Corpus half of #1151. The two engine PRs are open alongside it: markup-carve/carve-js#1041 and the carve-rs one.

## The hole

PART 9R R3 matches a term in RENDERED TEXT at word boundaries, and the container the text sits in does not change that. The corpus pinned exactly ONE case here - the explicit-`abbr` row, which every engine agreed on - so every neighbouring row was unpinned, and two engines kept **opposite** defects for months with no red test:

| written | js | php | rs |
| --- | --- | --- | --- |
| `[HTML]{.x}` ordinary span | expands | expands | **drops** |
| `[HTML]{kbd}` semantic span | expands | expands | **drops** |
| `:kbd[HTML]` extension form | **drops** | expands | expands |
| `*HTML*`, `[HTML](/u)`, `{abbr="Custom"}` | expands | expands | expands |

Re-measured against all three engines today rather than quoted from the ticket - the table holds. carve-php is right on every row.

## The cases

Five: the three containers, the two controls that already agreed, and the explicit-`abbr` exception.

The controls are not padding. Emphasis and a link pin that the containers above are not being special-cased in one direction, so a fix that over-reached in either engine shows up here rather than passing quietly.

## The pinned build fails one of them, and it is declared

The pin is carve-js, which has the `:name[…]` hole, so `engine:report` fails on exactly that row. It is declared in `resources/engine-pin-drift.txt` with the reason, rather than worked around. The category is also declared as lag on the comparison page, since carve-rs fails two rows and the published three-engine measurement cannot claim numbers nobody took.