### PR TITLE
docs: pin a list-table header case so the examples page shows one

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ tested against, and the design rationale behind each decision.
 | | |
 |---|---|
 | **Specification** | 0.1. Tier-1 core and Tier-2 standard extensions are normative and stable; Tier-3 app-level extensions ship but evolve. See [VERSIONING.md](VERSIONING.md). |
-| **Conformance** | Over 1,000 corpus examples pinning exact HTML output, plus 41 optional-corpus examples for host-dependent extensions. |
+| **Conformance** | Over 1,000 corpus examples pinning exact HTML output, plus 42 optional-corpus examples for host-dependent extensions. |
 | **Engines** | [carve-js](https://github.com/markup-carve/carve-js) (TypeScript, reference), [carve-php](https://github.com/markup-carve/carve-php), [carve-rs](https://github.com/markup-carve/carve-rs) - all three run the same corpus, with no open or intentional divergences ([tracker](MAINTAINING.md#known-cross-impl-divergences)). |
 | **Bindings** | Python, Ruby, Go, and WebAssembly, all over carve-rs. |
 | **Tooling** | Language server, tree-sitter grammar, formatter and linter (`carve fmt` / `carve lint`), converters from Markdown, HTML, Djot, and BBCode. |

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -657,10 +657,12 @@ rather than a parser one.
 
 Optional raw output:
 
-This run covers the whole optional corpus, so it carries no
-added-since-this-run declaration. When the corpus next grows ahead of a run,
-that declaration comes back: it names the cases and carries no count, so there
-is nothing in it to fabricate, and
+Optional corpus added since this run: `42-list-table-header-rows-cols`.
+
+It pins `{header-rows}` / `{header-cols}` on a list table and landed after the
+run above was taken, so the corpus is one case ahead of it again. The
+declaration is the same device the core block uses: it names the cases and
+carries no count, so there is nothing in it to fabricate, and
 `tests/implementation-comparison-counts.test.mjs` fails both when a named case
 stops existing and when the run is retaken without deleting the line.
 

--- a/tests/corpus-optional/42-list-table-header-rows-cols.crv
+++ b/tests/corpus-optional/42-list-table-header-rows-cols.crv
@@ -1,0 +1,8 @@
+{header-rows=1}
+{header-cols=1}
+::: list-table
+- - Region
+  - Q1
+- - EMEA
+  - 10
+:::

--- a/tests/corpus-optional/42-list-table-header-rows-cols.html
+++ b/tests/corpus-optional/42-list-table-header-rows-cols.html
@@ -1,0 +1,6 @@
+<table>
+  <thead><tr><th scope="col">Region</th><th scope="col">Q1</th></tr></thead>
+  <tbody>
+    <tr><th scope="row">EMEA</th><td>10</td></tr>
+  </tbody>
+</table>

--- a/tests/corpus-optional/manifest.json
+++ b/tests/corpus-optional/manifest.json
@@ -74,7 +74,7 @@
     {
       "slug": "15-citations-locator-labels",
       "feature": "citations-numbered",
-      "description": "Multiple locator labels (chap., §) parse to their canonical citeproc names."
+      "description": "Multiple locator labels (chap., \u00a7) parse to their canonical citeproc names."
     },
     {
       "slug": "16-citations-locator-default-page",
@@ -207,12 +207,17 @@
     {
       "slug": "40-semantic-span-extension",
       "feature": "semantic-span",
-      "description": "The four names core does not reserve - samp, var, cite, dfn - render as their elements when the SemanticSpan extension is enabled, under the same attribute spelling, nesting order and value mapping core uses for its three (PART 9 §10)."
+      "description": "The four names core does not reserve - samp, var, cite, dfn - render as their elements when the SemanticSpan extension is enabled, under the same attribute spelling, nesting order and value mapping core uses for its three (PART 9 \u00a710)."
     },
     {
       "slug": "41-semantic-span-extension-deprecated-spelling",
       "feature": "semantic-span",
       "description": "The extension also accepts the SOFT-DEPRECATED `:name[...]` spelling for all seven names, because it was released behavior in carve-js and carve-rs. Scheduled for removal in 0.2; the compact attribute is the form to write."
+    },
+    {
+      "slug": "42-list-table-header-rows-cols",
+      "feature": "list-table",
+      "description": "header-rows and header-cols promote the first N rows to <thead> and the first N cells of every row to row headers."
     }
   ]
 }

