### PR TITLE
Move the engine pin to carve-js main, and clear what the move cleared

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -617,9 +617,9 @@ A row may name an issue only where one of those still declares the debt.
 
 | engine | shape | positions |
 |---|---|---|
-| carve-js | §3a conformant on the resolved form: publishes `href`, `ref` and `rawRef` together | every block and inline placed, except the two categories §4 exempts: a coalesced `text` run, and a table cell continued on a `+` line |
-| carve-rs | §3a conformant on the resolved form: `ref` and `rawRef` survive resolution beside `href` | every block and inline placed, except the two categories §4 exempts: a coalesced `text` run, and a reassembled table cell |
-| carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries the resolution key in `ref` beside `rawRef`, the same label the other two publish on every corpus document | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the two categories §4 exempts: a coalesced `text` run, and a reassembled table cell |
+| carve-js | §3a conformant on the resolved form: publishes `href`, `ref` and `rawRef` together | every block and inline placed, except the categories §4 exempts: a coalesced `text` run, a table cell continued on a `+` line, and a verbatim run continued on a `+` line |
+| carve-rs | §3a conformant on the resolved form: `ref` and `rawRef` survive resolution beside `href` | every block and inline placed, except the categories §4 exempts: a coalesced `text` run, a reassembled table cell, and a verbatim run continued on a `+` line |
+| carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries the resolution key in `ref` beside `rawRef`, the same label the other two publish on every corpus document | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the two categories §4 exempts - a coalesced `text` run and a reassembled table cell - and a line block's spaced content, which the other two place and markup-carve/carve-php#1351 tracks |
 | carve-rb / carve-py / carve-go / carve-wasm | publish carve-rs's bytes | whatever carve-rs records |
 
 The gaps are listed rather than smoothed over on purpose: "six implementations"
@@ -633,11 +633,20 @@ written down.
 
 The definition-list entry this paragraph used to name is fixed: carve-rs places
 `definition_term` and `definition_description` today, checked over every corpus
-document that contains one. So is the gap that replaced it. Re-measured over 833
+document that contains one. So is the gap that replaced it - re-measured over 833
 documents on 2026-08-07, the OWED half of `resources/ast-position-waivers.txt`
-is EMPTY: the paragraphs a capped container degrades to are placed in all three
-engines now, and so is everything else that stood in that column a day earlier.
-Every position finding left is `permitted` under §4.
+was EMPTY.
+
+It did not stay empty. Re-measured on 2026-08-17 over 1124 documents, at
+carve-js e2e8460, carve-rs b6ff319 and carve-php b6d49a7, that half holds one
+defect again: carve-php drops the position of a line block's content where the
+source's spaces became indentation sentinels, and carve-rs publishes the same
+value WITH a span, so a true span exists. The corpus grew 291 documents between
+the two measurements, which is the whole reason an undated "the gap is closed"
+sentence is worth nothing here - a re-measurement is what says so, and only for
+the corpus it ran over.
+
+Every other position finding is `permitted` under §4.
 
 That is also how the carve-rs row went wrong. It named the capped-container gap
 for two days after the gap closed and the declaration behind it was deleted,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#620def4e4098df29ae8bc5e0ca58a81854b3f14b",
+        "@markup-carve/carve": "github:markup-carve/carve-js#e2e84605fc0da519054465d915090192977d5be8",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#620def4e4098df29ae8bc5e0ca58a81854b3f14b",
-      "integrity": "sha512-HG6FLUPCh50sg/7drGbhjpZlSlJG8tP88MPxjY2C6sDSh5WiYUS4cTaF85DknuGDydrR7auNktXPt/rjpE633A==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#e2e84605fc0da519054465d915090192977d5be8",
+      "integrity": "sha512-yuJVkci/fGyi0eX2XJ+g7NIrbYakyBahUVxSsO62QDmyVBbSMJCd9KbT7l/nMxG1UaVgy9I8iTo3m8acfV4omg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#620def4e4098df29ae8bc5e0ca58a81854b3f14b",
+    "@markup-carve/carve": "github:markup-carve/carve-js#e2e84605fc0da519054465d915090192977d5be8",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/ast-position-waivers.txt
+++ b/resources/ast-position-waivers.txt
@@ -26,17 +26,32 @@
 # added over the preceding week, while the owed half - 7 in carve-js, 17 in
 # carve-rs, 4 in carve-php - did not move at all.
 #
