### PR TITLE
docs: the release process counts every field that states the version

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,10 +18,26 @@ release goes in dependency order so the engines pin a released spec.
 For each repo, on `main`, with the spec submodule (if any) already advanced and
 CI green:
 
-1. **Bump the version field** to the target:
-   - `carve`, `carve-js`, `tree-sitter-carve`: `package.json` `"version"`
-   - `carve-rs`: `Cargo.toml` `version`
-   - `carve-php`: none - the version is derived from the git tag (Packagist)
+1. **Bump every field that states the version.** Three repos state it TWICE, and
+   this list named only the manifests until `markup-carve/carve-js#1074`: an
+   outside embedder found three published releases whose exported constant still
+   read `0.1.0`, because the constant was not on any checklist.
+
+   - `carve`, `tree-sitter-carve`: `package.json` `"version"`
+   - `carve-js`: `package.json` `"version"` AND `src/version.ts` `LIB_VERSION`
+   - `carve-rs`: `Cargo.toml` `version` (no separate constant; the build reports
+     `CARGO_PKG_VERSION`)
+   - `carve-php`: no manifest field - the version is derived from the git tag
+     (Packagist) - BUT `src/CarveConverter.php` `LIB_VERSION` must be set to the
+     target
+   - `carve-rb`: `lib/carve/version.rb` `VERSION` AND `ext/carve/Cargo.toml`
+     `version`
+   - `carve-py`: `pyproject.toml` `[project] version` AND `Cargo.toml`
+     `[package] version` - the second is what `carve.__version__` reports
+   - `carve-lsp`, `carve-wasm`: `package.json` / `Cargo.toml` `version`
+
+   "No manifest field" is not "nothing to bump": carve-php is the repo where
+   that reading is most tempting and most wrong.
 2. **Reconcile the CHANGELOG.** Make sure `## [Unreleased]` covers everything in
    the `lastTag..main` range (the draft release notes are the source of truth for
    scope), then cut it to `## [X.Y.Z] - YYYY-MM-DD` and open a fresh empty
@@ -109,6 +125,30 @@ The publish step is gated so a mistake cannot ship the wrong version:
 - **tree-sitter-carve**: no automated publish workflow; publish manually and run
   the pre-tag check first.
 
+A second layer guards the constants, which no publish workflow used to read.
+Each of these fails on every push, not only at tag time, so a missed bump
+surfaces in the PR that missed it:
+
+- **carve-js**: `test/the-lib-version-constant-tracks-the-package-version.test.ts`
+  ties `LIB_VERSION` to `package.json`.
+- **carve-php**: `tests/TestCase/ReleaseVersionTest.php` - the only version
+  check this repo has, since Packagist derives the version from the tag and
+  nothing else compares the constant to anything.
+- **carve-rs**: `tests/the_version_a_build_reports_is_the_one_that_shipped.rs`.
+- **carve-rb**: `test/release_version_test.rb`, plus a tag guard in
+  `.github/workflows/release.yml` that refuses to publish a gem whose
+  `Carve::VERSION` is not the tag.
+- **carve-py**: `.github/workflows/release.yml` has a tag guard, and it reads
+  `pyproject.toml` ONLY. `Cargo.toml` carries the version `carve.__version__`
+  actually reports, and no guard compares it to the tag; widening it, and the
+  matching `tests/test_release_version.py`, is open in
+  `markup-carve/carve-py#39`. Until that merges, check the second manifest by
+  hand.
+- **carve-wasm**: NO version guard on its publish workflow. `release.yml`
+  publishes to npm on any `v*` tag with no tag-versus-`Cargo.toml` comparison,
+  which is the one place in the org where a mistyped tag reaches a registry
+  unopposed. Run the pre-tag check by hand before tagging it.
+
 ## Never
 
 - Never tag before `pre-tag-check.sh` passes.
@@ -117,3 +157,10 @@ The publish step is gated so a mistake cannot ship the wrong version:
 - Never publish a version whose field or changelog does not match the tag.
 - Never bump a version field except as part of a release (version numbers are
   release artifacts, not commit counters).
