### PR TITLE
test: the converter ledger is empty, and the gate still says so

### DIFF
--- a/resources/converter-drift.txt
+++ b/resources/converter-drift.txt
@@ -23,19 +23,11 @@
 #
 # Format: <engine>/<case-slug><space><space><reason>
 
-# The stays-text escapes ruled on carve#1130 (CommonMark+GFM is the contract;
-# a construct only Carve or another flavour spells is escaped so the migrated
-# document keeps saying what its author wrote). carve-js shipped them in
-# carve-js#1060; carve-php shipped them in carve-php#1311, which is why only
-# the carve-rs line is left here.
-rust/05-markdown-verbatim-sigils-stay-text  ruled stays-text escape not shipped; math/literal sigils convert
-
-# carve#1210 ruling (2026-08-16): "a bare-text <li> imports as a TIGHT list
-# item; <li><p>...</p></li> stays loose. HTML draws the tight/loose distinction
-# the same way Carve does, and import preserves source structure rather than
-# normalizing." Carve spells tight/loose per LIST, so a MIXED list resolves the
-# way CommonMark resolves it - one paragraph item loosens the whole list - and
-# case 28 pins that. carve-php reads the source's own markup; carve-js shipped
-# the mixed-list half in carve-js#1110, which is why only the carve-rs line on
-# case 27 is left here.
-rust/27-html-a-bare-text-list-item-imports-tight  ruled tight-li import not shipped; a bare-text item imports loose
+# NO ENTRIES. Every engine converts every case in its formats to the corpus's
+# expectation, so there is nothing to declare - which is the state this file is
+# meant to be returned to, not an unusual one.
+#
+# An empty ledger and an unwired gate look identical from outside, so read the
+# converter summary rather than this file: `npm run compare:convert` prints a
+# convert_pass count per engine, and it is that count, not this emptiness, that
+# says the cases are being converted and compared.


### PR DESCRIPTION
markup-carve/carve-rs#1016 landed both converter fixes carve-rs owed, so the two remaining lines in `resources/converter-drift.txt` are stale. The convert gate fails on them in the declared-but-matching direction, which is the direction the file's own header calls for deleting the line in the commit that proves it.

Measured against a carve-rs built from `1351074`, with carve-js and carve-php built from their mains, in a fresh clone with a private `CARGO_TARGET_DIR` and a clean `npm ci`.

Before, `npm run compare:impls -- --corpus=convert --fail-on-diff` exits 1:

```
rust: convert_pass=26/26 declared_drift=0 mismatch=0 error=0 skipped=2
js:   convert_pass=26/26 declared_drift=0 mismatch=0 error=0 skipped=2
php:  convert_pass=28/28 declared_drift=0 mismatch=0 error=0 skipped=0
cross_convert_diffs=0

2 converter gate failure(s):
  - converter-drift.txt declares rust/05-markdown-verbatim-sigils-stay-text and the engine now matches ...
  - converter-drift.txt declares rust/27-html-a-bare-text-list-item-imports-tight and the engine now matches ...
```

No other engine or case mismatches, so nothing else was owed and nothing was declared to reach green. After, the same counts and exit 0.

The prose that explained each line went with it. Both paragraphs existed to say which engine still owed the fix and why the other two were absent, and neither sentence is true of a file with nothing left in it.

## The ledger is now empty, so the emptiness was checked

An empty exclusion file and a dead gate are indistinguishable by reading, so the gate was mutated in both of the directions it claims to fail in:

- Declaring a case that passes (`rust` on case 01) turns the run red naming that exact pair. That proves the declared-but-matching direction is live.
- Corrupting a passing case's `expected.html` turns it red with all three engines reported as diverging on it undeclared, and the pass counts drop by one each. That is the direction the first mutation cannot prove: a declaration goes stale whether the case was converted and matched or was never reached at all, and only this one shows the conversions and comparisons are actually happening.

Both mutations reverted. The header now points a reader at the `convert_pass` counts rather than at this file, since those counts are what separates "nothing is excluded" from "nothing is checked".

No CHANGELOG entry: a drift-ledger deletion changes nothing a consumer of the package can observe.