-# THE OWED HALF IS NOW EMPTY. Re-measured 2026-08-07 at carve-js 39b9223,
-# carve-rs 0d560cc and carve-php d45e250 over 833 documents, every one of those
-# 28 owed findings is gone: carve-js#813 and carve-js#814, carve-rs#716, #736
-# and #737, and carve-php#965 all landed, and the run reports 28 findings in
-# carve-js and 16 in each of the other two, all of them waived and none
-# outstanding. What remains below is the permitted half alone.
+# THE OWED HALF EMPTIED ONCE, AND DID NOT STAY EMPTY. Re-measured 2026-08-07 at
+# carve-js 39b9223, carve-rs 0d560cc and carve-php d45e250 over 833 documents,
+# all 28 owed findings were gone: carve-js#813 and carve-js#814, carve-rs#716,
+# #736 and #737, and carve-php#965 had all landed.
 #
-# That is the state this file was written to reach, and it is not a reason to
-# retire the file: the permitted lines still fail if an engine stops producing
-# them, and the OWED section is where the next gap gets declared. A ledger only
-# kept while it is non-empty is a ledger nobody starts again.
+# RE-MEASURED 2026-08-17 at carve-js e2e8460, carve-rs b6ff319 and carve-php
+# b6d49a7 over 1124 documents, the owed half holds four findings again, all in
+# carve-php and all one defect (markup-carve/carve-php#1351). Twenty-four new
+# PERMITTED findings arrived in the same window - 11 in carve-js, 8 in carve-rs
+# and 5 in carve-php, over 20 declaration lines - from the `333`
+# continuation-row fixtures. Findings, not lines: the count column is what the
+# run reconciles against, and a line may carry more than one.
+#
+# WHICH IS THE POINT OF DATING THE CLAIM. The corpus grew 291 documents between
+# those two measurements, and the header's own note that the permitted half
+# "grew with the fixtures added over the preceding week" says fixtures produce
+# position findings. An emptiness claim measured over a corpus a quarter smaller
+# than today's is not evidence the half is still empty - it is evidence of what
+# was true on the day, which is why the day is written down. Whoever re-measures
+# next: replace the paragraph above, do not append to it, and name the corpus
+# size and the three engine commits you measured at.
+#
+# The file was never going to be retired at empty: the permitted lines still
+# fail if an engine stops producing them, and the OWED section is where the next
+# gap gets declared. A ledger only kept while it is non-empty is a ledger nobody
+# starts again.
 #
 # Format: <engine>  <document>  <type>  <count>  <status>
 #
@@ -108,6 +123,20 @@ carve-php  41-line-blocks-9.crv                                   text  3  permi
 carve-php  63-table-multi-line-cell-continuation.crv              text  1  permitted
 carve-php  64-table-rowspan-with-multi-line-content.crv           text  1  permitted
 
+# The `333` fixtures, added 2026-08-16 by markup-carve/carve#1306: an inline run
+# left open at a row's closing pipe and continued on the `+` row below. The run's
+# value is the two lines JOINED - `x` and `y` become the one text run `x y` - so
+# it is the same reassembly as 237, reaching a new construct. The counts differ
+# per engine because the engines still parse these three documents differently
+# (resources/engine-pin-drift.txt declares the carve-js half), not because the
+# clause reaches them differently.
+
+carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe.crv    text  1  permitted
+carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4.crv  text  1  permitted
+carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  text  2  permitted
+carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  text  1  permitted
+carve-php  333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  text  1  permitted
+
 # ---- PERMITTED: a table cell continued on a `+` line -------------------------
 #
 # docs/ast-json.md names the construct in the §4 clause, and its conformance
@@ -136,9 +165,61 @@ carve-php  256-table-cell-padding-must-be-a-space-17.crv          table_cell  2 
 carve-php  63-table-multi-line-cell-continuation.crv              table_cell  1  permitted
 carve-php  64-table-rowspan-with-multi-line-content.crv           table_cell  1  permitted
 