+- Never leave a comment saying a version constant is kept in sync on release.
+  That sentence is what let carve-js publish three releases whose exported
+  constant read `0.1.0` (`markup-carve/carve-js#1074`, found by an outside
+  embedder rather than by CI): the comment described an intention, every reader
+  believed it, and nothing executed it. Point at the check instead - name the
+  test or the workflow step that fails when the two disagree - so a reader can
+  go see whether it still runs.

--- a/scripts/pre-tag-check.sh
+++ b/scripts/pre-tag-check.sh
@@ -74,8 +74,57 @@ elif [ -f Cargo.toml ]; then
   V="$(grep -m1 -E '^version[[:space:]]*=' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
   [ "$V" = "$VERSION" ] && ok "Cargo.toml version = $VERSION" \
     || bad "Cargo.toml version is '$V', expected $VERSION"
+  # A repo may carry BOTH, and the chain above stops at the first match. carve-py
+  # is that repo: `Cargo.toml` is what `carve.__version__` reports and
+  # `pyproject.toml` is what the tag guard in its release workflow reads, so
+  # checking only one leaves the other free to disagree with the tag. Additive,
+  # so a Rust-only repo is unaffected.
+  if [ -f pyproject.toml ]; then
+    PV="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' pyproject.toml | head -1)"
+    [ "$PV" = "$VERSION" ] && ok "pyproject.toml version = $VERSION" \
+      || bad "pyproject.toml version is '$PV', expected $VERSION"
+  fi
 else
   skip "no package.json/Cargo.toml version field (tag-derived, e.g. Packagist)"
+fi
+
+# 4b. Constants that state the version a SECOND time.
+#
+# Step 4 reads the manifest, and three repos also compile the version into a
+# constant an embedder can read back. Nothing here gated those, and carve-js
+# published three releases whose `LIB_VERSION` still said 0.1.0 before an
+# outside embedder noticed (markup-carve/carve-js#1074). carve-php is the sharper
+# case: it has no manifest field at all, so step 4 SKIPS it entirely and this is
+# the only version check the repo gets before a Packagist webhook publishes the
+# tag.
+#
+# Detected by file and extracted per file, deliberately not through one shared
+# pattern. A `\(LIB_VERSION\|VERSION\)` alternation looks tidier and is wrong:
+# `src/version.ts` declares `SPEC_VERSION` above `LIB_VERSION`, the alternation
+# matches the `VERSION` inside `SPEC_VERSION` on the earlier line, and the check
+# then compares the SPEC version ('0.1') against the release target and fails
+# for a reason that has nothing to do with the release.
+CONST_FILE=""
+CONST_VALUE=""
+if [ -f src/version.ts ]; then
+  CONST_FILE="src/version.ts"
+  CONST_VALUE="$(sed -n "s/.*LIB_VERSION[^'\"]*['\"]\([^'\"]*\)['\"].*/\1/p" src/version.ts | head -1)"
+elif [ -f src/CarveConverter.php ]; then
+  CONST_FILE="src/CarveConverter.php"
+  CONST_VALUE="$(sed -n "s/.*LIB_VERSION[^'\"]*['\"]\([^'\"]*\)['\"].*/\1/p" src/CarveConverter.php | head -1)"
+elif [ -f lib/carve/version.rb ]; then
+  CONST_FILE="lib/carve/version.rb"
+  CONST_VALUE="$(sed -n 's/.*VERSION[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' lib/carve/version.rb | head -1)"
+fi
+
+if [ -z "$CONST_FILE" ]; then
+  skip "no version constant file (carve-rs reports CARGO_PKG_VERSION; carve, tree-sitter-carve state it once)"
+elif [ "$CONST_VALUE" = "$VERSION" ]; then
+  ok "$CONST_FILE states $VERSION"
+else
+  # Name BOTH values. "does not match" sends the reader to open two files and
+  # diff them by eye, which is the same manual step this check exists to remove.
+  bad "$CONST_FILE states '$CONST_VALUE', expected $VERSION"
 fi
 
 # 5. Changelog has a cut section for the version (not just [Unreleased]).

--- a/scripts/pre-tag-check.sh
+++ b/scripts/pre-tag-check.sh
@@ -88,6 +88,19 @@ else
   skip "no package.json/Cargo.toml version field (tag-derived, e.g. Packagist)"
 fi
 
