### PR TITLE
spec: a diagnostic's path is a human-readable locator, not an XPath expression

### DIFF
--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -156,6 +156,58 @@ be in the wrong language entirely, and that is the one signal it could act on.
 Diagnostics have `code`, `message`, `severity` (`info`, `warning`, or `error`),
 and optional `path`, `line`, and `column`. Their order follows document order.
 
+## The `path` of a diagnostic
+
+`path` locates the node a diagnostic is about. It is a HUMAN-READABLE,
+engine-defined locator, and it is NOT an XPath expression. A consumer MUST NOT
+resolve it against the input document; it exists for a person reading a report.
+
+Implementations converge on one spelling. A path is rooted at the fragment's
+body children: there is no `/html[1]/body[1]` prefix, and no step for a wrapper
+element the importer added.
+
+Each step's index counts among ALL of the parent's child nodes, text nodes
+included, not among the same-named siblings.
+
+```html
+<p><abbr class="x" id="z" title="y">A</abbr> <kbd id="k" class="key">Tab</kbd> <abbr title="a b c">S</abbr> <abbr title="">E</abbr> <time datetime="">T</time> <kbd onclick="steal()">Esc</kbd></p>
+```
+
+The last `<kbd>` is the eleventh child of the paragraph, preceded by five
+elements and five whitespace text nodes, so it is reported at
+
+```
+/p[1]/kbd[11]
+```
+
+and not at `kbd[2]`, its position among the `kbd` elements, nor at `kbd[6]`,
+its position among the elements.
+
+A path names the importer's traversal, not the raw DOM. Table sections are
+flattened and rows are renumbered across the whole table, so a `<td>` inside a
+`<tbody>` that follows a `<thead>` carries no `tbody` step.
+
+```html
+<table><thead><tr><th>H</th></tr></thead><tbody><tr><td onclick="x()">B</td></tr></tbody></table>
+```
+
+```
+/table[1]/tr[2]/td[1]
+```
+
+The notation invites the XPath reading, and the reading is false. Every value an
+importer emits is valid XPath SYNTAX that finds nothing. Resolved as XPath
+against the paragraph above, `/p[1]/kbd[11]` selects zero nodes, and it misses
+on two counts at once: the root step, because a parsed fragment puts the
+paragraph under `/html[1]/body[1]`, and the predicate, because XPath counts
+`kbd` among its like-named siblings, where that node is `kbd[2]`. The node an
+XPath engine actually reaches is `/html[1]/body[1]/p[1]/kbd[2]`, which no
+importer writes.
+
+The field is therefore deliberately not machine-checkable. The schema gives it
+no pattern, and an implementation MAY change how it spells a path without that
+being a breaking change to the report format.
+
 ## Required API surface
 
 JavaScript exposes `htmlToAst(html, options)` and `htmlToCarve(html, options)`.

--- a/resources/html-import-schema.json
+++ b/resources/html-import-schema.json
@@ -18,7 +18,10 @@
           "code": { "enum": ["element-dropped", "element-unwrapped", "attribute-dropped", "style-unmapped", "table-degraded", "raw-preserved", "structure-unspellable", "encoding-assumed", "diagnostics-truncated"] },
           "message": { "type": "string" },
           "severity": { "enum": ["info", "warning", "error"] },
-          "path": { "type": "string" },
+          "path": {
+            "type": "string",
+            "description": "A human-readable, engine-defined locator for the node this diagnostic is about, rooted at the fragment's body children. It looks like an XPath expression and is NOT one: each index counts among all of the parent's child nodes rather than the same-named siblings, and it names the importer's traversal rather than the raw DOM. A consumer MUST NOT resolve it against the input document. Deliberately carries no pattern: the value is for a person reading a report, not for a machine."
+          },
           "line": { "type": "integer", "minimum": 1 },
           "column": { "type": "integer", "minimum": 1 }
         }


### PR DESCRIPTION
Closes #1257 (spec half).

An HTML import diagnostic carries a `path` locating the node it is about, and nothing in this repository said what the string means. `resources/html-import-schema.json` declared it as

``` json
"path": { "type": "string" }
```

with no pattern and no description, and `docs/html-import.md` only called it optional. Three engines each invented an answer, and the one shared fixture that states a `path` pinned whichever engine generated the file rather than a ruling.

The ruling on the issue is that all three converge on carve-js's convention, and that the spec documents it as a human-readable, engine-defined locator that is explicitly NOT an XPath expression. This is that clause.

