### PR TITLE
docs: make the cheatsheet's samples render, and name the rest notation

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -12,6 +12,14 @@ implementation — except rows marked **✦**, which are opt-in extensions
 (Tier-2/3) you enable in your processor. Look any feature up in the
 [feature → tier table](/extensions#feature-tiers-quick-reference).
 
+Two kinds of block appear below. A block tagged `carve` is a **document**: paste
+it into the [Playground](/playground) and you get what the text around it says.
+A block tagged `text` is **notation** - several constructs packed onto a line
+each, with the explanation in a right-hand column. That is how a reference card
+fits on one page, and it is not a document: pasted anywhere, the annotations
+make every line prose. For the working version of a notation block, see
+[Blocks & Attributes](/blocks-and-attributes) and [Examples](/examples).
+
 ## Inline
 
 | Write | Get | Mnemonic |
@@ -46,7 +54,7 @@ Bare delimiters work only at word boundaries; force one intraword with the brace
 
 ## Blocks
 
-````carve
+````text
 # H1   ## H2   ### H3        (ATX headings 1-6; put attributes on the
                               line above: {#id .class})
 
@@ -118,14 +126,25 @@ two
 
 ## Tables
 
-```carve
-|= Header |= Header |        (|= marks a header cell; also works in body
-| Cell    | Cell    |         rows for ROW headers)
-^ Table caption
+`|=` marks a header cell: in the first row it heads a column, in a body row it
+heads that row. A `^` line after the table is its caption.
 
-| ^      | spanned |         (^ = rowspan)
-| Header | <       |         (< = colspan)
-+ continuation cell |        (+ = multi-line cell)
+```carve
+|= Item |= Qty |
+|= Apple | 12 |
+| Pear   |  3 |
+^ Stock on hand
+```
+
+A cell holding only `^` merges upward (rowspan) and one holding only `<` merges
+leftward (colspan); a `+` row continues the row above it, cell by cell, joined
+with a space.
+
+```carve
+|= Item |= Qty |= Note |
+| Apple | 12 | fresh |
++       |    | picked today |
+| ^     |  3 | <     |
 ```
 
 ### Alignment
@@ -144,14 +163,22 @@ merge, `| ^ |` the rowspan merge.
 
 ## Captions (images, quotes, tables, code listings, equations, figure groups)
 
+One `^` line after the block adds a semantic `<figcaption>`:
+
 ```carve
 ![Photo](img.jpg)
-^ Figure 1: Caption text      (one ^ adds a semantic <figcaption>)
+^ Caption text
+```
 
+A `#` in the caption is the auto number, so a cross-reference to the element's
+id renders as "Figure 1" rather than repeating the caption:
+
+```carve
 {#fig-sun}
 ![A sunset](sun.jpg)
-^ Figure #: A sunset          (# = auto number; </#fig-sun> then renders
-                               as "Figure 1")
+^ Figure #: A sunset
+
+See </#fig-sun> for the view.
 ```
 
 A `^` caption after a fenced code block makes a numbered *listing*; after a
@@ -184,7 +211,7 @@ continues on the next line.
 
 ## Attributes & metadata
 
-```carve
+```text
 {#id .class key=value}        (attach to the preceding/following element)
 {:fr}  {:de-CH}  {:}          (language: short for lang="fr"; {:} = unknown)
 [Tab]{kbd}                    (semantic span: <kbd>Tab</kbd>; core names are
@@ -210,8 +237,10 @@ text %% trailing comment
 block comment
 %%%
 
-{+inserted+}  {-deleted-}  {~old~>new~}  {#a comment#}   (CriticMarkup)
+{+inserted+}  {-deleted-}  {~old~>new~}  {#a comment#}
 ```
+
+The last line is CriticMarkup: insert, delete, substitute, comment.
 
 ## Diagrams & charts
 

--- a/docs/parsing-ambiguities.md
+++ b/docs/parsing-ambiguities.md
@@ -135,7 +135,7 @@ braced `| {^2^} |`.
 4. **Literal:** Everything else
 
 **Examples:**
-```carve
+```text
 | Header | <       |           # Colspan
 
 <https://example.com>          # Autolink
@@ -463,7 +463,7 @@ Inside code spans, backslash is literal:
 
 ## 16. Empty/Whitespace-Only Elements
 
-```carve
+```text
 **               # Not bold (no content)
 //               # Not italic (no content between //)
 {^^}             # Not superscript (no content)

--- a/tests/doc-carve-samples.test.mjs
+++ b/tests/doc-carve-samples.test.mjs
@@ -57,17 +57,37 @@ const samplesIn = (text) => {
 }
 
 /*
- * Samples that are annotated syntax DIAGRAMS rather than documents: the cheat
- * sheet writes the construct on the left and its explanation in a column on the
- * right, so the block never was a parseable document and rendering it proves
- * nothing.
+ * A line that OPENS a block, at column 0 where the language requires it.
  *
- * Keyed by a substring rather than only an index, so inserting a sample above
- * one of these fails loudly instead of silently waiving a different block.
+ * Column 0 on purpose: a marker indented past its container's content column is
+ * literal paragraph text by design, so a sample demonstrating that is not a
+ * sample that failed - anchoring here keeps the check off it.
+ *
+ * Two groups, because paragraph interruption is not uniform and a check that
+ * pretended it was would fire on the samples that TEACH the difference. A table
+ * row, heading, quote, `:::` fence, code fence, definition marker or thematic
+ * break interrupts an open paragraph; a list marker does not - it folds in as
+ * lazy continuation (PART 10), which is the whole subject of the paragraph
+ * interruption section in docs/parsing-ambiguities.md. So a list marker only
+ * counts as an opener where a list can actually start: at the top of the sample
+ * or after a blank line. Each row of this split is pinned by measurement in the
+ * discriminator test below.
+ *
+ * A caption line (`^ `) is in neither group: it folds into a paragraph like a
+ * list marker AND it needs a captionable block above it, which is already in
+ * the first group.
  */
-const ANNOTATED = [
-  { file: 'docs/cheatsheet.md', index: 1, contains: '(|= marks a header cell' },
-]
+const INTERRUPTS = /^(\|=?|#{1,6} |> |:::|```|:: |(-{3,}|\*{3,}|_{3,})\s*$)/m
+const LIST_OPENER = /(^|\n[ \t]*\n)([-*+] |\d+[.)] |\. )/
+const opensABlock = (source) => INTERRUPTS.test(source) || LIST_OPENER.test(source)
+
+/*
+ * What proves a block was actually built. Deliberately a FLOOR and not a
+ * per-marker mapping: the failure this exists for is total collapse - every row
+ * of a table, every `:::` container, the whole sample coming back as prose -
+ * and a floor cannot rot the way a marker table would.
+ */
+const BUILT_A_BLOCK = /<(h[1-6]|table|blockquote|ul|ol|dl|div|aside|figure|hr|pre|section)\b/
 
 const samples = files.flatMap((file) =>
   samplesIn(readFileSync(resolve(repoRoot, file), 'utf8')).map((source, index) => ({
@@ -82,21 +102,42 @@ test('the docs carry carve samples to check', () => {
   assert.ok(samples.length >= 20, `expected inline carve samples, found ${samples.length}`)
 })
 
-test('every annotated-sample waiver still names that sample', () => {
-  for (const waiver of ANNOTATED) {
-    const sample = samples.find((s) => s.file === waiver.file && s.index === waiver.index)
-    assert.ok(sample, `waiver names ${waiver.file} sample ${waiver.index}, which does not exist`)
-    assert.ok(
-      sample.source.includes(waiver.contains),
-      `waiver for ${waiver.file} sample ${waiver.index} no longer matches - a sample was probably inserted above it`,
-    )
+test('the block-opener and block-built patterns still discriminate', () => {
+  /*
+   * Both patterns are what every assertion below rests on, and either one
+   * silently matching nothing (or everything) would make the sweep vacuous.
+   */
+  const annotated = '|= Header |= Header |        (|= marks a header cell)'
+  assert.ok(opensABlock(annotated), 'a table row must read as a block opener')
+  assert.ok(!BUILT_A_BLOCK.test(carveToHtml(annotated)), 'the annotated row must build no block')
+  assert.ok(BUILT_A_BLOCK.test(carveToHtml('|= Header |\n| Cell |')), 'a real table must build one')
+  assert.ok(!opensABlock('{#the-id .class}'), 'an attribute block opens no block')
+
+  /*
+   * The interrupt split is a claim about the language, so it is measured
+   * against the engine rather than asserted from the pattern. Each marker is
+   * put after a prose line: the first group must still build its block, and a
+   * list marker must not - if that ever changes, this fails here instead of
+   * quietly firing on the samples that document the difference.
+   */
+  for (const marker of ['| a | b |', '# H', '> q', '::: note\nbody\n:::', '```\nc\n```', ':: t\n:  d', '---']) {
+    const html = carveToHtml(`prose line\n${marker}`)
+    assert.ok(BUILT_A_BLOCK.test(html), `${JSON.stringify(marker)} must interrupt a paragraph`)
+    assert.ok(INTERRUPTS.test(marker), `${JSON.stringify(marker)} must be in the interrupting group`)
   }
+  for (const marker of ['- item', '* item', '1. item', '^ cap']) {
+    assert.ok(
+      !BUILT_A_BLOCK.test(carveToHtml(`prose line\n${marker}`)),
+      `${JSON.stringify(marker)} must fold into the paragraph above it`,
+    )
+    assert.ok(!opensABlock(`prose line\n${marker}`), `${JSON.stringify(marker)} must not count as an opener there`)
+  }
+  assert.ok(opensABlock('- item'), 'a list marker at the top of a sample does open a list')
+  assert.ok(opensABlock('prose\n\n- item'), 'a list marker after a blank line does too')
 })
 
-const waived = (file, index) => ANNOTATED.some((w) => w.file === file && w.index === index)
-
 for (const { file, index, source } of samples) {
-  test(`${file} carve sample ${index} renders`, { skip: waived(file, index) ? 'annotated syntax diagram, not a document' : false }, () => {
+  test(`${file} carve sample ${index} renders`, () => {
     let html
     assert.doesNotThrow(() => {
       html = carveToHtml(source)
@@ -109,5 +150,26 @@ for (const { file, index, source } of samples) {
      */
     const leak = html.replace(/<pre>[\s\S]*?<\/pre>/g, '').match(/<p[^>]*>\s*(:::|\{[#.]|\|=)/)
     assert.equal(leak, null, `${file} sample ${index}: block markup leaked as paragraph text: ${leak?.[0]}`)
+
+    /*
+     * The failure the check above cannot see. A sample written in the cheat
+     * sheet's annotated style - the construct on the left, its explanation in a
+     * right-hand column - parses without throwing and without leaking anything
+     * the pattern above recognizes: the trailing parenthetical simply means the
+     * line no longer ends a row, so every row becomes prose. Nothing was
+     * malformed, so nothing complained, and the page teaching the syntax showed
+     * samples that do something else when pasted (markup-carve/carve#1247).
+     *
+     * A sample that opens a block and renders no block is that failure. Such a
+     * block is notation, not a document - tag it ```text so no reader pastes it
+     * expecting output, rather than waiving it here.
+     */
+    if (opensABlock(source)) {
+      assert.ok(
+        BUILT_A_BLOCK.test(html),
+        `${file} sample ${index}: opens a block and renders none - it came back as prose. ` +
+          `If it is annotated notation rather than a document, tag the fence \`\`\`text.`,
+      )
+    }
   })
 }


### PR DESCRIPTION
Closes #1247.

The page teaching the syntax showed samples that do something else when pasted. The Tables sample came back as two paragraphs, not a table - the annotation in the right-hand column means the line no longer ends a row, so every row is prose. Nothing was malformed, so nothing complained.

### What the sweep found

Rendering every ` ```carve ` block on every authored page, the annotated style breaks more than tables:

| block | what it loses |
| --- | --- |
| cheatsheet, Blocks | **all five** `:::` samples (admonition, tab, nesting, line block, hard-break block), the thematic break, the `+` continuation, the quote-with-list |
| cheatsheet, Tables | the whole table, both blocks |
| cheatsheet, Attributes | the frontmatter |
| cheatsheet, Captions | renders, but the explanation lands **inside** the `figcaption` |
| cheatsheet, Math | renders, but a stray `(CriticMarkup)` ends the last paragraph |
| parsing-ambiguities, sections 3 and 16 | render flat |

The issue's second example (`|= Name |=> Age |=~ City |`) is not in the table above because #1246 already removed it.

### Two shapes, treated differently

They are not the same problem, so they do not get the same fix.

**Tables and Captions are documents that were merely annotated.** Rewritten as real Carve with the explanation moved into the prose around them, which is the shape the Alignment section from #1246 already uses. Each was checked by rendering it.

Input:

```
|= Item |= Qty |= Note |
| Apple | 12 | fresh |
+       |    | picked today |
| ^     |  3 | <     |
```

Output:

```html
<table>
  <thead><tr><th scope="col">Item</th><th scope="col">Qty</th><th scope="col">Note</th></tr></thead>
  <tbody>
    <tr><td rowspan="2">Apple</td><td>12</td><td>fresh picked today</td></tr>
    <tr><td colspan="2">3</td></tr>
  </tbody>
</table>
```

One sample now carries the caption, the row header, the rowspan, the colspan and the `+` continuation, and the prose beside it describes what the reader can see happen.

**The Blocks and Attributes blocks are not documents and never were.** They pack several constructs onto a line each, which is what lets a reference card carry the whole syntax on one page, and no rewriting makes this parse as three headings:

```
# H1   ## H2   ### H3        (ATX headings 1-6; put attributes on the
                              line above: {#id .class})
```

So they are notation, tagged ` ```text `, and the page says up front which kind of block is which and where the working version lives. Same for the two blocks in parsing-ambiguities.

### The check that would have caught it

`doc-carve-samples` asserted that a sample parses and that no block marker leaks into a paragraph. Both hold for every sample above - the collapse is silent by construction, which is why the test was green while the page was wrong.

A sample that **opens a block and renders none** is now a failure. Restoring the Tables sample as it stood fails it:

```
not ok 14 - docs/cheatsheet.md carve sample 1 renders
  error: 'docs/cheatsheet.md sample 1: opens a block and renders none - it came
          back as prose. If it is annotated notation rather than a document, tag
          the fence ```text.'
```

Paragraph interruption is not uniform, so the opener test is not either. A list marker folds into an open paragraph as lazy continuation, and a check that ignored that fires on the sample in parsing-ambiguities that teaches exactly this:

```
Die Frage ist x = 5
* 3 + 17 wahr.
```

That sample is correct - it renders one paragraph, and the prose under it says so. So a list marker counts as an opener only where a list can start, at the top of the sample or after a blank line. The split between what interrupts and what folds is **measured against the engine** in a discriminator test rather than asserted from the pattern, so the day interruption changes it fails there rather than on the documents.

### No waiver

The waiver list is deleted, not grown. It held one entry, for the Tables sample. A block that would need it is notation and should say so in its fence, where a reader sees it too - a waiver is only visible to whoever opens the test.
