### PR TITLE
docs: name the attribution and the header-cell scope where a reader looks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   attributes come last. A structural CLASS still merges at the front of the
   class slot. This matches reference djot on every shape measured.
 
+- **A mandatory base class keeps the author's class slot in place**
+  (carve#1168, carve#1170). A base class merges INTO the class slot at the
+  position a class first appears in what the author wrote, rather than being
+  emitted ahead of everything. Writing it first silently reordered the rest:
+  `:widget[x]{#i .c k=v}` produced `class="ext-widget c" id="i" k="v"` and
+  `` $`E=mc^2`{#i .c k=v} `` produced `class="math inline c" id="i"`, both
+  moving an id the author had put first. With no class slot to merge into
+  there is no authored position to respect, so the base class leads.
+
+- **A table header cell states what it heads** (carve#1149). Every `<th>`
+  carries a `scope`: `col` in the run of header rows, `row` for a `|=` cell in
+  a body row. The language already distinguished those two positions, so this
+  states an association the table had rather than adding a concept - without
+  it assistive technology infers from position and infers wrong on any table
+  carrying both kinds. An authored `scope` REPLACES the default rather than
+  joining it.
+
+- **A caption on a block quote is an attribution** (carve#1161). Four of the
+  five captionable hosts become a numbered thing - figure, table, listing,
+  equation. The quote is the odd one out: `^ Socrates` under a `>` block is who
+  said it, not what it depicts, so it renders `<footer>` inside the
+  `<blockquote>` rather than wrapping the quote in `<figure>` /
+  `<figcaption>`. A captioned quote is therefore not numbered and not a figure
+  cross-reference target.
+
+- **The Markdown target escapes an angle bracket only where it opens markup**
+  (carve#1172). PART 11 §8 defines that target's escaping as exactly M1-M3 and
+  none of them mentions an entity, yet every engine rewrote `<` and `>` to
+  `&lt;` / `&gt;` in ordinary text - three engines agreeing on behavior the
+  document did not describe, which the corpus then scored as conformance
+  (carve#1148). Measured through a CommonMark reader, `a <b> c` round-trips
+  unchanged, so the escape is now applied where a bracket would open a tag and
+  nowhere else.
+
 - **Footnote labels are matched exactly, and never cross a line**
   (carve#1112). A label is a physical-line identifier: it may contain spaces
   and tabs but not a source newline, and matching does not normalize

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -27,8 +27,9 @@ implementation — except rows marked **✦**, which are opt-in extensions
 | `` `code` `` | `code` | backticks |
 | `` !`/kaet/` `` | /kaet/ | inline literal — verbatim prose, no `code` styling; `!` mirrors `$`-math |
 | `[text](url)` | link | |
+| `[text][ref]` | reference link | `[ref]: https://url` on its own line, anywhere |
 | `[Page Name][]` | wiki-style link | resolves to a heading |
-| `<https://url>` | autolink | |
+| `<https://url>` | autolink | bare URLs stay literal (autolinking them is Tier-2 opt-in) |
 | `</#section-id>` | cross-reference | link text cloned from the target |
 | `![alt](img.jpg)` | image | |
 | `[^1]` / `^[inline note]` | footnote | reference / inline form |

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,11 +29,11 @@ features:
   - title: Interactive Online, Readable Offline
     details: "Built for the interactive web first — diagrams, math, charts and tabs hydrate into rich output online. With no JavaScript every block degrades to clean semantic HTML: a Mermaid fence still shows its source, <details> stays native, tables stay tables."
   - title: Captions Everywhere
-    details: One ^ prefix adds captions to images, blockquotes, and tables — emitting semantic figure / figcaption / caption HTML.
+    details: One ^ prefix captions images, tables, listings and equations — emitting semantic figure / figcaption / caption HTML. On a blockquote it is an attribution instead, and renders footer.
   - title: Friendly Tables
     details: "|= for headers, ^ for rowspan, < for colspan, + for multi-line cells. No separator row required."
   - title: Built-in Extensions
-    details: ":type[content]{attrs} for keyboard hints, semantic spans, video embeds. @mentions and #tags as you'd expect from social platforms."
+    details: ":type[content]{attrs} for video embeds and the rest of the handler family. Keyboard hints and the other semantic spans are core attributes instead — [Tab]{kbd}. @mentions and #tags as you'd expect from social platforms."
   - title: Safe With Untrusted Input
     details: "Always-on URL-scheme and attribute hardening, Trojan-Source stripping in presentation targets, and linear-time DoS limits neutralize the common Markdown attack classes with no separate sanitizer. Canonical Carve preserves source and warns through lint. Raw HTML passthrough is the one switch you own: on by default, off with a single flag or a safe mode. Carve never executes embedded code (unlike MDX)."
 ---

--- a/docs/native-features-analysis.md
+++ b/docs/native-features-analysis.md
@@ -74,8 +74,11 @@ part of Carve syntax; the examples remain as a feature-level reference.
 ```
 
 Output varies by context:
-- Images/blockquotes → `<figure>` + `<figcaption>`
+- Images → `<figure>` + `<figcaption>`
 - Tables → `<caption>` element
+- Blockquotes → `<footer>` inside the `<blockquote>`: the line names the source
+  of the quotation rather than describing it, so it is an attribution and is not
+  numbered as a figure
 
 ### 2. Abbreviations
 
@@ -92,15 +95,21 @@ The HTML spec defines WWW standards.
 
 ### 3. Semantic Inline Elements
 
-Use the extension syntax for semantic elements:
+The attribute form names the element:
 
 ```carve
-Press :kbd[Ctrl+C] to copy.
-The term :dfn[markup] means...
-:abbr[HTML]{title="HyperText Markup Language"} is a standard.
+Press [Ctrl+C]{kbd} to copy.
+The term [markup]{dfn} means...
+[HTML]{abbr="HyperText Markup Language"} is a standard.
 ```
 
-This fits the `:type[content]{attrs}` pattern already in the spec.
+`abbr`, `time` and `kbd` are core; `dfn` (with `samp`, `var` and `cite`) needs
+the SemanticSpan extension and is an ordinary attribute until it is enabled.
+
+This shipped as an attribute rather than as the `:type[content]{attrs}` pattern
+this document originally proposed: a consumed name renames the span, so the id
+and classes an author wrote land on the produced element, and several names
+combine on one span where the `:type[…]` form cannot nest.
 
 ### 4. Table Enhancements (from proposals)
 

--- a/docs/technical-rationale.md
+++ b/docs/technical-rationale.md
@@ -494,7 +494,7 @@ Example:
 
 *[HTML]: HyperText Markup Language
 
-Press :kbd[Ctrl+C].
+Press [Ctrl+C]{kbd}.
 ```
 
 The technical point is not merely convenience. Native syntax gives the parser a


### PR DESCRIPTION
Rewritten after review. The first version padded the cheatsheet with the quote attribution and the header-cell `scope`, which was the wrong instinct - a cheatsheet earns its value by what it leaves out, and neither is something an author writes. The `scope` is emitted, not spelled; the attribution is one sentence about an output tag.

## What was actually wrong

Four pages still describe the world before those changes:

| page | claim | today |
| --- | --- | --- |
| `docs/index.md` | a `^` prefix captions "images, blockquotes, and tables" emitting figure / figcaption | the quote emits `<footer>` |
| `docs/index.md` | `:type[content]{attrs}` is how you write "keyboard hints, semantic spans" | `:kbd[Tab]` renders `<span class="ext-kbd">` - the landing page taught a form that does not produce the element it promises |
| `docs/native-features-analysis.md` | both of the above, in its caption table and in a worked `:kbd[…]` / `:dfn[…]` / `:abbr[…]{title=…}` example | same |
| `docs/technical-rationale.md` | `Press :kbd[Ctrl+C].` | `Press [Ctrl+C]{kbd}.` |

Measured before editing:

```
:kbd[Tab]      ->  <p><span class="ext-kbd">Tab</span></p>
[Tab]{kbd}     ->  <p><kbd>Tab</kbd></p>
```

## What the cheatsheet gains instead

One row and one parenthetical.

**The ordinary reference link.** `[text][ref]` with its `[ref]: https://url` definition line. The page showed the inline form and the collapsed heading form and never the one Markdown authors reach for most.

**Bare URLs stay literal** - a parenthetical on the existing autolink row, not a row of its own, since it is not something an author writes:

```
| `<https://url>` | autolink | bare URLs stay literal (autolinking them is Tier-2 opt-in) |
```

Markdown and GFM autolink a bare URL by default, so the page's silence read as a promise. Measured:

```
See https://example.com now.                     ->  See https://example.com now.
  ... with the autolink extension registered     ->  See <a href="…">https://example.com</a> now.
```

Net: two lines changed in the cheatsheet, where the first version of this PR added 22.

## CHANGELOG

Unchanged from the first version. Four shipped changes that alter HTML output had no entry: the mandatory base class keeping the author's class slot (markup-carve/carve#1168, markup-carve/carve#1170), the table header cell's scope (markup-carve/carve#1149), the block-quote attribution (markup-carve/carve#1161), and the Markdown target's angle-bracket escaping (markup-carve/carve#1172).

## Not included

The abbreviation-precedence gap found in the same pass is filed as markup-carve/carve#1176: markup-carve/carve#1127 pinned explicit `abbr` precedence on HTML only, and on `markdown` and `ansi` all three engines disagree.