### PR TITLE
chore: take the dependency fixes that exist, and say why the rest do not

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@markup-carve/carve": "github:markup-carve/carve-js#f05f3a7622e55f8b90f0b8c60e44feae4066eeee",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
-        "@mermaid-lint/cli": "^0.42.1",
+        "@mermaid-lint/cli": "^0.53.1",
         "ajv": "^8.20.0",
         "markdown-it-container": "^4.0.0",
         "ohm-js": "^17.5.0",
@@ -1054,21 +1054,21 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@mermaid-lint/cli": {
-      "version": "0.42.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-lint/cli/-/cli-0.42.1.tgz",
-      "integrity": "sha512-sF79MlVmW7WBTlXx+qJfVwJMBvY8OEWAYfbdVQh/6V9kKiXchSNoqQGM/1oUuFfnOxdVOF4reXRA0+QaSX5Xqg==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-lint/cli/-/cli-0.53.1.tgz",
+      "integrity": "sha512-uByzN0hI6sJM91l5vHV9fn3L6p74qd+it2xdmi5UIQcrWrFm/N2Egb9VZ/quM+DYSHup1t+/zOhZmHS/Dr0IUA==",
       "dev": true,
       "dependencies": {
-        "@mermaid-lint/core": "0.42.1",
+        "@mermaid-lint/core": "0.53.1",
         "chalk": "^5.4.1",
         "fast-glob": "^3.3.3"
       },
@@ -1080,16 +1080,16 @@
       }
     },
     "node_modules/@mermaid-lint/core": {
-      "version": "0.42.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-lint/core/-/core-0.42.1.tgz",
-      "integrity": "sha512-uTsJXxVCYvF26jXIK9HySxjdJJD+CsZK2KCxIPXJGOpe6wuXrtS0pvrCLCijDPbSTS8FAmgExZpWQ6lqBLIElQ==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-lint/core/-/core-0.53.1.tgz",
+      "integrity": "sha512-QJ4RdvUfBHXQ9/ANtJZGVaWsryGOeHnC1XWSfWsGnqfIkot9rE8QrATs8/pf7+2zAc0pD/yChXSCz6+kJB8v3w==",
       "dev": true,
       "dependencies": {
         "@mermanjs/web": "^0.7.0",
-        "dompurify": "^3.4.12",
+        "dompurify": "^3.4.13",
         "jsdom": "^26.1.0",
         "lilconfig": "^3.0.0",
-        "mermaid": "11.15.0",
+        "mermaid": "11.16.1",
         "micromatch": "^4.0.0"
       },
       "engines": {
@@ -3521,26 +3521,26 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -3679,9 +3679,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4557,9 +4557,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
-      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@markup-carve/carve": "github:markup-carve/carve-js#f05f3a7622e55f8b90f0b8c60e44feae4066eeee",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
-    "@mermaid-lint/cli": "^0.42.1",
+    "@mermaid-lint/cli": "^0.53.1",
     "ajv": "^8.20.0",
     "markdown-it-container": "^4.0.0",
     "ohm-js": "^17.5.0",


### PR DESCRIPTION
`npm audit` reported **seven** advisories, all in devDependencies. Two have a fix and are taken here; the other five are one chain with no non-alpha upgrade path.

## Taken

| Package | Change | Advisory |
|---|---|---|
| `nanoid` | → 3.3.18 (transitive, plain `npm audit fix`) | custom generators can loop indefinitely when size is zero |
| `@mermaid-lint/cli` | 0.42.1 → **0.53.1** (semver-major) | carries the `mermaid` prototype-pollution and CSS-injection advisories |

The mermaid-lint bump is a major, so it was verified rather than assumed:

```
$ npm run lint:mermaid
checked 2 diagrams in 1155 files — all valid
  flowchart        1
  sequenceDiagram  1
```

Same diagram count, same result. For this repo it's a version bump, not a behavior change.

**7 advisories → 3.**

## Not taken, and why

`vite`, `esbuild` and `vitepress` are one chain:

- `vitepress@1.6.4` is the **current stable release** — there is no 1.6.5.
- It depends on `vite@^5.4.14`.
- The advisory is fixed in **vite 6.4.3+**, outside that range.
- The only vitepress that moves is `2.0.0-alpha.19`.

Forcing an alpha into the docs toolchain to silence this is the worse trade. The vite advisory is about the **dev server** (`npm run docs:dev`); the published site is static HTML built ahead of time, so the artifact users receive is unaffected. Recorded in the commit message so the next person doesn't re-derive it.

## Separately: the Dependabot alerts are stale

Both alerts open on the default branch name `postcss`:

| Alert | Wants | Committed lock has |
|---|---|---|
| high — path traversal in source-map auto-loading | ≥ 8.5.18 | **8.5.25** |
| moderate — incomplete fix of the same | ≥ 8.5.23 | **8.5.25** |

`origin/main`'s `package-lock.json` has resolved `postcss` to 8.5.25 since before either alert was raised (2026-08-02 and 2026-08-12, neither updated since). There is one lockfile, one installed copy, and `npm audit` does not flag postcss at all.

So those two need no code change — they're awaiting a rescan. They can be left to close on their own, or dismissed explicitly; I didn't dismiss them since that's a security-posture call.

## Verification

2098 tests pass · docs build clean · `corpus:build` produces no fixture changes.
