### PR TITLE
Two more carve-php span fixes, and the second row this hour to outlive its issue

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -751,6 +751,23 @@ six carve-php position findings arrived undeclared in
 `resources/ast-position-waivers.txt`. The two ledgers cover each other's blind
 spot, which is worth knowing before anyone proposes folding them into one.
 
+It happened a second time within the hour, which is what makes it a pattern
+rather than an anecdote. At carve-php `1f60342` the span declaration is three
+rows across seven documents: `paragraph (extent)` came `AGREED` and
+`definition_list (extent)` dropped from two documents to one - but the surviving
+document is not either of the two the closed issue named. Both `329` fixtures
+agree now; what is left is `266-a-reference-definition-is-anchored-at-end-of-line-12`,
+where the list's extent runs one line PAST a reference definition it does not
+consume, the mirror of the gap that was fixed
+([carve-php#1371](https://github.com/markup-carve/carve-php/issues/1371)).
+
+So twice in an hour a fix landed correctly on the documents its issue named and
+over-reached onto one it did not. The count moved just enough to read as
+progress. A row here is a NODE TYPE, and the documents behind a type turn over
+faster than the row does - which is why the ledger records document names in
+prose beside each count, and why "the number went down" is not an answer to
+"did that gap close".
+
 An empty declaration is a statement about the corpus, which is the only thing
 the run measures. Four collapsed-reference labels the corpus does not hold - one
 carrying `/emphasis/`, one an escape, one a nested link, one a symbol shortcode

--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -170,7 +170,41 @@
 # ledgers cover each other, and neither is sufficient alone. Worth knowing
 # before anyone proposes dropping one.
 
+# AND ONCE MORE, at carve-js c8c8dc3, carve-rs 71318e9 and carve-php 1f60342
+# over the same 1131 corpus documents plus 3 synthetic samples. Of 22,763
+# comparable spans, THREE rows across 7 documents:
+#
+#   paragraph (extent)        1 -> 0   markup-carve/carve-php#1363, closed by
+#                                      markup-carve/carve-php#1367. AGREED.
+#   definition_list (extent)  2 -> 1   markup-carve/carve-php#1362, closed by
+#                                      markup-carve/carve-php#1366. COUNT - and
+#                                      the ONE that is left is not one of the
+#                                      two it declared.
+#
+# THE SURVIVING DOCUMENT IS A DIFFERENT ONE, AND THE DIRECTION IS REVERSED.
+# #1362 was carve-php ending a list one line SHORT of the floating attribute it
+# scopes, on `329-...-5` and `-6`; both now agree. The row's remaining document
+# is `266-a-reference-definition-is-anchored-at-end-of-line-12`, where carve-php
+# ends one line LONG, covering a reference definition the list does not consume
+# (markup-carve/carve-php#1371).
+#
+# THAT IS THE SECOND TIME IN AN HOUR a carve-php span fix landed correctly on
+# the documents its issue named and over-reached onto one the issue did not -
+# #1365 for `code (presence)` and #1366 here. Both times the count changed just
+# enough to look like progress and the row described something new. The lesson
+# is not about carve-php: it is that a row is a TYPE, and the documents behind a
+# type turn over faster than the row does. Anyone reading a count here to decide
+# whether a gap closed should re-run the check and read the document names.
+#
+# WHAT REMAINS, all carve-php, all against carve-js and carve-rs agreeing:
+#
+#   text (presence)           3 doc(s)  268-...-12, 41-line-blocks-2 and -3;
+#                                       php absent (markup-carve/carve-php#1351)
+#   code (presence)           3 doc(s)  11-fenced-code-16, 149-..., 276-...-7;
+#                                       php absent (markup-carve/carve-php#1369)
+#   definition_list (extent)  1 doc(s)  266-...-12; php one line long
+#                                       (markup-carve/carve-php#1371)
+
 text (presence) 3
 code (presence) 3
-definition_list (extent) 2
-paragraph (extent) 1
+definition_list (extent) 1

--- a/tests/ast-spans.test.mjs
+++ b/tests/ast-spans.test.mjs
@@ -216,29 +216,31 @@ test('a malformed declaration line is an error, never a silent skip', () => {
  * ledger is empty - every declared row becomes an AGREED.
  *
  * Measured 2026-08-17 over 1131 corpus documents plus 3 synthetic samples, at
- * carve-js c8c8dc3, carve-rs 71318e9 and carve-php 30cc587, each built from a
- * fresh clone of main. Four rows across 8 documents, of 22,763 spans compared.
+ * carve-js c8c8dc3, carve-rs 71318e9 and carve-php 1f60342, each built from a
+ * fresh clone of main. Three rows across 7 documents, of 22,763 spans compared.
  *
- * The counts below are UNCHANGED from the measurement before this one and one
- * of the rows is not: `code (presence)` swapped its three documents and its
- * engine direction under a steady count of 3, which this map cannot see and
- * resources/ast-position-waivers.txt did - see the note in
- * resources/ast-span-divergence.txt. A stable number here is not evidence the
- * panel stood still.
+ * A NUMBER HERE IS NOT A GAP. Twice in the hour before this measurement a
+ * carve-php fix closed the documents its issue named and over-reached onto one
+ * it did not, so the row survived with a different document behind it and the
+ * engines the other way round - once at a count that did not move at all. This
+ * map cannot see that, and it is not supposed to: what it pins is that the
+ * shipped ledger matches the last run. The document names live in
+ * resources/ast-span-divergence.txt, and re-running the check is the only thing
+ * that says which gap a row currently describes.
  *
- * It read nine rows across 21 documents that morning and five across 9 an hour
- * later. carve-php shipped the 326/327/329/333 container rulings, then carve-js
- * shipped #1152 and #1154, and each time ast:check reported the rows AGREED or
- * COUNT and this map moved with the run rather than with the merge
- * notifications. Every remaining row is carve-php alone, and each names its own
- * tracker in resources/ast-span-divergence.txt: carve-php#1351, #1361, #1362
- * and #1363.
+ * It read nine rows across 21 documents that morning, five across 9 an hour
+ * later, and four across 8 twice after that. carve-php shipped the
+ * 326/327/329/333 container rulings, carve-js shipped #1152 and #1154, and
+ * carve-php then shipped #1365, #1366 and #1367 - and each time ast:check
+ * reported the rows AGREED or COUNT and this map moved with the run rather than
+ * with the merge notifications. Every remaining row is carve-php alone, each
+ * naming its own tracker in resources/ast-span-divergence.txt: carve-php#1351,
+ * #1369 and #1371.
  */
 const LAST_MEASURED = new Map([
   ['text (presence)', 3],
   ['code (presence)', 3],
-  ['definition_list (extent)', 2],
-  ['paragraph (extent)', 1],
+  ['definition_list (extent)', 1],
 ])
 
 const asMeasured = (counts) =>


### PR DESCRIPTION
markup-carve/carve-php#1367 and #1366 closed markup-carve/carve-php#1363 and
#1362. Re-measured over 1131 corpus documents plus 3 synthetic samples, at
carve-js c8c8dc3, carve-rs 71318e9 and carve-php 1f60342, each built from a fresh
clone of main: THREE rows across 7 documents, of 22,763 comparable spans.

  paragraph (extent)        1 -> 0   AGREED.
  definition_list (extent)  2 -> 1   COUNT - and the one that is left is not one
                                     of the two the closed issue named.

THE SURVIVING DOCUMENT IS A DIFFERENT ONE AND THE DIRECTION IS REVERSED. #1362
was carve-php ending a definition list one line SHORT of the floating attribute
it scopes, on the two `329` fixtures; both agree now. What the row still holds is
`266-a-reference-definition-is-anchored-at-end-of-line-12`, where carve-php ends
one line LONG, covering a reference definition the list does not consume. Filed
as markup-carve/carve-php#1371. The rendered HTML agrees in all three engines, so
the corpus fixture cannot see it and this panel is what reports it.

That is the SECOND time this hour a carve-php span fix landed correctly on the
documents its issue named and over-reached onto one it did not - #1365 for `code
(presence)`, where the count did not move at all, and #1366 here, where it moved
by one and looked like partial progress. The note is not about carve-php: a row
is a NODE TYPE, and the documents behind a type turn over faster than the row
does. The ledger already records document names in prose beside each count; this
adds why that is load-bearing rather than decorative, so nobody reads a falling
count as a closing gap.

What remains is three rows, all carve-php, all against carve-js and carve-rs
agreeing: markup-carve/carve-php#1351 (text presence, 3), #1369 (code presence,
3) and #1371 (definition_list extent, 1).

`npm run ast:check` exits 0. tests/ast-spans, ast-values, ast-waivers and
ast-json-claims are 63 passing, 0 failing.
