### PR TITLE
Re-measure both AST divergence ledgers at the engine mains that exist now

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -637,16 +637,19 @@ document that contains one. So is the gap that replaced it - re-measured over 83
 documents on 2026-08-07, the OWED half of `resources/ast-position-waivers.txt`
 was EMPTY.
 
-It did not stay empty. Re-measured on 2026-08-17 over 1124 documents, at
-carve-js 02c4d80, carve-rs 1ad93f0 and carve-php 4610ef8, that half holds one
+It did not stay empty. Re-measured on 2026-08-17 over 1131 documents, at
+carve-js 80537c8, carve-rs 71318e9 and carve-php 84c422b, that half holds one
 defect again: carve-php drops the position of a line block's content where the
 source's spaces became indentation sentinels, and carve-rs publishes the same
-value WITH a span, so a true span exists. The corpus grew 291 documents between
-that measurement and the 833-document one above, which is the whole reason an
-undated "the gap is closed" sentence is worth nothing here - a re-measurement is
-what says so, and only for the corpus it ran over. The same 1124 documents at
-carve-js e2e8460, carve-rs b6ff319 and carve-php b6d49a7 read the same way
-earlier that day, across the five carve-js fixes in between.
+value WITH a span, so a true span exists
+([carve-php#1351](https://github.com/markup-carve/carve-php/issues/1351)). Four
+findings over three documents, with nothing outstanding in carve-js or carve-rs.
+The corpus grew 298 documents between that measurement and the 833-document one
+above, which is the whole reason an undated "the gap is closed" sentence is worth
+nothing here - a re-measurement is what says so, and only for the corpus it ran
+over. Three earlier reads that day, at 1124 documents and across three separate
+sets of engine mains, said the same thing: nothing in that file moved while the
+span and value ledgers moved twice.
 
 Every other position finding is `permitted` under §4.
 
@@ -685,19 +688,37 @@ corpus, so both lines were deleted rather than reworded. The caption line that
 sat beside it went the same way, fixed under
 [carve#963](https://github.com/markup-carve/carve/issues/963).
 
-It did not stay empty either. Re-measured on 2026-08-17 over 1124 documents plus
-3 synthetic samples, at carve-js `02c4d80`, carve-rs `1ad93f0` and carve-php
-`4610ef8`, two fields disagree across four documents
-(`paragraph.attrs.classes` and `paragraph.attrs.order`) and nine node types are
-spanned differently across twenty-one. Eight of those nine are carve-php alone
-on the `326`, `327`, `329` and `333` fixtures, where it has not yet implemented
-the container rulings the other two ship
-([carve-php#1354](https://github.com/markup-carve/carve-php/issues/1354)); the
-ninth is carve-js alone, spanning a verbatim run one codepoint past the trailing
-space the content line drops
-([carve-js#1145](https://github.com/markup-carve/carve-js/issues/1145)). All
-eleven are declared in the two files rather than left to fail the run, which is
-what those files are for.
+It did not stay empty either. Re-measured on the morning of 2026-08-17 over 1124
+documents plus 3 synthetic samples, at carve-js `02c4d80`, carve-rs `1ad93f0` and
+carve-php `4610ef8`, two fields disagreed across four documents
+(`paragraph.attrs.classes` and `paragraph.attrs.order`) and nine node types were
+spanned differently across twenty-one. All eleven were declared in the two files
+rather than left to fail the run, which is what those files are for.
+
+Both halves moved again later the same day, and the two moved in opposite
+directions - which is the case for re-measuring rather than reading the ledger.
+At carve-js `80537c8`, carve-rs `71318e9` and carve-php `84c422b`, over the 1131
+corpus documents plus 3 synthetic samples, `npm run ast:check` reports:
+
+- **The value declaration is EMPTY again.** carve-php shipped the `326`/`329`
+  container rulings, and both fields now agree everywhere. The run reported the
+  two rows `FIXED` and stayed red until they were deleted.
+- **The span declaration holds five rows across nine documents**, down from nine
+  across twenty-one. `list`, `list_item`, `block_quote` and
+  `definition_description` came `AGREED`; `text (presence)`,
+  `code (presence)` and `definition_list (extent)` moved count.
+
+The morning's block attributed eight span rows to a single carve-php issue. That
+was too coarse, and the rows that survived their own issue's work are how it
+shows: each surviving row now names its own tracker, in carve-php
+([#1351](https://github.com/markup-carve/carve-php/issues/1351),
+[#1361](https://github.com/markup-carve/carve-php/issues/1361),
+[#1362](https://github.com/markup-carve/carve-php/issues/1362),
+[#1363](https://github.com/markup-carve/carve-php/issues/1363)) and in carve-js
+([#1145](https://github.com/markup-carve/carve-js/issues/1145),
+[#1153](https://github.com/markup-carve/carve-js/issues/1153)). Two of those are
+carve-js standing alone, so "one engine is behind" was never the whole shape
+either.
 
 An empty declaration is a statement about the corpus, which is the only thing
 the run measures. Four collapsed-reference labels the corpus does not hold - one

--- a/resources/ast-position-waivers.txt
+++ b/resources/ast-position-waivers.txt
@@ -40,6 +40,17 @@
 # nothing outstanding in the first two. Findings, not lines: the count column is
 # what the run reconciles against, and a line may carry more than one.
 #
+# AND AGAIN LATER THAT DAY at carve-js 80537c8, carve-rs 71318e9 and carve-php
+# 84c422b, over 1131 documents - across carve-php shipping four container
+# rulings, seven new corpus documents and a carve-js comment-fence fix. NOTHING
+# IN THIS FILE MOVED EITHER TIME. Same four owed findings under the same open
+# issue, and the same permitted totals: 38, 35 and 32.
+#
+# WHICH IS WORTH RECORDING RATHER THAN SKIPPING. The span ledger beside this one
+# moved twice on those same engine builds - nine rows to five - so "the engines
+# moved, therefore this moved too" is exactly the inference a re-measurement is
+# here to refuse. A file that does not move still has to be run to say so.
+#
 # The measurement this replaces ran the same 1124 documents at carve-js
 # e2e8460, carve-rs b6ff319 and carve-php b6d49a7, and reported both halves the
 # same way. Between the two, carve-js closed the five engine gaps

--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -58,12 +58,61 @@
 # to hold rather than a disagreement it is built to hide: a new type, a moved
 # count and a row that stops disagreeing each fail the run from here.
 
-list (extent) 12
-list_item (extent) 12
-text (presence) 5
-block_quote (extent) 2
-code (presence) 2
+# RE-MEASURED AGAIN 2026-08-17, later the same day, over 1131 corpus documents
+# plus 3 synthetic samples, at carve-js 80537c8, carve-rs 71318e9 and carve-php
+# 84c422b, each built from a fresh clone of main. Of 22,775 comparable spans,
+# FIVE rows disagree across 9 documents. The block above is the morning's state
+# and no longer holds.
+#
+# Four rows went, and NOT on the strength of a merge notification. carve-php
+# shipped the container rulings in markup-carve/carve-php#1355, #1357, #1359 and
+# #1360; `npm run ast:check` then reported `list`, `list_item`, `block_quote` and
+# `definition_description` AGREED - "no longer disagrees, delete its line" - and
+# it kept failing until the lines went, which is this file's second direction
+# doing its job. Three of the surviving rows moved count in the same run.
+#
+# WHAT SURVIVED, per document, and every one now names its own tracker. The
+# morning's block attributed eight rows to one carve-php issue; that was too
+# coarse, and the four rows that did NOT clear when that issue's work shipped are
+# the proof. There are five distinct defects here, in four engines' worth of
+# directions:
+#
+#   text (presence)              6 doc(s)   TWO defects under one row key:
+#                                           268-...-12, 41-line-blocks-2 and -3
+#                                           are php absent / js and rs placed
+#                                           (markup-carve/carve-php#1351), and
+#                                           333, 333-4 and 333-5 are js absent /
+#                                           rs and php placed
+#                                           (markup-carve/carve-js#1153).
+#   code (presence)              3 doc(s)   333, 333-4, 333-5: php places a span
+#                                           over a run reassembled from two
+#                                           segments, covering the `|` and `+ `
+#                                           between them; js and rs omit it
+#                                           (markup-carve/carve-php#1361).
+#   definition_list (extent)     2 doc(s)   329-...-5 and -6: php ends the list
+#                                           one line short of the floating
+#                                           attribute it now scopes
+#                                           (markup-carve/carve-php#1362).
+#   paragraph (extent)           1 doc(s)   268-...-12: php spans the trailing
+#                                           space the content line drops
+#                                           (markup-carve/carve-php#1363).
+#   code (extent)                1 doc(s)   268-...-13: js spans that same
+#                                           trailing space, in the other engine
+#                                           and on the other node
+#                                           (markup-carve/carve-js#1145).
+#
+# THE ROW KEY IS A TYPE, NOT A DEFECT, which `text (presence)` is now the
+# standing example of: six documents, one key, two engines each standing alone on
+# three of them, in opposite directions. A count that moves says the panel moved;
+# it does not say which half. Both halves are named above so that when one clears
+# the count drops by three and the remaining prose still describes what is left.
+#
+# `code (extent)` is unchanged from the morning's measurement and from
+# 2026-08-14 before it. It was the row worth watching when the other eight went,
+# and it is still here.
+
+text (presence) 6
+code (presence) 3
+definition_list (extent) 2
 paragraph (extent) 1
-definition_list (extent) 1
-definition_description (extent) 1
 code (extent) 1

--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -66,11 +66,11 @@
 # unresolved, or slugs the heading differently - so they are ordinary corpus
 # conformance, owed a fixture rather than a line (markup-carve/carve#1011).
 #
-# NOT EMPTY IN FACT, AS OF 2026-08-17. Measured over 1124 corpus documents plus
-# 3 synthetic samples, at carve-js 02c4d80, carve-rs 1ad93f0 and carve-php
-# 4610ef8 - each built from a fresh clone of main - `npm run ast:check` reports
-# TWO fields disagreeing across four documents, both declared at the bottom of
-# this file:
+# NOT EMPTY FOR ONE MORNING, on 2026-08-17. Measured over 1124 corpus documents
+# plus 3 synthetic samples, at carve-js 02c4d80, carve-rs 1ad93f0 and carve-php
+# 4610ef8 - each built from a fresh clone of main - `npm run ast:check` reported
+# TWO fields disagreeing across four documents, and both were declared at the
+# bottom of this file:
 #
 #   paragraph.attrs.classes  4 doc(s)  js and rs absent, php ["k"]
 #   paragraph.attrs.order    4 doc(s)  js and rs absent, php [".class"]
@@ -113,6 +113,23 @@
 # both rows cite it. Both clear together in whichever carve-php PR ships them,
 # and the run fails until the lines go, which is the reminder rather than the
 # waste.
-
-paragraph.attrs.classes  4  carve-php alone: the 326/329 container rulings are unimplemented (markup-carve/carve-php#1354)
-paragraph.attrs.order    4  the same defect over the same four documents (markup-carve/carve-php#1354)
+#
+# EMPTY AGAIN, later the same day, and by measurement rather than by reading a
+# merge notification. Both rows named one carve-php gap, and carve-php closed it
+# in markup-carve/carve-php#1355, #1357, #1359 and #1360 - but a merged PR is not
+# evidence about a tree. What is: `npm run ast:check` over 1131 corpus documents
+# plus 3 synthetic samples, at carve-js 80537c8, carve-rs 71318e9 and carve-php
+# 84c422b, each built from a fresh clone of main, reports
+#
+#   THREE-WAY VALUE COMPARISON: the engines publish the same values everywhere.
+#
+# and reported both rows FIXED until they were deleted, which is the direction
+# this file's header promises and the reason it fails until the lines go.
+#
+# The corpus grew from 1124 to 1131 between the two measurements
+# (markup-carve/carve#1311's seven comment-fence documents). Those seven DO
+# separate the engines - carve-php parses them into a different shape, tracked
+# at markup-carve/carve-php#1349 - but a shape difference is what the shape
+# panel reports, not this one: a node that is not in the tree publishes no
+# scalar to disagree about. So the emptiness here is about scalars across 1134
+# samples, and says nothing about that gap.

--- a/tests/ast-spans.test.mjs
+++ b/tests/ast-spans.test.mjs
@@ -215,22 +215,22 @@ test('a malformed declaration line is an error, never a silent skip', () => {
  * shipped file against an EMPTY measurement only stays falsifiable while the
  * ledger is empty - every declared row becomes an AGREED.
  *
- * Measured 2026-08-17 over 1124 corpus documents plus 3 synthetic samples, at
- * carve-js 02c4d80, carve-rs 1ad93f0 and carve-php 4610ef8. Eight rows are
- * carve-php alone on the 326/327/329/333 container rulings
- * (markup-carve/carve-php#1354); `code (extent)` is carve-js alone, spanning a
- * verbatim run past the trailing space the content line drops
- * (markup-carve/carve-js#1145).
+ * Measured 2026-08-17 over 1131 corpus documents plus 3 synthetic samples, at
+ * carve-js 80537c8, carve-rs 71318e9 and carve-php 84c422b, each built from a
+ * fresh clone of main. Five rows across 9 documents, of 22,775 spans compared.
+ *
+ * It read nine rows across 21 documents earlier the same day. carve-php shipped
+ * the 326/327/329/333 container rulings, ast:check reported four rows AGREED and
+ * three moved count, and this map moved with the run rather than with the merge
+ * notifications. Each surviving row names its own tracker in
+ * resources/ast-span-divergence.txt: carve-php#1351, #1361, #1362 and #1363, and
+ * carve-js#1145 and #1153.
  */
 const LAST_MEASURED = new Map([
-  ['list (extent)', 12],
-  ['list_item (extent)', 12],
-  ['text (presence)', 5],
-  ['block_quote (extent)', 2],
-  ['code (presence)', 2],
+  ['text (presence)', 6],
+  ['code (presence)', 3],
+  ['definition_list (extent)', 2],
   ['paragraph (extent)', 1],
-  ['definition_list (extent)', 1],
-  ['definition_description (extent)', 1],
   ['code (extent)', 1],
 ])
 

--- a/tests/ast-values.test.mjs
+++ b/tests/ast-values.test.mjs
@@ -81,19 +81,23 @@ const shippedDeclaration = () =>
  * WHAT `npm run ast:check` LAST MEASURED, written down so a host with no engine
  * checkouts can still say something falsifiable about the shipped file.
  *
- * Measured 2026-08-17 over 1124 corpus documents plus 3 synthetic samples, at
- * carve-js 02c4d80, carve-rs 1ad93f0 and carve-php 4610ef8. Both rows are
- * carve-php alone on the 326/329 container rulings
- * (markup-carve/carve-php#1354).
+ * Measured 2026-08-17 over 1131 corpus documents plus 3 synthetic samples, at
+ * carve-js 80537c8, carve-rs 71318e9 and carve-php 84c422b, each built from a
+ * fresh clone of main. `npm run ast:check` prints "the engines publish the same
+ * values everywhere", so the map is EMPTY.
  *
- * This is the "moves with the measurement" the note below describes: when that
- * issue lands, ast:check reports both rows FIXED, and the same commit that
- * deletes them from the ledger empties this map.
+ * It held two rows earlier the same day - carve-php alone on the 326/329
+ * container rulings, markup-carve/carve-php#1354 - and this is the "moves with
+ * the measurement" that note described: carve-php shipped them, ast:check
+ * reported both FIXED, and the commit that deleted them from the ledger emptied
+ * this map. Nothing was removed on the strength of the merge notification; the
+ * run is what says so.
+ *
+ * NO FLOOR either way. An empty map against an empty ledger reconciles to
+ * nothing, which is the state the panel is trying to reach, and a row that
+ * appears in either place alone still fails.
  */
-const LAST_MEASURED = new Map([
-  ['paragraph.attrs.classes', 4],
-  ['paragraph.attrs.order', 4],
-])
+const LAST_MEASURED = new Map([])
 
 /** A measurement of `count` distinct documents - the reconciler counts them. */
 const documents = (count) =>


### PR DESCRIPTION
`AST conformance` has been failing on main. The run the tracking ticket names
(markup-carve/carve#1312, run 31994777829, 04:31 UTC) failed three steps, and
none of the three was the panel the ledgers gate - so a ledger read alone would
have diagnosed the wrong thing. Measured over 1131 corpus documents plus 3
synthetic samples, at carve-js 80537c8, carve-rs 71318e9 and carve-php 84c422b,
each built from a fresh clone of main:

  - PART 12 conformance failed on BINDING PARITY, not on a divergence row.
    carve-rb's `ext/carve/Cargo.toml` pinned carve-rs twenty commits back, so the
    binding published the pre-ruling parse under its own name on 26 documents.
    Fixed in markup-carve/carve-rb#71, where the same run reports "carve-rb's
    tree matches carve-rs on all 1134 shared document(s)".
  - The two compare:impls steps failed on 6 documents in one engine, carve-php
    on the `335` through `340` comment-fence fixtures
    (markup-carve/carve-php#1349, open). carve-rs and carve-js are 1220/1220
    clean across all five render targets. That step stays red until carve-php
    ships; nothing in this repo can move it, and declaring it is not available -
    the core corpus comparison has no drift ledger, by design.

What this commit changes is the third thing the same run measured, which is that
BOTH divergence ledgers had gone stale in the few hours since they were written -
and in OPPOSITE directions, which is the case for running the check rather than
reading the file.

`resources/ast-value-divergence.txt` is EMPTY again. Its two rows waited on the
326/329 container rulings, carve-php shipped them, and `ast:check` reported both
FIXED and kept failing until the lines went. Nothing came out on the strength of
a merged PR: four carve-php PRs merged this morning, and what deleted the rows
was the run printing "the engines publish the same values everywhere".

`resources/ast-span-divergence.txt` goes from nine rows across 21 documents to
five across 9, of 22,775 spans compared. `list`, `list_item`, `block_quote` and
`definition_description` came back AGREED; `text (presence)`, `code (presence)`
and `definition_list (extent)` each moved count.

THE ATTRIBUTION WAS WRONG, AND THE ROWS THAT SURVIVED ARE THE PROOF. The morning
pass filed eight of nine span rows under one carve-php issue about the container
rulings. That issue's work shipped and four rows stayed, so the attribution
described a cause four of them did not have. Each row now names its own tracker,
measured per document rather than per fixture family:

  text (presence)          6  three php-absent (carve-php#1351) and three
                              js-absent (carve-js#1153, filed here) - ONE row
                              key, TWO engines, OPPOSITE directions
  code (presence)          3  php spans a run reassembled from two segments,
                              covering the `|` and `+ ` between them
                              (carve-php#1361, filed here)
  definition_list (extent) 2  php ends the list one line short of the floating
                              attribute it now scopes (carve-php#1362, filed
                              here)
  paragraph (extent)       1  php spans the trailing space the content line
                              drops (carve-php#1363, filed here)
  code (extent)            1  js spans that same trailing space, other engine,
                              other node (carve-js#1145, unchanged since
                              2026-08-14)

Four of those five were unfiled or misfiled, which is what "every declared row
names where it is tracked" is for and what the previous pass could not do while
one issue stood in for eight rows.

`resources/ast-position-waivers.txt` did NOT move, and that is recorded rather
than skipped: same four owed findings under the same open carve-php#1351, same
permitted totals of 38, 35 and 32, across four container rulings, seven new
corpus documents and a carve-js comment-fence fix. A file that does not move
still has to be run to say so - the ledger beside it moved twice on those same
builds.

Both engine-free tests move with the measurement, so a host with no checkouts
still reconciles the shipped files against something falsifiable in all three
directions.

`npm run ast:check` exits 0 again with carve-rb#71 applied. `npm test` is 2365
tests, 0 failures.
