### PR TITLE
docs: move the pin past the writer's alt-text escape, and delete the block that declared it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#54536ac06cbc257976a7907d438a7e4c22d3d516",
+        "@markup-carve/carve": "github:markup-carve/carve-js#f05f3a7622e55f8b90f0b8c60e44feae4066eeee",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.42.1",
@@ -985,8 +985,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#54536ac06cbc257976a7907d438a7e4c22d3d516",
-      "integrity": "sha512-DAjNHUeawG2oBdnS7OvR2AKdd5idARbqpQyVskAoFqMCvQ2qJRh9Xpu5HokJrxhO4sJIiu42ZpvVJq2fsFnPGA==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#f05f3a7622e55f8b90f0b8c60e44feae4066eeee",
+      "integrity": "sha512-BH+0cYS4/1giX5JCHNygvdqo3/M3HaX81BW+YYJOToa1QLZE7TT08+K+zgznmb1CHofzZrFArEic0vIPRdjxfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#54536ac06cbc257976a7907d438a7e4c22d3d516",
+    "@markup-carve/carve": "github:markup-carve/carve-js#f05f3a7622e55f8b90f0b8c60e44feae4066eeee",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.42.1",

--- a/resources/engine-fmt-drift.txt
+++ b/resources/engine-fmt-drift.txt
@@ -8,16 +8,3 @@
 # engine-pin-drift.txt says the same thing for the same reason.
 #
 # Format: <slug><space><space><reason>
-
-# The alt-text close again, on the WRITER side (carve#1197). The pinned build
-# READS a bracket in alt text correctly - every one of these documents renders
-# byte-for-byte - but `fmt` escapes the bracket on the way out, as if the run
-# stopped at the first `]`. Nothing resolves that escape: alt is an HTML
-# attribute and its content is raw, so the backslash lands in the attribute
-# value and the document says something else. It is not idempotent either -
-# each pass escapes the backslash it wrote last time. Clears with the carve-js
-# formatter fix and a pin bump.
-316-an-image-s-alt-text-closes-where-a-link-s-text-closes-2  `fmt` writes `![t\[z\]](/i.png)`, so the alt becomes `t\[z\]`.
-316-an-image-s-alt-text-closes-where-a-link-s-text-closes-4  `fmt` escapes the backslash of an already-escaped `]`, and again on every later pass.
-316-an-image-s-alt-text-closes-where-a-link-s-text-closes-5  `fmt` escapes the `]` inside a code span in alt text, where it was already content.
-317-an-editorial-comment-s-bracket-is-content-not-the-close-4  `fmt` escapes the `]` inside an editorial comment in alt text, where it was already content.


### PR DESCRIPTION
`resources/engine-fmt-drift.txt` carried four lines that could not be deleted yet. They declared the writer-side half of the alt-text close ruled in markup-carve/carve#1197: the pinned build READ a bracket in alt text correctly, and `fmt` wrote it back escaped, so

```
![t[z]](/i.png)
```

came out as

```
![t\[z\]](/i.png)
```

and the backslash landed in the `alt` attribute, whose content is raw. It was not idempotent either, each pass escaping the backslash the last one wrote.

markup-carve/carve-js#1068 fixed the writer. The lines only go stale once this repo's pin includes that commit, and it did not: `54536ac` was one commit short of `f05f3a7`. So this moves the pin to current merged carve-js `main` and deletes the block, including its comment header, in the same commit. That is the order `RELEASING.md` asks for since markup-carve/carve#1204.

## Pin

| | |
|---|---|
| before | `github:markup-carve/carve-js#54536ac06cbc257976a7907d438a7e4c22d3d516` |
| after | `github:markup-carve/carve-js#f05f3a7622e55f8b90f0b8c60e44feae4066eeee` |

`npm install` ran after the bump, and the installed tree is what the report measured rather than the pin the report was asked about:

