### PR TITLE
docs: file per-cell table alignment where a reader looks for it

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -657,18 +657,10 @@ rather than a parser one.
 
 Optional raw output:
 
-Optional corpus added since this run: `34-plain-typography-source`,
-`35-ansi-typography-source`, `36-crossref-label-typography-source`,
-`37-crossref-label-typography-source-markdown`,
-`38-crossref-label-typography-source-ansi`,
-`39-crossref-label-typography-glyphs`.
-
-The first two pin `smartTypography` on the plain-text and ANSI targets; the
-other four pin a RESOLVED CROSSREF's label under the same switch, on three
-targets plus a default-mode control. All six landed on a host with no engine
-checkouts, so the run below predates them. The
-declaration is the same device the core block uses: it names the cases and
-carries no count, so there is nothing in it to fabricate, and
+This run covers the whole optional corpus, so it carries no
+added-since-this-run declaration. When the corpus next grows ahead of a run,
+that declaration comes back: it names the cases and carries no count, so there
+is nothing in it to fabricate, and
 `tests/implementation-comparison-counts.test.mjs` fails both when a named case
 stops existing and when the run is retaken without deleting the line.
 
@@ -679,39 +671,41 @@ came to say 4 when the corpus held 33.
 
 ```text
 Implementation summary
-profile=optional/opt-in corpus=optional corpus_pairs=35 targets=html,markdown
-rust: pass=5/5 mismatch=0 error=0 skipped=28 runs=5 avg_ms=22.17
-js: pass=32/32 mismatch=0 error=0 skipped=1 runs=32 avg_ms=64.69
-php: pass=31/31 mismatch=0 error=0 skipped=2 runs=31 avg_ms=54.55
+profile=optional/opt-in corpus=optional corpus_pairs=41 targets=html,markdown,plain,ansi
+rust: pass=12/12 mismatch=0 error=0 skipped=29 runs=12 avg_ms=5.21
+js: pass=41/41 mismatch=0 error=0 skipped=0 runs=41 avg_ms=157.43
+php: pass=39/39 mismatch=0 error=0 skipped=2 runs=39 avg_ms=103.44
 cross_impl_diffs=0
 
 Target agreement (implementations compared against each other)
-html: compared=30 diffs=0 errors=0 fixtures=yes
-markdown: compared=2 diffs=0 errors=0 fixtures=yes
+html: compared=33 diffs=0 errors=0 fixtures=yes
+markdown: compared=3 diffs=0 errors=0 fixtures=yes
+plain: compared=3 diffs=0 errors=0 fixtures=yes
+ansi: compared=2 diffs=0 errors=0 fixtures=yes
 
 Optional feature coverage
 social-link-templates (html): rust, js, php
 symbol-map (html): rust, js
-smart-quotes-locale-de (html): php
+smart-quotes-locale-de (html): rust, js, php
 bare-url-autolink (html): js, php
 citations-numbered (html): js, php
 code-callouts (html): js, php
 ...
 
-NOT COMPARED: 1 of 33 optional cases reached fewer than two engines, so they
-contribute no agreement evidence. This is not a pass.
+All optional cases reached at least two engines.
 ```
 
-**Read the last block, not the `cross_impl_diffs=10` above it.** One of the 33
-optional cases still reaches fewer than two engines and contributes no
-evidence.
+**Every optional case now reaches at least two engines.** That line at the
+bottom of the block is the one to read: for the first time the optional corpus
+carries agreement evidence for all of it, with no case left contributing
+nothing.
 
