### PR TITLE
spec: one label per section in every PART, and a citation gate that reads all of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -477,7 +477,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   document-level `*[HTML]: …` definition no longer overrides
   `[HTML]{abbr="Custom"}`.
 
-- **PART 10 §8b: the plain-text target preserves list depth** (carve#1084). A
+- **PART 11 §10h: the plain-text target preserves list depth** (carve#1084). A
   nested item is indented two spaces per list ancestor. The target may discard
   marker style and tight/loose layout, but flattening parent, child and
   grandchild into siblings erases structure the reader has no other way to

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -134,7 +134,7 @@ authored text it may have a reason to withhold, so it must be able to name the
 type. "Renders nothing" described one target out of four.
 
 **`link_reference_definition` moves with it**, which is what this page has always
-said - the two are one case. The reason is now PART 10 §10a rather than a
+said - the two are one case. The reason is now PART 11 §10a rather than a
 measurement: that clause is normative, and since PART 12 §10 gave the link
 definition a node it covers all three definition kinds, requiring an unused
 definition of any kind to survive the Markdown, plain-text and terminal

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -135,7 +135,7 @@ a typo rather than half-parsing.
 
 **6. The plain-text target stopped flattening nested lists.** Before, depth was
 erased and every item came out a sibling; now each list ancestor indents its
-item by two spaces (PART 10 §8b). A pipeline that parsed the plain output by
+item by two spaces (PART 11 §10h). A pipeline that parsed the plain output by
 column will see different columns.
 
 To find affected documents, search for the seven names used as attributes on a

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3683,8 +3683,9 @@ EOF = (* end of file *) ;
       two jobs. Both halves are wrong. `figure` does one job here, as the code
       block above shows; and a caption with no bare `#` takes no number under
       either model, so a quote captioned `^ William Shakespeare` never entered a
-      counter. That clause is withdrawn (carve#1213), and PART 11 §10d, which
-      carried the attribution onto the other three targets, goes with it.
+      counter. That clause is withdrawn (carve#1213), and the PART 11 clause
+      that carried the attribution onto the other three targets goes with it.
+      Its number is retired, not reused, which is why PART 11 runs 10c, 10e.
 
       HTML AGREES, AND IN THE OTHER DIRECTION. The HTML Standard's `blockquote`
       section requires that "attribution for the quotation, if any, must be
@@ -8011,14 +8012,6 @@ EOF = (* end of file *) ;
       M1b keeps exactly those escapes, and that is why the minimum is stated
       at this width and not another.
 
-   8b. THE PLAIN-TEXT TARGET PRESERVES LIST DEPTH -- NORMATIVE. A nested list
-      item is indented by TWO ASCII SPACES for each list ancestor. The target
-      may discard marker style and tight/loose layout, but it MUST NOT flatten
-      parent, child, and grandchild items into siblings: indentation is the
-      plain-text representation of that structure. ANSI and canonical Carve
-      use the same two-space depth step; plain text differs only by omitting
-      presentation styling, not by erasing hierarchy.
-
       THE BOUNDARY IS THE CLAUSE, NOT A FLOOR. M1b is written as an
       if-and-only-if on purpose. An escape it drops is dropped and an escape
       it keeps is kept; it is not a minimum an implementation may build a
@@ -8667,6 +8660,14 @@ EOF = (* end of file *) ;
       Tabs, `presentation=` hints and PDF layout are renderer/extension
       business and out of this clause's scope; hint classes reach the HTML
       target only.
+
+  10h. THE PLAIN-TEXT TARGET PRESERVES LIST DEPTH -- NORMATIVE. A nested list
+      item is indented by TWO ASCII SPACES for each list ancestor. The target
+      may discard marker style and tight/loose layout, but it MUST NOT flatten
+      parent, child, and grandchild items into siblings: indentation is the
+      plain-text representation of that structure. ANSI and canonical Carve
+      use the same two-space depth step; plain text differs only by omitting
+      presentation styling, not by erasing hierarchy.
 
   11. THE MARKDOWN TARGET'S CROSS-REFERENCES -- NORMATIVE. A resolved
       cross-reference is emitted as a Markdown link to the target heading's id,

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -1068,7 +1068,7 @@ const activeTargets = ALL_TARGETS.filter((target) =>
  * engines-agree check. This is what gives a Tier-1 rule about the Markdown,
  * plain or terminal output somewhere to live: engine-against-engine agreement
  * is a necessary invariant, not a sufficient one, and it cannot tell "all three
- * are right" from "all three are wrong" - which is the state PART 10 §10a is in
+ * are right" from "all three are wrong" - which is the state PART 11 §10a is in
  * (carve#589).
  *
  * A fixture that should exist and does not is a hard error: continuing without

--- a/tests/corpus-targets.test.mjs
+++ b/tests/corpus-targets.test.mjs
@@ -32,7 +32,7 @@ const manifest = JSON.parse(readFileSync(resolve(corpusDir, 'manifest.json'), 'u
 test('a core case may pin a non-HTML target by adding the file', () => {
   // Engine-against-engine agreement is a NECESSARY invariant, not a sufficient
   // one: it cannot tell "all three are right" from "all three are wrong", which
-  // is the state PART 10 §10a is in (carve#589). A Tier-1 rule about the
+  // is the state PART 11 §10a is in (carve#589). A Tier-1 rule about the
   // Markdown, plain or terminal output needs somewhere to be written down, and
   // that somewhere is a file beside the case, named by the same pairing rule
   // the optional corpus uses.

--- a/tests/corpus/README.md
+++ b/tests/corpus/README.md
@@ -21,7 +21,7 @@ says which: `markdown: compared=548 diffs=0 fixtures=3`.
 
 This exists because engine-against-engine agreement is a **necessary** invariant
 and not a sufficient one - it cannot tell "all three are right" from "all three
-are wrong". PART 10 §10a is normative, is about the Markdown, plain and terminal
+are wrong". PART 11 §10a is normative, is about the Markdown, plain and terminal
 targets, and every engine currently violates it identically, so nothing failed
 (carve#589). A Tier-1 rule about those targets needs a file to be written down
 in, and this is it.

--- a/tests/normativity.test.mjs
+++ b/tests/normativity.test.mjs
@@ -23,28 +23,47 @@ const repo = resolve(here, '..')
 const grammarPath = resolve(repo, 'resources/grammar.ebnf')
 const grammar = readFileSync(grammarPath, 'utf8')
 
-// Collect PART 9's section numbers from the "   N. TITLE" headings between its
-// banner and the next PART banner. Bounding the slice matters: PART 10 and
-// PART 11 have their own numbered items, and letting those leak in would make a
-// dangling "PART 9 §N" reference resolve against a section that lives
-// somewhere else entirely.
-const part9Start = grammar.indexOf('PART 9: SEMANTIC CONSTRAINTS')
-const part10Start = grammar.indexOf('PART 10: HTML SERIALIZATION', part9Start)
-const part9 = grammar.slice(part9Start, part10Start === -1 ? undefined : part10Start)
-const part9Sections = new Set(
-  [...part9.matchAll(/^ {3}(\d+)\. {1,3}[A-Z]/gm)].map((m) => Number(m[1])),
-)
+// Every PART's section labels, keyed by PART number, read from the
+// "  N. TITLE" headings that follow each PART banner.
+//
+// A heading qualifies only when its TITLE OPENS IN CAPS, and that is a
+// discriminator rather than decoration: PART 8 carries two numbered lists that
+// are PRECEDENCE ORDERS, not sections - "1. Frontmatter (--- delimited at
+// document start)", "1. Escaped characters (\x)" - written in sentence case,
+// numbered 1..11 and 1..13 in the same PART, and never cited as "PART 8 §N".
+// Counting those as sections would make the uniqueness check below fail on a
+// document that is correct.
+const opensInCaps = (title) => {
+  const words = title.match(/[A-Za-z]+/g) ?? []
+  if (words.length === 0) return false
+  const upper = (w) => w === w.toUpperCase()
+  // "TIGHT vs LOOSE LISTS" qualifies on its first word; "A `+` CONTINUATION
+  // EXTENDS" has a one-letter first word, so the second word carries the caps.
+  return upper(words[0]) && (words[0].length >= 2 || (words[1] !== undefined && upper(words[1])))
+}
 
-// PART 12's sections are cited the same way and can dangle the same way, with
-// one wrinkle: it has lettered sections (§1a, §3a), so the numbers alone are
-// not the valid set. The docs cite them both as "PART 12 §3a" and, once the
-// part is established on the page, as a bare "(§3a)" - so the bare form has to
-// be checked too, which is only safe on the pages that are ABOUT PART 12.
-const part12Start = grammar.indexOf('PART 12: AST SERIALIZATION')
-const part12 = grammar.slice(part12Start)
-const part12Sections = new Set(
-  [...part12.matchAll(/^ {3}(\d+[a-z]?)\. {1,3}[A-Z]/gm)].map((m) => m[1]),
-)
+const sectionsByPart = () => {
+  const parts = new Map()
+  let part = null
+  for (const line of grammar.split('\n')) {
+    const banner = /^\s*PART (\d+):/.exec(line)
+    if (banner) {
+      part = Number(banner[1])
+      if (!parts.has(part)) parts.set(part, [])
+      continue
+    }
+    if (part === null) continue
+    // The label field is right-aligned, so "   8." and "  10h." both occur.
+    const m = /^ {1,4}(\d+[a-z]?)\. {1,3}(\S.*)$/.exec(line)
+    if (m && opensInCaps(m[2])) parts.get(part).push(m[1])
+  }
+  return parts
+}
+
+const partSections = sectionsByPart()
+const sectionSet = (n) => new Set(partSections.get(n) ?? [])
+const part9Sections = sectionSet(9)
+const part12Sections = sectionSet(12)
 
 // Pages whose bare "§N" citations mean PART 12.
 const part12Pages = ['docs/ast-json.md']
@@ -58,34 +77,121 @@ const docFiles = [
     .map((f) => resolve(repo, 'docs/case-study', f)),
 ]
 
+// Everything that can carry a normative citation. The docs are not the only
+// place one lands: one mistyped PART number sat in a test, a script, the
+// corpus README and the changelog for weeks - five copies of the same wrong
+// citation - because the gate looked at docs/ only (carve#1365). A walk rather
+// than a list, so a new page is covered the day it is written.
+//
+// This scan reads its own source too, so a citation written here as an EXAMPLE
+// would be reported as a defect. Name a bad citation in prose, never spell it.
+const CITABLE = /\.(md|mjs|js|json|txt|ebnf)$/
+const SKIP_DIRS = new Set(['node_modules', '.git'])
+const citationSources = (() => {
+  const out = []
+  const walk = (dir, rel) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const child = resolve(dir, entry.name)
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name)) continue
+        // The corpus holds ~1200 documents whose .md/.txt/.json bodies are
+        // rendered CONTENT, not prose about the grammar. Its README is prose.
+        if (childRel === 'tests/corpus') {
+          out.push(resolve(child, 'README.md'))
+          continue
+        }
+        walk(child, childRel)
+        continue
+      }
+      if (childRel === 'package-lock.json') continue
+      if (CITABLE.test(entry.name)) out.push(child)
+    }
+  }
+  walk(repo, '')
+  return out
+})()
+
 test('grammar.ebnf declares the normativity policy', () => {
   assert.match(grammar, /\bNORMATIVITY\b/)
   assert.match(grammar, /NORMATIVE specification of\s+Carve/)
 })
 
-test('PART 9 has at least the known semantic-constraint sections', () => {
-  // Sanity: parsing worked and found a plausible set.
-  assert.ok(part9Sections.size >= 8, `found sections: ${[...part9Sections]}`)
+test('the section index finds a plausible set for every sectioned PART', () => {
+  // Sanity: parsing worked. A floor per PART, so a regex that silently stopped
+  // matching shows up here rather than as a citation test that passes because
+  // it has nothing left to check.
+  for (const [part, floor] of [
+    [2, 3],
+    [9, 8],
+    [10, 8],
+    [11, 20],
+    [12, 6],
+  ]) {
+    assert.ok(
+      sectionSet(part).size >= floor,
+      `PART ${part} scan found only: ${[...sectionSet(part)]}`,
+    )
+  }
+  // PART 8's numbered lists are precedence orders, not sections. If this ever
+  // trips, opensInCaps has stopped discriminating and the uniqueness check
+  // below is about to report a collision that is not one.
+  assert.deepEqual([...sectionSet(8)], [], 'PART 8 has no cited sections')
 })
 
-test('every "PART 9 §N" reference resolves to a real section', () => {
-  // Match a whole citation group so multi-section shorthand like
-  // "PART 9 §1, §9 and §10" is fully validated, not just the first.
-  const citation = /PART 9 §\d+(?:\s*(?:,|&|and|or|to|–|-)?\s*§\d+)*/g
+test("every PART's section labels are unique", () => {
+  // PART 11 carried two sections labelled §8b for a week: a citation to
+  // "PART 11 §8b" named either of them and nothing failed, because the only
+  // citation gates looked at PART 9 and PART 12 (carve#1365).
+  const collisions = []
+  for (const [part, labels] of partSections) {
+    const seen = new Set()
+    for (const label of labels) {
+      if (seen.has(label)) collisions.push(`PART ${part} §${label}`)
+      seen.add(label)
+    }
+  }
+  assert.deepEqual(
+    collisions,
+    [],
+    `duplicate section labels - a citation to one of these resolves to either clause:\n${collisions.join('\n')}`,
+  )
+})
+
+// Both spellings are in use: "PART 12 §3a" and "PART 12 section 3a". A citation
+// GROUP is matched whole, so multi-section shorthand reaches every clause it
+// names and not only the first: "PART 9 §1, §9 and §10", "PART 12 §1-2".
+const CLAUSE = String.raw`\d+[a-z]?`
+const citationGroup = (lead) =>
+  new RegExp(`${lead}(${CLAUSE})((?:\\s*(?:,|&|and|or|to|–|-)\\s*§?${CLAUSE})*)`, 'g')
+
+const scanGroups = (text, lead, onHit) => {
+  for (const m of text.matchAll(citationGroup(lead))) {
+    onHit(m[1])
+    for (const t of m[2].matchAll(new RegExp(`§?(${CLAUSE})`, 'g'))) onHit(t[1])
+  }
+}
+
+test('every "PART N §M" citation resolves to a real section', () => {
   const dangling = []
-  for (const file of docFiles) {
+  for (const file of citationSources) {
+    if (!existsSync(file)) continue
     const text = readFileSync(file, 'utf8')
-    for (const group of text.match(citation) ?? []) {
-      for (const sm of group.matchAll(/§(\d+)/g)) {
-        const n = Number(sm[1])
-        if (!part9Sections.has(n)) dangling.push(`${file}: PART 9 §${n}`)
-      }
+    for (const part of partSections.keys()) {
+      const valid = sectionSet(part)
+      if (valid.size === 0) continue
+      scanGroups(text, `PART ${part} (?:§|section )`, (id) => {
+        if (!valid.has(id)) dangling.push(`${file}: PART ${part} §${id}`)
+      })
     }
   }
   assert.deepEqual(
     dangling,
     [],
-    `dangling normative references (valid: §${[...part9Sections].sort((a, b) => a - b).join(', §')}):\n${dangling.join('\n')}`,
+    `citations that name no clause. A label that was RETIRED rather than\n` +
+      `mistyped - PART 11's withdrawn 10d, carve#1213 - is not written as a\n` +
+      `citation at all: describe the clause instead, so this stays a list of\n` +
+      `defects:\n${dangling.join('\n')}`,
   )
 })
 
@@ -141,47 +247,17 @@ test('the normative inventory names every clause in the grammar', () => {
 
 // The §3a case: eight references across the docs, the AST schema and the
 // changelog went on pointing at a clause that was no longer in the file. The
-// inventory above would now catch the deletion; this catches the other
-// direction - a clause renamed or renumbered while its citations stay put.
-test('every PART 12 section reference resolves to a real clause', () => {
-  assert.ok(
-    part12Sections.size >= 6,
-    `PART 12 clause scan found only: ${[...part12Sections]}`,
-  )
+// qualified spelling is covered by the generic citation test above; this is the
+// BARE "(§3a)" form, which is only unambiguous on the pages that are ABOUT
+// PART 12 - elsewhere a bare §N means PART 9.
+test('every bare PART 12 clause reference resolves to a real clause', () => {
   const dangling = []
-  const check = (file, id) => {
-    if (!part12Sections.has(id)) dangling.push(`${file}: §${id}`)
-  }
-  // A citation GROUP, so shorthand reaches every clause it names and not only
-  // the first: "§1-2", "§3a and §4", "PART 12 §1, §1a, §6". Without this a
-  // renumbering that orphaned the far end of a range would leave this green,
-  // which is the same shape of dead check the deletion slipped past.
-  const CLAUSE = String.raw`\d+[a-z]?`
-  const group = (lead) =>
-    new RegExp(
-      `${lead}(${CLAUSE})((?:\\s*(?:,|&|and|or|to|–|-)\\s*§?${CLAUSE})*)`,
-      'g',
-    )
-  const scan = (file, text, lead) => {
-    for (const m of text.matchAll(group(lead))) {
-      check(file, m[1])
-      for (const t of m[2].matchAll(new RegExp(`§?(${CLAUSE})`, 'g'))) check(file, t[1])
-    }
-  }
-  // Both spellings are in use: "PART 12 §3a" and "PART 12 section 3a".
-  const QUALIFIED = String.raw`PART 12 (?:§|section )`
-  const sources = [
-    ...docFiles,
-    resolve(repo, 'resources/ast-schema.json'),
-    resolve(repo, 'CHANGELOG.md'),
-  ]
-  for (const file of sources) {
-    if (!existsSync(file)) continue
+  for (const file of citationSources) {
+    if (!part12Pages.some((page) => file.endsWith(page))) continue
     const text = readFileSync(file, 'utf8')
-    scan(file, text, QUALIFIED)
-    // Bare "(§3a)" only where the page is ABOUT PART 12; elsewhere a bare §N
-    // means PART 9 and is checked by the test above.
-    if (part12Pages.some((page) => file.endsWith(page))) scan(file, text, '§')
+    scanGroups(text, '§', (id) => {
+      if (!part12Sections.has(id)) dangling.push(`${file}: §${id}`)
+    })
   }
   assert.deepEqual(
     dangling,

--- a/tests/normativity.test.mjs
+++ b/tests/normativity.test.mjs
@@ -172,17 +172,29 @@ const scanGroups = (text, lead, onHit) => {
   }
 }
 
+// The PART NUMBER is read from the citation, never iterated over the parts the
+// grammar happens to have. Building one pattern per known part would skip a
+// citation into a part number that does not exist at all, and one into a part
+// that exists but has no sections - PART 8, whose numbered lists are precedence
+// orders - which is the same hole one size up from the one this closes.
+const QUALIFIED_CITATION = new RegExp(
+  `PART (\\d+) (?:§|section )(${CLAUSE})((?:\\s*(?:,|&|and|or|to|–|-)\\s*§?${CLAUSE})*)`,
+  'g',
+)
+
 test('every "PART N §M" citation resolves to a real section', () => {
   const dangling = []
   for (const file of citationSources) {
     if (!existsSync(file)) continue
     const text = readFileSync(file, 'utf8')
-    for (const part of partSections.keys()) {
+    for (const m of text.matchAll(QUALIFIED_CITATION)) {
+      const part = Number(m[1])
       const valid = sectionSet(part)
-      if (valid.size === 0) continue
-      scanGroups(text, `PART ${part} (?:§|section )`, (id) => {
+      const check = (id) => {
         if (!valid.has(id)) dangling.push(`${file}: PART ${part} §${id}`)
-      })
+      }
+      check(m[2])
+      for (const t of m[3].matchAll(new RegExp(`§?(${CLAUSE})`, 'g'))) check(t[1])
     }
   }
   assert.deepEqual(

--- a/tests/schema-fields-are-produced.test.mjs
+++ b/tests/schema-fields-are-produced.test.mjs
@@ -8,7 +8,7 @@
  * schema alone cannot tell the two apart - `additionalProperties: false` checks
  * that no engine invents a field, and nothing checked the other direction.
  *
- * That gap is the same shape as PART 10 §10a, which every engine violated
+ * That gap is the same shape as PART 11 §10a, which every engine violated
  * identically, and as §3a's resolved half, which the reference implementation
  * did not meet: a rule stated in one place, enforced in none. Here it hid
  * `block_quote.attribution`, described as "the `-- attribution` line" - a syntax


### PR DESCRIPTION
Closes #1365.

## What was wrong

`PART 11` carried **two** sections labelled `§8b`, so a citation to `PART 11 §8b` named either of them. Nothing failed, because `tests/normativity.test.mjs` resolved citations for `PART 9` and `PART 12` only: neither a duplicate label nor a dangling citation into `PART 10` or `PART 11` was reachable by any gate. The `markup-carve/carve#755` shape - the check that would have caught it does not look here.

The second `§8b` arrived with `carve#1084`, which inserted **THE PLAIN-TEXT TARGET PRESERVES LIST DEPTH** into the *middle of `§8a`'s body*, between `§8a`'s opening prose and its own "THE BOUNDARY IS THE CLAUSE, NOT A FLOOR" continuation. So the label collision came with a structural one.

## The renumbering

The clause moves to **`PART 11 §10h`**, next to the other non-HTML target rules (`§10a` through `§10g`). Three consequences, all deliberate:

- the Markdown `§8b` **keeps its number**, so the three citations that resolve correctly today are untouched (`resources/examples/edge-cases.md`, `CHANGELOG.md`, and the clause's own self-reference);
- `§8a`'s body is contiguous again;
- the moved clause had **no** correct citation anywhere - both of its citations said `PART 10 §8b` - so this is the renaming that breaks nothing.

## What widening the gate surfaced

Seven more dangling citations. Six are one mistyped PART number, copied:

| citation | where | is |
|---|---|---|
| `PART 10 §8b` | `docs/versioning.md`, `CHANGELOG.md` | `PART 11 §10h` |
| `PART 10 §10a` | `docs/profiles.md`, `scripts/compare-impls.mjs`, `tests/corpus-targets.test.mjs`, `tests/corpus/README.md`, `tests/schema-fields-are-produced.test.mjs` | `PART 11 §10a` |

Four of those five `§10a` sites are **outside `docs/`**, which is why a docs-only gate could not have found them even with `PART 10` added to it.

**The eighth is a different failure, and it is the interesting one.** `resources/grammar.ebnf` cited `PART 11 §10d` - a label that was **retired**, not moved or mistyped: `carve#1213` withdrew the clause that carried a quote attribution onto the non-HTML targets, and its number went with it. There is nothing to repoint it at. The sentence now describes the withdrawn clause instead of citing a number, and records that `PART 11` runs `10c`, `10e` for exactly that reason.

## The gate

- Section labels are read for **every** PART. A heading counts only when its title opens in caps, and that discriminator is load-bearing: `PART 8`'s two numbered lists are **precedence orders** in sentence case, numbered 1..11 and 1..13 in the same PART, and counting them as sections would report a collision that is not one. A test pins `PART 8` at zero sections, so a discriminator that stops discriminating fails there rather than as a bogus collision.
- Labels must be unique within a PART.
- Citations resolve for every PART, in both spellings (`§N` and `section N`) and across citation groups, over every `.md` / `.mjs` / `.js` / `.json` / `.txt` / `.ebnf` file in the repo rather than `docs/` alone.
- The PART number is read **out of the citation**, not iterated over the parts the grammar has, so a citation into a part that does not exist - or into one with no sections - is reported too. (Codex review caught the first pass skipping those; the finding was real and is fixed in the second commit.)

The `PART 12` test keeps only the half the generic one cannot do: the bare `(§3a)` form, which is unambiguous only on the pages about `PART 12`.

## Proof that the gate can fail

Six mutants, each restored afterwards. `pass/fail` is `node --test tests/normativity.test.mjs`.

| mutant | new gate | old gate |
|---|---|---|
| A: a dangling `PART 10` citation in `docs/versioning.md` | **11 pass / 1 fail** | **11 pass / 0 fail** |
| B: reintroduce the duplicate `§8b` label | 10 pass / 2 fail | - |
| C: revert one `PART 11 §10a` back to the mistyped form, in a non-`docs/` file | 11 pass / 1 fail | - |
| D: make the caps discriminator return `true` for every numbered line | 10 pass / 2 fail | - |
| E: a citation into a PART number that does not exist | 11 pass / 1 fail | - |
| F: a citation into `PART 8`, which has no sections | 11 pass / 1 fail | - |
| control: unmutated | 12 pass / 0 fail | - |

Mutant A run against `HEAD~1`'s test file is the dead-check demonstration: **the old gate stayed green on a citation that resolves to nothing.**

A note the gate now carries in its own failure message: this scan reads its own source, so a bad citation written as an *example* is reported as a defect. Name one in prose, never spell it.

## Scope

No normative text changes meaning. One clause moves and is renumbered; nothing about what it requires changes, and the corpus is untouched.