+# The same `333` fixtures. A cell whose content is split across the row and its
+# `+` continuation has no contiguous extent - covering both halves would sweep
+# in the row boundary and the `+` marker, which are not the cell's text.
+
+carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe.crv    table_cell  1  permitted
+carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4.crv  table_cell  1  permitted
+carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  table_cell  2  permitted
+carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe.crv    table_cell  1  permitted
+carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4.crv  table_cell  1  permitted
+carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  table_cell  2  permitted
+carve-php  333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe.crv    table_cell  1  permitted
+carve-php  333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4.crv  table_cell  1  permitted
+carve-php  333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  table_cell  2  permitted
+
+# ---- PERMITTED: a verbatim run continued on a `+` line -----------------------
+#
+# NEW TYPE, same clause. A verbatim run left open at the row's closing pipe:
+#
+#     | a `b |
+#     + c` |
+#
+# The run closes on the continuation row, so its value is `b c` - assembled
+# from two lines, and no offset slices it. carve-php does not reach this
+# population: it parses these three documents into a shape with no such node,
+# which is a SHAPE divergence the panel above reports and not a position one.
+
+carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe.crv    code  1  permitted
+carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4.crv  code  1  permitted
+carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  code  1  permitted
+carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe.crv    code  1  permitted
+carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4.crv  code  1  permitted
+carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  code  1  permitted
+
 # ---- OWED --------------------------------------------------------------------
 #
-# EMPTY as of 2026-08-07, and deliberately kept as a section.
+# NOT EMPTY as of 2026-08-17. It was empty from 2026-08-07 until this
+# re-measurement, over a corpus that grew by 291 documents in between.
+#
+# carve-php drops the position of a line-block `text` node whose value is the
+# source's spaces rewritten as indentation sentinels. carve-rs publishes the
+# SAME value WITH a span, and one sentinel stands for one space, so the value's
+# length is the slice's length and a true span exists. Not §4: the node is
+# placeable and has not been placed.
+#
+# The control is `41-line-blocks-9`, listed permitted above. It uses TABS, a tab
+# expands to a variable number of sentinels, no slice has the value's length,
+# and all three engines omit. Per-engine symmetry is the tell - when the cause
+# is the construct every engine omits, and when one engine is alone the finding
+# is owed.
+
+carve-php  268-trailing-whitespace-on-a-content-line-is-dropped-12.crv  text  1  markup-carve/carve-php#1351
+carve-php  41-line-blocks-2.crv                                         text  1  markup-carve/carve-php#1351
+carve-php  41-line-blocks-3.crv                                         text  2  markup-carve/carve-php#1351
+
+# WHAT USED TO BE HERE, and was deliberately kept as a section while empty.
 #
 # What used to be here, each deleted because `ast:check` reported it FIXED
 # against the engine's main and a direct probe of that engine agreed:

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,13 +24,7 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-322-an-attribute-block-reaches-the-nested-list-it-precedes  the pin predates markup-carve/carve-js#1107, so an attribute block before a nested list is dropped
-322-an-attribute-block-reaches-the-nested-list-it-precedes-2  same, without the blank line before the attribute block
-322-an-attribute-block-reaches-the-nested-list-it-precedes-5  same, with an ordered nested list
-322-an-attribute-block-reaches-the-nested-list-it-precedes-6  same, with two stacked attribute blocks
-322-an-attribute-block-reaches-the-nested-list-it-precedes-7  same, with the attribute line ending a run that also holds a paragraph
-323-a-block-attached-after-an-invisible-line-leaves-the-item-tight  the pin predates markup-carve/carve-js#1107, so the attribute block before the nested list is dropped; the tightness half it already gets right
-326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open  the pin predates markup-carve/carve#1280, so a column-0 line still folds into an item whose last block is a heading
+326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open  the pin now postdates markup-carve/carve#1280 but carve-js has not implemented the ruling, so a column-0 line still folds into an item whose last block is a heading
 326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-3  same, with a table as the item's last block
 326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-4  same, with a thematic break
 326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-5  same, with a line comment