-That was 30 until carve#521. The features were implemented everywhere all
-along; what was missing was a way for this tool to switch them on. carve-js and
-carve-php are driven through an inline script here, so a shared table of
-feature to extension name reached both without either engine changing - taking
-the compared count from 2 to 27, and covering citations, which is 16 of the 33
-on its own.
+It was 30 of 33 uncompared until carve#521, and exactly one after that until
+carve-js gained locale-aware smart quotes (carve-js#996). The features were implemented
+everywhere all along; what was missing was a way for this tool to switch them
+on. carve-js and carve-php are driven through an inline script here, so a
+shared table of feature to extension name reached both without either engine
+changing - covering citations, which is 16 of the 41 on its own.
 
 The rest need a renderer or parser OPTION rather than an extension, and an
 option is per-engine API, so there is no shared table for them.
@@ -722,17 +716,15 @@ carve-php: carve-php#537 added the `HtmlRenderer::setSectionWrapping()`
 opt-out those two adapters drive, and carve-php#679 fixed the id/stamp
 ordering the second case pins (carve#535).
 
-Reaching an engine is not the same as being compared. One case remains
-single-engine, and the run says why rather than reporting a uniform "no CLI
-path":
+Reaching an engine is not the same as being compared, and when a case was
+single-engine this page named why rather than reporting a uniform "no CLI
+path". The last such case was `smart-quotes-locale-de`, held there because
+carve-js had no quote-locale option; carve-js#996 added one, the adapter drives
+it, and the case now reaches all three engines.
 
-| case | why |
-| --- | --- |
-| `smart-quotes-locale-de` | carve-js has no quote-locale option (carve#560) |
-
-That distinction is the point. A missing adapter is this repo's backlog; a
-missing option is the engine's, and the difference decides who fixes it. This
-one is a capability gap, which is why no amount of harness work would move it.
+That distinction is still the point for whatever lands next. A missing adapter
+is this repo's backlog; a missing option is the engine's, and the difference
+decides who fixes it - no amount of harness work moves a capability gap.
 
 carve-rs is driven through its binary and exposes no flag for the sections
 switch or the source-line stamp, so `section-wrapper-off` and

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -68,6 +68,8 @@ out: examples/core.md
   09-tables-7
   09-tables-8
   table-column-alignment
+  table-per-cell-alignment-override
+  headerless-table-alignment
   table-multi-line-cell-continuation
   tables-with-rowspan-and-colspan
   11-fenced-code
@@ -189,8 +191,6 @@ source: examples-tier3.md
 > Alignment, spans, multi-line cells, ragged rows and the pipe rules that decide whether a table exists at all.
 out: examples/edge-cases/tables.md
 index: examples/edge-cases/index.md
-  table-per-cell-alignment-override
-  headerless-table-alignment
   table-without-alignment
   table-alignment-with-colspan
   table-doubled-alignment-marker


### PR DESCRIPTION
Follow-up to the review comment on #1246: the core examples page shows column alignment and nothing else.

The cause is routing, not missing content. Both per-cell alignment cases exist and are corpus-pinned, they were just filed on the edge-cases tables page:

```
[core]         ...  table-column-alignment
                    table-multi-line-cell-continuation
                    tables-with-rowspan-and-colspan

[edge-tables]  ...  table-per-cell-alignment-override
                    headerless-table-alignment
                    table-without-alignment
```

So `examples/core#tables` answers "how do I align a column" and never "how do I align one cell", even though the feature is Tier-1 and all three engines agree on it.

That routing is also what produced #1244. The report did not miss the docs: per-cell alignment was filed as an edge case, so the page a reader learns tables from never showed it, and the workaround the report proposed (make the cell a header cell to get the alignment) is exactly what the core page leaves a reader to invent.

## What changes

Two slugs move from `[edge-tables]` to `[core]`, right after `table-column-alignment`. Nothing else: `docs/examples/` is generated and gitignored, so the diff is two lines in the routing file.

`headerless-table-alignment` moves as well, not just the override. The table in #1244 had no header row at all, so leaving that case on the edge page would reproduce the same gap one level down.

The genuinely marginal cases stay put: `table-without-alignment`, `table-alignment-with-colspan`, `table-doubled-alignment-marker`.

## Note on the suggestion as worded

The review asked for the existing column-alignment section to be expanded to cover cell alignment in general. Section headings are derived from case slugs, so the core page gains two sibling sections next to "Table column alignment" rather than one merged section. Matching the wording literally would mean renaming corpus fixtures, which churns the corpus for a cosmetic result.

A case can have only one reading location - the generator rejects a slug that appears twice - so this is a move rather than a mirror.
