### PR TITLE
docs: say that a body cell can align itself

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -123,17 +123,24 @@ two
 | Cell    | Cell    |         rows for ROW headers)
 ^ Table caption
 
-|= Name |=> Age |=~ City |   (column alignment glued to |=: < ~ >;
-| Sum    |< 12   | NYC    |   a data-cell marker overrides per cell)
-
-| Name  | Age |              (GFM separator row accepted as a
-|-------|----:|               compatibility alias: marks the header
-| Alice |  30 |               row + column alignment)
-
 | ^      | spanned |         (^ = rowspan)
 | Header | <       |         (< = colspan)
 + continuation cell |        (+ = multi-line cell)
 ```
+
+### Alignment
+
+`<` left, `~` center, `>` right, glued to the pipe. On `|=` it aligns the whole
+column; on a plain `|` it aligns that one cell and overrides the column.
+
+```carve
+|=~ Item |=> Qty |
+| Apple | 12 |
+| Subtotal |< 12 |
+```
+
+Glued is what makes it an alignment: a standalone `| < |` cell is the colspan
+merge, `| ^ |` the rowspan merge.
 
 ## Captions (images, quotes, tables, code listings, equations, figure groups)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,13 +50,15 @@ underscores sit below, tildes run through:
 H{,2,}O and E=mc{^2^}
 ```
 
-Tables without a separator row. `|=` marks a header cell, `|=>` aligns it right,
-and one `^` line captions the whole thing:
+Tables without a separator row. `|=` marks a header cell, `|=>` aligns that
+column right, a bare `|>` aligns a single body cell, and one `^` line captions
+the whole thing:
 
 ```carve
 |= Fruit  |=> Price |
 | Apple    | $1      |
 | Pear     | $2      |
+|~ Total  |< $3     |
 ^ Table 1: no separator row needed
 ```
 


### PR DESCRIPTION
Closes #1244 as a documentation fix.

Per-cell alignment already works in all three engines and is corpus-pinned (`49-table-per-cell-alignment-override`, `50-headerless-table-alignment`). The only place a reader could find it was a parenthetical on the header-cell line of the cheatsheet - "a data-cell marker overrides per cell" - with no heading and no example. #1244 asked for the feature and proposed making the cell a header cell to get the alignment, which is exactly the workaround the docs left a reader to invent.

## What changes

A short **Alignment** section on the cheatsheet: the marker set in one line (`<` left, `~` center, `>` right, glued to the pipe), one table showing the header form and a body cell overriding it, and the trap named - the marker has to be glued, because a standalone `| < |` cell is the colspan merge and `| ^ |` the rowspan merge.

The home page mentioned only the header-cell form; its sample now shows both markers and the prose matches it.

The separator-row form is deliberately left out. It is a compatibility alias rather than the canonical way to write a table, so it does not belong on the page a reader learns the syntax from.

## One thing found on the way

The new sample is written as plain Carve rather than in the annotated style the rest of the page uses, because samples in that style **do not render as the construct they document**: the trailing parentheticals turn every row into paragraph text, and `=>` / `=~` get smart-typography'd. Rendering the existing Tables sample produces paragraphs and no table.

`tests/doc-carve-samples.test.mjs` catches samples that fail to parse, not samples that parse into something else, so this has been silent. That is a page-wide problem rather than a tables one, and is filed separately as #1247.