### PR TITLE
docs: stop naming a lint flag that reports nothing

### DIFF
--- a/docs/portable-whitespace.md
+++ b/docs/portable-whitespace.md
@@ -112,7 +112,7 @@ them - a document using them is Carve, not Djot, by design.
 
 **Link reference definitions.** A `[b]: /url` line directly under a paragraph
 diverges the same way, but it leaves no node in the tree for the linter to
-anchor on, so `--portable` does not report it. Give it a blank line too.
+anchor on, so `carve lint` does not report it. Give it a blank line too.
 
 (Abbreviation definitions and comment fences were once listed here as well.
 They are not exceptions: both produce real nodes and both **are** reported.)


### PR DESCRIPTION
Docs half of #1142. The carve-js half removes the dead collector: markup-carve/carve-js#1042.

## The change

`docs/portable-whitespace.md` said `--portable` does not report a link reference definition, which reads as though the flag reports the other cases. It does not report anything - the blockquote marker rule became core syntax and is covered by `blockquote-marker-without-space`, which is documented and does fire.

The sentence now names `carve lint`, which is true and is what an author would run.

## Two of the ticket's premises are already stale

Checked rather than assumed:

- the `carve lint --portable doc.crv` section it quotes is **gone** from this page
- `portable-blank-line-before-block` appears **nowhere** in `docs/validation.md`

So the page-side half of this ticket is one sentence, not a section removal.

## What is deliberately left

The `UNPRODUCIBLE_IN_BUILD` entry in `tests/lint-rule-table-claims.test.mjs` describes the PINNED build, which still carries the dead collector. It is accurate until the pin moves past carve-js#1042; deleting it here would assert something about a build that does not exist yet.