### PR TITLE
spec: name the kind that hoists, not "the other two"

### DIFF
--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -35,7 +35,7 @@
     "link_reference_definition": {
       "type": "object",
       "title": "link_reference_definition (block)",
-      "description": "The `[label]: /url \"title\" {attrs}` definition line. Renders nothing in HTML itself; it feeds every link or image that resolves the label (PART 9R R1). Hoisted to the document like the other two definition kinds (PART 12 section 7), so a definition authored inside a container is a child of the document and its `pos` still says where it was written.",
+      "description": "The `[label]: /url \"title\" {attrs}` definition line. Renders nothing in HTML itself; it feeds every link or image that resolves the label (PART 9R R1). Hoisted to the document like the footnote definition (PART 12 section 7; an abbreviation definition inside a container is not a definition at all, so nothing is hoisted), so a definition authored inside a container is a child of the document and its `pos` still says where it was written.",
       "required": [
         "type",
         "label",

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -7791,7 +7791,7 @@ EOF = (* end of file *) ;
       which is worse and which §6 does not measure. (carve#524)
 
       §10 HAS SINCE ANSWERED IT: a link reference definition IS a node, hoisted
-      to the document like the other two definition kinds, and it carries the
+      to the document like the footnote definition, and it carries the
       destination. Both documents above now publish one - measured across all
       three engines, the definition-only document has a single
       `link_reference_definition` child holding `/u`, and the resolved one a
@@ -7905,7 +7905,7 @@ EOF = (* end of file *) ;
 
       WHAT WOULD MAKE `href: ""` DEFENSIBLE, and is not proposed here: a
       `link_reference_definition` node in the vocabulary, hoisted to the
-      document like the other two definition kinds. Then the destination
+      document like the footnote definition. Then the destination
       survives serialization and a consumer can resolve for itself. It is a
       bigger change than this clause is worth -- a new node type, a new hoisting
       rule, three engines to move, and every consumer obliged to run a
@@ -8539,12 +8539,20 @@ EOF = (* end of file *) ;
         title   the quoted title, unescaped, when the definition carries one
         attrs   a trailing attribute block on the definition line (§15 A2b)
 
-      IT HOISTS TO THE DOCUMENT, exactly as §7 requires of the other two
-      definition kinds: a definition authored inside a block quote or a list
-      item is a child of the DOCUMENT, and its `pos` still says where it was
-      written. The container is left as the author's remaining content, which is
-      what corpus 117-footnote-definition-inside-a-container-is-collected
-      already pins for the footnote case.
+      IT HOISTS TO THE DOCUMENT, exactly as §7 requires of the FOOTNOTE
+      definition: a definition authored inside a block quote or a list item is
+      a child of the DOCUMENT, and its `pos` still says where it was written.
+      The container is left as the author's remaining content, which is what
+      corpus 117-footnote-definition-inside-a-container-is-collected already
+      pins for the footnote case.
+
+      THE ABBREVIATION DEFINITION IS NOT THE THIRD KIND HERE. §7's clause AN
+      ABBREVIATION DEFINITION IS RECOGNIZED ONLY AT DOCUMENT LEVEL says the
+      opposite for that one: inside a container the line is not a definition
+      at all, it is paragraph text, and nothing is hoisted because nothing was
+      collected. Reading this section first, "the other two definition kinds"
+      said the reverse and made the abbreviation look like an unimplemented
+      hoist rather than a ruled-out one (carve#1267).
 
       WHY A NODE AND NOT A ROOT MAP. §7 fixes the root at three fields, and its
       reason is the one that decides this: §4 requires every node except the


### PR DESCRIPTION
Wording fix found while working markup-carve/carve#1267. No rule changes.

PART 12 §10 introduced hoisting like this:

> IT HOISTS TO THE DOCUMENT, exactly as §7 requires of **the other two definition kinds**

"The other two" reads as footnote **and abbreviation**. §7 says the opposite of the abbreviation:

> **AN ABBREVIATION DEFINITION IS RECOGNIZED ONLY AT DOCUMENT LEVEL -- NORMATIVE.** [...] Written inside a block quote, a list item or a div, the line is not a definition at all: it is ordinary paragraph text, it defines nothing, and it is preserved as the text the author typed.

So the section that introduces hoisting contradicted the section that rules on it, in the direction that makes #1267 look like an unimplemented hoist rather than a ruled-out one. It read that way to me first, and I recommended the wrong fix on that issue before finding §7.

## What changes

- §10 names the **footnote** definition, and gains a short clause saying the abbreviation is not the third kind here, with the reason and a pointer to §7.
- The same phrase appeared twice more in PART 9's link-reference rationale (`§10 HAS SINCE ANSWERED IT`, and the `WHAT WOULD MAKE href: "" DEFENSIBLE` note) and once in `resources/ast-schema.json`'s description of `link_reference_definition`. All four now say the same thing.

## Test note

`npm test` is green on this branch (2253 pass, 0 fail).

An earlier revision of this description claimed three pre-existing failures. That was a stale local `node_modules`: `package.json` pins `@markup-carve/carve` to carve-js `620def4e`, my install predated that bump, and the older build has no `{% … %}` support - so the delimited-comment schema field, the `braced-comment-in-a-template-source` lint trigger and one converter fixture all looked unimplemented. After `npm install` they pass. Nothing in the repo needed fixing.