### PR TITLE
Declare what carve-php's discontiguous-source fix moved, in both directions

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -619,7 +619,7 @@ A row may name an issue only where one of those still declares the debt.
 |---|---|---|
 | carve-js | §3a conformant on the resolved form: publishes `href`, `ref` and `rawRef` together | every block and inline placed, except the categories §4 exempts: a coalesced `text` run, a table cell continued on a `+` line, and a verbatim run continued on a `+` line |
 | carve-rs | §3a conformant on the resolved form: `ref` and `rawRef` survive resolution beside `href` | every block and inline placed, except the categories §4 exempts: a coalesced `text` run, a reassembled table cell, and a verbatim run continued on a `+` line |
-| carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries the resolution key in `ref` beside `rawRef`, the same label the other two publish on every corpus document | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the two categories §4 exempts - a coalesced `text` run and a reassembled table cell - and a line block's spaced content, which the other two place and markup-carve/carve-php#1351 tracks |
+| carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries the resolution key in `ref` beside `rawRef`, the same label the other two publish on every corpus document | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the categories §4 exempts - a coalesced `text` run, a reassembled table cell, and a verbatim run continued on a `+` line - plus two gaps the other two engines do not have: a line block's spaced content (markup-carve/carve-php#1351) and a fenced code block's extent, dropped along with the reassembled run's span (markup-carve/carve-php#1369) |
 | carve-rb / carve-py / carve-go / carve-wasm | publish carve-rs's bytes | whatever carve-rs records |
 
 The gaps are listed rather than smoothed over on purpose: "six implementations"
@@ -734,6 +734,22 @@ up" and names it the one worth watching; it cleared within two hours, in the
 other engine, for an unrelated reason. Every remaining span row is carve-php
 alone - the first time that day the panel had one engine on every row, and the
 third consecutive block to claim something like it.
