### PR TITLE
Both ledgers down to one declared row, measured from clones made for it

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -619,7 +619,7 @@ A row may name an issue only where one of those still declares the debt.
 |---|---|---|
 | carve-js | §3a conformant on the resolved form: publishes `href`, `ref` and `rawRef` together | every block and inline placed, except the categories §4 exempts: a coalesced `text` run, a table cell continued on a `+` line, and a verbatim run continued on a `+` line |
 | carve-rs | §3a conformant on the resolved form: `ref` and `rawRef` survive resolution beside `href` | every block and inline placed, except the categories §4 exempts: a coalesced `text` run, a reassembled table cell, and a verbatim run continued on a `+` line |
-| carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries the resolution key in `ref` beside `rawRef`, the same label the other two publish on every corpus document | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the categories §4 exempts - a coalesced `text` run, a reassembled table cell, and a verbatim run continued on a `+` line - plus two gaps the other two engines do not have: a line block's spaced content (markup-carve/carve-php#1351) and a fenced code block's extent, dropped along with the reassembled run's span (markup-carve/carve-php#1369) |
+| carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries the resolution key in `ref` beside `rawRef`, the same label the other two publish on every corpus document | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the categories §4 exempts - a coalesced `text` run, a reassembled table cell, and a verbatim run continued on a `+` line - and one gap the other two engines do not have: a line block's spaced content, which they place and markup-carve/carve-php#1351 tracks |
 | carve-rb / carve-py / carve-go / carve-wasm | publish carve-rs's bytes | whatever carve-rs records |
 
 The gaps are listed rather than smoothed over on purpose: "six implementations"
@@ -638,7 +638,7 @@ documents on 2026-08-07, the OWED half of `resources/ast-position-waivers.txt`
 was EMPTY.
 
 It did not stay empty. Re-measured on 2026-08-17 over 1131 documents, at
-carve-js c8c8dc3, carve-rs 71318e9 and carve-php 6bd856f, that half holds one
+carve-js c8c8dc3, carve-rs d981df8 and carve-php d2e2fd6, that half holds one
 defect again: carve-php drops the position of a line block's content where the
 source's spaces became indentation sentinels, and carve-rs publishes the same
 value WITH a span, so a true span exists
@@ -647,9 +647,13 @@ findings over three documents, with nothing outstanding in carve-js or carve-rs.
 The corpus grew 298 documents between that measurement and the 833-document one
 above, which is the whole reason an undated "the gap is closed" sentence is worth
 nothing here - a re-measurement is what says so, and only for the corpus it ran
-over. Three earlier reads that day, at 1124 documents and across three separate
-sets of engine mains, said the same thing: nothing in that file moved while the
-span and value ledgers moved twice.
+over.
+
+That one defect is the ONLY thing either ledger still declares, and it survived
+a day in which the span ledger was re-measured six times and rewritten five. It
+is the constant because nobody has started it, not because it is small - which
+is a useful thing to know about a ledger: what stays in it is what nobody is
+working on.
 
 Every other position finding is `permitted` under §4.
 
@@ -767,6 +771,23 @@ progress. A row here is a NODE TYPE, and the documents behind a type turn over
 faster than the row does - which is why the ledger records document names in
 prose beside each count, and why "the number went down" is not an answer to
 "did that gap close".
