### PR TITLE
chore: move the engine pin to carve-js 79b3b3b, and empty the drift ledger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#02c4d80b262fcace000842857c01e3c2edadad90",
+        "@markup-carve/carve": "github:markup-carve/carve-js#79b3b3b002659b58f935f94150e9b7e74dd10133",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#02c4d80b262fcace000842857c01e3c2edadad90",
-      "integrity": "sha512-QvtB+SpNa1Qjyqz54zXFlOF46RxKowSUf2cl3FA95EJIYCNZS/XPp4B/UC+jrZGfTkfnPcZUA7GCJYWQggVdFQ==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#79b3b3b002659b58f935f94150e9b7e74dd10133",
+      "integrity": "sha512-/D7K9ZUlNHYE+eLRgjan8Maa8z4Mg/xrTc8gQc6g3TAGmYRlvbkkopRAZMOx6HEX0o8rU2bVNq2VVilZElMcxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#02c4d80b262fcace000842857c01e3c2edadad90",
+    "@markup-carve/carve": "github:markup-carve/carve-js#79b3b3b002659b58f935f94150e9b7e74dd10133",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,11 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-
-342-url-list-attributes-are-probed-token-wise-2  §25 now probes a URL-list attribute at every candidate; the pin reads the leading scheme only and emits the second srcset candidate verbatim (carve#1320).
-342-url-list-attributes-are-probed-token-wise-3  Same rule on `imagesrcset`, which the pin treats as an ordinary attribute.
-342-url-list-attributes-are-probed-token-wise-4  Same rule with no space after the comma, where a whitespace-only split would also miss the candidate.
-342-url-list-attributes-are-probed-token-wise-5  Same rule on `ping`, whose non-leading URL the pin emits verbatim.
-342-url-list-attributes-are-probed-token-wise-6  Same rule on `attributionsrc`, the fourth member of the named set.
-342-url-list-attributes-are-probed-token-wise-8  The srcset comma split deliberately over-blanks a URL that itself holds a comma; the pin keeps it, having no split at all.
-342-url-list-attributes-are-probed-token-wise-9  Same rule with the name spelled in upper case, which the pin does not lower-case for this probe.


### PR DESCRIPTION
The drift ledger declared seven rows and all seven named the same rule: §25 probing a URL-list attribute at every candidate rather than at its head, amended by #1326 while the pinned reference build still read the leading scheme only. carve-js implemented it in `markup-carve/carve-js#1164`, so the window the ledger existed to describe has closed.

Pin moves `02c4d80b262fcace000842857c01e3c2edadad90` -> `79b3b3b002659b58f935f94150e9b7e74dd10133`, and `resources/engine-pin-drift.txt` goes back to header-only.

Every deletion is proved by a render rather than inferred from the merged engine PR. A control run at the old pin, on a fresh `npm ci`, reported exactly those seven as mismatched and nothing else, which rules out the stale-install reading. At the new pin the report is 1141 of 1141 corpus documents reproduced, 0 mismatched, 0 thrown, and it names all seven STALE.

The check was mutated in both directions to confirm it can still fail. Re-adding a cleared row goes red as STALE; perturbing a fixture so the pin genuinely misses it goes red as UNDECLARED with the ledger empty. The first attempt at the second direction was a no-op edit that produced a false pass, so the retry asserts the bytes actually changed before rendering.
