### PR TITLE
spec: an attribution does not count the quote's blocks

### DIFF
--- a/docs/examples/edge-cases.md
+++ b/docs/examples/edge-cases.md
@@ -16565,3 +16565,127 @@ The [HTML]{abbr="Custom"} key.
 ```
 
 :::
+
+## A captioned quote holds more than one block
+
+PART 9 §4a makes a caption on a block quote its ATTRIBUTION: the source goes
+inside the `<blockquote>` as a `<footer>`, and the quote takes no figure number.
+
+The clause does not count the quote's blocks, and nothing else does either. A
+multi-paragraph epigraph is ordinary, and so are a quoted list, a nested quote, a
+quoted code block and a quoted heading. Each one takes its attribution the same
+way, in the same place.
+
+This needed pinning because the executable spec refused every shape but a single
+paragraph, and no corpus document held any of the others - so the refusal was
+unreachable, `npm run core:check` reported every input conformant either way, and
+the gap was guarded by the absence of a fixture rather than by a decision
+(markup-carve/carve#1181, the markup-carve/carve#755 class).
+
+::: compare
+
+```carve
+> Nothing in this world is certain except death and taxes.
+>
+> The second of the two arrives rather more often.
+^ Benjamin Franklin
+```
+
+```html
+<blockquote>
+  <p>Nothing in this world is certain except death and taxes.</p>
+  <p>The second of the two arrives rather more often.</p>
+  <footer>Benjamin Franklin</footer>
+</blockquote>
+```
+
+:::
+
+A quoted list. The attribution follows the list inside the quote; it is not a
+sibling of it and not an item of it.
+
+::: compare
+
+```carve
+> - Be skeptical.
+> - Be kind.
+^ House rules
+```
+
+```html
+<blockquote>
+  <ul>
+    <li>Be skeptical.</li>
+    <li>Be kind.</li>
+  </ul>
+  <footer>House rules</footer>
+</blockquote>
+```
+
+:::
+
+A nested quote. The caption attaches to the OUTER quote - the one whose marker
+column the caption line sits against - so the inner quote carries no attribution
+of its own.
+
+::: compare
+
+```carve
+> > I never said that.
+^ Quoted in the report
+```
+
+```html
+<blockquote>
+  <blockquote><p>I never said that.</p></blockquote>
+  <footer>Quoted in the report</footer>
+</blockquote>
+```
+
+:::
+
+A quoted code block. The `<pre>` is the quote's only child and the attribution
+still lands beside it, which is the case that shows the rule is about the quote
+rather than about a paragraph.
+
+::: compare
+
+```carve
+> ~~~
+> git bisect run ./check
+> ~~~
+^ The release runbook
+```
+
+```html
+<blockquote>
+  <pre><code>git bisect run ./check
+</code></pre>
+  <footer>The release runbook</footer>
+</blockquote>
+```
+
+:::
+
+A quoted heading. The heading keeps its id, and PART 9R leaves it out of the
+implicit-reference index because it sits inside a quote - the attribution does
+not change that either way.
+
+::: compare
+
+```carve
+> ## Terms
+>
+> Delivery is at the discretion of the vendor.
+^ Appendix B
+```
+
+```html
+<blockquote>
+  <h2 id="Terms">Terms</h2>
+  <p>Delivery is at the discretion of the vendor.</p>
+  <footer>Appendix B</footer>
+</blockquote>
+```
+
+:::

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -90,7 +90,8 @@ Corpus added since this run: `254-colon-fence-separator-must-be-a-space`,
 under the same semantic-span rule,
 `302-a-math-span-s-base-class-keeps-the-class-slot-in-place`,
 `304-an-angle-bracket-is-escaped-only-where-it-opens-markup`,
-`305-an-abbreviation-expands-inside-an-inline-container`.
+`305-an-abbreviation-expands-inside-an-inline-container`,
+`306-a-captioned-quote-holds-more-than-one-block`.
 
 Those categories landed on hosts that could not retake the run above, so its
 numbers describe the corpus WITHOUT them. The alternative was to edit the

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ block comment
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 957 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 962 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -86,6 +86,11 @@
 07-blockquote-with-attribution  A captioned quote renders `<blockquote><footer>`; the pin renders `<figure><figcaption>`.
 55-blockquote-caption-after-a-blank-line  A captioned quote renders `<blockquote><footer>`; the pin renders `<figure><figcaption>`.
 282-two-blank-lines-detach-a-caption-5  A captioned quote renders `<blockquote><footer>`; the pin renders `<figure><figcaption>`.
+306-a-captioned-quote-holds-more-than-one-block  A captioned quote renders `<blockquote><footer>`; the pin renders `<figure><figcaption>`.
+306-a-captioned-quote-holds-more-than-one-block-2  A captioned quote renders `<blockquote><footer>`; the pin renders `<figure><figcaption>`.
+306-a-captioned-quote-holds-more-than-one-block-3  A captioned quote renders `<blockquote><footer>`; the pin renders `<figure><figcaption>`.
+306-a-captioned-quote-holds-more-than-one-block-4  A captioned quote renders `<blockquote><footer>`; the pin renders `<figure><figcaption>`.
+306-a-captioned-quote-holds-more-than-one-block-5  A captioned quote renders `<blockquote><footer>`; the pin renders `<figure><figcaption>`.
 
 # PART 9R R3: a term expands in rendered text at word boundaries, whatever
 # container the text sits in. The pinned carve-js build drops the expansion

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3265,6 +3265,16 @@ EOF = (* end of file *) ;
       `^` IS UNCHANGED as the spelling. No document migrates, and the canonical
       writer emits the same source it read.
 
+      THE QUOTE'S BLOCKS ARE NOT COUNTED. A multi-paragraph epigraph is
+      ordinary, and so are a quoted list, a nested quote, a quoted code block
+      and a quoted heading; each takes its attribution the same way, and the
+      `footer` is the LAST child of the `blockquote` whatever precedes it.
+      This sentence was implied rather than written, and the executable spec
+      read the silence the other way: it rendered a single-paragraph quote and
+      refused every other shape. No corpus document held one, so the refusal
+      was unreachable and nothing failed (carve#1181, carve#755). Corpus
+      `306-a-captioned-quote-holds-more-than-one-block` pins the five shapes.
+
       A QUOTE TAKES NO NUMBER, which is the point rather than a side effect.
       Numbering keys on the `#` placeholder, so `^ Figure #: Hamlet` on a quote
       used to produce "Figure 1", consume a number from the document's figure

