### PR TITLE
docs: the release reconciles the engine pin drift, and the check enforces it

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,13 +32,23 @@ CI green:
 
    ```sh
    npm run bump-carve-pin          # against current carve-js main
+   npm install                     # the bump edits package.json and installs nothing
    npm run engine:report -- --check
    ```
+
+   `npm install` is not optional. The report renders through the INSTALLED
+   build, so skipping it produces a ledger for the pin you just replaced. The
+   bump script prints the same instruction, and the pre-tag check below refuses
+   to run the report when the two disagree.
 
    Delete every line the report says now reproduces, in the same commit that
    moves the pin. That is the step the drift file's own header already describes
    ("emptying this file is the normal end state after `npm run bump-carve-pin`")
    and the release process used to omit.
+
+   The drift file is not the only thing a bump makes stale - extension
+   classification and the Tier-3 snapshots go with it. `MAINTAINING.md`, under
+   "What a pin bump has to sweep", is the list; do not move the pin without it.
 
    **The bar is accurate, not empty.** The pin is a git dependency on a carve-js
    COMMIT, `bump-carve-pin` will only move it to a merged one, and the order

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,8 +26,31 @@ CI green:
    the `lastTag..main` range (the draft release notes are the source of truth for
    scope), then cut it to `## [X.Y.Z] - YYYY-MM-DD` and open a fresh empty
    `## [Unreleased]` above it.
-3. **Run the pre-tag check** (fails on a stale version field, an un-cut
-   changelog, a dirty tree, a missing tag, or an uninitialized spec submodule):
+3. **`carve` only - reconcile the engine pin drift.** `resources/engine-pin-drift.txt`
+   lists the corpus documents the pinned reference build does not reproduce, and
+   a release is the moment that list has to be true rather than merely present:
+
+   ```sh
+   npm run bump-carve-pin          # against current carve-js main
+   npm run engine:report -- --check
+   ```
+
+   Delete every line the report says now reproduces, in the same commit that
+   moves the pin. That is the step the drift file's own header already describes
+   ("emptying this file is the normal end state after `npm run bump-carve-pin`")
+   and the release process used to omit.
+
+   **The bar is accurate, not empty.** The pin is a git dependency on a carve-js
+   COMMIT, `bump-carve-pin` will only move it to a merged one, and the order
+   above releases `carve` FIRST - so at this repo's tag moment the corpus is
+   routinely ahead of a build that has not shipped the newest rules yet, and a
+   non-empty file is the correct state. What must hold is that every remaining
+   entry names a rule the pinned build has not shipped. An entry whose rule the
+   pin already reproduces is the "nobody ran the bump" case wearing the
+   "corpus is ahead" label, and those are different facts.
+4. **Run the pre-tag check** (fails on a stale version field, an un-cut
+   changelog, a dirty tree, a missing tag, an uninitialized spec submodule, or a
+   drift entry the pinned build now reproduces):
 
    ```sh
    bash scripts/pre-tag-check.sh X.Y.Z
@@ -35,8 +58,8 @@ CI green:
    bash ../carve/scripts/pre-tag-check.sh X.Y.Z
    ```
 
-4. Land steps 1-2 via a PR to `main` and merge it.
-5. **Publish the prepared draft GitHub Release.** Publishing creates the tag at
+5. Land steps 1-3 via a PR to `main` and merge it.
+6. **Publish the prepared draft GitHub Release.** Publishing creates the tag at
    the current `main`; the tag then drives the registry publish.
 
 ## Guards
@@ -56,6 +79,8 @@ The publish step is gated so a mistake cannot ship the wrong version:
 ## Never
 
 - Never tag before `pre-tag-check.sh` passes.
+- Never tag `carve` on a drift file nobody reconciled. CI gates that drift is
+  DECLARED; only the step above gates that it is CURRENT.
 - Never publish a version whose field or changelog does not match the tag.
 - Never bump a version field except as part of a release (version numbers are
   release artifacts, not commit counters).

--- a/scripts/pre-tag-check.sh
+++ b/scripts/pre-tag-check.sh
@@ -3,8 +3,9 @@
 # pre-tag-check.sh <version> [repo-dir]
 #
 # Validates that a repository is ready to be tagged <version>, so a release is
-# never cut with a stale version field or an un-cut changelog. Run it from a
-# repo root (or pass the repo dir) BEFORE publishing the draft release / tagging.
+# never cut with a stale version field, an un-cut changelog, or - in the spec
+# repo - an engine pin drift file nobody reconciled. Run it from a repo root (or
+# pass the repo dir) BEFORE publishing the draft release / tagging.
 #
 #   bash scripts/pre-tag-check.sh 0.1.2                 # check the current repo
 #   bash /path/to/carve/scripts/pre-tag-check.sh 0.1.1 ../carve-rs
@@ -96,6 +97,36 @@ if [ -f .gitmodules ] && grep -q 'carve' .gitmodules 2>/dev/null; then
       bad "spec submodule '$SPEC' is not initialized (git submodule update --init)"
     else
       ok "spec submodule '$SPEC' initialized"
