### PR TITLE
spec: name the diagnostic for an encoding the source never declared

### DIFF
--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -97,7 +97,19 @@ lossy decision should be observable. The common diagnostic codes are:
   no spelling for, so it survives in the AST and not in written Carve. The
   AST-returning entry point loses nothing and reports nothing; the one that
   writes source reports this.
+- `encoding-assumed`: the source did not declare how to read a value, and the
+  importer assumed an encoding to map it. An importer MUST emit this whenever
+  the node it produced is only correct if that assumption holds. The motivating
+  case is `<math alttext="...">` with no `<annotation encoding="...">`: MathML
+  never says what `alttext` contains, so reading it as TeX is a guess, and the
+  math node may hold something that is not TeX at all.
 - `diagnostics-truncated`: the diagnostic cap was reached.
+
+`encoding-assumed` is deliberately not filed under `element-unwrapped`.
+Unwrapping is a note about the input's structure and loses no meaning;
+an assumed encoding is a warning about the output. A consumer told only that an
+element is gone cannot tell a harmless structural event from content that may
+be in the wrong language entirely, and that is the one signal it could act on.
 
 Diagnostics have `code`, `message`, `severity` (`info`, `warning`, or `error`),
 and optional `path`, `line`, and `column`. Their order follows document order.

--- a/resources/html-import-schema.json
+++ b/resources/html-import-schema.json
@@ -15,7 +15,7 @@
         "required": ["code", "message", "severity"],
         "additionalProperties": false,
         "properties": {
-          "code": { "enum": ["element-dropped", "element-unwrapped", "attribute-dropped", "style-unmapped", "table-degraded", "raw-preserved", "structure-unspellable", "diagnostics-truncated"] },
+          "code": { "enum": ["element-dropped", "element-unwrapped", "attribute-dropped", "style-unmapped", "table-degraded", "raw-preserved", "structure-unspellable", "encoding-assumed", "diagnostics-truncated"] },
           "message": { "type": "string" },
           "severity": { "enum": ["info", "warning", "error"] },
           "path": { "type": "string" },


### PR DESCRIPTION
`resources/html-import-schema.json` closed `diagnostics[].code` at eight values
with `additionalProperties: false`. An importer that reads a value whose
encoding the source never declared had no code for saying so, so it filed the
event under `element-unwrapped`, which is what all three engines do today
(markup-carve/carve-php#1301, titled for exactly that constraint: the MathML
alttext diagnostic uses a code the spec admits).

## The name

`encoding-assumed` follows the enum's existing `<subject>-<participle>` shape
and names the condition - a value was read under an encoding nobody declared -
rather than the construct that motivated it. Nothing here is specific to math:
any format that carries a value without stating how to read it produces the
same event, and a code named after MathML would need widening again the first
time another one does.

## Why not reuse `element-unwrapped`

`element-unwrapped` is what an importer says when it replaced a `<span>` by its
children: a structural note about the input, lossless in meaning. An assumed
encoding is a correctness warning about the OUTPUT - the node produced is only
right if the guess was right. A consumer receiving `element-unwrapped` at
`info` cannot tell "an element is gone, harmlessly" from "the content I
produced may be in the wrong language entirely", and the second is the only one
it could act on. Collapsing them discards that signal.

The motivating case is MathML tier 2: `<math alttext="...">` with no
`<annotation encoding="...">`. MathML never declares what `alttext` contains,
so an importer that reads it as TeX is guessing, and the math node may hold
something that is not TeX.

## What changed

- `resources/html-import-schema.json`: the code added to the enum, between
  `structure-unspellable` and `diagnostics-truncated` - the same slot the last
  widening used.
- `docs/html-import.md`: the code documented in the diagnostic list with the
  condition that makes emitting it mandatory, plus a short paragraph on why it
  is not `element-unwrapped`, since that is the question a reader arrives with.

Those are the only two homes. Grepping every existing code name
(`structure-unspellable`, `style-unmapped`, `table-degraded`, `raw-preserved`,
`diagnostics-truncated`) finds no third file that documents the set.

## Nothing pinned the eight-value set

Worth stating plainly, because it is a check that cannot fail.
`tests/html-import-contract.check.mjs` asserts that every fixture's code is IN
the enum - a subset check, not an equality one - and the fixtures only ever use
`element-dropped` and `attribute-dropped`. Measured rather than assumed:
deleting five of the eight codes from the enum leaves `npm test` with its exact
baseline failure set and `html-import:check` at exit 0. The enum is prose that
happens to live in a JSON file; the repo does not hold it to anything.

I have not added a pin. Equality-pinning the enum here would only restate the
schema, and the thing worth pinning - that an engine emits the right code for
the right condition - lives in the engines and their fixtures, not here.

## No CHANGELOG entry

Matching precedent and the release baseline. The whole html-import contract is
post-0.1.2: `resources/html-import-schema.json` was introduced by
markup-carve/carve#1098 after the tag, and its Unreleased entry ("The HTML
import contract is specified") already covers the code set as a whole. The
eight-value enum has never been released, so widening it breaks nothing and
needs no BC framing. The previous widening (markup-carve/carve#1216, which
added `structure-unspellable`) touched these same two files and added no
CHANGELOG entry either.

## No engine changes

Deliberately. An engine emitting `encoding-assumed` while still pinned to the
pre-widening spec would fail its own schema validation, so the engines fan out
in a separate PR once this merges.
