### PR TITLE
spec: stop the AST panel reporting an unordered map as a divergence

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,6 +58,29 @@ CI green:
    entry names a rule the pinned build has not shipped. An entry whose rule the
    pin already reproduces is the "nobody ran the bump" case wearing the
    "corpus is ahead" label, and those are different facts.
+
+   **Three more files declare the same kind of debt, and they read a different
+   thing.** `engine:report` renders through the INSTALLED carve-js, so the pin
+   is its whole input. These three drive all three engine CHECKOUTS:
+
+   ```sh
+   npm run ast:check   # resources/ast-value-divergence.txt, ast-span-divergence.txt
+   npm run fmt:check   # resources/engine-fmt-drift.txt
+   ```
+
+   So their precondition is not the pin - it is that `../carve-js`, `../carve-rs`
+   and `../carve-php` are at their `main` AND rebuilt. Pulling without rebuilding
+   leaves the old binary in place and the gates read it. Measured 2026-08-14,
+   stale checkouts reported carve-rs at 39 distinct AST findings where `main` had
+   2, carve-php at 11 where it had 2, and four `fmt:check` failures that did not
+   exist. Both gates fail in both directions, like the pin report, so reconciling
+   means editing until they are green rather than appending.
+
+   ```sh
+   (cd ../carve-js  && git pull --ff-only && npm ci && npm run build)
+   (cd ../carve-rs  && git pull --ff-only && cargo build --release)
+   (cd ../carve-php && git pull --ff-only && composer install)
+   ```
 4. **Run the pre-tag check** (fails on a stale version field, an un-cut
    changelog, a dirty tree, a missing tag, an uninitialized spec submodule, or a
    drift entry the pinned build now reproduces):

--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -50,3 +50,6 @@
 # unresolved, or slugs the heading differently - so they are ordinary corpus
 # conformance, owed a fixture rather than a line (markup-carve/carve#1011).
 
+
+link.href   3  carve-rs publishes "" where carve-js and carve-php publish the resolved destination. Two spec rules landed 2026-08-14 that carve-rs has not shipped: markup-carve/carve#1196 (a reference link's text survives its own resolution frame) and #1203 (an inline note carries a frame its content can nest inside). Delete on the carve-rs release that ships them.
+image.src   2  Same rules, same engine, the image half of them: carve-rs publishes "" for a reference image's resolved source. Delete with the line above.