+
+Both over-reaches were then fixed, and the day's last measurement - taken from a
+clone made for it, at carve-js `c8c8dc3`, carve-rs `d981df8` and carve-php
+`d2e2fd6` - reads ONE span row across three documents, of 22,766 spans:
+carve-php dropping the position of a line block's spaced content
+([carve-php#1351](https://github.com/markup-carve/carve-php/issues/1351)). The
+same three documents are the owed half of
+`resources/ast-position-waivers.txt`, so for the first time that day the two
+ledgers describe one gap rather than covering for each other. The value
+declaration is empty and carve-rb's tree matches carve-rs on all 1134 shared
+documents.
+
+Six measurements in one day, each taken because the one before it had stopped
+being true. That is the number worth carrying forward from this section: not
+which rows are declared, but how quickly a declared row stops describing
+anything, and therefore that the run - not the ledger, and not a merged pull
+request - is what answers a question about the engines.
 
 An empty declaration is a statement about the corpus, which is the only thing
 the run measures. Four collapsed-reference labels the corpus does not hold - one

--- a/resources/ast-position-waivers.txt
+++ b/resources/ast-position-waivers.txt
@@ -266,9 +266,6 @@ carve-php  333-a-continuation-row-s-open-run-and-an-escaped-closing-pipe-5.crv  
 carve-php  268-trailing-whitespace-on-a-content-line-is-dropped-12.crv  text  1  markup-carve/carve-php#1351
 carve-php  41-line-blocks-2.crv                                         text  1  markup-carve/carve-php#1351
 carve-php  41-line-blocks-3.crv                                         text  2  markup-carve/carve-php#1351
-carve-php  11-fenced-code-16.crv                                        code  1  markup-carve/carve-php#1369
-carve-php  149-fence-folds-as-lazy-inline-code-above-the-content-column.crv  code  1  markup-carve/carve-php#1369
-carve-php  276-a-fence-opened-on-a-list-marker-line-body-below-the-content-column-7.crv  code  1  markup-carve/carve-php#1369
 
 # WHAT USED TO BE HERE, and was deliberately kept as a section while empty.
 #

--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -205,6 +205,46 @@
 #   definition_list (extent)  1 doc(s)  266-...-12; php one line long
 #                                       (markup-carve/carve-php#1371)
 
+# AND THE LAST MEASUREMENT OF THE DAY, from a FRESH clone of every engine, at
+# carve-js c8c8dc3, carve-rs d981df8 and carve-php d2e2fd6 over the same 1131
+# corpus documents plus 3 synthetic samples. Of 22,766 comparable spans, ONE row
+# disagrees, across 3 documents.
+#
+#   code (presence)           3 -> 0   markup-carve/carve-php#1369, closed by
+#                                      markup-carve/carve-php#1370. AGREED.
+#   definition_list (extent)  1 -> 0   markup-carve/carve-php#1371, closed by
+#                                      markup-carve/carve-php#1372. AGREED.
+#
+# Both over-reaches described two blocks up are gone, and this time the row went
+# to zero rather than to a different document - which is the thing the previous
+# two blocks could not say and the reason they said so much.
+#
+# FRESH CLONE, DELIBERATELY. The earlier measurements ran against a carve-php
+# checkout shared with other work, and a mutant lived in that checkout for a
+# couple of seconds while a run was in flight. Nothing in this file was removed
+# on the strength of one of those runs: every deletion above and here is
+# reproduced by this one, taken against a clone made for it. A ledger row is
+# exactly the kind of claim that reads as verified a week later, so the
+# provenance of the run that removed it is part of the record.
+#
+# WHAT REMAINS is one row, one engine, one issue:
+#
+#   text (presence)  3 doc(s)  268-...-12, 41-line-blocks-2 and -3: carve-php
+#                              drops the position of a line block's spaced
+#                              content, where the source's spaces became
+#                              indentation sentinels and carve-js and carve-rs
+#                              both place it (markup-carve/carve-php#1351,
+#                              analysed and not started).
+#
+# The same three documents are the OWED half of
+# resources/ast-position-waivers.txt, which is what it looks like when the two
+# ledgers agree about one gap instead of covering for each other.
+#
+# CONFIRMED AT A SECOND SET OF MAINS, forty minutes later and without editing a
+# line: carve-js c8c8dc3, carve-rs ff54c44 and carve-php 5e6ab9a read the same
+# one row over the same three documents and the same 22,766 spans. carve-rs
+# moved twice and carve-php once in between. That is the first time all day a
+# re-measurement did NOT move this file, and it is the only reason the state
+# above is worth writing down rather than superseding again.
+
 text (presence) 3
-code (presence) 3
-definition_list (extent) 1

--- a/tests/ast-spans.test.mjs
+++ b/tests/ast-spans.test.mjs
@@ -216,8 +216,12 @@ test('a malformed declaration line is an error, never a silent skip', () => {
  * ledger is empty - every declared row becomes an AGREED.
  *
  * Measured 2026-08-17 over 1131 corpus documents plus 3 synthetic samples, at
- * carve-js c8c8dc3, carve-rs 71318e9 and carve-php 1f60342, each built from a
- * fresh clone of main. Three rows across 7 documents, of 22,763 spans compared.
+ * carve-js c8c8dc3, carve-rs d981df8 and carve-php d2e2fd6, each built from a
+ * clone made for this run. ONE row across 3 documents, of 22,766 spans compared:
+ * carve-php dropping a line block's spaced content position
+ * (markup-carve/carve-php#1351). The same one row, three documents and 22,766
+ * spans read again at carve-rs ff54c44 and carve-php 5e6ab9a, two engine mains
+ * later, with nothing edited in between.
  *
  * A NUMBER HERE IS NOT A GAP. Twice in the hour before this measurement a
  * carve-php fix closed the documents its issue named and over-reached onto one
@@ -229,19 +233,14 @@ test('a malformed declaration line is an error, never a silent skip', () => {
  * that says which gap a row currently describes.
  *
  * It read nine rows across 21 documents that morning, five across 9 an hour
- * later, and four across 8 twice after that. carve-php shipped the
- * 326/327/329/333 container rulings, carve-js shipped #1152 and #1154, and
- * carve-php then shipped #1365, #1366 and #1367 - and each time ast:check
- * reported the rows AGREED or COUNT and this map moved with the run rather than
- * with the merge notifications. Every remaining row is carve-php alone, each
- * naming its own tracker in resources/ast-span-divergence.txt: carve-php#1351,
- * #1369 and #1371.
+ * later, four across 8 twice after that, three, and now one. carve-php shipped
+ * the 326/327/329/333 container rulings, carve-js shipped #1152 and #1154, and
+ * carve-php then shipped #1365, #1366, #1367, #1370 and #1372 - and each time
+ * ast:check reported the rows AGREED or COUNT and this map moved with the run
+ * rather than with the merge notifications. Six measurements in one day, each
+ * one taken because the previous one had stopped being true.
  */
-const LAST_MEASURED = new Map([
-  ['text (presence)', 3],
-  ['code (presence)', 3],
-  ['definition_list (extent)', 1],
-])
+const LAST_MEASURED = new Map([['text (presence)', 3]])
 
 const asMeasured = (counts) =>
   new Map(


### PR DESCRIPTION
carve-php closed markup-carve/carve-php#1369 in #1370 and markup-carve/carve-php#1371
in #1372, which retires the last two over-reaches the previous two commits
declared. `npm run ast:check` reports both AGREED and three position waivers
FIXED, and kept failing until the lines went.

Measured over 1131 corpus documents plus 3 synthetic samples at carve-js
c8c8dc3, carve-rs d981df8 and carve-php d2e2fd6: ONE span row across 3
documents, of 22,766 comparable spans.

  code (presence)           3 -> 0   markup-carve/carve-php#1369, closed by #1370
  definition_list (extent)  1 -> 0   markup-carve/carve-php#1371, closed by #1372
  three owed waiver lines   FIXED    the same #1369, now placing those spans

FROM A CLONE MADE FOR THE RUN. The earlier measurements in this series used a
carve-php checkout shared with other work, and a mutant was resident in that
checkout for a couple of seconds while a run was in flight. Rather than reason
about whether any particular run overlapped it, every deletion here - and every
deletion the two commits before it made - is reproduced by this one, against a
clone that existed only for it. Provenance is part of a ledger row: it is the
kind of claim that reads as verified a week later.

CONFIRMED AT A SECOND SET OF MAINS, forty minutes later, without editing a line:
carve-js c8c8dc3, carve-rs ff54c44 and carve-php 5e6ab9a read the same one row,
the same three documents and the same 22,766 spans, across two carve-rs merges
and one carve-php merge. That is the first re-measurement all day that did not
move this file, which is the only reason it is worth writing down rather than
superseding again.

WHAT REMAINS is one row, one engine, one issue, and it is the same three
documents in BOTH ledgers: carve-php drops the position of a line block's spaced
content, where the source's spaces became indentation sentinels and carve-js and
carve-rs both place it (markup-carve/carve-php#1351, analysed and not started).
The two files describing one gap, rather than covering for each other, is what
this panel looks like when it is caught up.

Six measurements in one day, five rewrites: nine rows, five, four, four, three,
one. The number worth carrying forward is not which rows are declared but how
fast a declared row stops describing anything - so the run, not the ledger and
not a merged pull request, is what answers a question about the engines.

`npm run ast:check` exits 0 at both sets of mains. tests/ast-spans, ast-values,
ast-waivers and ast-json-claims are 63 passing, 0 failing.