--- a/tests/corpus-optional/manifest.json
+++ b/tests/corpus-optional/manifest.json
@@ -74,7 +74,7 @@
     {
       "slug": "15-citations-locator-labels",
       "feature": "citations-numbered",
-      "description": "Multiple locator labels (chap., \u00a7) parse to their canonical citeproc names."
+      "description": "Multiple locator labels (chap., §) parse to their canonical citeproc names."
     },
     {
       "slug": "16-citations-locator-default-page",
@@ -207,7 +207,7 @@
     {
       "slug": "40-semantic-span-extension",
       "feature": "semantic-span",
-      "description": "The four names core does not reserve - samp, var, cite, dfn - render as their elements when the SemanticSpan extension is enabled, under the same attribute spelling, nesting order and value mapping core uses for its three (PART 9 \u00a710)."
+      "description": "The four names core does not reserve - samp, var, cite, dfn - render as their elements when the SemanticSpan extension is enabled, under the same attribute spelling, nesting order and value mapping core uses for its three (PART 9 §10)."
     },
     {
       "slug": "41-semantic-span-extension-deprecated-spelling",


### PR DESCRIPTION
Addresses the docs half of #1248.

`{header-rows=N}` / `{header-cols=N}` have worked in all three engines since ListTable shipped and are documented in the extensions contract (§5.1). The [examples page](https://markup-carve.github.io/carve/examples/extensions#listtable) did not show them, because it is generated from the optional corpus and the only list-table fixture there pinned the caption. Headers were pinned inside each engine's own suite, where a reader never looks - which is why #1248 asked for the feature and proposed new markers for something two attributes already do.

## What this adds

`tests/corpus-optional/42-list-table-header-rows-cols` pins both attributes in one case:

```
{header-rows=1}
{header-cols=1}
::: list-table
- - Region
  - Q1
- - EMEA
  - 10
:::
```

```html
<table>
  <thead><tr><th scope="col">Region</th><th scope="col">Q1</th></tr></thead>
  <tbody>
    <tr><th scope="row">EMEA</th><td>10</td></tr>
  </tbody>
</table>
```

carve-js and carve-php produce that byte-for-byte (checked directly). carve-rs pins the same behavior in its own `tests/list_table.rs`, but the comparison harness has no adapter to enable the extension there, so it skips the case - visible in the run as `list-table (html): js, php`.

`npm run docs:pages` puts the example on the generated page; `docs/examples/` is gitignored, so the fixture *is* the docs change.

The case is declared as added-since-the-run rather than retaking the published snapshot in `docs/implementation-comparison.md` - the device that block already carries for the six cases before it. README optional-corpus count goes 41 → 42.

## A measurement note worth having in the record

The first optional sweep I ran reported `cross_impl_diffs=1` on `03-smart-quotes-locale-de`. That was not a divergence: the harness resolves carve-rs through `<carve-rs>/target/release/carve`, and that binary was five days old and predates the `--quote-locale` flag, so the run compared a build that could not do the thing being measured. Rebuilt at `origin/main`, the sweep is clean (`cross_impl_diffs=0`, 42 pairs, every case reaching at least two engines).

That also means the published snapshot understates the current state in two ways worth a separate look: it says one case reaches fewer than two engines, and its table attributes that to carve-js having no quote-locale option (carve#560) - the fresh run shows `smart-quotes-locale-de (html): rust, js, php`. Not touched here; it needs its own PR and its own reasoning.
