### PR TITLE
spec: a line's content position is after its container prefix (PART 11 section 8b)

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -131,7 +131,8 @@ under the same semantic-span rule,
 `339-a-wider-comment-fence-inside-an-item-hides-its-body-the-same-way`,
 `340-an-abbreviation-inside-a-comment-defines-nothing`,
 `341-a-comment-fence-inside-a-colon-container-registers-nothing`,
-`342-url-list-attributes-are-probed-token-wise`.
+`342-url-list-attributes-are-probed-token-wise`,
+`343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position`.
 
 Every category up to and including `334` landed on a host that could not retake
 the run above, so its numbers describe the corpus WITHOUT them. The alternative

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1143 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1145 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/corpus-sidecars.lock.json
+++ b/resources/corpus-sidecars.lock.json
@@ -71,6 +71,8 @@
   "320-the-canonical-writer-glues-a-code-fence-to-its-info-string-2.fmt": "aea9fb74f9cbccb1",
   "320-the-canonical-writer-glues-a-code-fence-to-its-info-string.fmt": "9c280a0ce3124f6e",
   "34-thematic-breaks.fmt": "24dd5947e79012c3",
+  "343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position-2.md": "6fa3e320979d16b0",
+  "343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position.md": "73b8a82dc542e525",
   "40-superscript-and-subscript-2.fmt": "2fcb4ff9ef264022",
   "43-abbreviations.ansi": "4332a088c2ae546d",
   "43-abbreviations.md": "4332a088c2ae546d",

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -371,6 +371,7 @@ index: examples/edge-cases/index.md
   a-math-span-s-base-class-keeps-the-class-slot-in-place
   a-marker-glued-to-a-name-opens-nothing
   an-angle-bracket-is-escaped-only-where-it-opens-markup
+  an-escaped-hash-keeps-its-escape-at-a-container-s-content-position
   01-emphasis-2
   01-emphasis-3
   01-emphasis-6

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -20839,3 +20839,66 @@ The comma-separated half of the set is pinned separately, because its split is t
 ```
 
 :::
+
+## An escaped hash keeps its escape at a container's content position
+
+PART 11 §8b M2b is decided on the EMITTED LINE, so a container prefix is passed
+over before the position is read. A hash at the start of a block quote's or a
+list item's content opens an ATX heading exactly as one at column 0 does, and
+its escape is kept there. All three engines dropped it, and a round trip through
+the Markdown target turned the author's text into a heading
+(markup-carve/carve#1330).
+
+The narrowing itself does not move, which is the half a correction here is most
+likely to lose. A hash the prefix does not put at the content position is still
+emitted bare, and so is one that stands there but opens no heading, since M2b's
+reading is CommonMark's and a run closed by a letter is not a heading. This pair
+carries both directions.
+
+::: compare
+
+```carve
+> \# heading
+>
+> C\# is a language
+
+- \# heading
+- \#tag rest
+```
+
+```html
+<blockquote>
+  <p># heading</p>
+  <p>C# is a language</p>
+</blockquote>
+<ul>
+  <li># heading</li>
+  <li>#tag rest</li>
+</ul>
+```
+
+:::
+
+Nesting needs no rule of its own: the prefix is whatever the writer emitted,
+`> > ` included. Neither does lazy continuation, which is a parser concept - this
+writer re-prefixes every line of a container, so the last line below is emitted
+with its `> ` and read at the content position like any other.
+
+::: compare
+
+```carve
+> > \# deep
+
+> a
+\# heading
+```
+
+```html
+<blockquote>
+  <blockquote><p># deep</p></blockquote>
+</blockquote>
+<blockquote><p>a
+# heading</p></blockquote>
+```
+
+:::

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -7429,7 +7429,14 @@ EOF = (* end of file *) ;
           BARE.
       M2b `#` IS READ AS MARKUP ONLY AT A LINE'S CONTENT POSITION, where it
           opens an ATX heading. An `escaped_text` hash anywhere else on the