+# 4a. A native extension's manifest, which the chain above cannot reach.
+#
+# carve-rb has no ROOT manifest of either kind - its crate lives at
+# ext/carve/Cargo.toml - so the chain takes its `else` and skips, and the gem
+# would ship a stale extension version with nothing objecting. Checked outside
+# the chain rather than inside it, so a repo carrying both a root manifest and a
+# nested one gets both.
+if [ -f ext/carve/Cargo.toml ]; then
+  EV="$(grep -m1 -E '^version[[:space:]]*=' ext/carve/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+  [ "$EV" = "$VERSION" ] && ok "ext/carve/Cargo.toml version = $VERSION" \
+    || bad "ext/carve/Cargo.toml version is '$EV', expected $VERSION"
+fi
+
 # 4b. Constants that state the version a SECOND time.
 #
 # Step 4 reads the manifest, and three repos also compile the version into a


### PR DESCRIPTION
Two defects in the release PROCESS, not only in a release. A sibling audit of
the version constant across every implementation turned them up; every claim
below was re-verified against the live file on each repo's `main` before it was
written down.

## The checklist named manifests, and three repos state the version twice

`RELEASING.md` step 1 listed one field per repo. carve-js published three
releases whose exported `LIB_VERSION` still read `0.1.0` because the constant
was on no checklist and no workflow read it, and an outside embedder found it
rather than CI (`markup-carve/carve-js#1074`).

carve-php is the sharper case. Its entry said "none - the version is derived
from the git tag", which reads as "nothing to bump", while
`src/CarveConverter.php` carries a `LIB_VERSION` that ships to every install.

The list now spans every repo that has a version field, with the fields it
actually has: carve-js and carve-php's constants, carve-rb's `VERSION` plus its
extension crate, carve-py's two manifests, and carve-lsp and carve-wasm.

## The Guards section described only the publish workflows

It now also names the per-push checks that gate the constants
(`ReleaseVersionTest.php`, `the_version_a_build_reports_is_the_one_that_shipped.rs`,
`release_version_test.rb`, `the-lib-version-constant-tracks-the-package-version.test.ts`)
and records two holes found while checking that each one exists:

- **carve-py's tag guard reads `pyproject.toml` only.** `Cargo.toml` is the
  manifest `carve.__version__` reports, and nothing compares it to the tag.
  Widening it, and the `tests/test_release_version.py` that goes with it, is
  open and unmerged in `markup-carve/carve-py#39` - the audit's note that this
  had landed was one PR ahead of `main`, so the page says "check the second
  manifest by hand until that merges" rather than describing a guard that is
  not there.
- **carve-wasm has no version guard at all.** `release.yml` publishes to npm on
  any `v*` tag with no tag-versus-`Cargo.toml` comparison, unlike every sibling.
  That is the one place in the org where a mistyped tag reaches a registry
  unopposed.

The Never section gains the sentence that caused all of this: never leave a
comment saying a version constant is kept in sync on release. It described an
intention nothing executed, every reader believed it, and three releases went
out. Point at the check instead.

## `scripts/pre-tag-check.sh`

**Step 4b, the constants.** Step 4 reads the manifest and is blind to a
constant stating the version a second time. Detected by file and extracted per
file. A shared `\(LIB_VERSION\|VERSION\)` alternation is shorter and wrong, and
this is what it does to the real `src/version.ts`:

```
$ sed -n "s/.*LIB_VERSION[^'\"]*['\"]\([^'\"]*\)['\"].*/\1/p" src/version.ts | head -1
0.1.3
$ sed -n "s/.*\(LIB_VERSION\|VERSION\)[^'\"]*['\"]\([^'\"]*\)['\"].*/\2/p" src/version.ts | head -1
0.1
```

It matches `SPEC_VERSION` on the earlier line and compares the SPEC version
against the release target. Each extraction below was run against the live file
fetched from its repo's `main`:

| file | extraction | value |
|---|---|---|
| carve-js `src/version.ts` | `LIB_VERSION` | `0.1.3` |
| carve-php `src/CarveConverter.php` | `LIB_VERSION` | `0.1.4` |
| carve-rb `lib/carve/version.rb` | `VERSION` | `0.1.0` |

`ok` on equality, `bad` naming BOTH values otherwise, `skip` only when none of
the three files exists.

