### PR TITLE
test: the value ledger's emptiness is asserted, not just parsed

### DIFF
--- a/tests/ast-values.test.mjs
+++ b/tests/ast-values.test.mjs
@@ -74,26 +74,48 @@ test('a malformed declaration line is an error, never a silent zero', () => {
   assert.match(problems[0], /^MALFORMED\s+line 1/)
 })
 
-test('the shipped declaration parses', () => {
-  const problems = reconcileDeclared(
-    new Map(),
-    readFileSync(resolve(root, 'resources/ast-value-divergence.txt'), 'utf8'),
-  )
-  // Every problem must be a FIXED - i.e. a real declared line - and never a
-  // MALFORMED one. The file carried no entries between carve#846 and
-  // 2026-08-07, when `link.ref` and `text.value` were declared (carve#962,
-  // carve#963), so this loop now runs over two problems rather than none - and
-  // that is the point of asserting it this way rather than counting.
+const shippedDeclaration = () =>
+  readFileSync(resolve(root, 'resources/ast-value-divergence.txt'), 'utf8')
+
+test('the shipped declaration parses and currently needs no baseline rows', () => {
+  // Held to EMPTY, the way `tests/ast-spans.test.mjs` holds its own ledger.
   //
-  // NO FLOOR, and that is deliberate rather than an oversight: a declaration of
-  // zero divergences is the state the panel is trying to reach, so a floor
-  // would be the inverse defect, a gate that only works while something is
-  // wrong. What proves the parser discriminates is the six tests above, each of
-  // which feeds it a literal line and reads the verdict.
-  // `tests/ast-spans.test.mjs` floors its declaration, and the difference is
-  // not an inconsistency: that ledger records an open convention across two
-  // dozen node types, so an emptied one there is loss rather than progress.
-  for (const p of problems) assert.match(p, /^FIXED/, p)
+  // This assertion used to be `for (const p of problems) assert.match(p,
+  // /^FIXED/)`, which cannot fail on a declared row: reconciling against an
+  // empty measurement turns EVERY row into a FIXED, so the loop was handed the
+  // exact shape it accepts. Appending `text.value  3  x` to the shipped file
+  // left this suite green at 9 passing (carve#1271) - the same measurement that
+  // opened carve#534 against the script, now reproduced against the test that
+  // replaced it.
+  //
+  // NO FLOOR still, and the old comment was right about that much: a ledger of
+  // zero divergences is the state the panel is trying to reach, so requiring a
+  // minimum row count would be a gate that only works while something is wrong.
+  // The defect was the other end. Refusing to require rows is not the same as
+  // accepting any, and only one of those two was implemented.
+  //
+  // What the empty measurement means here: this suite runs on a host with no
+  // engine checkouts, so it cannot measure divergence itself. `npm run
+  // ast:check` does that, and it has verified the file empty against all three
+  // engines. Between those runs, the honest per-PR statement is "the ledger is
+  // still empty", and that is what this asserts. A row that is genuinely owed
+  // gets established by ast:check and moves this line with it - deliberately,
+  // in the commit that measures it, rather than slipping past unread.
+  assert.deepEqual(reconcileDeclared(new Map(), shippedDeclaration()), [])
+})
+
+test('and a real divergence the shipped file does not declare is caught', () => {
+  // The other direction, against the SHIPPED text rather than a literal. The
+  // test above would still pass if the file somehow declared everything, and
+  // the NEW case two tests up proves the reconciler on a fabricated
+  // declaration; neither one asserts that the file as shipped still lets an
+  // undeclared divergence through.
+  const problems = reconcileDeclared(
+    new Map([['table_cell.align', new Set(['a.crv', 'b.crv'])]]),
+    shippedDeclaration(),
+  )
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /^NEW\s+table_cell\.align diverges in 2 document\(s\)/)
 })
 
 test('the signature keeps scalars and drops positions', () => {


### PR DESCRIPTION
Closes markup-carve/carve#1271.

`resources/ast-value-divergence.txt` is empty and true, and until now nothing on a pull request could tell. Reproduced before changing anything: appending `text.value  3  x` to it left `tests/ast-values.test.mjs` green.

```
$ node --test tests/ast-values.test.mjs
exit 0    # tests 9   # pass 9   # fail 0
```

## Why it could not fail

Reconciling the shipped file against an empty measurement turns **every** row into a `FIXED` problem, and the assertion was:

```js
for (const p of problems) assert.match(p, /^FIXED/, p)
```

so it was handed exactly the shape it accepts. Same family as markup-carve/carve#755, and the same measurement that opened markup-carve/carve#534 against the script this test was written to replace, now true of the replacement.

The two sibling ledgers are guarded per-PR - mutating `ast-span-divergence.txt` fails `tests/ast-spans.test.mjs`, mutating `engine-fmt-drift.txt` fails `corpus-fmt-roundtrip.test.mjs` - so this was the third of three, and the asymmetry is the defect.

## The change

The shipped-declaration test takes the span sibling's shape: the ledger must reconcile to nothing. A second test covers the other direction against the shipped text rather than a literal, because the first would still pass if the file somehow declared everything.

The old comment's "NO FLOOR" reasoning is kept where it was right: a ledger of zero divergences is the state the panel is trying to reach, so requiring a minimum row count would be a gate that only works while something is wrong. The defect was at the other end. Refusing to require rows is not the same as accepting any, and only one of those two was implemented.

This suite runs without engine checkouts, so it cannot measure divergence itself; `npm run ast:check` does, and has verified the file empty against all three engines. The honest per-PR statement between those runs is "the ledger is still empty", which is what it now asserts. A row that is genuinely owed gets established by ast:check and moves this line with it.

## Mutations, each reverted

| mutation | before | after |
| --- | --- | --- |
| bogus `text.value  3` row in the value ledger | exit 0, 9 pass, 0 fail | **exit 1**, 8 pass, 2 fail |
| `NEW` branch disabled in `scripts/spec/ast-values.mjs` | - | **exit 1**, and the new shipped-text test is one of the two failures |
| control: bogus row in `ast-span-divergence.txt`, untouched here | - | **exit 1** in `tests/ast-spans.test.mjs` |

The second is how the undeclared-divergence direction is shown to be asserted rather than vacuous: with that branch removed the new test stops passing, so it is reading a real verdict off the shipped file. The third is the control, and it says the suite is live rather than skipped.

## Release coordination

`main` is frozen at `35b0453a` for today's release. **This diff is one file, `tests/ast-values.test.mjs`. It touches nothing under `tests/corpus/`, `resources/` or `docs/`,** and no resource any engine reads, so the release target does not have to move with it.

The ledger itself is left empty. This is about the gate, not the contents.

No CHANGELOG entry: test-only, nothing a consumer of the package can observe.