## The convention

Rooted at the fragment's body children. No `/html[1]/body[1]` prefix, and no step for a wrapper element the importer added.

Each step's index counts among ALL of the parent's child nodes, text nodes included, not among the same-named siblings. For the `semantic-span-attributes` fixture's input:

``` html
<p><abbr class="x" id="z" title="y">A</abbr> <kbd id="k" class="key">Tab</kbd> <abbr title="a b c">S</abbr> <abbr title="">E</abbr> <time datetime="">T</time> <kbd onclick="steal()">Esc</kbd></p>
```

the last `<kbd>` is the eleventh child of the paragraph, preceded by five elements and five whitespace text nodes, and is reported at

```
/p[1]/kbd[11]
```

not `kbd[2]` (its position among the `kbd` elements) and not `kbd[6]` (its position among the elements).

A path names the importer's traversal, not the raw DOM. Table sections are flattened and rows are renumbered across the whole table, so a `<td>` inside a `<tbody>` that follows a `<thead>` carries no `tbody` step:

``` html
<table><thead><tr><th>H</th></tr></thead><tbody><tr><td onclick="x()">B</td></tr></tbody></table>
```

```
/table[1]/tr[2]/td[1]
```

## Why the clause has to say it is not XPath

The notation invites the XPath reading and the reading is false. Every value an importer emits is valid XPath syntax that finds nothing. Resolved with a real `DOMXPath` against the fixture's own input, `/p[1]/kbd[11]` selects 0 nodes, and it misses on two counts at once:

```
/p[1]/kbd[11]                 -> 0 nodes
/p[1]/kbd[2]                  -> 0 nodes
/html[1]/body[1]/p[1]/kbd[11] -> 0 nodes
/html[1]/body[1]/p[1]/kbd[2]  -> 1 node: <kbd>Esc</kbd>
```

The root step misses, because a parsed fragment puts the paragraph under `/html[1]/body[1]`; and the predicate misses, because XPath counts `kbd` among its like-named siblings. The node an XPath engine actually reaches is `/html[1]/body[1]/p[1]/kbd[2]`, which no importer writes. So the clause states that a consumer MUST NOT resolve the value; it is for a person reading a report.

The schema gains a `description` saying the same and deliberately no `pattern`. Making the field machine-checkable is the option the ruling declined: it buys resolvability no known consumer has asked for, at the price of rewriting path production in two engines.

## Measured, not summarized

The three bullets were verified against a fresh carve-js clone built under /tmp, and again against the build this repo pins in `package.json`. Both agree:

```
A fixture (index among ALL children): /p[1]/kbd[11]
B root, no html/body prefix:          /p[1]/span[1]
C thead+tbody flattened:              /table[1]/tr[2]/td[1]
D two tbody, rows renumbered:         /table[1]/tr[2]/td[2]
E full document input:                /p[1]
```

Case D is the one a summary would have gotten wrong: rows renumber across the whole table, not within a section, so the second `<tbody>`'s first row is `tr[2]`. Case E shows the rooting rule holds even when the input spells `<html><body>` itself.

## Where the clause had to be stated

Two homes, the same two the code enum has. Grepping for `structure-unspellable` and `diagnostics-truncated` finds `docs/html-import.md` and `resources/html-import-schema.json` and nothing else; no PART 12 page or other doc describes the import diagnostic object.

## Separate finding, not fixed here

Nothing in this repository compares a diagnostic's `path`. `tests/html-import-contract.check.mjs` asserts that each fixture directory publishes its four files, that the two JSON files parse, and that every `code` is in the schema's enum. It never reads `path`, `message`, `severity`, or `line`/`column`. An unchecked column is how three conventions coexisted; worth its own ticket rather than a rider on the clause, and the ruling's point 6 puts the comparison in the engines' shared-fixture loops.

## No CHANGELOG entry

The last released tag is `0.1.2`. The whole HTML import contract, `path` included, landed after it and is still under one `Unreleased` entry, so nothing released is being changed. The two prior clarifications to this same schema, "name the diagnostic for a structure Carve cannot spell" and "name the diagnostic for an encoding the source never declared", each touched `docs/html-import.md` and `resources/html-import-schema.json` and added no CHANGELOG entry either.

## Engine halves

The engine changes are separate and are not in this PR: `markup-carve/carve-rs` starts its walk at the body's children, `markup-carve/carve-php` drops the wrapper `<div>` from the path and counts among all child nodes, and carve-js is already the target and changes nothing.
