### PR TITLE
spec: name the diagnostic for a structure Carve cannot spell

### DIFF
--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -93,6 +93,10 @@ lossy decision should be observable. The common diagnostic codes are:
 - `style-unmapped`: CSS had no explicit semantic mapping.
 - `table-degraded`: a table could not be represented structurally.
 - `raw-preserved`: unsupported trusted markup was retained as raw HTML.
+- `structure-unspellable`: the import produced a structure Carve source has
+  no spelling for, so it survives in the AST and not in written Carve. The
+  AST-returning entry point loses nothing and reports nothing; the one that
+  writes source reports this.
 - `diagnostics-truncated`: the diagnostic cap was reached.
 
 Diagnostics have `code`, `message`, `severity` (`info`, `warning`, or `error`),

--- a/resources/html-import-schema.json
+++ b/resources/html-import-schema.json
@@ -15,7 +15,7 @@
         "required": ["code", "message", "severity"],
         "additionalProperties": false,
         "properties": {
-          "code": { "enum": ["element-dropped", "element-unwrapped", "attribute-dropped", "style-unmapped", "table-degraded", "raw-preserved", "diagnostics-truncated"] },
+          "code": { "enum": ["element-dropped", "element-unwrapped", "attribute-dropped", "style-unmapped", "table-degraded", "raw-preserved", "structure-unspellable", "diagnostics-truncated"] },
           "message": { "type": "string" },
           "severity": { "enum": ["info", "warning", "error"] },
           "path": { "type": "string" },


### PR DESCRIPTION
Companion to markup-carve/carve-js#1069, which needs a code this contract does not define.

## Why

PART 12 sections 14, 15 and 16 each describe a shape that reaches the AST through a bridge and has **no Carve source spelling** — `shortCaption`, `rowGroups`, and a figure wrapping a table. Each says a bridge or API exposing conversion diagnostics SHOULD report the structural loss.

The html-import contract defined no code for that, so an engine obeying the clause had two bad options: invent a code the published schema forbids, or file the loss under a code that describes something else.

`tests/html-import-contract.check.mjs` enforces the enum against every shared fixture, so an engine-invented code cannot be fixtured — the three engines would silently diverge on diagnostics instead.

## The distinction it carries

Which entry point loses anything:

- `htmlToAst` keeps the structure and reports **nothing** — a consumer holding the AST loses nothing.
- `htmlToCarve` writes source, which is where the loss happens, and reports it.

That is why this is not `table-degraded`. That code means a table could not be represented at all; here the table is represented perfectly and it is the **wrapper around it** that has no spelling.

## Changed

- `resources/html-import-schema.json` — `structure-unspellable` added to the diagnostics `code` enum
- `docs/html-import.md` — the matching entry in the code list

Additive only: no existing code changes meaning, and no fixture changes.

## Verification

`npm run html-import:check` passes · 2177 tests pass · `corpus:build` produces no fixture changes.
