### PR TITLE
fix: the resolved carve-rs path is absolute, so a relative checkout still runs

### DIFF
--- a/scripts/lib/engine-locations.mjs
+++ b/scripts/lib/engine-locations.mjs
@@ -45,7 +45,16 @@ export function rustBinaryCandidates(dir = rustDir()) {
     const base = isAbsolute(targetDir) ? targetDir : resolve(dir ?? root, targetDir)
     candidates.push(join(base, 'release/carve'), join(base, 'debug/carve'))
   }
-  if (dir) candidates.push(join(dir, 'target/release/carve'), join(dir, 'target/debug/carve'))
+  // ABSOLUTE, always. `CARVE_RS_DIR` may be relative - docs/implementation-
+  // comparison.md spells it `../carve-rs` - and compare-impls spawns this
+  // binary with `cwd` set to the checkout. A path relative to THIS repo is
+  // then re-resolved against the checkout and lands where nothing built:
+  // `vendor/carve-rs` becomes `vendor/carve-rs/vendor/carve-rs/...` and the
+  // spawn fails ENOENT, so the runner drops carve-rs and exits 2. The runners
+  // that spawn WITHOUT a cwd never saw it, which is why only one of the seven
+  // was affected. `resolve` anchors against this process's cwd, the same base
+  // `existsSync` above uses, so the check and the spawn cannot disagree.
+  if (dir) candidates.push(resolve(dir, 'target/release/carve'), resolve(dir, 'target/debug/carve'))
   return candidates
 }
 

--- a/tests/rust-binary-resolution.test.mjs
+++ b/tests/rust-binary-resolution.test.mjs
@@ -24,7 +24,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { isAbsolute, join, relative, resolve } from 'node:path'
 import { rustBinary, rustBinaryCandidates } from '../scripts/lib/engine-locations.mjs'
 
 /** Lay down an executable-shaped file at `dir/rel`, creating the parents. */
@@ -120,6 +120,28 @@ test('an unbuilt checkout still resolves to null', () => {
 
   assert.equal(withTargetDir(undefined, () => rustBinary(checkout)), null)
   assert.equal(withTargetDir(join(root, 'nowhere'), () => rustBinary(checkout)), null)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('a relative CARVE_RS_DIR still resolves to an absolute binary', () => {
+  // `compare:impls` spawns this binary with `cwd` set to the carve-rs checkout,
+  // and `CARVE_RS_DIR` may be relative - docs/implementation-comparison.md
+  // spells it `../carve-rs`. A candidate relative to THIS repo is re-resolved
+  // against the checkout by the child, so `vendor/carve-rs/target/release/carve`
+  // is looked for under `vendor/carve-rs/vendor/carve-rs/...`, the spawn fails
+  // ENOENT and the runner drops carve-rs. The six runners that spawn with no
+  // `cwd` never saw it, so nothing else in the suite would catch this.
+  const root = sandbox()
+  const checkout = join(root, 'vendor', 'carve-rs')
+  const built = plant(checkout, 'target/release/carve')
+  const asRelative = relative(process.cwd(), checkout)
+
+  const found = withTargetDir(undefined, () => rustBinary(asRelative))
+  assert.equal(found, built)
+  assert.ok(isAbsolute(found), `not absolute: ${found}`)
+  // The property that actually matters: re-resolving from the CHILD's cwd is
+  // a no-op, so the path the check found is the path the spawn runs.
+  assert.equal(resolve(checkout, found), built)
   rmSync(root, { recursive: true, force: true })
 })
 


### PR DESCRIPTION
Follows a post-merge review of #1291, which was merged without a `codex review` pass.

`rustBinaryCandidates` builds the checkout fallback with `join(dir, 'target/release/carve')`, where `dir` is whatever `CARVE_RS_DIR` holds. That variable may be relative - `docs/implementation-comparison.md` spells it exactly that way:

```
CARVE_RS_DIR=../carve-rs \
```

so the candidate comes back relative to this repo.

Six of the seven runners spawn the binary with no `cwd`, and for them a path relative to this repo is right. `compare:impls` is the odd one out: it sets `cwd` to the carve-rs checkout, so the child re-resolves the relative path against that directory.

With `CARVE_RS_DIR=vendor/carve-rs`, the resolver returns `vendor/carve-rs/target/release/carve`, `existsSync` finds it from this repo's cwd, and the spawn then looks for it under `vendor/carve-rs/vendor/carve-rs/target/release/carve`. It fails ENOENT, carve-rs is dropped, and the runner exits 2 for want of a third engine - the same "a gate that measures two engines while claiming three" shape #1291 was written to close, arriving from the other side.

Reproduced directly with a planted binary:

```
resolved    = vendor/carve-rs/target/release/carve
spawn status= null error= ENOENT
OLD spawn   = 0 stdout= "RAN\n"
```

`OLD` is the code #1291 replaced, which returned `./target/release/carve` - relative to the CHILD's cwd, so it worked.

Resolving the candidates to absolute paths works for both shapes of caller, and anchors against the same cwd `existsSync` uses on the line below, so the check and the spawn cannot disagree.

The documented `../carve-rs` spelling happens to survive the bug: `..` from inside the checkout is the checkout's own parent, so the doubled path collapses back to the right one. That is why the spelling in the docs did not surface it.

## What is not changed here

The `CARGO_TARGET_DIR` branch already produced absolute paths (`resolve` on a relative value, `join` on an absolute one), so only the checkout fallback moves. The ordering, the fallback semantics and the seven call sites are untouched.

The review also raised the shared-`CARGO_TARGET_DIR` hazard: with two carve-rs checkouts pointing at one target directory, the artifact belongs to whichever built last, and running it directly skips the fingerprint check `cargo run` would have made. That is real, and `scripts/compare-impls.mjs` already documents the failure it caused once. It is not addressed here - telling the two apart means reimplementing cargo's fingerprints, and the alternative is a per-checkout `CARGO_TARGET_DIR`, which is a call for the maintainer rather than something to slip into a path fix.

No CHANGELOG entry, per the single CHANGELOG pass at the end of this batch.
