### PR TITLE
chore: move the engine pin to carve-js 02c4d80, and empty the drift ledger

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -638,13 +638,15 @@ documents on 2026-08-07, the OWED half of `resources/ast-position-waivers.txt`
 was EMPTY.
 
 It did not stay empty. Re-measured on 2026-08-17 over 1124 documents, at
-carve-js e2e8460, carve-rs b6ff319 and carve-php b6d49a7, that half holds one
+carve-js 02c4d80, carve-rs 1ad93f0 and carve-php 4610ef8, that half holds one
 defect again: carve-php drops the position of a line block's content where the
 source's spaces became indentation sentinels, and carve-rs publishes the same
 value WITH a span, so a true span exists. The corpus grew 291 documents between
-the two measurements, which is the whole reason an undated "the gap is closed"
-sentence is worth nothing here - a re-measurement is what says so, and only for
-the corpus it ran over.
+that measurement and the 833-document one above, which is the whole reason an
+undated "the gap is closed" sentence is worth nothing here - a re-measurement is
+what says so, and only for the corpus it ran over. The same 1124 documents at
+carve-js e2e8460, carve-rs b6ff319 and carve-php b6d49a7 read the same way
+earlier that day, across the five carve-js fixes in between.
 
 Every other position finding is `permitted` under §4.
 
