### PR TITLE
docs: one engine is no longer behind on the comment-fence documents

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -170,7 +170,7 @@ pin; the corpus has no xfail). A row moves to *Resolved* once all impls agree.
 
 | Input | Canonical, and who still diverges |
 |-------|-----------------------------------|
-| `- item`<br>`  %%%`<br>`  [r]: /url`<br>`  %%%` plus a `[r][]` below it - a definition inside a comment fence that is NOT at column 0 | The label is not registered and the reference stays literal, at every column a fence can sit at: PART 9 §24 S1 places a line by the column it reaches, S2 makes it verbatim under a fenced body, and §28 scopes neither to column 0. carve-js and the executable spec already do this. **carve-php** fails `335`, `336`, `337`, `338`, `339` and `340` (markup-carve/carve-php#1349); **carve-rs** fails `335`, `336`, `337`, `338` and `339` (markup-carve/carve-rs#1047, fix in flight at markup-carve/carve-rs#1052). Filed as carve#1309. |
+| `- item`<br>`  %%%`<br>`  [r]: /url`<br>`  %%%` plus a `[r][]` below it - a definition inside a comment fence that is NOT at column 0 | The label is not registered and the reference stays literal, at every column a fence can sit at: PART 9 §24 S1 places a line by the column it reaches, S2 makes it verbatim under a fenced body, and §28 scopes neither to column 0. carve-js, carve-rs and the executable spec already do this - carve-rs since markup-carve/carve-rs#1052 landed, which is why it no longer appears here. **carve-php** is the only engine still diverging: it fails `335`, `336`, `337`, `338`, `339` and `340` (markup-carve/carve-php#1349). Filed as carve#1309. |
 
 The quoted spelling of the same shape (`> %%%` over a definition) is NOT in that
 row and is deliberately unpinned: all three engines register there and only the

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -145,12 +145,23 @@ and carve-php `876e312`).
 `335` THROUGH `341` ARE A SECOND KIND OF LAG, and they are declared for a
 different reason than every category before them. The host that added them HAD
 all three checkouts and could have retaken the run. It did not, because two of
-the engines fail six of the seven ON PURPOSE: those documents pin a rule
+the engines failed six of the seven ON PURPOSE: those documents pin a rule
 carve-rs and carve-php had drifted from (carve#1309, markup-carve/carve-rs#1047,
 markup-carve/carve-php#1349), so a retaken snapshot's mismatch counts would
-describe a window two open fixes are closing, and would go stale the day either
-one lands. Naming the window is what the declaration is for, and here it is the
+describe a window two open fixes were closing, and would go stale the day either
+one landed. Naming the window is what the declaration is for, and here it is the
 honest line where a fresh measurement would be the misleading one.
+
+ONE OF THOSE TWO FIXES HAS SINCE LANDED, so the window is now narrower than the
+paragraph above described it. markup-carve/carve-rs#1052 merged, and carve-rs
+main renders all seven byte-exact - re-measured here on `71318e91`, whose parent
+still failed `335` through `339`, which is what makes the seven documents
+load-bearing rather than trivially green. **carve-php is the only engine still
+behind**, on `335` through `340` (markup-carve/carve-php#1349); `341` never
+failed on any engine. The declaration is kept rather than deleted because the
+run above still predates all seven, but it now names one engine, not two: a
+declared lag that keeps naming an engine somebody has since fixed reads as
+verified while being false, which is the failure this device exists to prevent.
 
 A CATEGORY THAT ALREADY EXISTED CAN GO STALE TOO, and the declaration above
 cannot say so - it names categories ADDED since the run, and its count is

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -20515,7 +20515,7 @@ At the HTML layer these rows cannot separate "not a reference label" from "a lab
 
 :::
 
-The corpus stated the rule and pinned only the column-0 spelling, which is the gap two engines drifted through while staying green: carve-rs and carve-php collected the label here and resolved the reference, where carve-js and the executable spec leave it literal (carve#1309, markup-carve/carve-rs#1047, markup-carve/carve-php#1349). Nothing about the item's own rendering was ever in question - all three render the comment as nothing and the item as `item`. The disagreement is entirely in the link table, which is why the document has to be read past the list to see it at all.
+The corpus stated the rule and pinned only the column-0 spelling, which is the gap two engines drifted through while staying green: carve-rs and carve-php both collected the label here and resolved the reference, where carve-js and the executable spec leave it literal (carve#1309, markup-carve/carve-rs#1047, markup-carve/carve-php#1349). carve-rs has since been fixed and reproduces this document (markup-carve/carve-rs#1052); carve-php still collects the label. Nothing about the item's own rendering was ever in question - all three render the comment as nothing and the item as `item`. The disagreement is entirely in the link table, which is why the document has to be read past the list to see it at all.
 
 ## A footnote definition inside an item's comment registers nothing
 


### PR DESCRIPTION
Follow-up to #1311, which added corpus `335` through `341` and declared the lag in three places while **both** carve-rs and carve-php failed them.

markup-carve/carve-rs#1052 has since merged, so those declarations now name an engine that is already fixed. A stale declaration is worse than no declaration: it reads as verified.

Re-measured rather than taken on report - carve-rs `71318e91` renders all seven byte-exact, and its parent `1ad93f0e` still fails `335` through `339`. So the seven documents are load-bearing, not trivially green. `340` and `341` never failed on carve-rs, and `341` never failed on any engine.

**carve-php is now the only engine behind**, on `335` through `340`, tracked at markup-carve/carve-php#1349.

Narrowed, not deleted, in:

- the "Corpus added since this run" block in `docs/implementation-comparison.md` - the original paragraph moves to past tense and a new one states which fix landed and what is left
- the "Open (tracked)" row in `MAINTAINING.md`
- the commentary under the case in `resources/examples/edge-cases.md`, which said in the present tense that carve-rs collects the label

The comparison run still predates all seven documents, so the lag itself is real. It is one engine wide now instead of two.

`resources/engine-pin-drift.txt` is untouched and still carries no slugs: the pinned build reproduces 1131 of 1131 pairs, the seven new ones included.

`npm run corpus:build` and `npm run docs:pages` produce no diff from the prose edit.
