### PR TITLE
fix: the value declaration drops two divergences the engines fixed

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -37,10 +37,26 @@
 #   text.value  declared 1 document, measured 0. carve-php kept the trailing
 #               space on a caption line; fixed under carve#963.
 #
+# EMPTY AGAIN, and re-measured the same way. The two lines added on 2026-08-14
+# by markup-carve/carve#1218 were deleted on the `AST conformance` run
+# 31876260970, over 1006 corpus documents plus 3 synthetic samples, against
+# carve-js de67c1f, carve-rs 810fb80 and carve-php 34f8d9a, each checked out
+# and built from main by that run:
+#
+#   footnote_ref.number     declared 2 documents, measured 0.
+#   inline_footnote.number  declared 1 document, measured 0.
+#
+# Both described one carve-php defect - a number published on a footnote inside
+# an UNRESOLVED reference link, which markup-carve/carve#1198 ruled gets none -
+# and markup-carve/carve-php#1270 dropped the field. The run reported both as
+# `FIXED ... no longer diverges`, which is the direction this file's header
+# promises and the reason it fails until the lines go.
+#
 # WHAT AN EMPTY FILE DOES NOT MEAN. It says the three agree on every scalar in
-# 870 documents, and the corpus is what it can say. A shape the corpus does not
-# hold is a shape this file has never measured - so deleting a line is evidence
-# about the corpus, not a certificate about the engines.
+# the 1009 samples the run above measured, and the corpus is what it can say. A
+# shape the corpus does not hold is a shape this file has never measured - so
+# deleting a line is evidence about the corpus, not a certificate about the
+# engines.
 #
 # Measured off-corpus while emptying it: in a collapsed reference whose label
 # holds `/emphasis/`, a `\_` escape, a `:symbol:` shortcode or a nested link,
@@ -49,7 +65,3 @@
 # and those four shapes change the HTML too - carve-php leaves the reference
 # unresolved, or slugs the heading differently - so they are ordinary corpus
 # conformance, owed a fixture rather than a line (markup-carve/carve#1011).
-
-
-footnote_ref.number     2  carve-php publishes a number on a footnote reference written inside an UNRESOLVED reference link; carve-js and carve-rs publish none. markup-carve/carve#1198 ruled that such a reference does not count as a reference, so it gets no number, no endnote and no backlink. carve-php shipped the render half (markup-carve/carve-php#1257 - the HTML is identical in all three engines, which is why the corpus gate cannot see this) and left the serialized number behind. Tracked at markup-carve/carve-php#1269; delete on the release that drops the field.
-inline_footnote.number  1  Same ruling, same engine, the inline half: carve-php publishes a number on an inline note written inside an unresolved reference link. Delete with the line above.


### PR DESCRIPTION
`resources/ast-value-divergence.txt` fails in both directions by design, so a line naming a field that no longer diverges fails the scheduled `AST conformance` job exactly like an undeclared one does. The two lines the file carried, added by markup-carve/carve#1218, are now in that state: they described a single carve-php defect, a number published on a footnote written inside an unresolved reference link, and markup-carve/carve-php#1270 dropped the field.

## What the run measured

`npm run ast:check` needs three built engine checkouts and could not run here, so the measurement comes from the gate that consults this file: `AST conformance` run 31876260970 on `main`, over 1006 corpus documents plus 3 synthetic samples, against carve-js `de67c1f`, carve-rs `810fb80` and carve-php `34f8d9a`, each checked out and built from its own main by that run.

Its `PART 12 conformance` step:

```
THREE-WAY SHAPE COMPARISON (1009 documents, 1009 unanimous)
  no engine stood alone.

THREE-WAY VALUE COMPARISON: the engines publish the same values everywhere.
  resources/ast-value-divergence.txt declares nothing that still diverges.

THREE-WAY SPAN COMPARISON: the engines place every node identically (20199 span(s) compared).
```

and its verdict on this file:

```
THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:
  FIXED      footnote_ref.number no longer diverges - delete its line
  FIXED      inline_footnote.number no longer diverges - delete its line
```

Those two lines were the whole of that step's failure. Nothing else in it drifted, and `BINDING PARITY: carve-rb's tree matches carve-rs on all 1009 shared document(s)` now holds, so the value comparison ran rather than being masked.

## Any other stale line

No. The file declared exactly two fields and the run reports both as fixed, which leaves it with no declarations at all. The neighboring `resources/ast-span-divergence.txt` is comment-only and the span comparison found nothing, so it is not stale either. The engine work that landed today shows up elsewhere: markup-carve/carve-rb#64 cleared the binding parity block, and markup-carve/carve-js#1076 with markup-carve/carve-php#1271 took the markdown trailing-space diffs down to 4, which is a different step and not declared in this file.

## The check is load-bearing in both directions

The FIXED direction fired for real: run 31876260970 is `main` with these lines still present, which is the same state as re-adding a deleted line, and it failed with the two `FIXED` problems quoted above.

Reproduced locally through `reconcileDeclared`, the function the gate calls, fed the map that run measured:

```
--- branch as it ships, measured map from run 31876260970 (empty)
  (no problems)
--- with footnote_ref.number put back
  FIXED      footnote_ref.number no longer diverges - delete its line
--- with footnote_ref.number diverging again and undeclared
  NEW        footnote_ref.number diverges in 2 document(s) and is not declared
```

The NEW case is stated the way it is because after this deletion no line legitimately stands: the file declares nothing and the run measures nothing, so there is no standing line left to remove. The state that removing one produces, a field diverging and undeclared, is presented directly, at the document count the deleted line itself declared.

No allowlist entry was added. An allowlist would silence the ratchet whether or not the engines are right, which is the failure catalogued at markup-carve/carve#755.

## Gates that could not run here

`gate-run` reports `partial`, with `failed` empty. Seven gates ran clean: `npm test`, `npm run combinatorial:check`, `npm run core:check`, `npm run html-import:check`, `npm run links:check`, `npm run property:check`, `npm run test:conformance`. Four could not run, verbatim:

- `npm run ast:check`: `a dependency outside the repository is missing: /tmp/carve-js/dist`
- `npm run claims:check`: `engine-claims: need all three engines, found 0 (none).`
- `npm run degradation:check`: `degradation-claims: need all three engines, found 0 (none).`
- `npm run fmt:check`: `fmt-fixture-claims: need all three engines, found 0 (none).`

Every one of them wants built engine checkouts, which is what run 31876260970 provisions and why the measurement above comes from there.

The header records this second emptying the way it records the first, naming the run and the three builds behind it, so the next reader can tell what the empty file is evidence about. The corpus size in the paragraph below moves with it, since that sentence quantifies over the run that certified the file empty.

A fresh `AST conformance` run is dispatched after this merges, and markup-carve/carve#1147 is maintained by that workflow rather than by hand.