@@ -39,19 +33,12 @@
 326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-8  same, with a footnote definition
 326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-9  same, with an attribute block
 326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-11  same, with a block quote whose own last block is a heading
-327-a-continuation-marker-attaches-one-block-and-the-boundary-is-that-block-s-extent  the pin predates markup-carve/carve#1290, so one `+` still attaches every block up to the boundary
+327-a-continuation-marker-attaches-one-block-and-the-boundary-is-that-block-s-extent  the pin now postdates markup-carve/carve#1290 but carve-js has not implemented the ruling, so one `+` still attaches every block up to the boundary
 327-a-continuation-marker-attaches-one-block-and-the-boundary-is-that-block-s-extent-3  same, with the attached paragraph wrapped over two lines
 327-a-continuation-marker-attaches-one-block-and-the-boundary-is-that-block-s-extent-6  same, in the `- +` first-block form
 327-a-continuation-marker-attaches-one-block-and-the-boundary-is-that-block-s-extent-7  a different pin defect the case uncovers: after a `- +` first-block attachment the pin does not recognize a second `+`, rendering it as a literal paragraph and leaving the quote at top level
 327-a-continuation-marker-attaches-one-block-and-the-boundary-is-that-block-s-extent-8  same, in the block-quote form
-328-an-unclosed-verbatim-run-in-a-row-stops-at-the-closing-pipe  the pin predates markup-carve/carve#1284, so an unclosed verbatim run swallows the row's closing pipe and the line stays prose
-328-an-unclosed-verbatim-run-in-a-row-stops-at-the-closing-pipe-2  same, with a second row below it
-328-an-unclosed-verbatim-run-in-a-row-stops-at-the-closing-pipe-3  same, under a header row
-328-an-unclosed-verbatim-run-in-a-row-stops-at-the-closing-pipe-4  same, with a double-backtick run
-329-a-floating-attribute-is-scoped-to-the-container-that-holds-it-2  the pin predates markup-carve/carve#1280, so the flush-left line still joins the quote and the attribute reaches it
-329-a-floating-attribute-is-scoped-to-the-container-that-holds-it-6  the pin predates markup-carve/carve#1281, so a wrapped attribute block at the end of a definition body still folds the flush-left line in and attributes it
-331-an-unclosed-inline-run-in-a-line-block-reaches-the-end-of-the-block  the pin predates markup-carve/carve-js#1116, so an unclosed run still closes at the line block's line break
-331-an-unclosed-inline-run-in-a-line-block-reaches-the-end-of-the-block-4  same, in the math form of the run
-333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe  the pin predates markup-carve/carve#1284, so the open run still swallows the row's closing pipe and the continuation row's leftover `|` rides out as text
-333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4  same, with a pipe inside the run on the continuation row
-333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5  same, with the run opening in the second column of a two-column row
+328-an-unclosed-verbatim-run-in-a-row-stops-at-the-closing-pipe-4  markup-carve/carve-js#1126 shipped markup-carve/carve#1284 for the single-backtick run only, so a double-backtick run still closes at the row's first pipe and the row splits into two cells
+329-a-floating-attribute-is-scoped-to-the-container-that-holds-it-2  the pin now postdates markup-carve/carve#1280 but carve-js has not implemented the ruling, so the flush-left line still joins the quote and the attribute reaches it
+329-a-floating-attribute-is-scoped-to-the-container-that-holds-it-6  the pin now postdates markup-carve/carve#1281 but carve-js has not implemented the ruling, so a wrapped attribute block at the end of a definition body still folds the flush-left line in and attributes it
+333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4  markup-carve/carve-js#1126 shipped markup-carve/carve#1284 for the row's closing pipe only, so a pipe inside the run on the continuation row still ends the run and the rest of the row is dropped