+
+One more measurement that day, at carve-php `30cc587`, is the one worth keeping
+for what it says about the ledgers rather than about the engines. The span
+declaration read four rows across eight documents again, with all four counts
+identical to the measurement before it - and `code (presence)` had swapped both
+its three documents and which engine stood alone. carve-php stopped publishing a
+position for a node assembled from discontiguous source, which is right for a
+verbatim run carried across a `+` row and wrong for a fenced code block, whose
+position is an extent over one contiguous region
+([carve-php#1369](https://github.com/markup-carve/carve-php/issues/1369)).
+
+A row that changes its documents and its direction while holding its count is
+invisible to a count-based declaration - and the run still failed, because the
+six carve-php position findings arrived undeclared in
+`resources/ast-position-waivers.txt`. The two ledgers cover each other's blind
+spot, which is worth knowing before anyone proposes folding them into one.
 
 An empty declaration is a statement about the corpus, which is the only thing
 the run measures. Four collapsed-reference labels the corpus does not hold - one

--- a/resources/ast-position-waivers.txt
+++ b/resources/ast-position-waivers.txt
@@ -225,6 +225,9 @@ carve-js   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  
 carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe.crv    code  1  permitted
 carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4.crv  code  1  permitted
 carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  code  1  permitted
+carve-php  333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe.crv    code  1  permitted
+carve-php  333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-4.crv  code  1  permitted
+carve-php  333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  code  1  permitted
 
 # ---- OWED --------------------------------------------------------------------
 #
@@ -242,10 +245,30 @@ carve-rs   333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  
 # and all three engines omit. Per-engine symmetry is the tell - when the cause
 # is the construct every engine omits, and when one engine is alone the finding
 # is owed.
+#
+# A SECOND OWED DEFECT ARRIVED THE SAME DAY, and it arrived as the over-reach of
+# a fix. markup-carve/carve-php#1365 stopped publishing a position for a node
+# assembled from discontiguous source, which is correct for the inline verbatim
+# run markup-carve/carve-php#1361 was about - carve-php's three `333` `code`
+# omissions are now PERMITTED above, matching carve-js and carve-rs, and that
+# row is a genuine fix.
+#
+# It also reached fenced code BLOCKS, whose position is an EXTENT rather than a
+# slice of the value. A fence is one contiguous region, carve-js and carve-rs
+# both place it, and §4 exempts what CANNOT be placed - so these three are owed
+# (markup-carve/carve-php#1369).
+#
+# WHICH IS THE SAME SHAPE AS THE PARAGRAPH ABOVE, in the other direction: one
+# engine alone is the tell either way. Here the engine standing alone had just
+# stopped standing alone somewhere else, in one commit, which is why a run
+# rather than a diff is what this file reconciles against.
 
 carve-php  268-trailing-whitespace-on-a-content-line-is-dropped-12.crv  text  1  markup-carve/carve-php#1351
 carve-php  41-line-blocks-2.crv                                         text  1  markup-carve/carve-php#1351
 carve-php  41-line-blocks-3.crv                                         text  2  markup-carve/carve-php#1351
+carve-php  11-fenced-code-16.crv                                        code  1  markup-carve/carve-php#1369
+carve-php  149-fence-folds-as-lazy-inline-code-above-the-content-column.crv  code  1  markup-carve/carve-php#1369
+carve-php  276-a-fence-opened-on-a-list-marker-line-body-below-the-content-column-7.crv  code  1  markup-carve/carve-php#1369
 
 # WHAT USED TO BE HERE, and was deliberately kept as a section while empty.
 #

--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -142,6 +142,34 @@
 # only because the previous two blocks each said something like it and were
 # wrong - which is the argument for the count column rather than the prose.
 
+# AND ONE MORE TIME, at carve-js c8c8dc3, carve-rs 71318e9 and carve-php
+# 30cc587 over the same 1131 corpus documents plus 3 synthetic samples. Of
+# 22,763 comparable spans, FOUR rows across 8 documents - the same four keys and
+# the same four counts as the block above.
+#
+# THE COUNTS DID NOT MOVE AND THE ROW DID. `code (presence)` still reads 3, and
+# it is now a different three documents with the engines the other way round:
+#
+#   before  333, 333-4, 333-5              php PLACED, js and rs absent
+#   after   11-fenced-code-16, 149-...,    php ABSENT, js and rs placed
+#           276-...-7
+#
+# markup-carve/carve-php#1365 closed markup-carve/carve-php#1361 by dropping the
+# position on a node assembled from discontiguous source. On the `333` documents
+# that is the fix, and those three omissions are now `permitted` in
+# resources/ast-position-waivers.txt beside carve-js's and carve-rs's. It also
+# reached fenced code BLOCKS, where the position is an extent over one
+# contiguous region and both other engines place it, so three honest spans went
+# with it (markup-carve/carve-php#1369).
+#
+# A COUNT ALONE WOULD HAVE CALLED THAT NO CHANGE. This is the one case the
+# file's own header does not catch: "a listed field's DOCUMENT COUNT moves"
+# fails, and a row that swaps its documents and its direction while holding its
+# count does not. What caught it was the sibling file - the six carve-php
+# position findings arrived UNDECLARED there and failed the run - so the two
+# ledgers cover each other, and neither is sufficient alone. Worth knowing
+# before anyone proposes dropping one.
+
 text (presence) 3
 code (presence) 3
 definition_list (extent) 2

--- a/tests/ast-spans.test.mjs
+++ b/tests/ast-spans.test.mjs
@@ -216,8 +216,15 @@ test('a malformed declaration line is an error, never a silent skip', () => {
  * ledger is empty - every declared row becomes an AGREED.
  *
  * Measured 2026-08-17 over 1131 corpus documents plus 3 synthetic samples, at
- * carve-js c8c8dc3, carve-rs 71318e9 and carve-php 6bd856f, each built from a
- * fresh clone of main. Four rows across 8 documents, of 22,769 spans compared.
+ * carve-js c8c8dc3, carve-rs 71318e9 and carve-php 30cc587, each built from a
+ * fresh clone of main. Four rows across 8 documents, of 22,763 spans compared.
+ *
+ * The counts below are UNCHANGED from the measurement before this one and one
+ * of the rows is not: `code (presence)` swapped its three documents and its
+ * engine direction under a steady count of 3, which this map cannot see and
+ * resources/ast-position-waivers.txt did - see the note in
+ * resources/ast-span-divergence.txt. A stable number here is not evidence the
+ * panel stood still.
  *
  * It read nine rows across 21 documents that morning and five across 9 an hour
  * later. carve-php shipped the 326/327/329/333 container rulings, then carve-js


### PR DESCRIPTION
markup-carve/carve-php#1365 stopped publishing a position for a node assembled
from discontiguous source. It closed markup-carve/carve-php#1361 correctly and
over-reached, and `npm run ast:check` reports both halves.

Re-measured over 1131 corpus documents plus 3 synthetic samples, at carve-js
c8c8dc3, carve-rs 71318e9 and carve-php 30cc587, each built from a fresh clone of
main. Six carve-php position findings arrived UNDECLARED, and they are two
different things:

  PERMITTED  333, 333-4, 333-5, `code`. A verbatim run carried across a `+` row
             is stitched from two segments with the row's `|` and the marker
             between them, so no honest span exists. carve-js and carve-rs
             already sit here; carve-php now joins them, which is the fix.
  OWED       11-fenced-code-16, 149-fence-folds-as-lazy-inline-code-above-the-
             content-column, 276-a-fence-opened-on-a-list-marker-line-body-
             below-the-content-column-7, `code`. A fenced block's position is an
             EXTENT over one contiguous region and both other engines place it,
             so §4 does not exempt it (markup-carve/carve-php#1369, filed here).

Never widened to `permitted` to quiet the run, which is what the file's own
header forbids: the three owed lines name an issue.

THE SPAN LEDGER'S COUNTS DID NOT MOVE AND ONE OF ITS ROWS DID. `code (presence)`
reads 3 before and after, over three different documents with the engines the
other way round - carve-php placed and the other two absent, now carve-php absent
and the other two placed. A count-based declaration cannot see that, and this is
the first case today where it mattered.

What caught it was the OTHER ledger. The six findings were undeclared in
resources/ast-position-waivers.txt and failed the run there. The two files cover
each other's blind spot, and neither is sufficient alone - recorded in both,
because "the counts are unchanged, so nothing moved" is the reading this
otherwise invites.

docs/ast-json.md's conformance table moves with it: carve-php's positions cell
now names the verbatim-run category it permits and both gaps it owes, which
tests/ast-json-claims.test.mjs reconciles against the ledger in both directions.

`npm run ast:check` exits 0. tests/ast-spans, ast-values, ast-waivers and
ast-json-claims are 63 passing, 0 failing.
