### PR TITLE
spec: the token pass runs in addition to the value-wide probe, not instead of it

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1141 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1143 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/docs/security.md
+++ b/docs/security.md
@@ -111,13 +111,17 @@ Specifically, on every rendered element:
   `expression(...)`, `url(...)`, `@import`, `behavior:`, or `-moz-binding` - is
   blanked (whitespace collapsed first to defeat evasion);
 - `srcset`, `imagesrcset`, `ping` and `attributionsrc` hold a **list** of URLs
-  rather than one, so they are probed at **every** token instead of at the
+  rather than one, so they are probed at **every** token **as well as** at the
   value's head, and any hit blanks the whole value. Reading only the leading
   scheme meant
   `srcset="safe.png 1x, javascript:alert(1) 2x"` rendered verbatim while the
-  same two candidates in the other order were blanked. Prose attributes -
-  `title`, `alt`, `aria-label` - are deliberately **not** tokenized, so an
-  ordinary colon in text is never mistaken for a scheme.
+  same two candidates in the other order were blanked. The token pass is
+  additive rather than a replacement: the value-wide probe strips the ASCII
+  whitespace the split breaks on, so `ping="java script:alert(1)"` is two
+  harmless tokens and one denied value, and an engine that ran only the token
+  pass would deny **less** than it did before the rule existed. Prose
+  attributes - `title`, `alt`, `aria-label` - are deliberately **not**
+  tokenized, so an ordinary colon in text is never mistaken for a scheme.
 
 All other attributes pass through with their values HTML-escaped (quotes
 included, so a value cannot break out of its attribute). This baseline is

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -20670,7 +20670,7 @@ The quoted spelling is deliberately NOT here. `> %%%` over a definition is colle
 
 ## URL-list attributes are probed token-wise
 
-`srcset`, `imagesrcset` and `ping` carry a LIST of URLs rather than one, so the scheme probe runs on every token of the value instead of on its head, and any hit blanks the WHOLE value (PART 9 §25). The point is that a dangerous scheme gets the SAME answer wherever in the list it sits: reading position one and vouching for the rest is not a defense, it is a coincidence.
+`srcset`, `imagesrcset` and `ping` carry a LIST of URLs rather than one, so the scheme probe runs on every token of the value as well as on its head, and any hit blanks the WHOLE value (PART 9 §25). The point is that a dangerous scheme gets the SAME answer wherever in the list it sits: reading position one and vouching for the rest is not a defense, it is a coincidence.
 
 A `javascript:` candidate in the FIRST `srcset` position blanks the attribute:
 
@@ -20808,6 +20808,34 @@ PROSE ATTRIBUTES ARE NOT TOKENIZED, and this pair is the reason the rule names a
 
 ```html
 <p><a href="safe.html" title="See: RFC 3986, http://example.com">z</a></p>
+```
+
+:::
+
+THE TOKEN PASS IS ADDITIVE, and this pair is what says so out loud. The four names keep the leading-scheme probe on the WHOLE value too, so a value is blanked when EITHER the whole value probes dangerous OR any token does. Every case above blanks under both readings, which is why this one exists: the value-wide probe strips the ASCII whitespace the SPLIT breaks on, so `java script:alert(1)` is two harmless tokens -- `java` carries no scheme and `script` is not denylisted -- and one denied value. An implementation that ran the token pass INSTEAD of the value-wide probe would deny less here than the leading rule denied before this rule existed, and every other document in this section would still pass:
+
+::: compare no-render
+
+```carve
+[y](safe.html){ping="java script:alert(1)"}
+```
+
+```html
+<p><a href="safe.html" ping="">y</a></p>
+```
+
+:::
+
+The comma-separated half of the set is pinned separately, because its split is the one an implementation spells on its own: an additive value-wide probe wired into the `ping` branch and forgotten in the `srcset` branch is a reachable state, and it renders this verbatim:
+
+::: compare no-render
+
+```carve
+![a](safe.png){srcset="java script:alert(1) 1x, safe.png 2x"}
+```
+
+```html
+<img src="safe.png" alt="a" srcset="">
 ```
 
 :::

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -5474,6 +5474,18 @@ EOF = (* end of file *) ;
         value as a whole, and blank the ENTIRE value when ANY token matches.
         This rule changes WHERE the probe runs, not WHAT it denies. Every
         other attribute keeps the leading-scheme rule exactly as stated above.