@@ -682,6 +684,20 @@ declaration is now EMPTY: no field the three publish differs anywhere in the
 corpus, so both lines were deleted rather than reworded. The caption line that
 sat beside it went the same way, fixed under
 [carve#963](https://github.com/markup-carve/carve/issues/963).
+
+It did not stay empty either. Re-measured on 2026-08-17 over 1124 documents plus
+3 synthetic samples, at carve-js `02c4d80`, carve-rs `1ad93f0` and carve-php
+`4610ef8`, two fields disagree across four documents
+(`paragraph.attrs.classes` and `paragraph.attrs.order`) and nine node types are
+spanned differently across twenty-one. Eight of those nine are carve-php alone
+on the `326`, `327`, `329` and `333` fixtures, where it has not yet implemented
+the container rulings the other two ship
+([carve-php#1354](https://github.com/markup-carve/carve-php/issues/1354)); the
+ninth is carve-js alone, spanning a verbatim run one codepoint past the trailing
+space the content line drops
+([carve-js#1145](https://github.com/markup-carve/carve-js/issues/1145)). All
+eleven are declared in the two files rather than left to fail the run, which is
+what those files are for.
 
 An empty declaration is a statement about the corpus, which is the only thing
 the run measures. Four collapsed-reference labels the corpus does not hold - one

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#e2e84605fc0da519054465d915090192977d5be8",
+        "@markup-carve/carve": "github:markup-carve/carve-js#02c4d80b262fcace000842857c01e3c2edadad90",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#e2e84605fc0da519054465d915090192977d5be8",
-      "integrity": "sha512-yuJVkci/fGyi0eX2XJ+g7NIrbYakyBahUVxSsO62QDmyVBbSMJCd9KbT7l/nMxG1UaVgy9I8iTo3m8acfV4omg==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#02c4d80b262fcace000842857c01e3c2edadad90",
+      "integrity": "sha512-QvtB+SpNa1Qjyqz54zXFlOF46RxKowSUf2cl3FA95EJIYCNZS/XPp4B/UC+jrZGfTkfnPcZUA7GCJYWQggVdFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#e2e84605fc0da519054465d915090192977d5be8",
+    "@markup-carve/carve": "github:markup-carve/carve-js#02c4d80b262fcace000842857c01e3c2edadad90",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/ast-position-waivers.txt
+++ b/resources/ast-position-waivers.txt
@@ -31,17 +31,27 @@
 # all 28 owed findings were gone: carve-js#813 and carve-js#814, carve-rs#716,
 # #736 and #737, and carve-php#965 had all landed.
 #
-# RE-MEASURED 2026-08-17 at carve-js e2e8460, carve-rs b6ff319 and carve-php
-# b6d49a7 over 1124 documents, the owed half holds four findings again, all in
-# carve-php and all one defect (markup-carve/carve-php#1351). Twenty-four new
-# PERMITTED findings arrived in the same window - 11 in carve-js, 8 in carve-rs
-# and 5 in carve-php, over 20 declaration lines - from the `333`
-# continuation-row fixtures. Findings, not lines: the count column is what the
-# run reconciles against, and a line may carry more than one.
+# RE-MEASURED 2026-08-17 at carve-js 02c4d80, carve-rs 1ad93f0 and carve-php
+# 4610ef8 - the three mains at the moment the pin moved to 02c4d80 - over the
+# same 1124 documents. NOTHING IN THIS FILE MOVED. The owed half still holds
+# four findings, all in carve-php and all one defect
+# (markup-carve/carve-php#1351, still open). Every permitted line still
+# reconciles: 38 findings in carve-js, 35 in carve-rs and 32 in carve-php, with
+# nothing outstanding in the first two. Findings, not lines: the count column is
+# what the run reconciles against, and a line may carry more than one.
+#
+# The measurement this replaces ran the same 1124 documents at carve-js
+# e2e8460, carve-rs b6ff319 and carve-php b6d49a7, and reported both halves the
+# same way. Between the two, carve-js closed the five engine gaps
+# `resources/engine-pin-drift.txt` declared - so five merged engine fixes moved
+# the HTML that file is about and moved no position at all. The permitted half
+# it recorded growing by 24 findings over 20 declaration lines, from the `333`
+# continuation-row fixtures, is the state measured above.
 #
 # WHICH IS THE POINT OF DATING THE CLAIM. The corpus grew 291 documents between
-# those two measurements, and the header's own note that the permitted half
-# "grew with the fixtures added over the preceding week" says fixtures produce
+# the 2026-08-07 measurement and the two above, and the header's own note that
+# the permitted half "grew with the fixtures added over the preceding week"
+# says fixtures produce
 # position findings. An emptiness claim measured over a corpus a quarter smaller
 # than today's is not evidence the half is still empty - it is evidence of what
 # was true on the day, which is why the day is written down. Whoever re-measures

--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -13,5 +13,57 @@
 # text nodes and 12 continued/reassembled table cells, declared per engine and
 # document in resources/ast-position-waivers.txt.
 #
-# There are currently no declared cross-engine span divergences. Any new row,
-# changed count, or undeclared disagreement is a conformance failure.
+# That paragraph is the 2026-08-10 state, when nothing was declared. Any new
+# row, changed count, or undeclared disagreement is a conformance failure, which
+# is what the re-measurement below had to be turned into declarations to keep.
+
+# RE-MEASURED 2026-08-17 over 1124 corpus documents plus 3 synthetic samples, at
+# carve-js 02c4d80, carve-rs 1ad93f0 and carve-php 4610ef8, each built from a
+# fresh clone of main. The claim above is the 2026-08-10 state and no longer
+# holds: of 22,618 comparable spans, NINE rows disagree across 21 documents.
+# Each is declared at the bottom of this file; the attribution the row syntax
+# has no room for is here.
+#
+#   list (extent)                    12 doc(s)   php alone
+#   list_item (extent)               12 doc(s)   php alone
+#   text (presence)                   5 doc(s)   php absent, js and rs placed
+#   block_quote (extent)              2 doc(s)   php alone
+#   code (presence)                   2 doc(s)   php placed, js and rs absent
+#   paragraph (extent)                1 doc(s)   php alone
+#   definition_list (extent)          1 doc(s)   php alone
+#   definition_description (extent)   1 doc(s)   php alone
+#   code (extent)                     1 doc(s)   JS alone
+#
+# EIGHT OF THE NINE ARE ONE ENGINE BEHIND TWO. They sit on the `326`, `327`,
+# `329` and `333` fixtures, where markup-carve/carve#1280, #1281, #1284 and
+# #1290 ruled how a container ends and what a floating attribute reaches.
+# carve-rs already implemented those and carve-js did in
+# markup-carve/carve-js#1140 through #1144; carve-php has not, so it parses the
+# documents into a different shape and every extent row follows from the shape.
+# Tracked as markup-carve/carve-php#1354 - the row syntax here carries no note
+# column, so the issue is named in prose and the rows below are bare.
+#
+# THE NINTH IS NOT LAG, and it is the reason this panel was worth reading rather
+# than waving through. On
+# `268-trailing-whitespace-on-a-content-line-is-dropped-13` all three engines
+# publish the same value for the verbatim run, `"a\nb"`, and carve-js spans one
+# codepoint wider - endOffset 8 against 7 - covering the trailing space the
+# fixture's own rule drops. A span "ends immediately after the last source
+# codepoint the construct owns", so the wider one is the one that moves. Filed
+# as markup-carve/carve-js#1145; it will not clear when carve-php catches up,
+# and it is the row worth watching when the other eight go.
+#
+# DECLARED, not left red. Nine rows against a panel that has been failing since
+# the fixtures landed, and every one of them is a baseline this file was built
+# to hold rather than a disagreement it is built to hide: a new type, a moved
+# count and a row that stops disagreeing each fail the run from here.
+
+list (extent) 12
+list_item (extent) 12
+text (presence) 5
+block_quote (extent) 2
+code (presence) 2
+paragraph (extent) 1
+definition_list (extent) 1
+definition_description (extent) 1
+code (extent) 1

--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -65,3 +65,54 @@
 # and those four shapes change the HTML too - carve-php leaves the reference
 # unresolved, or slugs the heading differently - so they are ordinary corpus
 # conformance, owed a fixture rather than a line (markup-carve/carve#1011).
+#
+# NOT EMPTY IN FACT, AS OF 2026-08-17. Measured over 1124 corpus documents plus
+# 3 synthetic samples, at carve-js 02c4d80, carve-rs 1ad93f0 and carve-php
+# 4610ef8 - each built from a fresh clone of main - `npm run ast:check` reports
+# TWO fields disagreeing across four documents, both declared at the bottom of
+# this file:
+#
+#   paragraph.attrs.classes  4 doc(s)  js and rs absent, php ["k"]
+#   paragraph.attrs.order    4 doc(s)  js and rs absent, php [".class"]
+#
+# One cause, measured rather than inferred. The documents are the `326` and
+# `329` fixtures. On `329-...-2`:
+#
+#     > q
+#     > {.k}
+#     tail
+#
+# carve-js and carve-rs close the quote at the flush-left line, so the attribute
+# reaches nothing and `tail` is a bare top-level paragraph:
+#
+#     <blockquote><p>q</p></blockquote>
+#     <p>tail</p>
+#
+# carve-php folds `tail` into the quote and applies the attribute to it, which
+# is where the class the other two publish nowhere comes from:
+#
+#     <blockquote>
+#       <p>q</p>
+#       <p class="k">tail</p>
+#     </blockquote>
+#
+# markup-carve/carve#1280 and markup-carve/carve#1281 ruled that; carve-rs
+# already implemented it and carve-js did in markup-carve/carve-js#1140 and
+# markup-carve/carve-js#1142, so carve-php is the engine that has not caught up.
+#
+# DECLARED RATHER THAN LEFT RED, which is the whole reason this file exists -
+# "a gate would have failed on day one for reasons already tracked, so the debt
+# is DECLARED instead". The previous pass measured the same panel and left it
+# undeclared, reasoning that the counts would flip as each engine landed fixes.
+# They did not: carve-js shipped five fixes in between and the row count did not
+# move, because these rows wait on carve-php and nothing else. A panel that is
+# red for a known reason cannot report the next reason.
+#
+# The missing piece was this file's own third column - a row names where it is
+# TRACKED, and no carve-php issue existed for the rulings. One does now, and
+# both rows cite it. Both clear together in whichever carve-php PR ships them,
+# and the run fails until the lines go, which is the reminder rather than the
+# waste.
+
+paragraph.attrs.classes  4  carve-php alone: the 326/329 container rulings are unimplemented (markup-carve/carve-php#1354)
+paragraph.attrs.order    4  the same defect over the same four documents (markup-carve/carve-php#1354)

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,21 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open  the pin now postdates markup-carve/carve#1280 but carve-js has not implemented the ruling, so a column-0 line still folds into an item whose last block is a heading
-326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-3  same, with a table as the item's last block
-326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-4  same, with a thematic break
-326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-5  same, with a line comment
-326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-6  same, with a comment fence
-326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-7  same, with a link reference definition
-326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-8  same, with a footnote definition
-326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-9  same, with an attribute block
-326-a-column-0-line-after-a-container-s-last-block-when-that-block-left-no-paragraph-open-11  same, with a block quote whose own last block is a heading
-327-a-continuation-marker-attaches-one-block-and-the-boundary-is-that-block-s-extent  the pin now postdates markup-carve/carve#1290 but carve-js has not implemented the ruling, so one `+` still attaches every block up to the boundary
-327-a-continuation-marker-attaches-one-block-and-the-boundary-is-that-block-s-extent-3  same, with the attached paragraph wrapped over two lines
-327-a-continuation-marker-attaches-one-block-and-the-boundary-is-that-block-s-extent-6  same, in the `- +` first-block form
-327-a-continuation-marker-attaches-one-block-and-the-boundary-is-that-block-s-extent-7  a different pin defect the case uncovers: after a `- +` first-block attachment the pin does not recognize a second `+`, rendering it as a literal paragraph and leaving the quote at top level
-327-a-continuation-marker-attaches-one-block-and-the-boundary-is-that-block-s-extent-8  same, in the block-quote form
-328-an-unclosed-verbatim-run-in-a-row-stops-at-the-closing-pipe-4  markup-carve/carve-js#1126 shipped markup-carve/carve#1284 for the single-backtick run only, so a double-backtick run still closes at the row's first pipe and the row splits into two cells
-329-a-floating-attribute-is-scoped-to-the-container-that-holds-it-2  the pin now postdates markup-carve/carve#1280 but carve-js has not implemented the ruling, so the flush-left line still joins the quote and the attribute reaches it
-329-a-floating-attribute-is-scoped-to-the-container-that-holds-it-6  the pin now postdates markup-carve/carve#1281 but carve-js has not implemented the ruling, so a wrapped attribute block at the end of a definition body still folds the flush-left line in and attributes it
-333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4  markup-carve/carve-js#1126 shipped markup-carve/carve#1284 for the row's closing pipe only, so a pipe inside the run on the continuation row still ends the run and the rest of the row is dropped

--- a/tests/ast-spans.test.mjs
+++ b/tests/ast-spans.test.mjs
@@ -208,8 +208,55 @@ test('a malformed declaration line is an error, never a silent skip', () => {
   assert.match(problems[0], /^MALFORMED\s+line 1/)
 })
 
-test('the shipped span declaration parses and currently needs no baseline rows', () => {
-  const text = readFileSync(resolve(root, 'resources/ast-span-divergence.txt'), 'utf8')
-  const problems = reconcileSpans(new Map(), text)
-  assert.deepEqual(problems, [])
+/*
+ * WHAT `npm run ast:check` LAST MEASURED. Same contract, and same reason, as
+ * `LAST_MEASURED` in tests/ast-values.test.mjs: this suite runs on a host with
+ * no engine checkouts, so it cannot measure spans itself, and reconciling the
+ * shipped file against an EMPTY measurement only stays falsifiable while the
+ * ledger is empty - every declared row becomes an AGREED.
+ *
+ * Measured 2026-08-17 over 1124 corpus documents plus 3 synthetic samples, at
+ * carve-js 02c4d80, carve-rs 1ad93f0 and carve-php 4610ef8. Eight rows are
+ * carve-php alone on the 326/327/329/333 container rulings
+ * (markup-carve/carve-php#1354); `code (extent)` is carve-js alone, spanning a
+ * verbatim run past the trailing space the content line drops
+ * (markup-carve/carve-js#1145).
+ */
+const LAST_MEASURED = new Map([
+  ['list (extent)', 12],
+  ['list_item (extent)', 12],
+  ['text (presence)', 5],
+  ['block_quote (extent)', 2],
+  ['code (presence)', 2],
+  ['paragraph (extent)', 1],
+  ['definition_list (extent)', 1],
+  ['definition_description (extent)', 1],
+  ['code (extent)', 1],
+])
+
+const asMeasured = (counts) =>
+  new Map(
+    [...counts].map(([key, count]) => [
+      key,
+      new Set(Array.from({ length: count }, (_, i) => `measured-${i}.crv`)),
+    ]),
+  )
+
+const shippedSpanDeclaration = () =>
+  readFileSync(resolve(root, 'resources/ast-span-divergence.txt'), 'utf8')
+
+test('the shipped span declaration is exactly what ast:check last measured', () => {
+  // All three directions stay live without engines: a row in the file with no
+  // measurement is AGREED, a measured row the file omits is NEW, and a count
+  // edited on either side is COUNT. An empty ledger against an empty
+  // `LAST_MEASURED` still reconciles to nothing, so there is no floor.
+  assert.deepEqual(reconcileSpans(asMeasured(LAST_MEASURED), shippedSpanDeclaration()), [])
+})
+
+test('and a disagreement the shipped file does not declare is caught', () => {
+  const measured = asMeasured(LAST_MEASURED)
+  measured.set('table_cell (presence)', new Set(['a.crv', 'b.crv']))
+  const problems = reconcileSpans(measured, shippedSpanDeclaration())
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /^NEW\s+table_cell \(presence\) disagrees in 2 document\(s\)/)
 })

--- a/tests/ast-values.test.mjs
+++ b/tests/ast-values.test.mjs
@@ -77,8 +77,34 @@ test('a malformed declaration line is an error, never a silent zero', () => {
 const shippedDeclaration = () =>
   readFileSync(resolve(root, 'resources/ast-value-divergence.txt'), 'utf8')
 
-test('the shipped declaration parses and currently needs no baseline rows', () => {
-  // Held to EMPTY, the way `tests/ast-spans.test.mjs` holds its own ledger.
+/*
+ * WHAT `npm run ast:check` LAST MEASURED, written down so a host with no engine
+ * checkouts can still say something falsifiable about the shipped file.
+ *
+ * Measured 2026-08-17 over 1124 corpus documents plus 3 synthetic samples, at
+ * carve-js 02c4d80, carve-rs 1ad93f0 and carve-php 4610ef8. Both rows are
+ * carve-php alone on the 326/329 container rulings
+ * (markup-carve/carve-php#1354).
+ *
+ * This is the "moves with the measurement" the note below describes: when that
+ * issue lands, ast:check reports both rows FIXED, and the same commit that
+ * deletes them from the ledger empties this map.
+ */
+const LAST_MEASURED = new Map([
+  ['paragraph.attrs.classes', 4],
+  ['paragraph.attrs.order', 4],
+])
+
+/** A measurement of `count` distinct documents - the reconciler counts them. */
+const documents = (count) =>
+  new Set(Array.from({ length: count }, (_, i) => `measured-${i}.crv`))
+
+const asMeasured = (counts) =>
+  new Map([...counts].map(([key, count]) => [key, documents(count)]))
+
+test('the shipped declaration is exactly what ast:check last measured', () => {
+  // NOT `reconcileDeclared(new Map(), ...)` any more, and the reason is the
+  // trap this test already fell into once.
   //
   // This assertion used to be `for (const p of problems) assert.match(p,
   // /^FIXED/)`, which cannot fail on a declared row: reconciling against an
@@ -88,20 +114,21 @@ test('the shipped declaration parses and currently needs no baseline rows', () =
   // opened carve#534 against the script, now reproduced against the test that
   // replaced it.
   //
-  // NO FLOOR still, and the old comment was right about that much: a ledger of
-  // zero divergences is the state the panel is trying to reach, so requiring a
-  // minimum row count would be a gate that only works while something is wrong.
-  // The defect was the other end. Refusing to require rows is not the same as
-  // accepting any, and only one of those two was implemented.
+  // It then became `deepEqual(reconcileDeclared(new Map(), ...), [])`, which is
+  // falsifiable but only while the ledger is EMPTY: an empty measurement makes
+  // every declared row a FIXED, so the day a row is genuinely owed the
+  // assertion stops being about the file and starts being about the emptiness.
+  // Its own note said so - "a row that is genuinely owed gets established by
+  // ast:check and moves this line with it, deliberately, in the commit that
+  // measures it" - and this is that commit.
   //
-  // What the empty measurement means here: this suite runs on a host with no
-  // engine checkouts, so it cannot measure divergence itself. `npm run
-  // ast:check` does that, and it has verified the file empty against all three
-  // engines. Between those runs, the honest per-PR statement is "the ledger is
-  // still empty", and that is what this asserts. A row that is genuinely owed
-  // gets established by ast:check and moves this line with it - deliberately,
-  // in the commit that measures it, rather than slipping past unread.
-  assert.deepEqual(reconcileDeclared(new Map(), shippedDeclaration()), [])
+  // Reconciling against the recorded measurement keeps all three directions
+  // live on a host with no engines: a row added to the file without a
+  // measurement is FIXED, a row deleted from it is NEW, and a count edited on
+  // either side is COUNT. NO FLOOR, still: an empty `LAST_MEASURED` and an
+  // empty ledger reconcile to nothing, which is the state the panel is trying
+  // to reach.
+  assert.deepEqual(reconcileDeclared(asMeasured(LAST_MEASURED), shippedDeclaration()), [])
 })
 
 test('and a real divergence the shipped file does not declare is caught', () => {
@@ -110,12 +137,32 @@ test('and a real divergence the shipped file does not declare is caught', () => 
   // the NEW case two tests up proves the reconciler on a fabricated
   // declaration; neither one asserts that the file as shipped still lets an
   // undeclared divergence through.
-  const problems = reconcileDeclared(
-    new Map([['table_cell.align', new Set(['a.crv', 'b.crv'])]]),
-    shippedDeclaration(),
-  )
+  const measured = asMeasured(LAST_MEASURED)
+  measured.set('table_cell.align', new Set(['a.crv', 'b.crv']))
+  const problems = reconcileDeclared(measured, shippedDeclaration())
   assert.equal(problems.length, 1)
   assert.match(problems[0], /^NEW\s+table_cell\.align diverges in 2 document\(s\)/)
+})
+
+test('every declared row names a fully qualified engine issue', () => {
+  // The third column is the file's own format - "who diverges and where it is
+  // tracked" - and nothing enforced it, which is how a row could be added with
+  // a reason that names no ticket. A bare `#1354` in this repo resolves to
+  // carve#1354, not to the engine issue it means, so the qualification is the
+  // part that matters.
+  const rows = shippedDeclaration()
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#'))
+
+  assert.equal(rows.length, LAST_MEASURED.size, 'the ledger and the measurement disagree on row count')
+  for (const row of rows) {
+    assert.match(
+      row,
+      /[\w.-]+\/[\w.-]+#\d+/,
+      `declared row names no fully qualified engine issue: ${row}`,
+    )
+  }
 })
 
 test('the signature keeps scalars and drops positions', () => {


### PR DESCRIPTION
Moves the pinned reference build from carve-js `e2e8460` to `02c4d80` and clears every ledger the move actually cleared. `resources/engine-pin-drift.txt` goes from 18 entries to **EMPTY**.

## The file is empty, and a render is what says so

carve-js closed all five remaining engine gaps in markup-carve/carve-js#1140, #1141, #1142, #1143 and #1144, and its own pin bump markup-carve/carve-js#1115 is `02c4d80`. All five merge commits are ancestors of the pinned sha.

That is not the evidence for any deletion. `npm run engine:report -- --check` renders every corpus document through the INSTALLED build and reports a declared line that reproduces as STALE. It named all 18 before they came out:

```
pinned reference build:  github:markup-carve/carve-js#02c4d80...
corpus pairs:            1124
reproduced:              1124
mismatched:              0
threw:                   0
declared drift:          0 (resources/engine-pin-drift.txt)
Drift matches what is declared.
```

The mapping was one-to-one, as the carve-js side reported: 18 declared, 18 stale, nothing left over in either direction.

## The declaration still fails in both directions

Checked by mutating it rather than by reading it.

Re-adding one cleared entry:

```
declared drift:          1
  STALE  328-an-unclosed-verbatim-run-in-a-row-stops-at-the-closing-pipe-4 - reproduces now; drop the line
exit 1
```

Perturbing one corpus fixture with the file empty:

```
mismatched:              1
declared drift:          0
  UNDECLARED  328-an-unclosed-verbatim-run-in-a-row-stops-at-the-closing-pipe-4 - the pin does not reproduce this and nothing says why
exit 1
```

## The other ledgers, re-measured rather than assumed

All at carve-js `02c4d80`, carve-rs `1ad93f0` and carve-php `4610ef8`, each a fresh clone of main, over the same 1124 documents.

**`resources/ast-position-waivers.txt` did not move.** The owed half still holds four findings, all carve-php, all markup-carve/carve-php#1351, which is still open. Every permitted line still reconciles: 38 findings in carve-js, 35 in carve-rs, 32 in carve-php, nothing outstanding in the first two. So five merged carve-js fixes moved the HTML that the drift file is about and moved no position at all. The paragraph carried the previous pass's engine commits and a date, which reads as verified; it now names the commits this run measured at.

**`resources/ast-value-divergence.txt` and `ast-span-divergence.txt` were not empty, and both said they were.** The span file still claimed "all 18,315 comparable spans agree" from 2026-08-10. Measured now: 2 fields disagree across 4 documents, and 9 node types are spanned differently across 21, out of 22,618 spans compared.

Eight of the nine span rows and both value rows are carve-php standing alone on the `326` / `327` / `329` / `333` container rulings. Measured, not inferred - on `329-...-2`:

````
> q
> {.k}
tail
````

carve-js and carve-rs close the quote at the flush-left line:

````html
<blockquote><p>q</p></blockquote>
<p>tail</p>
````

carve-php folds the line in and lets the attribute reach it, which is where the class the other two publish nowhere comes from:

````html
<blockquote>
  <p>q</p>
  <p class="k">tail</p>
</blockquote>
````

Filed as markup-carve/carve-php#1354 with the four rulings and a case each.

**The ninth row is not lag, and it is the reason the panel was worth reading.** On `268-trailing-whitespace-on-a-content-line-is-dropped-13`:

````
:: `a
b 
:  d
````

(line 2 ends in one space). All three publish the same value for the verbatim run, `"a\nb"`, and carve-js spans one codepoint wider:

```
carve-js   startColumn=4 endColumn=3  startOffset=3 endOffset=8
carve-rs   startColumn=4 endColumn=2  startOffset=3 endOffset=7
carve-php  startColumn=4 endColumn=2  startOffset=3 endOffset=7
```

Offset 7 is the trailing space the fixture's own rule drops. `docs/ast-json.md` says a span "ends immediately after the last source codepoint the construct owns", so the wider one is the one that moves. Filed as markup-carve/carve-js#1145; it will not clear when carve-php catches up.

**`converter-drift.txt` and `engine-fmt-drift.txt` are still empty, by running them:** convert_pass 26/26, 26/26 and 28/28 with zero declared drift and zero cross-convert diffs, and 39/39 canonical fmt forms in all three engines.

**`PIN_LAG` in `tests/html-import-contract.check.mjs`** runs under `npm run html-import:check` and not under `npm test`. Run: still empty, 4/4 passing at the new pin.

## Declared, not left red

The previous pass measured the same panel and left it undeclared, reasoning that the counts would flip as each engine landed fixes. That prediction has now been tested: carve-js shipped five fixes in between and the row count did not move, because these rows wait on carve-php and on nothing else. `npm run ast:check` has been exiting 1 on those two panels since the fixtures landed, and a panel that is red for a known reason cannot report the next reason.

The piece that was actually missing is the value file's own third column - a row names where it is TRACKED, and no carve-php issue existed. One does now, and both rows cite it.

Declaring moves the per-PR assertion with it, which is what that assertion's own note asked for ("a row that is genuinely owed gets established by ast:check and moves this line with it, deliberately, in the commit that measures it"). Reconciling the shipped file against an EMPTY measurement is falsifiable only while the ledger is empty: the day a row is owed, every declared row becomes a FIXED and the assertion is about the emptiness rather than about the file. Both tests now reconcile against the recorded measurement instead, so an added row, a deleted row and a moved count each fail - proved by mutating each - and a new rule requires every declared value row to name a fully qualified engine issue.

With the rows declared, `npm run ast:check` exits 0.

## Not measured

carve-rb. The scheduled AST conformance workflow checks it out and builds it; this run had no Ruby extension, so the binding-parity panel did not run. Nothing in this diff depends on it.
