### PR TITLE
chore: move the engine pin past composite figures, and clear the drift file

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -114,6 +114,11 @@ the command-line and editor behavior stay aligned.
 | `semantic-attribute-outside-span` | a reserved semantic name used where PART 9 §9 does not apply - a code span, link, image, block-attribute line or table row - where it stays an ordinary attribute, so `` `c`{kbd} `` is `<code kbd="">` rather than a `<kbd>`; `cite` on a block quote is exempt, see [semantic span attribute rules](#semantic-span-attribute-rules) |
 | `platform-mention-token` | an at-prefixed word in text the document publishes, which a host platform re-linkifies into a user mention; opt-in and off by default, see [platform autolink rules](#platform-autolink-rules) |
 | `platform-issue-reference` | a hash-number in text the document publishes, which a host platform re-linkifies into an issue reference; opt-in and off by default, see [platform autolink rules](#platform-autolink-rules) |
+| `figure-group-nested` | a `::: figure` opener inside a composite figure's body; nesting is rejected (PART 9 §4c), so the inner fence stays a generic container |
+| `figure-group-opener-metadata` | a `::: figure` opener carrying a quoted title or `[label]`; the figure production takes neither, so the fence stays a generic container with both preserved (PART 9 §4c) |
+| `figure-group-panel-number` | a `#` placeholder in a PANEL caption; panels are not sequence units, so the placeholder stays a literal `#` (PART 9 §4c) - number the group caption instead |
+| `figure-group-empty` | a `::: figure` group with no captionable panel; the panels wrapper renders around the preserved content only (PART 9 §4c) |
+| `figure-group-single-panel` | a `::: figure` group holding a single panel; a plain captioned figure renders the same content without the group wrapper (PART 9 §4c) |
 
 ### Declaring a target version
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#f05f3a7622e55f8b90f0b8c60e44feae4066eeee",
+        "@markup-carve/carve": "github:markup-carve/carve-js#456ce0743b905f1c409d78b02baacaeddd79ac9c",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -985,8 +985,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#f05f3a7622e55f8b90f0b8c60e44feae4066eeee",
-      "integrity": "sha512-BH+0cYS4/1giX5JCHNygvdqo3/M3HaX81BW+YYJOToa1QLZE7TT08+K+zgznmb1CHofzZrFArEic0vIPRdjxfA==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#456ce0743b905f1c409d78b02baacaeddd79ac9c",
+      "integrity": "sha512-e6rhv7s0Y8sJhpaDinE6hICSlShehFeqnNKG06rN95VeyMQ9G2sMxdbhBdxPMn7PVRLKYttEg0xAF5dU+PkCGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#f05f3a7622e55f8b90f0b8c60e44feae4066eeee",
+    "@markup-carve/carve": "github:markup-carve/carve-js#456ce0743b905f1c409d78b02baacaeddd79ac9c",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,30 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-
-# PART 9 §4b (carve#1213): a captioned quote is a FIGURE again. The pinned
-# build carries the withdrawn carve#1161 shape and renders
-# `<blockquote><footer>`. Clears with the engine reverts and a pin bump.
-05-lists-20  A captioned quote renders `<figure><figcaption>`; the pin renders `<blockquote><footer>`.
-07-blockquote-with-attribution  A captioned quote renders `<figure><figcaption>`; the pin renders `<blockquote><footer>`.
-55-blockquote-caption-after-a-blank-line  A captioned quote renders `<figure><figcaption>`; the pin renders `<blockquote><footer>`.
-282-two-blank-lines-detach-a-caption-5  A captioned quote renders `<figure><figcaption>`; the pin renders `<blockquote><footer>`.
-306-a-captioned-quote-holds-more-than-one-block  A captioned quote renders `<figure><figcaption>`; the pin renders `<blockquote><footer>`.
-306-a-captioned-quote-holds-more-than-one-block-2  A captioned quote renders `<figure><figcaption>`; the pin renders `<blockquote><footer>`.
-306-a-captioned-quote-holds-more-than-one-block-3  A captioned quote renders `<figure><figcaption>`; the pin renders `<blockquote><footer>`.
-306-a-captioned-quote-holds-more-than-one-block-4  A captioned quote renders `<figure><figcaption>`; the pin renders `<blockquote><footer>`.
-306-a-captioned-quote-holds-more-than-one-block-5  A captioned quote renders `<figure><figcaption>`; the pin renders `<blockquote><footer>`.
-
-# PART 9 §4c composite figures (carve#1122): the pinned carve-js predates the
-# `::: figure` captionable host, so it renders these as a generic container
-# with a literal `^ ` paragraph. The engine PRs ship the host; the next pin
-# bump empties these entries.
-318-composite-figures  PART 9 §4c composite figures; pinned carve-js predates the host
-318-composite-figures-2  PART 9 §4c composite figures; pinned carve-js predates the host
-318-composite-figures-3  PART 9 §4c composite figures; pinned carve-js predates the host
-318-composite-figures-4  PART 9 §4c composite figures; pinned carve-js predates the host
-318-composite-figures-5  PART 9 §4c composite figures; pinned carve-js predates the host
-318-composite-figures-6  PART 9 §4c composite figures; pinned carve-js predates the host
-318-composite-figures-9  PART 9 §4c composite figures; pinned carve-js predates the host
-318-composite-figures-10  PART 9 §4c composite figures; pinned carve-js predates the host
-318-composite-figures-11  PART 9 §4c composite figures; pinned carve-js predates the host

--- a/tests/ast-schema.test.mjs
+++ b/tests/ast-schema.test.mjs
@@ -247,24 +247,7 @@ test('the corpus is non-trivial', () => {
  * that starts validating again has to leave this list in the commit that bumps
  * the pin, or the list becomes a blanket excuse with no expiry.
  */
-const SCHEMA_ROLLOUT_PENDING = new Map([
-  [
-    '05-lists-20.crv',
-    'PART 9 §4b: a captioned quote is a `figure` whose target is the quote; the pin still emits a `block_quote` carrying an `attribution`, the shape carve#1213 withdraws (carve#1161)',
-  ],
-  ['07-blockquote-with-attribution.crv', 'as 05-lists-20.crv'],
-  ['55-blockquote-caption-after-a-blank-line.crv', 'as 05-lists-20.crv'],
-  ['282-two-blank-lines-detach-a-caption-5.crv', 'as 05-lists-20.crv'],
-  ['306-a-captioned-quote-holds-more-than-one-block.crv', 'as 05-lists-20.crv'],
-  ['306-a-captioned-quote-holds-more-than-one-block-2.crv', 'as 05-lists-20.crv'],
-  ['306-a-captioned-quote-holds-more-than-one-block-3.crv', 'as 05-lists-20.crv'],
-  ['306-a-captioned-quote-holds-more-than-one-block-4.crv', 'as 05-lists-20.crv'],
-  ['306-a-captioned-quote-holds-more-than-one-block-5.crv', 'as 05-lists-20.crv'],
-  [
-    '318-composite-figures-10.crv',
-    'as 05-lists-20.crv - the captioned quote panel inside the group hits the same withdrawn attribution shape on the pin',
-  ],
-])
+const SCHEMA_ROLLOUT_PENDING = new Map([])
 
 test('every corpus document serializes to a schema-valid AST', () => {
   const failures = []
@@ -313,7 +296,6 @@ test('every node type the reference emits is declared in the schema', () => {
  */
 const NOT_PRODUCIBLE = {
   citation_group: 'citations (Tier-2) - off in a default-profile run, exercised by tests/corpus-optional',
-  figure_group: 'pinned engine predates PART 9 §4c composite figures; produced after the next pin bump',
 }
 
 test('every node type the schema declares is produced by a corpus document, or named as unproducible', () => {

--- a/tests/examples/demo.html
+++ b/tests/examples/demo.html
@@ -89,10 +89,10 @@ email autolink <a href="mailto:hello@example.com">hello@example.com</a>, and a r
   </section>
   <section id="Blockquotes">
     <h2>Blockquotes</h2>
-    <blockquote>
-      <p>The best way to predict the future is to invent it.</p>
-      <footer>Alan Kay</footer>
-    </blockquote>
+    <figure>
+      <blockquote><p>The best way to predict the future is to invent it.</p></blockquote>
+      <figcaption>Alan Kay</figcaption>
+    </figure>
   </section>
   <section id="Tables">
     <h2>Tables</h2>

--- a/tests/lint-rule-table-claims.test.mjs
+++ b/tests/lint-rule-table-claims.test.mjs
@@ -71,6 +71,11 @@ const TRIGGERS = {
   'fence-delimiter-indentation': '  ```\n  x\n  ```\n',
   'carve-version-unsupported': '---\ncarve-version: 99.0\n---\n\nx\n',
   'unclosed-container-fence': '::: note\nbody\n',
+  'figure-group-nested': ':::: figure\n::: figure\n![a](a.png)\n^ (a) A\n:::\n::::\n^ Figure #: G\n',
+  'figure-group-opener-metadata': '::: figure "Title"\n![a](a.png)\n^ (a) A\n:::\n',
+  'figure-group-panel-number': '::: figure\n![a](a.png)\n^ Figure #: panel\n:::\n^ Figure #: G\n',
+  'figure-group-empty': '::: figure\njust a paragraph\n:::\n^ Figure #: G\n',
+  'figure-group-single-panel': '::: figure\n![a](a.png)\n^ (a) A\n:::\n^ Figure #: G\n',
   'fence-title-syntax': '::: note Some Title\nbody\n:::\n',
   'platform-mention-token': {
     source: 'Use @minutely for that cron alias.\n',

--- a/tests/schema-fields-are-produced.test.mjs
+++ b/tests/schema-fields-are-produced.test.mjs
@@ -57,7 +57,6 @@ const repo = resolve(here, '..')
 const OPT_IN_ONLY = {
   'citation.*': 'citations (Tier-2): the citation item shape, including its resolution results',
   'citation_group.*': 'citations (Tier-2): the group wrapper and the integral `+` form',
-  'figure_group.*': 'composite figures (PART 9 §4c): the pinned engine predates the host; produced after the next pin bump',
 }
 
 /** Fields permitted by the schema before the corresponding engine rollout. */


### PR DESCRIPTION
Moves the carve-js pin to `456ce074` (the merged markup-carve/carve-js#1073) and empties `resources/engine-pin-drift.txt` - all 18 declared entries reproduce on the new build.

Pin-coupled bookkeeping in the same commit: drops the `SCHEMA_ROLLOUT_PENDING` slugs and the `figure_group` unproducible/opt-in exemptions (all now produced), documents the five `figure-group-*` lint rules in `docs/validation.md` with trigger samples, and refreshes the demo snapshot to the captioned-quote figure shape from #1213.

Closes the composite-figures rollout for this repo: #1122's spec landed in #1215, this reconciles the pin.