+    fi
+  fi
+fi
+
+# 7. Engine pin drift is CURRENT, not merely declared (carve#1200).
+#
+# CI gates that every mismatch between the corpus and the pinned reference build
+# is DECLARED in resources/engine-pin-drift.txt. Nothing gated that the
+# declarations are still true. A release is exactly where the difference shows:
+# an entry whose rule the pinned build now reproduces reads as "the corpus is
+# ahead of the engines" while meaning "nobody has run bump-carve-pin in a
+# while", and a reader of the release cannot tell those apart.
+#
+# `engine:report --check` already fails in both directions, so this is a gate on
+# a report rather than a second implementation of it.
+#
+# Only this repo has the file. Invoked from carve-js/carve-rs/carve-php the
+# block does not run, which is why it tests the file rather than the version
+# field.
+if [ -f resources/engine-pin-drift.txt ]; then
+  if [ ! -d node_modules ]; then
+    # NOT a skip. The drift file is present, so the claim is checkable and
+    # unchecked; passing here would report a verification that did not happen.
+    bad "engine pin drift not verified - node_modules missing, run npm ci first"
+  else
+    if DRIFT_OUT="$(npm run --silent engine:report -- --check 2>&1)"; then
+      ok "engine pin drift matches what is declared"
+    else
+      bad "engine pin drift is stale or undeclared - run npm run bump-carve-pin, then delete every line that now reproduces"
+      printf '%s\n' "$DRIFT_OUT" | grep -E 'UNDECLARED|reproduces|no longer|declared drift' | sed 's/^/         /'
     fi
   fi
 fi

--- a/scripts/pre-tag-check.sh
+++ b/scripts/pre-tag-check.sh
@@ -121,6 +121,44 @@ if [ -f resources/engine-pin-drift.txt ]; then
     # NOT a skip. The drift file is present, so the claim is checkable and
     # unchecked; passing here would report a verification that did not happen.
     bad "engine pin drift not verified - node_modules missing, run npm ci first"
+  # The report renders through the INSTALLED build, and the pin is a field in
+  # package.json. `bump-carve-pin` writes that field and installs nothing - it
+  # prints "Now run: npm install" - so running the report straight after a bump
+  # measures the build from BEFORE it and can call the ledger current for a
+  # commit that is no longer pinned. tests/engine-pin-matches-the-lock.test.mjs
+  # already ties package.json to package-lock.json; this ties both to the tree
+  # npm actually laid down, which is the copy the report reads.
+  elif ! PIN_MISMATCH="$(node -e '
+      const fs = require("fs")
+      const sha = (s) => (String(s).match(/[0-9a-f]{40}/) || [])[0]
+      const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"))
+      const dep = (pkg.devDependencies || {})["@markup-carve/carve"]
+        || (pkg.dependencies || {})["@markup-carve/carve"]
+      const declared = sha(dep)
+      const treeLock = "node_modules/.package-lock.json"
+      // EVERY unknown is a failure. A comparison that cannot be made has not
+      // been made, and exiting 0 here would hand the report an installation
+      // nothing vouched for - which is the case this whole block exists for.
+      if (!declared) {
+        console.error("package.json does not pin @markup-carve/carve to a commit")
+        process.exit(1)
+      }
+      if (!fs.existsSync(treeLock)) {
+        console.error("node_modules/.package-lock.json is missing, so the installed build is unverifiable")
+        process.exit(1)
+      }
+      const tree = JSON.parse(fs.readFileSync(treeLock, "utf8"))
+      const installed = sha((tree.packages || {})["node_modules/@markup-carve/carve"]?.resolved)
+      if (!installed) {
+        console.error("the installed tree records no commit for @markup-carve/carve")
+        process.exit(1)
+      }
+      if (installed !== declared) {
+        console.error(`installed ${installed.slice(0, 12)}, package.json pins ${declared.slice(0, 12)}`)
+        process.exit(1)
+      }
+    ' 2>&1)"; then
+    bad "installed reference build is not the pinned one ($PIN_MISMATCH) - run npm install, then re-check"
   else
     if DRIFT_OUT="$(npm run --silent engine:report -- --check 2>&1)"; then
       ok "engine pin drift matches what is declared"


### PR DESCRIPTION
Closes #1200

## Re-measured at HEAD

`099cc27`. The ticket measured `c0b7024`; #1201 has landed since, and every
claim still holds:

- `RELEASING.md` names neither `engine-pin-drift.txt` nor `engine:report` nor
  `bump-carve-pin`.
- `scripts/pre-tag-check.sh` checks a stale version field, an un-cut changelog,
  a dirty tree, a missing tag and an uninitialized spec submodule, and not this.
- `npm run engine:report -- --check` reports `declared drift: 60`, matching.

#1201 landed a `MAINTAINING.md` section on what a pin bump has to sweep, which
covers the drift file among two other things. It touches neither file this
changes, and the new checklist step points at it rather than restating it -
moving the pin also makes extension classification and the Tier-3 snapshots
stale, and a step naming only the drift file would read as though it did not.