**Step 4's manifest chain stopped at the first match.** It is `package.json`,
`elif Cargo.toml`, `else skip`. carve-py has `Cargo.toml` AND `pyproject.toml`,
so the chain stopped at the first and never reached the second. The `Cargo.toml`
branch now additionally requires `pyproject.toml` to equal the target when that
file is present.

**A third hole, found by review.** The same chain skips carve-rb entirely: it
has no root manifest of either kind, because its crate lives at
`ext/carve/Cargo.toml`. So the checklist above would have required a field the
check took the `else` branch past. Checked outside the chain, so a repo with
both a root and a nested manifest gets both.

## The check fails, in each direction

A check that only ever passes is the defect being fixed, so each shape was run
both ways against fixture repos built from the REAL files fetched from each
repo's `main`.

carve-js shape, target equal to the constant, then one ahead of it:

```
  [ok]   package.json version = 0.1.3
  [ok]   src/version.ts states 0.1.3
PRE-TAG CHECK PASSED - ready to tag 0.1.3.
exit=0

  [FAIL] package.json version is '0.1.3', expected 0.1.4
  [FAIL] src/version.ts states '0.1.3', expected 0.1.4
PRE-TAG CHECK FAILED - do not tag 0.1.4 yet.
exit=1
```

carve-php shape, where step 4 skips and 4b is the only version check the repo
gets before a Packagist webhook publishes the tag:

```
  [skip] no package.json/Cargo.toml version field (tag-derived, e.g. Packagist)
  [ok]   src/CarveConverter.php states 0.1.4
PRE-TAG CHECK PASSED - ready to tag 0.1.4.
exit=0

  [skip] no package.json/Cargo.toml version field (tag-derived, e.g. Packagist)
  [FAIL] src/CarveConverter.php states '0.1.4', expected 0.1.5
PRE-TAG CHECK FAILED - do not tag 0.1.5 yet.
exit=1
```

carve-py shape, with `Cargo.toml` bumped and `pyproject.toml` left behind:

```
  [ok]   Cargo.toml version = 0.1.2
  [FAIL] pyproject.toml version is '0.1.1', expected 0.1.2
PRE-TAG CHECK FAILED - do not tag 0.1.2 yet.
exit=1
```

carve-rb shape, no root manifest, nested crate:

```
  [skip] no package.json/Cargo.toml version field (tag-derived, e.g. Packagist)
  [ok]   ext/carve/Cargo.toml version = 0.1.0
  [ok]   lib/carve/version.rb states 0.1.0
exit=0

  [skip] no package.json/Cargo.toml version field (tag-derived, e.g. Packagist)
  [FAIL] ext/carve/Cargo.toml version is '0.1.0', expected 0.1.1
  [FAIL] lib/carve/version.rb states '0.1.0', expected 0.1.1
exit=1
```

And the same two fixtures through the script as it stands on `main`, which is
what "this was passing" means concretely:

```
$ pre-tag-check.sh 0.1.5 <carve-php shape>     # constant says 0.1.4
  [skip] no package.json/Cargo.toml version field (tag-derived, e.g. Packagist)
PRE-TAG CHECK PASSED - ready to tag 0.1.5.
exit=0

$ pre-tag-check.sh 0.1.2 <carve-py shape>      # pyproject.toml says 0.1.1
  [ok]   Cargo.toml version = 0.1.2
PRE-TAG CHECK PASSED - ready to tag 0.1.2.
exit=0
```

## What ran and what could not

`gate-run` returned `partial`, `failed: []`, with these seven green: `npm test`,
`npm run combinatorial:check`, `npm run core:check`,
`npm run html-import:check`, `npm run links:check`, `npm run property:check`,
`npm run test:conformance`. `npm run docs:build` and `npm run lint:mermaid`
were run separately, since CI runs them and gate detection does not; both exit
0. Re-run after rebasing onto the current `main`, not only before.

Four gates could not run here, all because this checkout has no engine builds
beside it:

- `npm run ast:check` - `a dependency outside the repository is missing: /tmp/carve-js/dist`
- `npm run claims:check` - `engine-claims: need all three engines, found 0 (none).`
- `npm run degradation:check` - `degradation-claims: need all three engines, found 0 (none).`
- `npm run fmt:check` - `fmt-fixture-claims: need all three engines, found 0 (none).`

No version field is touched anywhere in this change; it only adds checks and
documents fields.
