### PR TITLE
chore: reconcile the AST span and position ledgers with the engines' mains

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -789,6 +789,19 @@ which rows are declared, but how quickly a declared row stops describing
 anything, and therefore that the run - not the ledger, and not a merged pull
 request - is what answers a question about the engines.
 
+The seventh, on 2026-08-18 at carve-js `020c73e8`, carve-rs `a33c42ad` and
+carve-php `f30ebd1` over 1259 corpus documents, made that point again and
+changed the kind of row it makes it with. `text (presence)` came `AGREED` and
+carve-php's owed position findings emptied; what replaced it is
+`hard_break (extent)` on one document, where all three engines publish the same
+two offsets and disagree about the line and column the end offset names
+([carve-php#1457](https://github.com/markup-carve/carve-php/issues/1457)). The
+clause deciding it is not the markup-inclusive rule the other rows turn on but
+the sentence beside it: a break owns its line terminator and ends at column 1 of
+the following line. Three `permitted` position waivers went in the same run, two
+of them lines that had described a node carve-js and carve-rs were placing all
+along.
+
 An empty declaration is a statement about the corpus, which is the only thing
 the run measures. Four collapsed-reference labels the corpus does not hold - one
 carrying `/emphasis/`, one an escape, one a nested link, one a symbol shortcode

--- a/resources/ast-position-waivers.txt
+++ b/resources/ast-position-waivers.txt
@@ -75,6 +75,39 @@
 # three-way comparison reporting 1262 of 1262 documents unanimous - not from a
 # build of their release commits. The scheduled run is what confirms it.
 #
+# AND THE MEASUREMENT ARRIVED, later the same day, and corrected three of the
+# 62. Taken from fresh worktrees of every engine's main - carve-js 020c73e8,
+# carve-rs a33c42ad, carve-php f30ebd1 - over the same 1259 corpus documents
+# plus 3 synthetic samples, with each engine reporting 55 findings and 0
+# outstanding. The paragraph above is what the inference produced; this is what
+# a build of those mains says, and where the two differ the build wins:
+#
+#   carve-php  344 `code`    FIXED, deleted. All three engines place this span
+#                            and carve-js and carve-rs always did, which is the
+#                            tell the inference missed: a clause about the
+#                            CONSTRUCT cannot reach one engine only. The run's
+#                            value drops the comment line, but the region it owns
+#                            is contiguous from the opening backtick to its last
+#                            codepoint, so an honest extent exists. §4 exempts a
+#                            value no offset slices; it does not exempt a node
+#                            whose value is shorter than its extent.
+#   carve-php  355-2 `text`  FIXED, deleted. The continuation row here is `+ |`
+#                            and carries nothing, so the cell's text is the
+#                            contiguous `a` on the header row above it. Nothing
+#                            is reassembled and all three engines place it.
+#   carve-php  354 `text`    COUNT, 2 -> 1. The joined cell's `a cont` is still
+#                            unplaceable in every engine and its line stays; the
+#                            second cell's `b` is contiguous and carve-php now
+#                            places it, the same retirement
+#                            markup-carve/carve-js#1154 made for carve-js.
+#
+# NONE OF THE THREE WAS WIDENED and none went because the run wanted it gone:
+# each was probed directly against carve-rs and carve-php on the document named,
+# and the construct is what decided. Two of them were `permitted` lines
+# describing a node the other two engines had been placing all along - a waiver
+# sized to one engine's gap rather than to the clause, which is
+# markup-carve/carve#755's hole in its quietest form.
+#
 # WHICH IS WHY THE "NOTHING MOVED" NOTE ABOVE IS KEPT RATHER THAN OVERWRITTEN.
 # It was true when it was measured and false ninety minutes later, and the two
 # together are the actual claim this file can support: a permitted line is a
@@ -321,7 +354,6 @@ carve-js   356-a-quote-inside-a-quote-is-asked-what-it-ends-on-8.crv            
 carve-js   356-a-quote-inside-a-quote-is-asked-what-it-ends-on-8.crv                text        1  permitted
 carve-js   356-a-quote-inside-a-quote-is-asked-what-it-ends-on-9.crv                table_cell  1  permitted
 carve-js   356-a-quote-inside-a-quote-is-asked-what-it-ends-on-9.crv                text        1  permitted
-carve-php  344-a-comment-only-line-in-a-line-block-is-removed-before-any-inline-run.crv code        1  permitted
 carve-php  349-a-container-whose-table-ends-on-a-continuation-row-3.crv             table_cell  1  permitted
 carve-php  349-a-container-whose-table-ends-on-a-continuation-row-3.crv             text        1  permitted
 carve-php  349-a-container-whose-table-ends-on-a-continuation-row-5.crv             table_cell  1  permitted
@@ -333,8 +365,7 @@ carve-php  349-a-container-whose-table-ends-on-a-continuation-row.crv           
 carve-php  354-a-continuation-row-joins-the-row-above-it-whatever-its-cells-hold-2.crv table_cell  1  permitted
 carve-php  354-a-continuation-row-joins-the-row-above-it-whatever-its-cells-hold-2.crv text        1  permitted
 carve-php  354-a-continuation-row-joins-the-row-above-it-whatever-its-cells-hold.crv table_cell  1  permitted
-carve-php  354-a-continuation-row-joins-the-row-above-it-whatever-its-cells-hold.crv text        2  permitted
-carve-php  355-a-container-whose-table-ends-on-a-joined-header-row-2.crv            text        1  permitted
+carve-php  354-a-continuation-row-joins-the-row-above-it-whatever-its-cells-hold.crv text        1  permitted
 carve-php  355-a-container-whose-table-ends-on-a-joined-header-row-3.crv            table_cell  1  permitted
 carve-php  355-a-container-whose-table-ends-on-a-joined-header-row-3.crv            text        1  permitted
 carve-php  355-a-container-whose-table-ends-on-a-joined-header-row.crv              table_cell  1  permitted

--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -247,4 +247,38 @@
 # re-measurement did NOT move this file, and it is the only reason the state
 # above is worth writing down rather than superseding again.
 
-text (presence) 3
+# AND THE RELEASE-FREEZE MEASUREMENT, 2026-08-18, from fresh worktrees of every
+# engine's main: carve-js 020c73e8, carve-rs a33c42ad and carve-php f30ebd1,
+# over 1259 corpus documents plus 3 synthetic samples. Of 25,563 comparable
+# spans, ONE row disagrees across ONE document - and it is a different row.
+#
+#   text (presence)      3 -> 0   markup-carve/carve-php#1351, closed. AGREED,
+#                                 and the same fix emptied the OWED half of
+#                                 resources/ast-position-waivers.txt.
+#   hard_break (extent)  0 -> 1   NEW, and declared below.
+#
+# THE NEW ROW IS NOT A DISPUTE ABOUT OFFSETS. On
+# `346-a-line-block-s-last-body-line-keeps-its-backslash-4` all three engines
+# publish startOffset 8 and endOffset 10 - the backslash and the newline it
+# precedes - so all three span the markup and the §4 rule this panel usually
+# turns on does not separate them. They disagree about the LINE AND COLUMN that
+# offset 10 names: carve-js and carve-rs say line 3 column 1, carve-php says line
+# 2 column 5.
+#
+# WHICH `checkOpeningMarkup` CANNOT SETTLE, because it carries no `hard_break`
+# pattern and so names no side here. docs/ast-json.md settles it in one sentence
+# instead: "Break nodes own their line terminator and therefore end at column 1
+# of the following line." carve-php is the engine that moves.
+#
+# NARROW, AND CHECKED RATHER THAN ASSUMED. Thirty corpus documents produce a
+# `hard_break` and carve-php agrees with carve-rs on twenty-nine. The one it does
+# not is the one whose following line is a comment-only line the block layer
+# removes before any inline run; replace that line with ordinary content and
+# carve-php agrees, and with two breaks in one block only the one followed by the
+# removed line moves. Filed as markup-carve/carve-php#1457.
+#
+# DECLARED rather than tolerated, on the same terms as every block above: the row
+# fails this run the moment carve-php agrees, which is what makes deleting it the
+# closing step of that issue rather than a chore nobody is holding.
+
+hard_break (extent) 1

--- a/tests/ast-spans.test.mjs
+++ b/tests/ast-spans.test.mjs
@@ -215,13 +215,21 @@ test('a malformed declaration line is an error, never a silent skip', () => {
  * shipped file against an EMPTY measurement only stays falsifiable while the
  * ledger is empty - every declared row becomes an AGREED.
  *
- * Measured 2026-08-17 over 1131 corpus documents plus 3 synthetic samples, at
- * carve-js c8c8dc3, carve-rs d981df8 and carve-php d2e2fd6, each built from a
- * clone made for this run. ONE row across 3 documents, of 22,766 spans compared:
- * carve-php dropping a line block's spaced content position
- * (markup-carve/carve-php#1351). The same one row, three documents and 22,766
- * spans read again at carve-rs ff54c44 and carve-php 5e6ab9a, two engine mains
- * later, with nothing edited in between.
+ * Measured 2026-08-18 over 1259 corpus documents plus 3 synthetic samples, at
+ * carve-js 020c73e8, carve-rs a33c42ad and carve-php f30ebd1, each built from a
+ * worktree of that engine's main made for this run. ONE row across 1 document,
+ * of 25,563 spans compared: carve-php ending a hard break on the line the break
+ * is on rather than at column 1 of the following line, where the following line
+ * is a comment-only line the block layer removes
+ * (markup-carve/carve-php#1457).
+ *
+ * THE ROW BEFORE IT WAS A DIFFERENT KIND OF DISAGREEMENT ENTIRELY. The
+ * 2026-08-17 measurement this replaces read `text (presence)` across 3
+ * documents, carve-php dropping a line block's spaced content position
+ * (markup-carve/carve-php#1351, since closed). That row was about a span being
+ * ABSENT; this one is about a present span's line and column, with all three
+ * engines agreeing on both offsets. A key here says which type moved and
+ * nothing about which half of §4 it turned on.
  *
  * A NUMBER HERE IS NOT A GAP. Twice in the hour before this measurement a
  * carve-php fix closed the documents its issue named and over-reached onto one
@@ -232,15 +240,16 @@ test('a malformed declaration line is an error, never a silent skip', () => {
  * resources/ast-span-divergence.txt, and re-running the check is the only thing
  * that says which gap a row currently describes.
  *
- * It read nine rows across 21 documents that morning, five across 9 an hour
- * later, four across 8 twice after that, three, and now one. carve-php shipped
+ * It read nine rows across 21 documents on 2026-08-17, five across 9 an hour
+ * later, four across 8 twice after that, three, then one. carve-php shipped
  * the 326/327/329/333 container rulings, carve-js shipped #1152 and #1154, and
  * carve-php then shipped #1365, #1366, #1367, #1370 and #1372 - and each time
  * ast:check reported the rows AGREED or COUNT and this map moved with the run
  * rather than with the merge notifications. Six measurements in one day, each
- * one taken because the previous one had stopped being true.
+ * one taken because the previous one had stopped being true, and a seventh the
+ * next day that replaced the surviving row with a different one.
  */
-const LAST_MEASURED = new Map([['text (presence)', 3]])
+const LAST_MEASURED = new Map([['hard_break (extent)', 1]])
 
 const asMeasured = (counts) =>
   new Map(


### PR DESCRIPTION
`AST conformance` is red on `main` on five rows, four of them ledger lines that
no longer describe anything and one new divergence. Measured from worktrees of
every engine's main, built for this run: carve-js `020c73e8`, carve-rs
`a33c42ad`, carve-php `f30ebd1`, carve-rb `2773de0`, over 1259 corpus documents
plus 3 synthetic samples. Three-way shape is 1262 of 1262 unanimous, values
agree everywhere, binding parity is 1262 of 1262, and every engine reports 55
findings with 0 outstanding.

### `resources/ast-position-waivers.txt`

Three lines, all carve-php, each checked against the construct rather than
against the run:

- `344 code`, deleted. carve-js and carve-rs have always placed this span and
  now carve-php does too, which is the tell the line was wrong when it was
  written: a clause about the construct cannot reach one engine only. The code
  span's value drops the comment-only line the block layer removes, but the
  region it owns is contiguous from the opening backtick to its last codepoint,
  so an honest extent exists. §4 exempts a value no offset slices; it does not
  exempt a node whose value is shorter than its extent.
- `355-2 text`, deleted. The continuation row here is `+ |` and carries nothing,
  so the cell's text is the contiguous `a` on the header row above it. Nothing
  is reassembled and all three engines place it.
- `354 text`, 2 to 1. The joined cell's `a cont` is still unplaceable in every
  engine and keeps its line; the second cell's `b` is contiguous and carve-php
  now places it, the same retirement markup-carve/carve-js#1154 made for
  carve-js.

Two of the three were `permitted` lines describing a node the other two engines
had been placing all along, which is a waiver sized to one engine's gap rather
than to the clause. They came in with the 62 lines the release freeze added,
whose header records that carve-rs's and carve-php's document lists were
inferred rather than measured. This is the measurement that header asked for.

### `resources/ast-span-divergence.txt`

`text (presence)` came `AGREED` and its line is deleted;
markup-carve/carve-php#1351 is closed and the same fix emptied the owed half of
the sibling ledger.

`hard_break (extent)` is new, on
`346-a-line-block-s-last-body-line-keeps-its-backslash-4`, and it is declared
rather than left red. All three engines publish `startOffset` 8 and `endOffset`
10, the backslash and the newline it precedes, so all three span the markup and
the markup-inclusive rule the other rows turn on does not separate them. They
disagree about the line and column that offset 10 names: carve-js and carve-rs
say line 3 column 1, carve-php says line 2 column 5.

`checkOpeningMarkup` carries no `hard_break` pattern and so names no side here.
What settles it is the sentence beside that rule in `docs/ast-json.md`: "Break
nodes own their line terminator and therefore end at column 1 of the following
line." carve-php is the engine that moves, and it is filed as
markup-carve/carve-php#1457.

It is narrow, and that was checked rather than assumed. Thirty corpus documents
produce a `hard_break` and carve-php agrees with carve-rs on twenty-nine. The
one it does not is the one whose following line is a comment-only line the block
layer removes; swap that line for ordinary content and carve-php agrees, and
with two breaks in one block only the one followed by the removed line moves.

### Not here

No CHANGELOG entry: `carve` is cut at 0.1.3 and this moves no behavior a
consumer of the spec can observe. `#1378` is filed and closed by the workflow
itself, so it is left alone.