## What landed

**Point 1.** The per-repo checklist gets a `carve`-only step before the pre-tag
check: run `bump-carve-pin` against current carve-js `main`, `npm install`, then
`engine:report -- --check`, and delete every line that now reproduces, in the
commit that moves the pin. That is the step the drift file's own header already
describes and the release process omitted. The install is spelled out because
the report renders through the INSTALLED build and the bump installs nothing -
without it the ledger describes the pin you just replaced.

**Point 2.** The bar is accuracy, not emptiness. Emptiness is unsatisfiable by
construction and the file says why: the pin is a git dependency on a carve-js
COMMIT, `bump-carve-pin` will only move it to a merged one, and the release
order puts `carve` first - so at this repo's tag moment the corpus is routinely
ahead of a build that has not shipped the newest rules, and a non-empty file is
correct. What must hold is that every remaining entry names a rule the pinned
build has not shipped. An entry the pin already reproduces is the "nobody ran
the bump" case wearing the "corpus is ahead" label, and a reader of a release
cannot currently tell those apart. That is the whole complaint.

**Point 3 landed too.** `pre-tag-check.sh` gates the same report, so the
"nobody ran the bump" case is caught at tag time rather than at the next CI run.
It is a gate on a report rather than a second implementation of one:
`engine:report --check` already fails in both directions. It runs only where
`resources/engine-pin-drift.txt` exists, so pointing the script at carve-js,
carve-rs or carve-php from their own roots is unaffected.

Every unknown is a **failure, not a skip** - a missing `node_modules`, a
missing installed-tree lockfile, a pin with no commit in it. The drift file is
present, so the claim is checkable; passing on an unmade comparison would report
a verification that did not happen.

## What deliberately did NOT land

The drift file itself is untouched. 53 of its 60 entries are two rules the
engines have already shipped and would clear on a bump - but deleting a line
means proving that line reproduces, and mixing that into a docs change hides it.
It is a separate, verifiable act.

## The findings from review, and the holes they named

A second commit closes a gap the first one left, and it is the gap the new step
itself would otherwise open. The report renders through the **installed** build
while the pin is a field in `package.json`, and `bump-carve-pin` writes that
field and installs nothing - it prints `Now run: npm install`. So the exact
sequence this PR documents, bump then report, measures the build from before the
bump unless the install happens between them.

Two changes: the checklist spells the install out, and the check compares
`node_modules/.package-lock.json` against the `package.json` pin before it will
run the report at all.

The first shape of that comparison exited 0 whenever it could not be made - no
installed-tree lockfile, no commit in the pin - which is the can't-fail check
this project keeps finding (markup-carve/carve#755). Each of those is now a
failure with its own message.

`tests/engine-pin-matches-the-lock.test.mjs` already ties `package.json` to
`package-lock.json` for the same reason; this ties both to the tree npm actually
laid down, which is the copy the report reads.

## Proof, both directions

**A listed entry that now reproduces.** Appending a real slug the pin does
reproduce:

```
  [FAIL] engine pin drift is stale or undeclared - run npm run bump-carve-pin, then delete every line that now reproduces
         declared drift:          61 (resources/engine-pin-drift.txt)
           STALE       01-emphasis-10 - reproduces now; drop the line (reason was: A rule the pinned build has already shipped.)
```

**A real entry removed.** Deleting the live `09-tables` line:

```
  [FAIL] engine pin drift is stale or undeclared - run npm run bump-carve-pin, then delete every line that now reproduces
         declared drift:          59 (resources/engine-pin-drift.txt)
           UNDECLARED  09-tables - the pin does not reproduce this and nothing says why
```

**A stale installed tree.** Pointing the `package.json` pin at a different
carve-js commit than the installed one:

```
  [FAIL] installed reference build is not the pinned one (installed fb7deeccf0e4, package.json pins 0123456789ab) - run npm install, then re-check
```

**Missing dependencies.** With `node_modules` moved aside:

```
  [FAIL] engine pin drift not verified - node_modules missing, run npm ci first
```

**An unverifiable installation.** With `node_modules/.package-lock.json` moved
aside, so the comparison cannot be made:

```
  [FAIL] installed reference build is not the pinned one (node_modules/.package-lock.json is missing, so the installed build is unverifiable) - run npm install, then re-check
```

**And clean.** On the unmodified tree:

```
  [ok]   engine pin drift matches what is declared
```

## Gates

`gate-run` reports `partial`: seven gates ran and passed (`npm test`,
`combinatorial:check`, `core:check`, `html-import:check`, `links:check`,
`property:check`, `test:conformance`), none failed, and four could not run
because this worktree has no engine checkouts beside it, which this session is
not permitted to build:

- `npm run ast:check` - `a dependency outside the repository is missing: /tmp/carve-js/dist`
- `npm run claims:check` - `engine-claims: need all three engines, found 0 (none).`
- `npm run degradation:check` - `degradation-claims: need all three engines, found 0 (none).`
- `npm run fmt:check` - `fmt-fixture-claims: need all three engines, found 0 (none).`