-          line is emitted bare.
+          line is emitted bare. A LINE'S CONTENT POSITION IS AFTER ITS
+          CONTAINER PREFIX: the position is measured on the EMITTED LINE, so
+          every prefix the writer put in front of the content is passed over
+          before the test is decided -- a block quote marker, a list or task
+          marker, a definition marker, the alignment §10 gives a continuation
+          line -- in whatever combination and to whatever depth the writer
+          emitted them. Column 0 is the content position of a line NO
+          container encloses, and of no other line.
       M2c NOTHING ELSE NARROWS. M1, M3 and §8a are untouched, and a character
           Markdown reads as markup at that position keeps M2 as written.
 
@@ -7477,6 +7484,96 @@ EOF = (* end of file *) ;
       any position on a line, so M2a keeps its escape everywhere and that
       argument stands unchanged. `#` is the character that differs, because
       its reading is positional and every position but one is inert.
+
+      A CONTAINER PREFIX IS PART OF THE LINE, WHICH IS WHY M2b MEASURES ON IT.
+      M2b's position is the ONLY narrowing in this clause -- M2a keeps the
+      escape by default and M2c closes the set -- so the whole of §8b turns on
+      where that position is. Read as an offset into the BLOCK'S CONTENT it
+      answers a question no reader asks: the string a reader parses is the
+      emitted line, and the two differ by exactly the prefix the writer put in
+      front. Measured on all three engines, which agreed:
+
+        > \# heading
+
+      emitted as
+
+        > # heading
+
+      and read back, through this project's own importer, as a heading:
+
+        before:  <blockquote><p># heading</p></blockquote>
+        after:   <blockquote><h1 id="heading">heading</h1></blockquote>
+
+      The author escaped the hash so it would stay text, and a round trip
+      returned it as structure. That is content corruption rather than a
+      rendering difference, and it is the case M2 exists to remove: §8a's
+      closing argument rests on M2 taking "out of the question every case
+      where the author said which reading they meant" (carve#1330).
+
+      §10 ALREADY DECIDED THIS, ONE CHARACTER OVER. A list item's continuation
+      line is aligned to the marker's width and kept literal by ESCAPING it:
+
+        1. outer
+           1\. inner
+
+      The inner line's text is `1. inner`, which is a list marker nowhere in
+      isolation. It is one only because three spaces of item alignment stand
+      in front of it, and §10 escapes it for that reason -- "§2 governs
+      whether a character is escaped GIVEN the line the writer emits; §10
+      fixes the line." So this project has already ruled that the escape test
+      is answered against the line as the reader receives it, and has already
+      rejected the alternative that reasons about the content alone: §10
+      refuses to indent less "because its correctness depends on the WIDTH of
+      the marker above it". The reading that produced this defect carries the
+      same dependency and does not notice it.
+
+      STATED OVER THE LINE, NOT AS A LIST OF CONTAINERS THAT COUNT. Two
+      consequences, both measured on all three engines:
+
+      - A container this target FLATTENS contributes no prefix and needs no
+        exemption. A colon fence emits no marker and a definition-list body
+        emits no indent, so a hash in either lands at column 0 and its escape
+        was already kept.
+      - A container this target DOES prefix is covered whatever its kind,
+        depth or mixture -- `> > `, `- > `, `- [ ] `, `[^a]: `, `   1. ` --
+        without naming any of them.
+
+      An enumeration would have to be revisited every time the writer gains a
+      prefix. The line does not.
+
+      THE LAZY CASE IS NOT A CASE. Lazy continuation is a PARSER concept: a
+      line belonging to a container without carrying its marker. This writer
+      emits no such line, because it re-prefixes every line of the container.
+      Measured, all three:
+
+        > a
+        \# heading
+
+      is emitted as
+
+        > a
+        > # heading
+
+      so the emitted line carries `> ` and M2b sees it. A rule for the
+      source's laziness would describe a line this target never writes.
+
+      NARROWING BY POSITION IS UNCHANGED, WHICH IS THE HALF THAT IS EASY TO
+      LOSE. Moving the position does not widen M2b into "an escape behind a
+      prefix is kept". The two documents carve#970 opened with keep their
+      narrowing inside a container exactly as they had it outside one, because
+      the hash is not at the content position there either:
+
+        > C\# is a language      ->  > C# is a language
+        - issue \#123 fixed      ->  - issue #123 fixed
+
+      and so does a hash that stands AT the content position but opens no
+      heading, since M2b's reading is CommonMark's and a run closed by a
+      letter is not one:
+
+        > \#tag rest             ->  > #tag rest
+
+      Both directions are pinned in the corpus. The first is what the clause
+      is for; the second is what stops the correction being taken too far.
 
       WHAT IS LOST IS BOUNDED BY §1. Carve source through this target and back
       stops recording which hash was text. §1 already defines the round-trip

