### PR TITLE
fix: the value declaration says what the engines actually disagree about

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -51,5 +51,5 @@
 # conformance, owed a fixture rather than a line (markup-carve/carve#1011).
 
 
-link.href   3  carve-rs publishes "" where carve-js and carve-php publish the resolved destination. Two spec rules landed 2026-08-14 that carve-rs has not shipped: markup-carve/carve#1196 (a reference link's text survives its own resolution frame) and #1203 (an inline note carries a frame its content can nest inside). Delete on the carve-rs release that ships them.
-image.src   2  Same rules, same engine, the image half of them: carve-rs publishes "" for a reference image's resolved source. Delete with the line above.
+footnote_ref.number     2  carve-php publishes a number on a footnote reference written inside an UNRESOLVED reference link; carve-js and carve-rs publish none. markup-carve/carve#1198 ruled that such a reference does not count as a reference, so it gets no number, no endnote and no backlink. carve-php shipped the render half (markup-carve/carve-php#1257 - the HTML is identical in all three engines, which is why the corpus gate cannot see this) and left the serialized number behind. Tracked at markup-carve/carve-php#1269; delete on the release that drops the field.
+inline_footnote.number  1  Same ruling, same engine, the inline half: carve-php publishes a number on an inline note written inside an unresolved reference link. Delete with the line above.


### PR DESCRIPTION
`npm run ast:check` gates `resources/ast-value-divergence.txt` in both
directions, so a line that no longer describes a divergence fails the job
exactly as an undeclared one does. Both halves had drifted. This is the
declaration half of what `AST conformance` is currently red on; the rest is
measured and reported below rather than changed here.

## What the report said

Measured locally over the four engines, each built from its own `main`:

| engine | commit |
| --- | --- |
| carve-js | `a0061cf` |
| carve-rs | `8dada73` |
| carve-php | `eda0a61` |
| carve-rb | `e5cc796` |

```
THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:
  NEW        footnote_ref.number diverges in 2 document(s) and is not declared
  NEW        inline_footnote.number diverges in 1 document(s) and is not declared
  FIXED      link.href no longer diverges - delete its line
  FIXED      image.src no longer diverges - delete its line
```

## Deleted, because the report says FIXED

`link.href` and `image.src` declared that carve-rs published `""` where the
other two published the resolved destination, pending two spec rules it had not
shipped. It has shipped them. carve-rs `8dada73` on `a [t][r] b` with
`[r]: /u`:

```json
{ "type": "link", "href": "/u", "children": [ { "type": "text", "value": "t" } ] }
```

## Added, because the report says NEW

carve-php publishes `number` on a footnote reference written inside an
unresolved reference link; carve-js and carve-rs publish none.

Input, `tests/corpus/314-a-footnote-in-an-unresolved-reference-is-not-a-reference.crv`:

```
a [t[^1]][nope] b

[^1]: n
```

Output, identical in all three engines, which is why the corpus gate cannot see
this:

```html
<p>a [t[^1]][nope] b</p>
```

carve-rs:

```json
{ "type": "footnote_ref", "id": "1" }
```

carve-php:

```json
{ "type": "footnote_ref", "id": "1", "number": 1 }
```

### How the question was settled

Not by counting engines. `number` is optional in `resources/ast-schema.json` -
`footnote_ref` requires only `type`, `inline_footnote` only `type` and `inline`
- so a tree carrying it validates and a tree omitting it validates. That alone
would make a declaration line the whole answer.

The deciding clause is narrower than optionality. The schema describes the field
as "Assigned during resolution, by document reference order", and PART 12 scopes
it to a reference that resolved: "a resolved footnote reference keeps its label
and gains its number". `markup-carve/carve#1198` ruled that a footnote inside an
unresolved reference is not a reference, and so "gets no number, no endnote, and
no backlink" - PART 9R R1, the literal-source fallback, means the noteref was
never written into the output at all.

The second corpus case makes the consequence visible rather than theoretical:

```
a [t[^1]][nope] b [^1] c

[^1]: n
```

The document renders exactly one noteref, the bare `[^1]`, numbered 1. carve-php
publishes `number: 1` on both `footnote_ref` nodes, so the discarded one carries
a number that appears nowhere in the output and duplicates the number of the
reference a reader can see. That is the failure mode this repo already recorded
once as a stale footnote number, and it is why "derived" was not treated as
settling the question on its own: the Pandoc bridge wanting a number without
re-deriving document order is a fair argument for publishing the field, and no
argument at all for publishing a value the render contradicts.

So the engines are not equally right here, and the declaration says which one is
wrong. carve-php shipped the render half under `markup-carve/carve-php#1257` and
left the serialized number behind; the residual is filed as
`markup-carve/carve-php#1269`, and both lines fail this job once it is dropped.

## The declaration file is load-bearing, in both directions

Re-adding a line the engines no longer disagree about:

```
THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:
  FIXED      link.href no longer diverges - delete its line
```

Removing a line that legitimately stands:

```
THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:
  NEW        footnote_ref.number diverges in 2 document(s) and is not declared
```

Both exited 1. No allowlist entry was added.

## What this does not fix

`ast:check` exits 0 on this branch with the four engines present. Under
`CARVE_REQUIRE_ALL_ENGINES=1`, which the workflow sets, `PART 12 conformance`
still exits 1 before reaching the value comparison, and a second step is red for
an unrelated reason. Both are engine-side and neither is touched here.

### Binding parity: the quote-attribution withdrawal, in carve-rb

```
BINDING PARITY: carve-rb's tree differs from carve-rs on 9 of 1009 document(s):
  05-lists-20.crv
  07-blockquote-with-attribution.crv
  282-two-blank-lines-detach-a-caption-5.crv
  306-a-captioned-quote-holds-more-than-one-block-2.crv
  306-a-captioned-quote-holds-more-than-one-block-3.crv
  306-a-captioned-quote-holds-more-than-one-block-4.crv
  306-a-captioned-quote-holds-more-than-one-block-5.crv
  306-a-captioned-quote-holds-more-than-one-block.crv
  55-blockquote-caption-after-a-blank-line.crv
```

Those nine are the quote-attribution documents. carve-rb still publishes
`attribution`; carve-rs no longer does. `carve-rb/ext/carve/Cargo.toml` pins
carve-rs at `971aecf`, which is 17 commits behind its `main` and predates
`markup-carve/carve-rs#984`, the withdrawal. A binding has no vote of its own,
so this is carve-rb's drift and not a second opinion about the withdrawal. Left
untouched deliberately: the topic is the maintainer's.

### Cross-engine render comparison: two Markdown-target divergences

`compare:report` gates `crossImplDiffs`, and the DIFF lines are on the
`markdown` target. Two distinct root causes, both one engine against the other
two.

carve-js writes a blank quoted line as the marker plus a trailing space, where
carve-rs and carve-php write the bare marker. On
`102-block-quote-continuation-marker`:

```
> quoted
+
- item
```

carve-rs and carve-php:

```
> quoted
>
> - item
```

carve-js emits `"> quoted\n> \n> - item\n"` - the middle line is `>` followed by
a space. This accounts for most of the DIFF lines, including the `306` cases
above.

carve-php escapes `<` in Markdown link text where the other two do not. On
`313-a-reference-link-s-text-survives-its-own-frame`:

```
a [t</#}>][r] b

[r]: /u
```

carve-js and carve-rs:

```
a [t</#}>](/u) b
```

carve-php:

```
a [t\</#}>](/u) b
```

Neither belongs in this repo, and neither is an allowlist candidate.

## Gates

`gate-run` on this worktree returned `green`, no unrunnable gates. Run directly
against the four built engines: `ast:check` exits 0 (without the require-all
flag, for the reason above), `claims:check` 10/10, `degradation:check` 7/7 in
all three engines, `fmt:check` 29/29 in all three.