--- a/tests/ast-json-claims.test.mjs
+++ b/tests/ast-json-claims.test.mjs
@@ -352,6 +352,7 @@ const permittedByEngine = () => {
 const PERMITTED_PHRASE = {
   text: 'coalesced `text` run',
   table_cell: 'table cell',
+  code: 'verbatim run continued on a `+` line',
 }
 
 test('every engine the position ledger names has a row, and every reconciled engine its own', () => {

--- a/tests/citation-definition-is-a-node.test.mjs
+++ b/tests/citation-definition-is-a-node.test.mjs
@@ -22,14 +22,23 @@
  *      the layer that can fail today: edit any part of the schema entry and
  *      one of these flips.
  *
- *   2. A ROLLOUT TRIPWIRE on the pinned reference build. No engine emits the
- *      node yet, so the positive assertion - parse the corpus-optional
- *      citation document and find a `citation_definition` in it - cannot be
- *      written without turning this repo red on a defect that lives elsewhere.
- *      What is written instead is what the pin ACTUALLY produces today, so the
- *      day carve-js emits the node this test fails and the pin flips to the
- *      positive form. A spec claim with no expiry is how the AST page has gone
- *      stale twice; this one has one.
+ *   2. WHAT THE PINNED REFERENCE BUILD PRODUCES. This began as a rollout
+ *      tripwire: no engine emitted the node, so the assertion recorded what
+ *      the pin ACTUALLY produced - a paragraph holding the citation group and
+ *      the literal `: ` separator - and was written to FAIL the day carve-js
+ *      emitted the node. It fired when the pin moved past
+ *      markup-carve/carve-js#1122, and the assertion is now the positive one:
+ *      parse the corpus-optional citation document and find the three
+ *      `citation_definition` nodes in it, schema-valid, with no paragraph left
+ *      behind. A spec claim with no expiry is how the AST page has gone stale
+ *      twice; this one had one, and it paid.
+ *
+ *      What does NOT follow from the rollout is the two exemptions that name
+ *      this type: `NOT_PRODUCIBLE` in tests/ast-schema.test.mjs and
+ *      `OPT_IN_ONLY` in tests/schema-fields-are-produced.test.mjs. Both are
+ *      claims about the DEFAULT-profile corpus, where citations is off and
+ *      `[@key]: entry` is ordinary paragraph text. An engine shipping §18 does
+ *      not change that, so both entries stay.
  */
 
 import { test } from 'node:test'
@@ -145,34 +154,51 @@ test('§18: the schema declares exactly the fields the clause names', () => {
 })
 
 /*
- * The tripwire. Everything above is about the shape; this is about where the
- * fleet is against it.
+ * Everything above is about the shape; this is about where the fleet is
+ * against it. It was a tripwire while the shape had no producer; it is a
+ * conformance assertion now that the pin has one.
  */
 const SOURCE = readFileSync(resolve(root, 'tests/corpus-optional/05-citations-numbered.crv'), 'utf8')
 
-test('the pinned reference build does not emit the node yet', () => {
+test('the pinned reference build emits the node', () => {
   // `parse` is the stage that matters: it is what `toAstJson` serializes, and
   // §3a makes the serialized tree the PRE-RESOLVE one. carve-js's own collect
   // pass runs in the citations extension's `afterParse` hook, which `parse`
-  // does not call - so the definition line survives into the published tree as
-  // the paragraph below, and an engine implementing §18 has to build the node
-  // here rather than in the hook.
+  // does not call - so an engine implementing §18 has to build the node here
+  // rather than in the hook, and markup-carve/carve-js#1122 is where it did.
   const tree = parse(SOURCE, { extensions: [citations()] })
-  const types = tree.children.map((node) => node.type)
-  assert.ok(
-    !types.includes('citation_definition'),
-    'carve-js now emits citation_definition: PART 12 §18 has shipped in the pin, so replace this ' +
-      'test with the positive assertion - the definition lines are citation_definition nodes with ' +
-      'their key, entry and metadata - and drop citation_definition from NOT_PRODUCIBLE in ' +
-      'tests/ast-schema.test.mjs and from OPT_IN_ONLY in tests/schema-fields-are-produced.test.mjs.',
-  )
+  const defs = tree.children.filter((node) => node.type === 'citation_definition')
+  assert.equal(defs.length, 3, 'the document has three bibliography lines, so it has three nodes')
 
-  // What it emits instead, recorded so the gap is a measurement rather than a
-  // sentence: the definition lines survive as one paragraph whose first child
-  // is the citation group and whose next child is the literal `: ` separator.
-  const last = tree.children[tree.children.length - 1]
-  assert.equal(last.type, 'paragraph')
-  assert.equal(last.children[0].type, 'citation_group')
-  assert.equal(last.children[0].items[0].key, 'smith2020')
-  assert.match(last.children[1].value, /^: /)
+  // The keys, in source order, and the metadata each line carries.
+  assert.deepEqual(defs.map((node) => node.key), ['smith2020', 'jones2019', 'doe2021'])
+  assert.deepEqual(defs.map((node) => node.attrs?.keyValues?.year), ['2020', '2019', '2021'])
+
+  // The entry is INLINE content in `children`, not a field and not a block: the
+  // emphasis in `*A Study*` has to survive as a node, or the entry is a string
+  // a consumer would have to re-parse to render.
+  const [smith] = defs
+  assert.deepEqual(smith.children.map((node) => node.type), ['text', 'strong', 'text'])
+  assert.equal(smith.children[1].children[0].value, 'A Study')
+
+  // And every node the engine builds is a node the schema declares. This is the
+  // join between the two layers: layer 1 proved the schema accepts the ruled
+  // shape, this proves the pin produces that shape and not a near-miss.
+  //
+  // ALL THREE, not just the first. A pin that kept `smith` valid while emitting
+  // a malformed `entry` for one of the others would still satisfy the key and
+  // year assertions above, and this is the only layer that would have caught it.
+  for (const node of defs) {
+    assert.equal(validate(doc(node)), true, `the pinned build's ${node.key} node failed the schema: ${errors()}`)
+  }
+
+  // The definition renders nothing where it sits, so no paragraph is left
+  // behind holding a citation group and the literal `: ` separator - the shape
+  // this test recorded for as long as the node was unimplemented. Only the
+  // prose paragraph cites.
+  const citing = tree.children.filter(
+    (node) => node.type === 'paragraph' && node.children.some((c) => c.type === 'citation_group'),
+  )
+  assert.equal(citing.length, 1)
+  assert.ok(!citing[0].children.some((c) => c.type === 'text' && c.value.startsWith(': ')))
 })

--- a/tests/corpus-convert.test.mjs
+++ b/tests/corpus-convert.test.mjs
@@ -146,9 +146,10 @@ const PINNED_UNIMPLEMENTED = {
  * that moves the pin, and the meaning assertion still runs regardless.
  */
 const PINNED_DRIFT = {
-  '28-html-a-mixed-list-stays-loose':
-    'carve#1260 ruling: a mixed list stays LOOSE; the pinned build imports it tight, ' +
-    'because carve-js#1106 made a bare-text item tight and the rule reaches a mixed list too',
+  // NO ENTRIES. The pin reproduces every converter case's expectation, which is
+  // the state this list is meant to return to rather than an unusual one. The
+  // last entry, 28-html-a-mixed-list-stays-loose, cleared when the pin moved
+  // past markup-carve/carve-js#1110.
 }
 
 /**

--- a/tests/html-import-contract.check.mjs
+++ b/tests/html-import-contract.check.mjs
@@ -76,11 +76,9 @@ test('every expected.crv is a fixed point of the canonical writer', async () => 
  * red too, so the line goes out with the pin bump that fixed it.
  */
 const PIN_LAG = new Map([
-  [
-    'blockquote-cite',
-    'the pin predates markup-carve/carve-js#1125, so the cite attribute is still dropped with an ' +
-      'attribute-dropped diagnostic instead of kept as {cite=u}',
-  ],
+  // NO ENTRIES. The pin imports every fixture the way the fixture says. The
+  // last entry, blockquote-cite, cleared when the pin moved past
+  // markup-carve/carve-js#1125.
 ])
 
 /*


### PR DESCRIPTION
Moves the pinned reference build from carve-js 620def4e to e2e8460 and clears every declared ledger the move actually cleared. `resources/engine-pin-drift.txt` goes from 31 entries to 18.

## What cleared, and what proved it

A merged PR does not prove a corpus document renders byte-exact, so nothing here was deleted on the strength of one. `npm run engine:report -- --check` reports a declared line that now reproduces as STALE, and it named all 13 before they came out:

| entries | cleared by |
|---|---|
| the five 322 attribute-block rows, and 323 | markup-carve/carve-js#1107 |
| 328, 328-2, 328-3, 333, 333-5 | markup-carve/carve-js#1126 |
| 331, 331-4 | markup-carve/carve-js#1116 |

Four more declared ledgers moved with it, each one measured by running it:

- `PINNED_DRIFT` in `tests/corpus-convert.test.mjs` is empty. The mixed-list import case cleared on markup-carve/carve-js#1110.
- `PIN_LAG` in `tests/html-import-contract.check.mjs` is empty. `blockquote-cite` cleared on markup-carve/carve-js#1125. That check runs under `npm run html-import:check`, outside `npm test`.
- The rollout tripwire in `tests/citation-definition-is-a-node.test.mjs` fired. markup-carve/carve-js#1122 ships PART 12 section 18, so the assertion is now the positive one.
- `resources/converter-drift.txt` and `resources/engine-fmt-drift.txt` were empty and still are: convert_pass 26/26, 26/26 and 28/28 with zero declared drift, and 39/39 canonical fmt forms in all three engines.

## Every remaining premise was stale

All 18 lines that stay said "the pin predates" a ruling the new pin **postdates** - the rulings closed between 20:42 and 22:49, the pin is from 01:12. They now say the ruling landed and carve-js has not implemented it.

Two are narrower, and are the useful finding: markup-carve/carve-js#1126 shipped markup-carve/carve#1284 only in part.

`328-...-4`, a double-backtick run:

```
| a ``b | c |
```

```html
<tr><td>a <code>b | c</code></td></tr>
```

The pin still splits it into two cells and closes the run at the first pipe.

`333-...-4`, a pipe inside the run on the continuation row:

```
| a `b |
+ c | d` |
```

```html
<tr><td>a <code>b c | d</code></td></tr>
```

The pin renders `b c` and drops `| d`.

Neither has an engine ticket. The other 16 wait on carve-js implementing markup-carve/carve#1280, markup-carve/carve#1281 or markup-carve/carve#1290, none of which has one either.

## The position ledger was running on a stale measurement

`resources/ast-position-waivers.txt` asserted "THE OWED HALF IS NOW EMPTY", dated to a re-measurement over **833** documents on 2026-08-07. The corpus is **1124** documents. Re-measured over all of them at carve-js e2e8460, carve-rs b6ff319 and carve-php b6d49a7, both halves had moved:

- **24 new permitted findings** over 20 declaration lines (11 carve-js, 8 carve-rs, 5 carve-php) from the `333` continuation-row fixtures. A run left open at a row's closing pipe and continued on the `+` row below has a value assembled from two lines, which is the section 4 reassembly clause reaching a new construct. `code` is a node type this ledger had not carried before.
- **4 owed findings**, all carve-php, all one defect: it drops the position of a line block's content where the source's spaces became indentation sentinels. carve-rs publishes the same value **with** a span, so a true span exists. Filed as markup-carve/carve-php#1351.

The control that separates the two populations is `41-line-blocks-9`, which uses tabs: a tab expands to a variable number of sentinels, no slice has the value's length, and all three engines omit it. Per-engine symmetry is the tell, and carve-php stood alone here.

`docs/ast-json.md` carried the same undated claim; a test binds the page to the ledger, so it is corrected in the same commit.

## Known red, and not from this change

`npm run ast:check` still exits 1 on the value and span panels: 11 undeclared cross-engine rows, every one of them on the `326` / `327` / `328` / `329` / `333` / `268` fixtures that landed tonight, where the three engines have not converged on the new rulings yet. Measured on a pristine `origin/main` checkout with the same three engine builds, the same 11 rows appear, so this is engine convergence lag rather than anything the pin move introduced. Left undeclared deliberately: the rows carry document counts that will flip to COUNT or FIXED as each engine lands its fix, so declaring them now buys a red run with a different message and a diff that has to be reverted within days.