+
+        THE TOKEN PASS IS IN ADDITION TO THE VALUE-WIDE PROBE, NOT INSTEAD OF
+        IT. These four names keep the leading-scheme probe on the WHOLE value
+        as well, and the value is blanked when EITHER the whole value probes
+        dangerous OR any token does. Reading the token pass as a replacement
+        would make these four names deny LESS than the leading rule already
+        denied, which is the opposite of what this paragraph is for: the
+        value-wide probe strips the ASCII whitespace the SPLIT breaks on, so
+        `ping="java script:alert(1)"` is two harmless tokens -- `java` carries
+        no scheme and `script` is not denylisted -- and one denied value. That
+        shape is pinned, in both separator sets (resources/examples/edge-cases.md
+        "URL-list attributes are probed token-wise").
         THE NAME MATCH IS CASE-INSENSITIVE, like the `on` prefix above: an
         attribute block may spell the name in any case and the element still
         carries the author's spelling, so matching on the exact bytes would

--- a/scripts/spec/render.mjs
+++ b/scripts/spec/render.mjs
@@ -140,10 +140,15 @@ const attrSem = g.createSemantics().addOperation('parseAttrs', {
 })
 
 /*
- * PART 9 SS25: the three attributes whose value is a LIST of URLs a consumer
- * resolves or fetches. The probe runs on every token rather than on the
- * value's head, and any hit blanks the WHOLE value, so the same value cannot
- * get one answer in position one and another in position two (carve#1320).
+ * PART 9 SS25: the four attributes whose value is a LIST of URLs a consumer
+ * resolves or fetches. The probe runs on every token AS WELL AS on the whole
+ * value, and any hit blanks the WHOLE value, so the same value cannot get one
+ * answer in position one and another in position two (carve#1320).
+ *
+ * THE TOKEN PASS IS ADDITIVE. Dropping the value-wide probe for these four
+ * would deny LESS than the leading-scheme rule already denied, because that
+ * probe strips the ASCII whitespace the SPLIT breaks on: `java script:alert(1)`
+ * is two harmless tokens and one denied value (carve#1329).
  *
  * THE SEPARATORS ARE THE ONES THE ATTRIBUTE'S OWN GRAMMAR USES. `ping` and
  * `attributionsrc` are space-separated sets and hold no commas at all, so
@@ -167,14 +172,15 @@ const urlListIsClean = (separator, value) =>
   value.split(separator).every((token) => token === '' || checkUrl(token) !== '')
 
 // PART 9 SS25 ATTRIBUTE HARDENING: drop on*/srcdoc/formaction; drop an