--- a/scripts/spec/ast-values.mjs
+++ b/scripts/spec/ast-values.mjs
@@ -37,6 +37,36 @@ const POSITION_KEYS = new Set([
  * `keyValues`, which is where the heading-id and fence-title divergences sit -
  * but its ORDER array is compared as a whole, since that is the field's meaning.
  */
+/*
+ * Stringify an attrs slot so that only MEANINGFUL order survives.
+ *
+ * `attrs.keyValues` is a JSON object, and the schema says so: it carries the
+ * pairs, while the sibling `attrs.order` array carries "source-appearance order
+ * of the slots". Object key order therefore means nothing there - which is the
+ * whole reason `order` exists as a separate field.
+ *
+ * Stringifying the object as-is made that meaningless order load-bearing:
+ * carve-rs emitted {"fr":"","lang":""} where carve-js and carve-php emitted
+ * {"lang":"","fr":""}, all three agreed on `order`, and the panel reported a
+ * span.attrs.keyValues divergence across three documents that is not one. It is
+ * the same mistake the comment below already describes for node fields, applied
+ * one level deeper.
+ *
+ * Arrays keep their order: `order` and `classes` accumulate in source order and
+ * a reordering there IS a divergence.
+ */
+const canonicalJson = (value) => {
+  if (Array.isArray(value)) return JSON.stringify(value)
+  if (value && typeof value === 'object') {
+    const sorted = {}
+    for (const key of Object.keys(value).sort()) sorted[key] = value[key]
+
+    return JSON.stringify(sorted)
+  }
+
+  return JSON.stringify(value)
+}
+
 export function valueSignature(node, out = [], path = '$') {
   if (Array.isArray(node)) {
     node.forEach((n, i) => valueSignature(n, out, `${path}[${i}]`))
@@ -54,7 +84,7 @@ export function valueSignature(node, out = [], path = '$') {
         fields.push(`${key}=${JSON.stringify(value)}`)
       } else if (key === 'attrs') {
         for (const attrKey of Object.keys(value).sort()) {
-          fields.push(`attrs.${attrKey}=${JSON.stringify(value[attrKey])}`)
+          fields.push(`attrs.${attrKey}=${canonicalJson(value[attrKey])}`)
         }
       }
     }


### PR DESCRIPTION
Follow-up to #1204, which added the release step for `resources/engine-pin-drift.txt`. Three things that step does not reach.

## 1. The AST panel was reporting a non-divergence

`ast:check` reported `span.attrs.keyValues` disagreeing across three documents:

```
carve-js  {"lang":"","fr":""}
carve-rs  {"fr":"","lang":""}
carve-php {"lang":"","fr":""}
```

That is not a divergence. The schema defines `attrs.keyValues` as a JSON object — formally unordered — and a **separate** `attrs.order` array whose description is *"Source-appearance order of the slots"*. `order` is where ordering lives, which is exactly why it exists as its own field. All three engines agree on it; `span.attrs.order` never appeared in the report.

`valueSignature` stringified the object as it came, so JSON key order became load-bearing. The function's own comment already states the principle for node fields:

> SORTED BY KEY … the engines serialize a node's fields in different orders … JSON object order carries no meaning.

This applies it one level deeper. Object keys are sorted before stringifying; **arrays keep their order**, because `order` and `classes` accumulate in source order and a reordering there *is* a divergence.

Worth stating plainly: without this, the natural next move is to declare a permanent divergence for something that isn't one — a checker teaching people to write down a fiction.

## 2. What remains is real, and was undeclared

`resources/ast-value-divergence.txt` declared nothing while two fields genuinely diverge:

```
link.href   3 documents
image.src   2 documents
```

carve-rs publishes `""` where carve-js and carve-php publish the resolved destination, because it has not shipped #1196 (a reference link's text survives its own resolution frame) or #1203 (an inline note carries a frame its content can nest inside), both landed today. Declared with measured counts and the condition for deleting the lines.

Counts are measured, not assumed — they moved from 1/1 to 3/2 while this branch was being written, because #1203 added corpus documents. The count-sensitivity of that file caught it.

## 3. These gates have a different precondition than the pin report

`engine:report` renders through the **installed** carve-js, so the pin is its whole input — which is what #1204 correctly documents.

`ast:check` and `fmt:check` drive the three engine **checkouts**. So their precondition is that `../carve-js`, `../carve-rs` and `../carve-php` are at `main` *and rebuilt*. Pulling without rebuilding leaves the old binary in place and the gate reads it.

That is not hypothetical. Measured today against stale local checkouts:

| Gate | Stale reading | Actual, rebuilt |
|---|---|---|
| `ast:check` carve-rs | 176 findings, 39 distinct | 27 findings, 2 distinct, 0 outstanding |
| `ast:check` carve-php | 36 findings, 11 distinct | 27 findings, 2 distinct, 0 outstanding |
| `fmt:check` | 4 failures | **29/29 pass** |
| three-way shape | 956/986 unanimous | **986/986** |

All three local checkouts were 6-7 commits behind. `ast:check` prints `STALE - source is newer, rebuild before believing this`; that warning is worth treating as a hard stop.

## Verification

`ast:check` exits 0 against carve-js `d107193`, carve-rs `0cc4756` and carve-php `4ae61f5`, each built from a fresh worktree of `main`. 2077 tests pass. Corpus output unchanged.