--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -201,11 +201,20 @@ function renderBlock(b, depth, ctx) {
         // source of a quotation, and the quote does not become a `figure` -
         // so it takes no figure number and no consumer counting figures finds
         // it (carve#1159).
-        if (b.children.length === 1 && b.children[0].t === 'para') {
-          const p = renderBlock(b.children[0], 0, ctx)
-          return `${pad}<blockquote${ba}>\n${pad}  ${p}\n${pad}  <footer>${renderInline(b.caption)}</footer>\n${pad}</blockquote>`
-        }
-        throw new Refuse('captioned multi-block quote')
+        //
+        // §4a DOES NOT COUNT THE QUOTE'S BLOCKS, and no other clause does
+        // either: a multi-paragraph epigraph, a quoted list, a nested quote,
+        // a quoted code block and a quoted heading each take an attribution
+        // the same way. This used to render only a single-paragraph quote and
+        // Refuse everything else, which no corpus document could reach - the
+        // refusal was guarded by the absence of a fixture rather than by a
+        // decision, so nothing failed while the oracle alone declined what
+        // every engine renders (carve#1181, the carve#755 class).
+        //
+        // `inner` rather than a re-render of the children: it is the one that
+        // was produced under `inBlockquote`, which is what keeps a quoted
+        // heading out of the implicit-reference index.
+        return `${pad}<blockquote${ba}>\n${inner}\n${pad}  <footer>${renderInline(b.caption)}</footer>\n${pad}</blockquote>`
       }
       if (b.children.length === 1 && b.children[0].t === 'para') {
         const p = renderBlock(b.children[0], 0, ctx)

--- a/tests/ast-schema.test.mjs
+++ b/tests/ast-schema.test.mjs
@@ -255,6 +255,11 @@ const SCHEMA_ROLLOUT_PENDING = new Map([
   ['07-blockquote-with-attribution.crv', 'as 05-lists-20.crv'],
   ['55-blockquote-caption-after-a-blank-line.crv', 'as 05-lists-20.crv'],
   ['282-two-blank-lines-detach-a-caption-5.crv', 'as 05-lists-20.crv'],
+  ['306-a-captioned-quote-holds-more-than-one-block.crv', 'as 05-lists-20.crv'],
+  ['306-a-captioned-quote-holds-more-than-one-block-2.crv', 'as 05-lists-20.crv'],
+  ['306-a-captioned-quote-holds-more-than-one-block-3.crv', 'as 05-lists-20.crv'],
+  ['306-a-captioned-quote-holds-more-than-one-block-4.crv', 'as 05-lists-20.crv'],
+  ['306-a-captioned-quote-holds-more-than-one-block-5.crv', 'as 05-lists-20.crv'],
 ])
 
 test('every corpus document serializes to a schema-valid AST', () => {

--- a/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-2.crv
+++ b/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-2.crv
@@ -1,0 +1,3 @@
+> - Be skeptical.
+> - Be kind.
+^ House rules

--- a/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-2.html
+++ b/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-2.html
@@ -1,0 +1,7 @@
+<blockquote>
+  <ul>
+    <li>Be skeptical.</li>
+    <li>Be kind.</li>
+  </ul>
+  <footer>House rules</footer>
+</blockquote>

--- a/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-3.crv
+++ b/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-3.crv
@@ -1,0 +1,2 @@
+> > I never said that.
+^ Quoted in the report

--- a/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-3.html
+++ b/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-3.html
@@ -1,0 +1,4 @@
+<blockquote>
+  <blockquote><p>I never said that.</p></blockquote>
+  <footer>Quoted in the report</footer>
+</blockquote>

--- a/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-4.crv
+++ b/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-4.crv
@@ -1,0 +1,4 @@
+> ~~~
+> git bisect run ./check
+> ~~~
+^ The release runbook

--- a/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-4.html
+++ b/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-4.html
@@ -1,0 +1,5 @@
+<blockquote>
+  <pre><code>git bisect run ./check
+</code></pre>
+  <footer>The release runbook</footer>
+</blockquote>

--- a/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-5.crv
+++ b/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-5.crv
@@ -1,0 +1,4 @@
+> ## Terms
+>
+> Delivery is at the discretion of the vendor.
+^ Appendix B

--- a/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-5.html
+++ b/tests/corpus/306-a-captioned-quote-holds-more-than-one-block-5.html
@@ -1,0 +1,5 @@
+<blockquote>
+  <h2 id="Terms">Terms</h2>
+  <p>Delivery is at the discretion of the vendor.</p>
+  <footer>Appendix B</footer>
+</blockquote>

--- a/tests/corpus/306-a-captioned-quote-holds-more-than-one-block.crv
+++ b/tests/corpus/306-a-captioned-quote-holds-more-than-one-block.crv
@@ -1,0 +1,4 @@
+> Nothing in this world is certain except death and taxes.
+>
+> The second of the two arrives rather more often.
+^ Benjamin Franklin

--- a/tests/corpus/306-a-captioned-quote-holds-more-than-one-block.html
+++ b/tests/corpus/306-a-captioned-quote-holds-more-than-one-block.html
@@ -1,0 +1,5 @@
+<blockquote>
+  <p>Nothing in this world is certain except death and taxes.</p>
+  <p>The second of the two arrives rather more often.</p>
+  <footer>Benjamin Franklin</footer>
+</blockquote>

--- a/tests/spec/306-a-captioned-quote-holds-more-than-one-block.test
+++ b/tests/spec/306-a-captioned-quote-holds-more-than-one-block.test
@@ -1,0 +1,64 @@
+A captioned quote holds more than one block
+
+```
+> Nothing in this world is certain except death and taxes.
+>
+> The second of the two arrives rather more often.
+^ Benjamin Franklin
+.
+<blockquote>
+  <p>Nothing in this world is certain except death and taxes.</p>
+  <p>The second of the two arrives rather more often.</p>
+  <footer>Benjamin Franklin</footer>
+</blockquote>
+```
+
+```
+> - Be skeptical.
+> - Be kind.
+^ House rules
+.
+<blockquote>
+  <ul>
+    <li>Be skeptical.</li>
+    <li>Be kind.</li>
+  </ul>
+  <footer>House rules</footer>
+</blockquote>
+```
+
+```
+> > I never said that.
+^ Quoted in the report
+.
+<blockquote>
+  <blockquote><p>I never said that.</p></blockquote>
+  <footer>Quoted in the report</footer>
+</blockquote>
+```
+
+```
+> ~~~
+> git bisect run ./check
+> ~~~
+^ The release runbook
+.
+<blockquote>
+  <pre><code>git bisect run ./check
+</code></pre>
+  <footer>The release runbook</footer>
+</blockquote>
+```
+
+```
+> ## Terms
+>
+> Delivery is at the discretion of the vendor.
+^ Appendix B
+.
+<blockquote>
+  <h2 id="Terms">Terms</h2>
+  <p>Delivery is at the discretion of the vendor.</p>
+  <footer>Appendix B</footer>
+</blockquote>
+```


### PR DESCRIPTION
PART 9 §4a makes a caption on a block quote its ATTRIBUTION. It says nothing about how many blocks the quote holds, and nothing needs to: a multi-paragraph epigraph is ordinary, and so are a quoted list, a nested quote, a quoted code block and a quoted heading.

The executable spec read that silence the other way. `scripts/spec/html.mjs` rendered a quote whose only child was a paragraph and threw `Refuse('captioned multi-block quote')` for every other shape, so the oracle was the only participant that declined a document the engines render. It predates §4a: `d0cf477~1` refuses the same inputs with the same message on the figure path.

Closes #1181

## Why nothing failed

The refusal was unreachable, and this was measured rather than reasoned. Instrumenting `Refuse` and rendering all 957 corpus documents through the executable spec reaches **zero** refusals - no document held a captioned quote with more than one block, `REFUSED_ALLOW` is empty, and the ratchet compares the refused set against corpus inputs alone. `core:check` reported every input conformant either way.

The gap was guarded by the absence of a fixture rather than by a decision, which is the class catalogued at markup-carve/carve#755.

## What the premise re-measurement changed

Measured at `cca1874` through the pinned `@markup-carve/carve` build (`fb7deec`), all five shapes the ticket names: the oracle refuses each one, the engine renders each one. That part holds.

The ticket also says the engines produce `<blockquote>…<footer>`. The pinned build does not yet - it renders `<figure>`/`<figcaption>` for a captioned quote, on the single-paragraph shape as well. That is the declared §4a pin lag from markup-carve/carve#1159, already carrying four documents in `resources/engine-pin-drift.txt`. It does not change the fix: what the ticket rests on is that the engines do not REFUSE this shape, and they do not.

So the five new slugs join the same declared drift window, in all three places that track it - `resources/engine-pin-drift.txt`, `SCHEMA_ROLLOUT_PENDING` in `tests/ast-schema.test.mjs`, and the declared-lag line on `docs/implementation-comparison.md`. All three clear together on the pin bump.

## The refusal is removed, not allowlisted

A `REFUSED_ALLOW` entry silences the ratchet whether or not the oracle is right, which is the same shape as the defect being fixed. The general path renders `inner` - the children produced under `inBlockquote` - rather than re-rendering them, so a quoted heading still stays out of the implicit-reference index, and the `footer` is the last child whatever precedes it. The single-paragraph output is byte-identical to before.

## Corpus

Category `306-a-captioned-quote-holds-more-than-one-block`, five cases, one per shape. 962 inputs, 962 conformant, 0 refused. The count is stated because 957/957 was true while the defect existed and is not evidence of anything.

`docs/implementation-comparison.md` declares the category as added since its quoted run rather than moving a denominator. No three-engine measurement was taken on this host, so none is published.

## Mutation proof, both directions

**The guarded thing fails.** Restoring the refusal on top of the committed tree:

```
corpus inputs:               962
executable-spec conformant:  957
refused (out of subset):     5

RATCHET FAILURE: 5 input(s) newly REFUSED (a construct escaped the executable spec):
  + 306-a-captioned-quote-holds-more-than-one-block
  + 306-a-captioned-quote-holds-more-than-one-block-2
  + 306-a-captioned-quote-holds-more-than-one-block-3
  + 306-a-captioned-quote-holds-more-than-one-block-4
  + 306-a-captioned-quote-holds-more-than-one-block-5
```

and `tests/corpus.test.mjs` goes `# pass 957 / # fail 5`, one per new case. Restored with `git restore --source=HEAD`, back to 962/962.

**The control is live.** Separately, one byte-run of case `-3`'s expected HTML was corrupted (`Quoted in the report` to `Quoted in the repot`) with the oracle untouched:

```
--- 306-a-captioned-quote-holds-more-than-one-block-3.crv
expected:
<blockquote>
  <blockquote><p>I never said that.</p></blockquote>
  <footer>Quoted in the repot</footer>
</blockquote>
got:
<blockquote>
  <blockquote><p>I never said that.</p></blockquote>
  <footer>Quoted in the report</footer>
</blockquote>
```

`core:check` exits 1 and `tests/corpus.test.mjs` reports `# pass 961 / # fail 1`. So the harness reaches these inputs and compares their bytes; they do not pass for the wrong reason.

## Sweep

Every `Refuse(...)` call in `scripts/spec/*.mjs` was enumerated and probed. Four more decline a shape the grammar already rules on and the pinned engine already renders - most pointedly `render.mjs:295`, where PART 9 §16 says an empty inline note "is literal" and the oracle refuses it. Filed as markup-carve/carve#1188 with the evidence; each needs its own fixture and a three-engine measurement, and this PR stays one rule wide.

## Gates

`partial`. Every gate that could run passed: `npm test`, `npm run combinatorial:check`, `npm run core:check`, `npm run html-import:check`, `npm run property:check`, `npm run test:conformance`.

Four could not run, verbatim:

- `npm run ast:check` - `a dependency outside the repository is missing: /tmp/carve-js/dist`
- `npm run claims:check` - `engine-claims: need all three engines, found 0 (none).`
- `npm run degradation:check` - `degradation-claims: need all three engines, found 0 (none).`
- `npm run fmt:check` - `fmt-fixture-claims: need all three engines, found 0 (none).`

Each needs engine checkouts that were deliberately not built here.

## Draft overlap

Drafts `#1026` ("docs: make examples migration-clean Carve") and `#291` ("spec: file inclusion / transclusion") both touch `docs/examples/edge-cases.md`; `#291` also touches `resources/grammar.ebnf`. No link and no topic match, so this proceeded expecting a rebase if either lands first. Corpus number 306 sits above `#291`'s 288.
