### PR TITLE
docs: argue every CHANGELOG entry from 0.1.2, not from main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   document. Shared fixtures under `tests/html-import` define the portable
   minimum.
 
+  The contract takes the lossless way wherever both are available: a
+  `<figure>` with a `<figcaption>` imports as the target block followed by a
+  caption line, and a `blockquote` `cite` attribute is kept on an ordinary
+  block-attribute line (carve#1286). Dropping either was available only with a
+  diagnostic attached, and keeping it costs the reader less than the diagnostic
+  would.
+
 - **PART 12 §14: a caption may carry a structured short caption** (carve#1117).
   A `figure` or `table` MAY carry `shortCaption`, an array of inline nodes, for
   a target's list of figures or tables. Carve 0.1 source has no spelling for it,
@@ -209,13 +216,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carries or contributes nothing, and which of the two it does is a property of
   the CONSTRUCT and not of what it renders, because the id is assigned before a
   cross-reference resolves or a symbol is looked up.
-
-- **HTML import keeps a figure's caption and a blockquote's `cite`**
-  (carve#1286). A `<figure>` with a `<figcaption>` imports as the target block
-  followed by a caption line, and a `blockquote` `cite` attribute is kept on an
-  ordinary block-attribute line. Both go the lossless way: dropping either was
-  available only with a diagnostic attached, and keeping it costs the reader
-  less than the diagnostic would.
 
 - **An unclosed inline run in a line block reaches the end of the block**
   (carve#1282). A line block is ONE block, so its line breaks are a rendering
@@ -512,19 +512,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same balanced-bracket, escape- and literal-span-aware scan `link_text`
   states. Every engine already read it that way; the production was the half
   that was spelled wrong.
-
-- **The `semantic-span-carve-outs` HTML-import fixture pins the canonical fence
-  opener.** `fenced_code_block` names the no-space form canonical ("The
-  no-space form (```php) is canonical and is what the X->Carve converters
-  emit"), and `docs/html-import.md` says every `expected.crv` under
-  `tests/html-import` is also a fixed point of `carve fmt` in all three
-  engines. This one held ` ``` js `, which the canonical writer rewrites, so it
-  pinned source no writer produces. The writer defect it was written against is
-  fixed in all three engines (markup-carve/carve-js#1072,
-  markup-carve/carve-php#1267, markup-carve/carve-rs#987) and the fixture now
-  matches what they emit. No corpus `.fmt` fixture moves: none of the 29
-  carries an info string, and all 29 were re-measured through all three
-  engines.
 
 ## [0.1.2] - 2026-08-10
 


### PR DESCRIPTION
The baseline for every entry in the `Unreleased` section is the last **released** tag - carve 0.1.2, 2026-08-10 - not `main`. A draft release is not a release. A change to something that did not exist at 0.1.2 is part of the feature, not a fix.

**The HTML-import contract is new in this window.** 0.1.2 has no `docs/html-import.md` and no `tests/html-import/` at all:

```
$ git ls-tree -r --name-only 0.1.2 docs/ | grep -i import
$ git ls-tree -r --name-only 0.1.2 | grep -c '^tests/html-import/'
0
```

Two entries argued from that contract as if a reader had it.

- The lossless figure-caption and blockquote-`cite` rules were filed under `Changed`. They move into the contract's own entry under `Added`.
- The `semantic-span-carve-outs` fixture entry is dropped. It corrects an info-string spelling in a fixture belonging to a suite that has never shipped, against a writer defect also fixed inside this window, so there is no reader who ran it. (It would not have earned a CHANGELOG line even if the suite were old - a fixture is not consumer-facing.)

Entries deliberately kept, having checked each against 0.1.2: the U+E000 sentinel entry (`git show 0.1.2:resources/ast-schema.json` really does name it on `text.value` alone) and the alt-text production (`0.1.2:resources/grammar.ebnf` really does spell `alt_text = {character - ']'}`, 7 occurrences of the symbol). The composite-figure entry already argues from the released state explicitly, naming the reclassification a document holding a bare `::: figure` fence sees inside 0.1.x - that is the model the rest of the file should follow.

The draft note for 0.1.3 carried the milder version of the same thing: the figure-caption bullet sat beside the contract bullet under Improvements rather than inside it, and said dropping either "was available", a past tense no released spec supports. It has been merged into the contract bullet. The draft stays a draft and its version is unchanged.
