### PR TITLE
spec: rule the two-caption collision the wrapper clause left open

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -8844,6 +8844,18 @@ EOF = (* end of file *) ;
       changes the rendering, which is why it is written down here rather than
       left to each writer to discover.
 
+      THE TARGET'S OWN CAPTION SLOT MAY ALREADY BE FULL. A `table` carries an
+      optional `caption`, so `figure{ target: table{ caption }, caption }` is a
+      schema-valid tree with TWO captions and only one `^ ` slot to write them
+      into. The wrapper's caption takes that slot only when the target has none;
+      where the target has its own, the figure's caption is LOST WITH THE
+      WRAPPER, exactly as the rest of the wrapper is, and the diagnostic above
+      covers it. A WRITER MUST NOT EMIT A SECOND `^ ` LINE for the figure's
+      caption. There is no second slot for it to land in: a `^ ` line after a
+      caption line is not a caption at all, it is an ordinary paragraph, so the
+      output would carry the caption text as literal body prose instead of
+      losing it cleanly, and the loss would stop being observable as a loss.
+
       A FIGURE GROUP'S TABLE PANEL IS NOT THIS WRAPPER. PART 9 §4c has since
       made `:::` a captionable host (carve#1122), and a reader arriving here
       will ask whether `::: figure` around a table now spells the shape. It


### PR DESCRIPTION
Split out of `markup-carve/carve#1211` so the descriptive part of that PR can land without carrying a normative decision with it.

#1211 documents that a `figure` may wrap a `table` and that no Carve source spells it. This is the case that clause left open, and it is normative rather than descriptive, which is why it is separated.

### The collision

A `table` carries an optional `caption`, so `figure{ target: table{ caption }, caption }` is a schema-valid tree with TWO captions and one `^ ` slot to write them into. The wrapper clause says the writer emits "the target and its caption" without saying whose, which is unambiguous only while the table has none.

### What happens today, measured on carve-js

With the slot free, the figure's caption fills it and the output reparses as a `table`. With the slot taken, the writer emits a second `^ ` line - and that line is not a caption. A `^ ` line following a caption line is an ordinary paragraph, so the outer caption lands in the output as literal body prose:

```html
<p>^ Outer</p>
```

That is worse than losing the wrapper. Losing the wrapper is observable through the diagnostic the clause already requires; spelling the caption as prose hides the loss inside the rendered output, where nothing reports it and a reader sees a stray line of text.

### Why this follows rather than decides

The rule is that the figure's caption is lost with the wrapper, and a writer must not emit a second `^ ` line. That is what the clause already says applied one step further: the wrapper is lost, the figure's caption is part of the wrapper, so it goes with it.

### The one thing worth your explicit nod

It is still a normative sentence, and **carve-js currently violates it** - that is how the behavior above was measured. Merging this creates a conformance gap that carve-js has to close. If you would rather state it as a note than as a MUST, say so and it becomes one; the argument for the behavior does not change either way.

Nothing else in the spec is touched: one 12-line addition to `resources/grammar.ebnf`, in the clause #1211 adds.
