### PR TITLE
docs: the lint rule table is no longer one engine's

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -154,6 +154,11 @@ build predating it takes no such selection and treats all seven reserved names
 as core, so the scoping described here is what to expect from an engine at or
 after that ruling rather than from every build in circulation.
 
+Whether an engine can register `SemanticSpan` at all is a separate question from
+the scoping, and the [extension catalog](./extensions) is where it is tracked -
+the reference engine does not export it yet, so its four names are what the
+scoping is for rather than something every caller can switch on today.
+
 #### The block quote exception
 
 `cite` on a block quote MUST NOT be reported by `semantic-attribute-outside-span`.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -138,13 +138,21 @@ document.
 ### Semantic span attribute rules
 
 `semantic-attribute-value-ignored` and `semantic-attribute-outside-span` read
-the same reserved names, and both depend on which of those names the render they
-are linting actually turns into an element. PART 9 §9 reserves `abbr`, `time`
-and `kbd` in core; `samp`, `var`, `cite` and `dfn` become elements only once the
+the same reserved names, and both are scoped to the names the render being
+linted actually turns into an element. PART 9 §9 reserves `abbr`, `time` and
+`kbd` in core; `samp`, `var`, `cite` and `dfn` become elements only once the
 `SemanticSpan` extension is registered. A name the caller's render leaves alone
 is an ordinary attribute whose value reaches the output intact, so reporting it