--- a/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position-2.crv
+++ b/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position-2.crv
@@ -1,0 +1,4 @@
+> > \# deep
+
+> a
+\# heading

--- a/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position-2.html
+++ b/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position-2.html
@@ -1,0 +1,5 @@
+<blockquote>
+  <blockquote><p># deep</p></blockquote>
+</blockquote>
+<blockquote><p>a
+# heading</p></blockquote>

--- a/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position-2.md
+++ b/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position-2.md
@@ -1,0 +1,4 @@
+> > \# deep
+
+> a
+> \# heading

--- a/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position.crv
+++ b/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position.crv
@@ -1,0 +1,6 @@
+> \# heading
+>
+> C\# is a language
+
+- \# heading
+- \#tag rest

--- a/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position.html
+++ b/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position.html
@@ -1,0 +1,8 @@
+<blockquote>
+  <p># heading</p>
+  <p>C# is a language</p>
+</blockquote>
+<ul>
+  <li># heading</li>
+  <li>#tag rest</li>
+</ul>

--- a/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position.md
+++ b/tests/corpus/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position.md
@@ -1,0 +1,6 @@
+> \# heading
+>
+> C# is a language
+
+- \# heading
+- #tag rest

--- a/tests/spec/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position.test
+++ b/tests/spec/343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position.test
@@ -1,0 +1,32 @@
+An escaped hash keeps its escape at a container's content position
+
+```
+> \# heading
+>
+> C\# is a language
+
+- \# heading
+- \#tag rest
+.
+<blockquote>
+  <p># heading</p>
+  <p>C# is a language</p>
+</blockquote>
+<ul>
+  <li># heading</li>
+  <li>#tag rest</li>
+</ul>
+```
+
+```
+> > \# deep
+
+> a
+\# heading
+.
+<blockquote>
+  <blockquote><p># deep</p></blockquote>
+</blockquote>
+<blockquote><p>a
+# heading</p></blockquote>
+```


### PR DESCRIPTION
Closes #1330.

PART 11 §8b M2b narrows an authored escape when the hash cannot open a heading at that position. The position was read as an offset into the BLOCK'S CONTENT, so a container prefix defeated it: a hash at the start of a quote's or an item's content scored as mid-line, the escape was dropped, and the author's text came back as structure.

Measured on all three engines, which agreed. Input:

```
> \# heading
```

Markdown, and the Carve that comes back from it:

```
> # heading
```

Through this project's own importer:

```
before:  <blockquote><p># heading</p></blockquote>
after:   <blockquote><h1 id="heading">heading</h1></blockquote>
```

Content corruption rather than a rendering difference, and exactly the case M2 exists to remove - §8a's argument rests on M2 taking "out of the question every case where the author said which reading they meant".

## It does not generalize past the hash

