### PR TITLE
docs: stop sending upgraders to a form that does not work yet

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -163,7 +163,31 @@ change beyond the markup: a quote no longer takes a figure number, so a `#`
 placeholder in its caption stays literal and a numbered cross-reference to it
 stops resolving; and the AST node is a `block_quote` carrying an `attribution`
 rather than a `figure` wrapping the quote, which matters to anything reading the
-tree. To number a quotation as a figure, write the figure (PART 9 §4a).
+tree.
+
+There is no replacement for the number in this version. PART 9 §4a describes
+writing the figure explicitly, and that form depends on `:::` becoming a
+captionable host, which has not landed (carve#1122). Written today it does not
+number anything - the caption line is not attached to the fence and renders as
+literal text:
+
+```carve
+{#ep}
+::: figure
+> To be
+:::
+^ Figure #: A pull quote
+```
+
+```html
+<div class="figure" id="ep">
+  <blockquote><p>To be</p></blockquote>
+</div>
+<p>^ Figure #: A pull quote</p>
+```
+
+So a quotation that has to carry a figure number needs a host that already takes
+one - an image, a table, a listing or an equation - until carve#1122 lands.
 
 ### Checking documents mechanically
 


### PR DESCRIPTION
Closes #1182

The 0.1.x entry for the captioned-quote change ended with:

> To number a quotation as a figure, write the figure (PART 9 §4a).

PART 9 §4a does describe that form, and it hedges it - "once `:::` is a captionable host (carve#1122)". This page carried no such condition, and this page is what an upgrader reads.

Written today the form numbers nothing. The caption line is not attached to the fence and renders as literal text, so the only documented recovery for a capability the same entry removes was unavailable, and following the instruction produced a document with a stray `^` line in it.

The entry now states that there is no replacement in this version, shows what the form actually renders, and points at the hosts that do take a number today.

The rendered block is the oracle's output for that exact source rather than typed by hand. This page's snippets are prose and nothing checks them, which is how the original instruction stayed wrong.