-would report a loss that is not happening. Lint with the same extension set you
-render with.
+would report a loss that is not happening.
+
+That makes the extension selection an input to the linter, not just to the
+renderer, and it is passed the way each engine already passes one:
+`lintCarve(source, { extensions })` in carve-js, an `extensions` option on
+`lint()` in carve-php, and `lint_carve_with_options` in carve-rs. The scoping was
+settled in [carve#1167](https://github.com/markup-carve/carve/issues/1167). A
+build predating it takes no such selection and treats all seven reserved names
+as core, so the scoping described here is what to expect from an engine at or
+after that ruling rather than from every build in circulation.
 
 #### The block quote exception
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -107,7 +107,7 @@ the command-line and editor behavior stay aligned.
 | `fence-title-syntax` | text after a fence type word that is neither a quoted `"title"` nor a `[label]`, which makes the whole opener line plain text |
 | `footnote-labels-differ-only-in-whitespace` | two footnote definitions whose labels differ only in whitespace; labels are matched exactly, so they are two separate footnotes and a reader comparing them sees no reason why |
 | `semantic-attribute-value-ignored` | a non-empty value on a semantic span name that only selects its wrapper - `kbd` in core, and `samp`, `var`, `cite` where the SemanticSpan extension is enabled. The value reaches no output at all, so `[Dune]{cite="https://example.org/dune"}` renders `<cite>Dune</cite>` and loses the URL (PART 9 §9, §10) |
-| `semantic-attribute-outside-span` | a reserved semantic name used where PART 9 §9 does not apply - a code span, link, image, block-attribute line or table cell - where it stays an ordinary attribute, so `` `c`{kbd} `` is `<code kbd="">` rather than a `<kbd>` |
+| `semantic-attribute-outside-span` | a reserved semantic name used where PART 9 §9 does not apply - a code span, link, image, block-attribute line or table row - where it stays an ordinary attribute, so `` `c`{kbd} `` is `<code kbd="">` rather than a `<kbd>`; `cite` on a block quote is exempt, see [semantic span attribute rules](#semantic-span-attribute-rules) |
 | `platform-mention-token` | an at-prefixed word in text the document publishes, which a host platform re-linkifies into a user mention; opt-in and off by default, see [platform autolink rules](#platform-autolink-rules) |
 | `platform-issue-reference` | a hash-number in text the document publishes, which a host platform re-linkifies into an issue reference; opt-in and off by default, see [platform autolink rules](#platform-autolink-rules) |
 
@@ -134,6 +134,52 @@ frontmatter declaration wins: the two answer different questions - what the
 document targets, versus what last processed it - and the rule is about intent.
 See [versioning](./versioning) for what a version difference means for a stored
 document.
+
+### Semantic span attribute rules
+
+`semantic-attribute-value-ignored` and `semantic-attribute-outside-span` read
+the same reserved names, and both depend on which of those names the render they
+are linting actually turns into an element. PART 9 §9 reserves `abbr`, `time`
+and `kbd` in core; `samp`, `var`, `cite` and `dfn` become elements only once the
+`SemanticSpan` extension is registered. A name the caller's render leaves alone
+is an ordinary attribute whose value reaches the output intact, so reporting it
+would report a loss that is not happening. Lint with the same extension set you
+render with.
+
+#### The block quote exception
+
+`cite` on a block quote MUST NOT be reported by `semantic-attribute-outside-span`.
+It is not a semantic span there, but `cite` is a URL attribute of `blockquote`
+and `q` in HTML, so the value the author wrote does reach the output:
+
+```
+{cite="https://example.org/dune"}
+> Fear is the mind-killer.
+```
+
+```html
+<blockquote cite="https://example.org/dune"><p>Fear is the mind-killer.</p></blockquote>
+```
+
+The exception is exactly that pairing. `cite` on any other off-span target still
+reports, and any other reserved name on a block quote still reports. An engine
+that ports the rule without the exception diverges on the first quote carrying a
+citation URL.
+
+#### What counts as an off-span target
+
+Every node an authored `{attrs}` block can reach other than an ordinary
+`[content]{attrs}` span. The size of that set is an AST fact rather than part of
+the rule, so it differs between engines without either being wrong: carve-php
+reaches 26 node types and carve-rs 29. carve-php folds an inline link, a
+reference link and an autolink into one `link` type where carve-rs carries a
+separate `autolink`, and each reaches a few types the other does not. An
+implementation should test the node type against the reserved names rather than
+enumerate the targets.
+
+One shape is not a target in any engine: a table **cell** takes no attributes,
+and `| a{kbd} |` leaves the braces literal. The table **row** takes them, on its
+closing pipe, and that is what the rule reports.
 
 ### Platform autolink rules
 
@@ -251,20 +297,31 @@ published page: the **caption of a captioned listing**, and the body of a
 
 ### Which implementations provide these rules
 
-The table above is carve-js. The other engines do not currently match it, and
-`carve lint` is not the same command everywhere:
+carve-js implements every rule in the table above. The other two engines
+implement part of it, and `carve lint` is not the same command everywhere:
 
 | implementation | `carve lint` | covers |
 |---|---|---|
-| carve-js | yes | the rules above, plus the Djot/Markdown migration checks |
-| carve-php | yes | `bidi-control-in-source` plus Markdown-habit checks (`markdown-strong-asterisks`, `markdown-strong-underscores`, `markdown-strikethrough`); none of the other semantic rules above, and neither platform autolink rule |
-| carve-rs | no | the binary has no `lint` command |
+| carve-js | yes | every rule above, plus the Djot/Markdown migration checks |
+| carve-php | yes | both semantic span attribute rules, both platform autolink rules, `bidi-control-in-source`, and Markdown-habit checks of its own (`markdown-strong-asterisks`, `markdown-strong-underscores`, `markdown-strikethrough`); none of the other rules above |
+| carve-rs | no | both semantic span attribute rules, through the library entry points `lint_carve` and `lint_carve_with_options`; the binary has no `lint` command |
 
-The two platform autolink rules are carve-js only today. They are specified here
-rather than left to one engine because the ids are shared surface: a second
-engine implementing the same condition takes the same two ids, the same
-`platforms` selection, and the same token tables, or a `--platform` config stops
-being portable the moment it moves between engines.
+`semantic-attribute-value-ignored` and `semantic-attribute-outside-span` are the
+first two rules all three engines carry. They share their ids, their triggers and
+the block quote exception above. Their **messages** are not aligned yet: the tail
+of the `semantic-attribute-outside-span` sentence quotes the attribute the
+renderer actually emits in carve-php, and a fixed empty value in carve-js and
+carve-rs, which is untrue whenever the author wrote one. Which spelling the
+engines converge on is open and tracked in
+[carve-js#1058](https://github.com/markup-carve/carve-js/issues/1058), so neither
+form is canonical here. A consumer keys on the rule id, which the next section
+makes binding, rather than on the sentence.
+
+The two platform autolink rules are in carve-js and carve-php, and not in
+carve-rs. They are specified here rather than left to one engine because the ids
+are shared surface: a second engine implementing the same condition takes the
+same two ids, the same `platforms` selection, and the same token tables, or a
+`--platform` config stops being portable the moment it moves between engines.
 
 ### A rule id is a contract
 


### PR DESCRIPTION
Closes #1131
Closes #1132

The maintainer ruling shared by both tickets is "build toward parity": the rule
lands in all three engines, and an engine that lacks the surface for it grows
one. Both engine halves have merged since, so this is the ruling's own last
clause, quoted from it:

> `docs/validation.md` says the rule table is carve-js. Once the other two
> engines carry rules of their own, that sentence needs to change with them.

## What the page claimed

Three things, all stale or wrong:

- **"The table above is carve-js."** Written when carve-js was the only engine
  with a linter worth tabulating.
- **carve-php "none of the other semantic rules above, and neither platform
  autolink rule".** The first half went stale with
  markup-carve/carve-php#1254, which gave carve-php its first AST-walking lint
  pass carrying both rules. The second half was already false before this cycle:
  `MarkdownHabitLinter` carries `platform-mention-token` and
  `platform-issue-reference`, and `bin/carve` takes `--platform` with a
  known-platform check. The sentence "The two platform autolink rules are
  carve-js only today" repeated the same error.
- **carve-rs "the binary has no `lint` command".** Still true as written, but it
  was the whole entry, and markup-carve/carve-rs#972 has since added the crate's
  first lint module.

## What it says now

The rule rows and their trigger documents already landed with an earlier pin
bump, so nothing was added there. What changed is the coverage prose, plus three
claims about the rules themselves.

Corrected:

- The lead sentence and the implementation table. carve-php runs both rules from
  `carve lint`; carve-rs exposes them through `lint_carve` and
  `lint_carve_with_options` and still has no `lint` subcommand. That difference
  is how a user actually reaches the rules, so it stays in the table rather than
  being flattened to "yes".
- Both platform-autolink claims, per the measurement above.
- The `semantic-attribute-outside-span` row named a table **cell** as a target.
  A cell takes no attributes at all. The **row** takes them, on its closing
  pipe. Measured on the pinned build rather than taken from the ticket:

  ```
  | a{kbd} |     ->  <th>a{kbd}</th>          lint: []
  | a |{kbd}     ->  <tr kbd=""><th>a</th>    lint: ["semantic-attribute-outside-span"]
  ```

Added, because the page documents rule behavior and these are part of it:

- **The block quote exception.** `cite` on a block quote must not be reported:
  it is a URL attribute of `blockquote` and `q` in HTML, so the value does reach
  the output. It is normative to the rule, both engine ports needed it to avoid
  diverging on the first cited quote, and it was documented nowhere. Confirmed
  live against the pinned build:

  Input:

  ```
  {cite="https://example.org/dune"}
  > Fear is the mind-killer.
  ```

  Output:

  ```html
  <blockquote cite="https://example.org/dune"><p>Fear is the mind-killer.</p></blockquote>
  ```

  and `lintCarve` on that source returns no findings.

- **Why the off-span target set differs per engine.** carve-php reaches 26 node
  types and carve-rs 29, on AST facts rather than on rule intent: carve-php
  folds an autolink into `link` where carve-rs carries a separate type, and each
  reaches a few the other does not. The page states both counts, because a
  single number would be wrong for two engines out of three.

- **The one wording divergence, named rather than papered over.** carve-php
  quotes the attribute the renderer emits; carve-js and carve-rs print a fixed
  empty value, which is untrue whenever the author wrote one. Neither form is
  presented as canonical while the direction is open in
  markup-carve/carve-js#1058.

## Proof the checked part can fail

`tests/lint-rule-table-claims.test.mjs` parses the rule table, and this change
edits a row it parses. Renaming that row's id to `semantic-attribute-outside-spam`:

```
not ok 3 - every rule the engine emits is on the page
    carve-js emits rule id(s) docs/validation.md does not list: semantic-attribute-outside-span.
not ok 6 - every rule id in the pinned build is on the page
    the pinned carve-js build carries rule id(s) docs/validation.md does not list: semantic-attribute-outside-span.
not ok 7 - every rule the page lists can actually be emitted
    docs/validation.md lists rule id(s) with no trigger here: semantic-attribute-outside-spam.
# pass 4
# fail 3
```

Restored from `HEAD`, same file, same command:

```
# pass 7
# fail 0
```

The prose added here is not machine-checkable in this repo. The claims inside it
were measured against the pinned build instead, and the measurements are quoted
above.

## Two findings from `codex review`, both real

**The extension scoping promised an API the reader may not have.** The first
draft said "lint with the same extension set you render with" without saying
how. The carve-js build this repo pins (`fb7deecc`) has no `extensions` option
on `lintCarve` at all and reports `[x]{cite="V"}` under default options, which
is the page's own trigger document for the rule. The scoping itself is settled
and implemented, and it is the pin that is behind: carve-js `main` carries
`lintCarve(source, { extensions })` from #1167, carve-php takes an `extensions`
option on `lint()`, and carve-rs has `lint_carve_with_options`. The paragraph
now names the entry point in each engine instead of issuing an instruction, and
says plainly that a build predating that ruling takes no selection.

**Naming those entry points then contradicted the extension catalog.**
`docs/extensions.md` says SemanticSpan is specified ahead of the engines and no
implementation registers it, which reads as the opposite instruction. The
catalog is the page that is right at this pin: the reference engine exports no
`semanticSpan` (104 exports, none matching), and
`tests/extension-catalog-claims.test.mjs` pins that wording through a gate
designed to fail once the export arrives. So the correction went here, and the
scoping paragraph now defers availability to the catalog rather than restating
it.

## Gate

`gate-run` reports `partial`, with no failure. Six gates ran green: `npm test`,
`npm run combinatorial:check`, `npm run core:check`, `npm run
html-import:check`, `npm run property:check`, `npm run test:conformance`.

Four are unrunnable here, verbatim:

- `npm run ast:check` - "a dependency outside the repository is missing:
  /tmp/carve-js/dist"
- `npm run claims:check` - "engine-claims: need all three engines, found 0
  (none)."
- `npm run degradation:check` - "degradation-claims: need all three engines,
  found 0 (none)."
- `npm run fmt:check` - "fmt-fixture-claims: need all three engines, found 0
  (none)."

All four build or read engine checkouts, which sibling work holds under its own
locks, so they were deliberately not run. None of them reads `docs/validation.md`.

Draft-check came back clear: no open draft in the org touches
`docs/validation.md`.

No CHANGELOG entry. This is documentation only, and the behavior it now
describes correctly was shipped by the engine PRs above rather than by this
change.
