### PR TITLE
chore: re-measure the flatten rows, and drop the four rust lines they closed

### DIFF
--- a/resources/converter-drift.txt
+++ b/resources/converter-drift.txt
@@ -25,20 +25,33 @@
 
 # PART 11 section 1b, ruled at carve#1325: a producer that flattens block
 # content into an inline slot emits a separator at every boundary between two
-# former sibling blocks. Measured 2026-08-18, no engine does: all three join the
-# blocks with nothing, so all three lead the corpus on all three cases. Each
-# line goes in the commit that lands the fix for that engine.
-rust/29-html-a-flattened-paragraph-boundary-survives  emits `onetwo`; PART 11 s1b not implemented
-rust/30-html-flattened-emphasis-runs-do-not-merge  emits `*a**b*`; PART 11 s1b not implemented
-rust/31-html-flattened-code-spans-do-not-merge  joins the two code spans; PART 11 s1b not implemented
+# former sibling blocks.
+#
+# Re-measured 2026-08-18 by converting all four inputs with each engine, built
+# from a clone made for this run: carve-rs `3f8bde7b`, carve-js `099db2cc`,
+# carve-php `925f7dcf`. carve-rs emits the separator on every row since
+# markup-carve/carve-rs#1094, so its four lines are gone; carve-js and carve-php
+# still join the blocks with nothing.
+#
+#     figcaption content                          rs        js and php
+#     <p>one</p><p>two</p>                        one two   onetwo
+#     <p><strong>a</strong></p>
+#     <p><strong>b</strong></p>                   *a* *b*   *a**b*
+#     <p><code>a</code></p>
+#     <p><code>b</code></p>                       `a` `b`   `a``b`
+#     <p>a</p><p></p><p>b</p>                     a b       ab
+#
+# The last row is the one that says the rule is over CONTRIBUTED TOKENS: the
+# empty block is not a side, so the emitted caption carries one separator and
+# not two. Each remaining line goes in the commit that lands the fix for that
+# engine.
 js/29-html-a-flattened-paragraph-boundary-survives  emits `onetwo`; PART 11 s1b not implemented
 js/30-html-flattened-emphasis-runs-do-not-merge  emits `*a**b*`; PART 11 s1b not implemented
 js/31-html-flattened-code-spans-do-not-merge  joins the two code spans; PART 11 s1b not implemented
+js/32-html-an-empty-flattened-block-is-not-a-side  emits `ab`; PART 11 s1b not implemented
 php/29-html-a-flattened-paragraph-boundary-survives  emits `onetwo`; PART 11 s1b not implemented
 php/30-html-flattened-emphasis-runs-do-not-merge  emits `*a**b*`; PART 11 s1b not implemented
 php/31-html-flattened-code-spans-do-not-merge  joins the two code spans; PART 11 s1b not implemented
-rust/32-html-an-empty-flattened-block-is-not-a-side  emits `ab`; PART 11 s1b not implemented
-js/32-html-an-empty-flattened-block-is-not-a-side  emits `ab`; PART 11 s1b not implemented
 php/32-html-an-empty-flattened-block-is-not-a-side  emits `ab`; PART 11 s1b not implemented
 #
 # A ledger and an unwired gate look identical from outside, so read the

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -7070,9 +7070,11 @@ EOF = (* end of file *) ;
       side exists at all, not what characters happen to sit on one.
 
       THE FAILURES ARE ONE FAILURE, and only some of them have a visible face.
-      Measured 2026-08-18 against carve-js `79b3b3b`, carve-php `c15ceeb` and
-      carve-rs `6976b60f`, each flattening a `<figcaption>` holding two
-      paragraphs, all three agreeing on every row:
+      Re-measured 2026-08-18 against carve-js `099db2cc`, carve-php `925f7dcf`
+      and carve-rs `3f8bde7b`, each built from a clone made for the run and each
+      flattening a `<figcaption>` holding two paragraphs. carve-rs emits the
+      separator on every row since markup-carve/carve-rs#1094; carve-js and
+      carve-php agree with each other on every row and lose the boundary:
 
         <p>one</p><p>two</p>                    ->  onetwo
         <p><strong>a</strong></p>


### PR DESCRIPTION
Both drift ledgers were read against fresh clones of all three engines, and only one of them was wrong.

## `resources/converter-drift.txt`

It still declared carve-rs behind on the four PART 11 s1b converter cases. `markup-carve/carve-rs#1094` landed the flatten boundary, so those four lines are stale in the direction the ledger's own contract calls red:

```
4 converter gate failure(s):
  - converter-drift.txt declares rust/29-html-a-flattened-paragraph-boundary-survives and the engine now matches (or the case is gone) - delete the STALE line in the commit that fixed it.
  ... and the same for 30, 31, 32
```

Deleted. `npm run compare:convert` now reads:

```
rust: convert_pass=30/30 declared_drift=0 mismatch=0 error=0 skipped=2
js:   convert_pass=26/30 declared_drift=4 mismatch=0 error=0 skipped=2
php:  convert_pass=28/32 declared_drift=4 mismatch=0 error=0 skipped=0
```

The eight carve-js and carve-php lines stay, because those two engines still join the blocks with nothing. Measured by converting all four inputs with each engine, each built from a clone made for this run - carve-rs `3f8bde7b`, carve-js `099db2cc`, carve-php `925f7dcf`:

| figcaption content | carve-rs | carve-js and carve-php |
| --- | --- | --- |
| `<p>one</p><p>two</p>` | `one two` | `onetwo` |
| `<p><strong>a</strong></p><p><strong>b</strong></p>` | `*a* *b*` | `*a**b*` |
| `<p><code>a</code></p><p><code>b</code></p>` | `` `a` `b` `` | `` `a``b` `` |
| `<p>a</p><p></p><p>b</p>` | `a b` | `ab` |

## `resources/grammar.ebnf`, PART 11 s1b

The same measurement was stale one file over, and this is the copy a reader actually meets. It said "Measured 2026-08-18 against carve-js `79b3b3b`, carve-php `c15ceeb` and carve-rs `6976b60f` ... all three agreeing on every row". Two of those three commits are behind their engine's main and the agreement claim is now false. The passage carries the fresh commits and names carve-rs as the engine that ships the rule; the three example rows are unchanged, because they are still what carve-js and carve-php emit.

## `resources/engine-pin-drift.txt` - no change, and that is the finding

`npm run engine:report -- --check` reads 32 declared against 32 real at the pinned build `79b3b3b`. Exact match, both directions, so nothing to add or delete.

That file describes the PINNED carve-js build only and has never held a carve-rs entry. The `6976b60f` that looked like one was the grammar passage above - the only place in the repo that string appears.

One measurement trap worth recording: a first pass reported seven UNDECLARED `342-url-list-attributes-are-probed-token-wise-*` slugs. That was a stale local `node_modules` predating the pin move in #1327, not ledger drift. `npm ci` first, then measure.

## Notes

- Draft #291 (`spec/includes-section-19`) also edits `resources/grammar.ebnf`. Different PART, no topic overlap; expect a trivial rebase there if it ever lands.
- No corpus documents added, so the freeze commit does not move.
