### PR TITLE
The span ledger and the waivers, re-measured after two carve-js fixes

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -638,7 +638,7 @@ documents on 2026-08-07, the OWED half of `resources/ast-position-waivers.txt`
 was EMPTY.
 
 It did not stay empty. Re-measured on 2026-08-17 over 1131 documents, at
-carve-js 80537c8, carve-rs 71318e9 and carve-php 84c422b, that half holds one
+carve-js c8c8dc3, carve-rs 71318e9 and carve-php 6bd856f, that half holds one
 defect again: carve-php drops the position of a line block's content where the
 source's spaces became indentation sentinels, and carve-rs publishes the same
 value WITH a span, so a true span exists
@@ -710,15 +710,30 @@ corpus documents plus 3 synthetic samples, `npm run ast:check` reports:
 
 The morning's block attributed eight span rows to a single carve-php issue. That
 was too coarse, and the rows that survived their own issue's work are how it
-shows: each surviving row now names its own tracker, in carve-php
+shows: each surviving row was given its own tracker, in carve-php
 ([#1351](https://github.com/markup-carve/carve-php/issues/1351),
 [#1361](https://github.com/markup-carve/carve-php/issues/1361),
 [#1362](https://github.com/markup-carve/carve-php/issues/1362),
 [#1363](https://github.com/markup-carve/carve-php/issues/1363)) and in carve-js
 ([#1145](https://github.com/markup-carve/carve-js/issues/1145),
-[#1153](https://github.com/markup-carve/carve-js/issues/1153)). Two of those are
+[#1153](https://github.com/markup-carve/carve-js/issues/1153)). Two of those were
 carve-js standing alone, so "one engine is behind" was never the whole shape
 either.
+
+Ninety minutes later it was four rows across eight documents, of 22,769 spans, at
+carve-js `c8c8dc3`, carve-rs `71318e9` and carve-php `6bd856f`. Both carve-js
+rows went in the two PRs that answered them - `code (extent)` came `AGREED` and
+`text (presence)` dropped from six documents to three - and that second fix also
+moved `resources/ast-position-waivers.txt`, which had not moved all day: a
+continuation row's carried text now has its own span, so two permitted omissions
+retire and a third halves.
+
+Which is the point of dating these paragraphs rather than writing them in the
+present tense. The block above says a row "will not clear when carve-php catches
+up" and names it the one worth watching; it cleared within two hours, in the
+other engine, for an unrelated reason. Every remaining span row is carve-php
+alone - the first time that day the panel had one engine on every row, and the
+third consecutive block to claim something like it.
 
 An empty declaration is a statement about the corpus, which is the only thing
 the run measures. Four collapsed-reference labels the corpus does not hold - one

--- a/resources/ast-position-waivers.txt
+++ b/resources/ast-position-waivers.txt
@@ -46,10 +46,19 @@
 # IN THIS FILE MOVED EITHER TIME. Same four owed findings under the same open
 # issue, and the same permitted totals: 38, 35 and 32.
 #
-# WHICH IS WORTH RECORDING RATHER THAN SKIPPING. The span ledger beside this one
-# moved twice on those same engine builds - nine rows to five - so "the engines
-# moved, therefore this moved too" is exactly the inference a re-measurement is
-# here to refuse. A file that does not move still has to be run to say so.
+# THEN IT MOVED, an hour later, at carve-js c8c8dc3 over the same 1131
+# documents. markup-carve/carve-js#1154 gave a continuation row's carried text
+# its own span, so three PERMITTED lines stopped describing anything: the `333`
+# and `333-4` text omissions are gone entirely and `333-5` went from two to one.
+# carve-js's permitted total is 35, not 38. carve-rs and carve-php did not move
+# and still read 35 and 32, and the OWED half is untouched - the same four
+# findings under the same open markup-carve/carve-php#1351.
+#
+# WHICH IS WHY THE "NOTHING MOVED" NOTE ABOVE IS KEPT RATHER THAN OVERWRITTEN.
+# It was true when it was measured and false ninety minutes later, and the two
+# together are the actual claim this file can support: a permitted line is a
+# statement about one build, and the engines land fixes faster than a paragraph
+# describing them stays accurate. The run is what says which state you are in.
 #
 # The measurement this replaces ran the same 1124 documents at carve-js
 # e2e8460, carve-rs b6ff319 and carve-php b6d49a7, and reported both halves the
@@ -152,9 +161,7 @@ carve-php  64-table-rowspan-with-multi-line-content.crv           text  1  permi
 # (resources/engine-pin-drift.txt declares the carve-js half), not because the
 # clause reaches them differently.
 
-carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe.crv    text  1  permitted
-carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4.crv  text  1  permitted
-carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  text  2  permitted
+carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  text  1  permitted
 carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  text  1  permitted
 carve-php  333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  text  1  permitted
 

--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -112,8 +112,37 @@
 # 2026-08-14 before it. It was the row worth watching when the other eight went,
 # and it is still here.
 
-text (presence) 6
+# AND AGAIN NINETY MINUTES LATER, at carve-js c8c8dc3, carve-rs 71318e9 and
+# carve-php 6bd856f over the same 1131 corpus documents plus 3 synthetic
+# samples. Of 22,769 comparable spans, FOUR rows disagree across 8 documents.
+# The block above is already the previous state.
+#
+# Both carve-js rows went, in the two PRs that answered them:
+#
+#   code (extent)    1 -> 0   markup-carve/carve-js#1145, closed by
+#                             markup-carve/carve-js#1152. Reported AGREED.
+#   text (presence)  6 -> 3   markup-carve/carve-js#1153, the issue this
+#                             ledger's previous block filed, closed by
+#                             markup-carve/carve-js#1154. Reported COUNT; the
+#                             three carve-php documents are what is left.
+#
+# So `text (presence)` is now ONE defect rather than two, and the row that the
+# previous block called "the row worth watching when the other eight go" was
+# gone within two hours of being written. Both were removed on the run
+# reporting them, not on the merge notification.
+#
+# markup-carve/carve-js#1154 also moved resources/ast-position-waivers.txt, which
+# had not moved all day: giving a continuation row's carried text its own span
+# retires two permitted omissions and halves a third.
+#
+# WHAT REMAINS IS carve-php ALONE, on four rows and three open issues:
+# markup-carve/carve-php#1351 (text presence), #1361 (code presence), #1362
+# (definition_list extent) and #1363 (paragraph extent). That is the first time
+# today this panel has had a single engine on every row, and it is worth saying
+# only because the previous two blocks each said something like it and were
+# wrong - which is the argument for the count column rather than the prose.
+
+text (presence) 3
 code (presence) 3
 definition_list (extent) 2
 paragraph (extent) 1
-code (extent) 1

--- a/tests/ast-spans.test.mjs
+++ b/tests/ast-spans.test.mjs
@@ -216,22 +216,22 @@ test('a malformed declaration line is an error, never a silent skip', () => {
  * ledger is empty - every declared row becomes an AGREED.
  *
  * Measured 2026-08-17 over 1131 corpus documents plus 3 synthetic samples, at
- * carve-js 80537c8, carve-rs 71318e9 and carve-php 84c422b, each built from a
- * fresh clone of main. Five rows across 9 documents, of 22,775 spans compared.
+ * carve-js c8c8dc3, carve-rs 71318e9 and carve-php 6bd856f, each built from a
+ * fresh clone of main. Four rows across 8 documents, of 22,769 spans compared.
  *
- * It read nine rows across 21 documents earlier the same day. carve-php shipped
- * the 326/327/329/333 container rulings, ast:check reported four rows AGREED and
- * three moved count, and this map moved with the run rather than with the merge
- * notifications. Each surviving row names its own tracker in
- * resources/ast-span-divergence.txt: carve-php#1351, #1361, #1362 and #1363, and
- * carve-js#1145 and #1153.
+ * It read nine rows across 21 documents that morning and five across 9 an hour
+ * later. carve-php shipped the 326/327/329/333 container rulings, then carve-js
+ * shipped #1152 and #1154, and each time ast:check reported the rows AGREED or
+ * COUNT and this map moved with the run rather than with the merge
+ * notifications. Every remaining row is carve-php alone, and each names its own
+ * tracker in resources/ast-span-divergence.txt: carve-php#1351, #1361, #1362
+ * and #1363.
  */
 const LAST_MEASURED = new Map([
-  ['text (presence)', 6],
+  ['text (presence)', 3],
   ['code (presence)', 3],
   ['definition_list (extent)', 2],
   ['paragraph (extent)', 1],
-  ['code (extent)', 1],
 ])
 
 const asMeasured = (counts) =>


### PR DESCRIPTION
markup-carve/carve#1314 landed the span ledger at five rows and said `code
(extent)` was "the row worth watching when the other eight go". It was gone two
hours later, in the other engine, for a reason unrelated to what that sentence
predicted. `AST conformance` run 32015752016 went red on PART 12 for exactly
that: a declared row that no longer reproduces.

Re-measured over the same 1131 corpus documents plus 3 synthetic samples, at
carve-js c8c8dc3, carve-rs 71318e9 and carve-php 6bd856f, each built from a fresh
clone of main. Of 22,769 comparable spans, FOUR rows disagree across 8 documents:

  code (extent)    1 -> 0   markup-carve/carve-js#1145, closed by
                            markup-carve/carve-js#1152. Reported AGREED.
  text (presence)  6 -> 3   markup-carve/carve-js#1153 - the issue #1314 filed -
                            closed by markup-carve/carve-js#1154. Reported
                            COUNT; the three carve-php documents remain.

Neither came out on a merge notification. `npm run ast:check` named both and kept
failing until the lines moved.

resources/ast-position-waivers.txt MOVED TOO, having not moved all day across
four carve-php container rulings, seven new corpus documents and a carve-js
comment-fence fix. carve-js#1154 gives a continuation row's carried text its own
span, so two PERMITTED omissions stop describing anything and a third halves:
carve-js's permitted total is 35, not 38. The OWED half is untouched - the same
four findings under the same open markup-carve/carve-php#1351.

The "NOTHING IN THIS FILE MOVED" note is kept rather than overwritten. It was
true when it was measured and false ninety minutes later, and the pair is the
actual claim the file can support.

Every remaining span row is carve-php alone, on four open issues: #1351 (text
presence), #1361 (code presence), #1362 (definition_list extent) and #1363
(paragraph extent). Said with the caveat the file now carries, because the two
preceding blocks each claimed something similar and were overtaken within the
hour.

`npm run ast:check` exits 0. tests/ast-spans, ast-values, ast-waivers and
ast-json-claims are 63 passing, 0 failing.