Measured rather than reasoned, because a per-character fix leaving most of the set live was the risk. 21 characters plus the two ordered-marker forms, six positions each, through all three engine builds at their current main. All three agree on all 138 cases.

| escaped char | col 0 | `> ` | `- ` | `> > ` | `- > ` | mid-line |
| --- | --- | --- | --- | --- | --- | --- |
| `#` | kept | **bare** | **bare** | **bare** | **bare** | bare |
| `-` `+` `*` `>` `=` `_` `` ` `` `~` `\|` `.` `"` `'` `[` `]` `(` `)` `!` `<` | kept | kept | kept | kept | kept | kept |
| `1\.` `1\)` | kept | kept | kept | kept | kept | kept |

The reason is in the clause: M2a keeps the escape by default, M2b is the only positional carve-out and it names one character, M2c closes the set. Every other character keeps its escape even mid-line - `a \+ b` emits `a \+ b`. So a hash-only correction is the whole correction.

## The ruling

M2b now states that a line's content position is after its container prefix, measured on the EMITTED LINE, so every prefix the writer put in front of the content is passed over before the test is decided, in whatever combination and to whatever depth. Column 0 is the content position of a line no container encloses, and of no other line.

**§10 already decided this, one character over.** It requires a list item's continuation line to be aligned to the marker's width and kept literal by escaping it:

```
1. outer
   1\. inner
```

`1. inner` is a list marker nowhere in isolation; it is one only because three spaces of item alignment stand in front of it. §10's closing sentence is the deciding clause: "§2 governs whether a character is escaped GIVEN the line the writer emits; §10 fixes the line." §10 also rejects the alternative that reasons about the content alone, "because its correctness depends on the WIDTH of the marker above it" - the same dependency the reading corrected here carries without noticing.

**Which prefixes count** is answered by the line, not by an enumeration. A container this target flattens contributes no prefix and needs no exemption: measured, a colon fence and a definition-list body both emit their hash at column 0, where the escape was already kept. A container it does prefix is covered whatever its kind, depth or mixture (`> > `, `- > `, `- [ ] `, `[^a]: `, `   1. `). An enumeration would need revisiting every time the writer gains a prefix.

**Nesting** needs no rule of its own - the prefix is whatever the writer emitted.

**Lazy continuation is not a case.** It is a parser concept: a line belonging to a container without carrying its marker. This writer emits no such line. Measured, all three engines:

```
> a
\# heading
```

is emitted as

```
> a
> # heading
```

so the emitted line carries its marker and M2b sees it. A rule for the source's laziness would describe a line this target never writes.

## The corpus, and proof each document discriminates

Two documents, both directions in each.

`343-an-escaped-hash-keeps-its-escape-at-a-container-s-content-position` pins the keep behind a quote and behind a bullet, and pins two narrowings alongside: a hash the prefix does not put at the content position, and a hash standing at that position whose run is closed by a letter rather than a space.

`...-2` pins nesting and the re-prefixed continuation line.

Discrimination was measured, not asserted. The corrected reading was patched into a carve-js build and the whole corpus rendered through both:

- 0 of the 1143 existing documents change their Markdown output.
- All 25 core and 3 optional `.md` sidecars are byte-identical under both builds.
- Both new documents differ between the two builds.

So nothing already in the corpus could tell the two readings apart, which is why this stayed invisible - and the narrowing rows are what stops an over-wide correction later: an implementation that kept every escape behind a prefix fails them.

The corpus grows to 1145, so the landing page's count moves with it, and the pair is declared as lag on the comparison page since no engine implements the correction yet. **Every engine pin has to move to carry the two new documents; that is not automatic.**

## Effect on #1331

The quadratic has two halves: a backward search for the line's newline, and a run count over every hash. This ruling makes the first half easier rather than worse. The writer emits the prefix, so it already knows where the line's content begins; the content position is available as carried state instead of being re-derived by scanning back to the newline. The run count is untouched and bounding it at 7 stays independent.