-// href/src override whose scheme is denylisted; blank a URL-list value with a
-// denylisted scheme in ANY candidate; blank a style value with a CSS execution
-// vector.
+// href/src override whose scheme is denylisted; blank any value whose own
+// leading scheme is denylisted, and a URL-list value with a denylisted scheme
+// in ANY candidate as well; blank a style value with a CSS execution vector.
 const STYLE_VECTOR = /expression\(|url\(|@import|behavior:|-moz-binding/i
 function hardenAttr(name, value) {
   const n = name.toLowerCase()
   if (n.startsWith('on') || n === 'srcdoc' || n === 'formaction') return null
   if ((n === 'href' || n === 'src') && checkUrl(value) === '') return null
+  if (value !== '' && checkUrl(value) === '') return { name, value: '' }
   const separator = Object.hasOwn(URL_LIST_SEPARATORS, n) ? URL_LIST_SEPARATORS[n] : null
   if (separator && !urlListIsClean(separator, value)) return { name, value: '' }
   if (n === 'style' && STYLE_VECTOR.test(value.replace(/\s+/g, ''))) return { name, value: '' }

--- a/tests/corpus/342-url-list-attributes-are-probed-token-wise-11.crv
+++ b/tests/corpus/342-url-list-attributes-are-probed-token-wise-11.crv
@@ -1,0 +1,1 @@
+[y](safe.html){ping="java script:alert(1)"}

--- a/tests/corpus/342-url-list-attributes-are-probed-token-wise-11.html
+++ b/tests/corpus/342-url-list-attributes-are-probed-token-wise-11.html
@@ -1,0 +1,1 @@
+<p><a href="safe.html" ping="">y</a></p>

--- a/tests/corpus/342-url-list-attributes-are-probed-token-wise-12.crv
+++ b/tests/corpus/342-url-list-attributes-are-probed-token-wise-12.crv
@@ -1,0 +1,1 @@
+![a](safe.png){srcset="java script:alert(1) 1x, safe.png 2x"}

--- a/tests/corpus/342-url-list-attributes-are-probed-token-wise-12.html
+++ b/tests/corpus/342-url-list-attributes-are-probed-token-wise-12.html
@@ -1,0 +1,1 @@
+<img src="safe.png" alt="a" srcset="">

--- a/tests/spec/342-url-list-attributes-are-probed-token-wise.test
+++ b/tests/spec/342-url-list-attributes-are-probed-token-wise.test
@@ -59,3 +59,15 @@ URL-list attributes are probed token-wise
 .
 <p><a href="safe.html" title="See: RFC 3986, http://example.com">z</a></p>
 ```
+
+```
+[y](safe.html){ping="java script:alert(1)"}
+.
+<p><a href="safe.html" ping="">y</a></p>
+```
+
+```
+![a](safe.png){srcset="java script:alert(1) 1x, safe.png 2x"}
+.
+<img src="safe.png" alt="a" srcset="">
+```


### PR DESCRIPTION
`markup-carve/carve#1326` amended §25 so the four URL-list attributes are probed
token-wise. The paragraph then says "every other attribute keeps the
leading-scheme rule", which reads as an exchange: the four get the token pass
INSTEAD OF the value-wide probe. That is not what it means, and the paragraph's
own "changes WHERE the probe runs, not WHAT it denies" did not stop two readers
taking it that way in one evening - carve-php shipped token-only to `main` and
corrected it in `markup-carve/carve-php#1390`, and a `codex review` at high
reasoning effort argued for token-only, quoting that sentence.

## Why the exchange reading is a regression, not a variant

The value-wide probe strips ASCII whitespace before it reads a scheme. The token
split breaks ON ASCII whitespace. So the strip closes exactly the gap the split
opens:

```
[y](safe.html){ping="java script:alert(1)"}
```

is two harmless tokens - `java` carries no scheme, `script` is not denylisted -
and one denied value:

```html
<p><a href="safe.html" ping="">y</a></p>
```

Under token-only it renders verbatim, which is LESS than the released engines
denied before the rule existed. Measured on carve-php at 79d9907, the commit that
shipped the wrong reading: the same value blanked under `title=` and survived
under `ping=`, so the four URL-list names were more permissive than prose.

## The corpus is the part that prevents recurrence

The ten documents that landed with the rule are satisfied by BOTH readings. A
token-only engine passed 1141 of 1141, so nothing would have caught the
regression. Two documents are added that only an additive implementation
produces.

**Proof they discriminate, twice over.** Against a mutant of the executable spec
with the value-wide probe removed, documents 11 and 12 fail and the other ten
still pass. Against the real token-only engine - carve-php at 79d9907 - the same
split: 11 and 12 fail, 0 of 10 fail.

One document per separator set and no more. The mechanism is single (ASCII
whitespace inside a scheme), but `ping` and `srcset` reach it through different
code, so an additive probe wired into the whitespace-split branch and forgotten
in the comma-split branch is a reachable state. `imagesrcset` and
`attributionsrc` share a branch with their partner and add nothing. A comma
inside the scheme defeats the value-wide probe too, so the comma split opens no
gap of its own and needs no further case.

## The executable spec was missing the value-wide probe entirely

Writing the fixtures found it: `hardenAttr` applied the scheme denylist to an
`href`/`src` override only, so the oracle rendered `title="javascript:alert(1)"`
verbatim - against a MUST in the same clause that all three engines keep. With
that unimplemented, "in addition to the existing value-wide probe" would have
been a sentence about nothing. One line, no existing fixture changes.

## Engine state

All three engines produce both documents as committed:

- carve-js - the pinned reference build (`79b3b3b`) reproduces 1143 of 1143, drift
  ledger stays empty.
- carve-php - `main` at 377cbb9, after `markup-carve/carve-php#1390`.
- carve-rs - `markup-carve/carve-rs#1068`, built from its branch head.

## Pins

The corpus grows from 1141 to 1143, so each engine's spec submodule pin must move
to carry the two documents. carve-rs#1068 is still open and will need its pin at
this commit; carve-js and carve-php are already additive and only need the pin
bump. The landing page's count moves with the corpus. The comparison page already
declares the whole `342` category as a lag window and needs no edit.
