### PR TITLE
chore: move the engine pin past the flat figure group, and clear the drift file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#f92c8150a81123d83c68882e6b2d1241e9928f7c",
+        "@markup-carve/carve": "github:markup-carve/carve-js#9c93a01d8a0974e86457da7c6a22c8f8afd8cdda",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#f92c8150a81123d83c68882e6b2d1241e9928f7c",
-      "integrity": "sha512-X0f6CCjignf4bVClPS/a2pXqUtVHr5iV8QOeZwAQQj7RgXISj+V67E5tmYVRl20pFtJNqzfKmuPK0z05mzG7+Q==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#9c93a01d8a0974e86457da7c6a22c8f8afd8cdda",
+      "integrity": "sha512-H8KZE0DfSX6tuiD0n8PnF9hRCluK3jV7m865xlvWF8qKDkc85nXxd+KGQVoWdkKNeujHs/Kle62S4iwObCW5NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#f92c8150a81123d83c68882e6b2d1241e9928f7c",
+    "@markup-carve/carve": "github:markup-carve/carve-js#9c93a01d8a0974e86457da7c6a22c8f8afd8cdda",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,17 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-
-# PART 9 §4c wrapper removal (carve#1122): panels nest directly in the group
-# figure; the pinned carve-js still wraps them in the withdrawn
-# `<div class="carve-figure-panels">`. Clears with the engine updates and a
-# pin bump.
-318-composite-figures  §4c wrapper removal; the pin still emits the panels div
-318-composite-figures-2  §4c wrapper removal; the pin still emits the panels div
-318-composite-figures-3  §4c wrapper removal; the pin still emits the panels div
-318-composite-figures-4  §4c wrapper removal; the pin still emits the panels div
-318-composite-figures-5  §4c wrapper removal; the pin still emits the panels div
-318-composite-figures-6  §4c wrapper removal; the pin still emits the panels div
-318-composite-figures-9  §4c wrapper removal; the pin still emits the panels div
-318-composite-figures-10  §4c wrapper removal; the pin still emits the panels div
-318-composite-figures-11  §4c wrapper removal; the pin still emits the panels div


### PR DESCRIPTION
Moves the carve-js pin to `9c93a01d` (the merged markup-carve/carve-js#1101) and empties `resources/engine-pin-drift.txt` - all nine declared wrapper-removal entries reproduce on the new build. Rendering-bytes only; no schema or exemption bookkeeping this time. Follows #1241.