```
node_modules/.package-lock.json
  "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#f05f3a7622e55f8b90f0b8c60e44feae4066eeee"
```

`package-lock.json` and `node_modules/.package-lock.json` agree on that sha, and both agree with `package.json`.

## `engine-pin-drift.txt` stays at zero

The bump introduces no render drift to declare:

```
pinned reference build:  github:markup-carve/carve-js#f05f3a7622e55f8b90f0b8c60e44feae4066eeee
corpus pairs:            1006
reproduced:              1006
mismatched:              0
threw:                   0

declared drift:          0 (resources/engine-pin-drift.txt)

Drift matches what is declared.
```

## The deletion is a measurement, not a reading of the carve-js diff

The writer-side file has its own ratchet, `every writer-drift line still names a document the pin writes wrongly` in `tests/corpus-fmt-roundtrip.test.mjs`. Against the newly installed build, before the deletion, it named all four:

```
resources/engine-fmt-drift.txt declares drift that no longer happens - delete the line in the commit that moves the pin past it:
  316-an-image-s-alt-text-closes-where-a-link-s-text-closes-2 (round-trips clean)
  316-an-image-s-alt-text-closes-where-a-link-s-text-closes-4 (round-trips clean)
  316-an-image-s-alt-text-closes-where-a-link-s-text-closes-5 (round-trips clean)
  317-an-editorial-comment-s-bracket-is-content-not-the-close-4 (round-trips clean)
```

Four lines out, none left. The file is back to its header.

## Both checks fail in both directions

A check that only ever passes is the thing this file was added to stop being, so each direction was made to fail on purpose and then restored.

Re-adding one deleted line, writer-drift ratchet:

```
not ok 4 - every writer-drift line still names a document the pin writes wrongly
    resources/engine-fmt-drift.txt declares drift that no longer happens - delete the line in the commit that moves the pin past it:
      316-an-image-s-alt-text-closes-where-a-link-s-text-closes-2 (round-trips clean)
```

Perturbing a committed corpus `.html` fixture, `npm run engine:report -- --check`:

```
declared drift:          0 (resources/engine-pin-drift.txt)
  UNDECLARED  316-an-image-s-alt-text-closes-where-a-link-s-text-closes-2 - the pin does not reproduce this and nothing says why

resources/engine-pin-drift.txt does not describe this build.
```

Perturbing a committed corpus `.crv` so the writer loses the document, the fmt sweep that the drift files excuse:

```
not ok 2 - formatting never changes what a corpus document says
    these documents render differently after formatting, and resources/engine-pin-drift.txt does not excuse it - the writer changed the document, not just its spelling:
      261-a-blank-line-holds-spaces-and-tabs-and-nothing-else-3
not ok 3 - formatting a corpus document settles on the first pass
      261-a-blank-line-holds-spaces-and-tabs-and-nothing-else-3
```

Both fixtures were restored and compared byte-for-byte with `cmp` before committing, and `git status --porcelain` is empty.

## Gates

`partial`. Seven ran with none failing: `npm test`, `npm run combinatorial:check`, `npm run core:check`, `npm run html-import:check`, `npm run links:check`, `npm run property:check`, `npm run test:conformance`.

Four were unrunnable, each because it drives the engine CHECKOUTS rather than the pin, and this run had none provisioned:

- `npm run ast:check` - `a dependency outside the repository is missing: /tmp/carve-js/dist`
- `npm run claims:check` - `engine-claims: need all three engines, found 0 (none).`
- `npm run degradation:check` - `degradation-claims: need all three engines, found 0 (none).`
- `npm run fmt:check` - `fmt-fixture-claims: need all three engines, found 0 (none).`

`fmt:check` is the cross-engine counterpart of the file this PR edits, so its absence is worth naming rather than glossing: it would tell us whether carve-rs and carve-php write the same documents correctly. It cannot tell us anything about the four lines removed here, which are about the build this repo pins, and the in-repo ratchet reads exactly that build.
