### PR TITLE
test: pin the ruled tight-li import, and give the pin its drift valve

### DIFF
--- a/resources/converter-drift.txt
+++ b/resources/converter-drift.txt
@@ -39,3 +39,11 @@ rust/05-markdown-verbatim-sigils-stay-text  ruled stays-text escape not shipped;
 # flattens to a tight Carve list, so the paragraph-ness of the source is lost.
 # carve-js and carve-rs both preserve it.
 php/23-html-ordinary-blocks-survive  a loose HTML list imports tight; item paragraphs are dropped
+
+# carve#1210 ruling (2026-08-16): a bare-text <li> imports as a TIGHT list
+# item, and a mixed list pins carve-php's normalization. carve-php conforms;
+# carve-js and carve-rs import both shapes loose and owe the fix.
+js/27-html-a-bare-text-list-item-imports-tight  ruled tight-li import not shipped; a bare-text item imports loose
+js/28-html-a-mixed-list-normalizes-tight  ruled tight-li import not shipped; the whole mixed list imports loose
+rust/27-html-a-bare-text-list-item-imports-tight  ruled tight-li import not shipped; a bare-text item imports loose
+rust/28-html-a-mixed-list-normalizes-tight  ruled tight-li import not shipped; the whole mixed list imports loose

--- a/tests/corpus-convert.test.mjs
+++ b/tests/corpus-convert.test.mjs
@@ -133,6 +133,25 @@ const PINNED_UNIMPLEMENTED = {
   djot: 'the pinned @markup-carve/carve exports no djotToCarve; the cross-engine gate covers this format',
 }
 
+/*
+ * Cases whose expectation encodes a ruling the PINNED build has not shipped -
+ * the per-PR twin of resources/converter-drift.txt, and deliberately a
+ * separate list: that file describes the engine CHECKOUTS the scheduled gate
+ * drives, this one describes the build package.json pins, and the two move at
+ * different times (a fix lands on an engine's main first, the pin follows).
+ *
+ * Same discipline as every declared list in this repo: a slug listed here is
+ * excused from the bytes assertion with its reason on record, a listed slug
+ * that starts matching fails as STALE until the entry is deleted in the commit
+ * that moves the pin, and the meaning assertion still runs regardless.
+ */
+const PINNED_DRIFT = {
+  '27-html-a-bare-text-list-item-imports-tight':
+    'carve#1210 ruling: a bare-text <li> imports TIGHT; the pinned build imports it loose',
+  '28-html-a-mixed-list-normalizes-tight':
+    'carve#1210 ruling: expected pins carve-php\'s normalization; the pinned build imports the whole list loose',
+}
+
 /**
  * The visible text of an HTML fragment.
  *
@@ -228,6 +247,13 @@ test('every declared pinned-build gap is still a gap', () => {
       )
     }
   }
+  // A drift entry naming no case excuses nothing while looking like it does -
+  // the renamed-slug failure mode the render corpus's declared lists guard
+  // against too.
+  const slugs = new Set(cases.map(({ slug }) => slug))
+  for (const slug of Object.keys(PINNED_DRIFT)) {
+    assert.ok(slugs.has(slug), `PINNED_DRIFT names "${slug}" but no such case exists - renamed, or a typo`)
+  }
 })
 
 test('convert then render matches the pinned bytes', () => {
@@ -247,7 +273,12 @@ test('convert then render matches the pinned bytes', () => {
     const actual = carveToHtml(FORMATS[format].convert(source))
     const withNewline = actual.endsWith('\n') ? actual : `${actual}\n`
     if (withNewline !== expected) {
+      if (Object.hasOwn(PINNED_DRIFT, slug)) continue // declared: the pin is behind the ruling
       wrong.push(`${slug}\n    expected: ${JSON.stringify(expected)}\n      actual: ${JSON.stringify(withNewline)}`)
+    } else if (Object.hasOwn(PINNED_DRIFT, slug)) {
+      wrong.push(
+        `${slug}: PINNED_DRIFT declares this case (${PINNED_DRIFT[slug]}) but the pinned build now matches - delete the STALE entry in the commit that moves the pin`,
+      )
     }
   }
   assert.deepEqual(wrong, [], `the converted document no longer renders as pinned:\n  ${wrong.join('\n  ')}`)

--- a/tests/corpus-convert/27-html-a-bare-text-list-item-imports-tight/expected.html
+++ b/tests/corpus-convert/27-html-a-bare-text-list-item-imports-tight/expected.html
@@ -1,0 +1,4 @@
+<ul>
+  <li>one</li>
+  <li>two</li>
+</ul>

--- a/tests/corpus-convert/27-html-a-bare-text-list-item-imports-tight/input.html
+++ b/tests/corpus-convert/27-html-a-bare-text-list-item-imports-tight/input.html
@@ -1,0 +1,1 @@
+<ul><li>one</li><li>two</li></ul>

--- a/tests/corpus-convert/28-html-a-mixed-list-normalizes-tight/expected.html
+++ b/tests/corpus-convert/28-html-a-mixed-list-normalizes-tight/expected.html
@@ -1,0 +1,4 @@
+<ul>
+  <li>one</li>
+  <li>two</li>
+</ul>

--- a/tests/corpus-convert/28-html-a-mixed-list-normalizes-tight/input.html
+++ b/tests/corpus-convert/28-html-a-mixed-list-normalizes-tight/input.html
@@ -1,0 +1,1 @@
+<ul><li>one</li><li><p>two</p></li></ul>


### PR DESCRIPTION
Follow-up to #1245: the tight-list import divergence the converter gate reported on arrival got its ruling on markup-carve/carve#1210 (ruling comment of 2026-08-16), and this pins it.

## The ruling, encoded

A bare-text `<li>` imports as a TIGHT list item; a mixed list pins carve-php's normalization. Two new HTML cases:

- `27-html-a-bare-text-list-item-imports-tight` - `<ul><li>one</li><li>two</li></ul>` imports as a tight Carve list.
- `28-html-a-mixed-list-normalizes-tight` - one bare item plus one `<li><p>` item; expected pins carve-php's current output, verified against the checkout.

Both expectations are carve-php's conversion rendered through the reference renderer - the engine the ruling names as conforming. carve-js and carve-rs import both shapes loose, so both carry entries in `resources/converter-drift.txt` naming the ruling until their fixes land.

## The pin gets its own drift valve

The pinned build is one of the engines that owes the fix - expected bytes the per-PR test cannot reproduce yet, a state it had no valve for. `PINNED_DRIFT` (in `tests/corpus-convert.test.mjs`) is that valve: the per-PR twin of `resources/converter-drift.txt`, deliberately separate because the drift file describes the engine checkouts the scheduled gate drives while this list describes the build package.json pins, and the two move at different times. Same declared-list discipline as everywhere else in the repo: a listed case is excused with its reason on record, goes stale-red the moment the pin catches up, is typo-guarded against the case list, and its meaning assertion runs regardless.

Cross-engine gate against the three checkouts after this change: 28 cases, 0 undeclared mismatches, 0 errors (rust 23/26 + 3 declared, js 24/26 + 2 declared, php 21/28 + 7 declared).

Part of #1130 and markup-carve/carve#1210.
