### PR TITLE
The span ledger's own summary miscounts the defects it then lists

### DIFF
--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -74,8 +74,9 @@
 # WHAT SURVIVED, per document, and every one now names its own tracker. The
 # morning's block attributed eight rows to one carve-php issue; that was too
 # coarse, and the four rows that did NOT clear when that issue's work shipped are
-# the proof. There are five distinct defects here, in four engines' worth of
-# directions:
+# the proof. FIVE rows, SIX defects, TWO engines - the counts differ because
+# `text (presence)` carries two of the six, and reading the row count as a defect
+# count is the same conflation the morning's block made:
 #
 #   text (presence)              6 doc(s)   TWO defects under one row key:
 #                                           268-...-12, 41-line-blocks-2 and -3


### PR DESCRIPTION
The block added by markup-carve/carve#1314 opens "There are five distinct
defects here" and immediately lists SIX: `text (presence)` carries two, in two
different engines and opposite directions, and the other four rows carry one
each. Five is the ROW count, and the sentence three paragraphs down is the one
that says why those are not the same number - "THE ROW KEY IS A TYPE, NOT A
DEFECT".

So the summary line made, in miniature, the conflation the block was written to
correct. The morning's version of the same block filed eight rows under one
issue by treating a fixture family as a cause; this one treated a row key as a
cause. Both read as verified and both are wrong by one level of grouping.

Rewritten to give all three numbers rather than pick one, since the whole point
of the paragraph is that they differ: five rows, six defects, two engines.

No row, count or tracker changes, so `ast:check` is unaffected and this cannot
move the ledger. tests/ast-spans.test.mjs and tests/ast-values.test.mjs are
26 passing, 0 failing.
