### PR TITLE
chore: finalize table engine pin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#4269ea88a596c464105f3cd7391882187e80da9c",
+        "@markup-carve/carve": "github:markup-carve/carve-js#9fbaed4d54437d02dd7f9a367cd12fac6771fb7d",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#4269ea88a596c464105f3cd7391882187e80da9c",
-      "integrity": "sha512-Dy1Y/iod8k/KfgInvorSYoiudJMrSBgCqORnsiANO9br8QgSDjKTkO0c3Q8zfqs188nyY8WohVpsWYviz87w0Q==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#9fbaed4d54437d02dd7f9a367cd12fac6771fb7d",
+      "integrity": "sha512-EF7kWbWDXZ/+L4v9LUgrTY9L6h3mE6MaBdRSnEGuytbht3rtpp8fyq7b1Bx7Zgd2bmNSS1w6HJkkh5d7QSKnnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#4269ea88a596c464105f3cd7391882187e80da9c",
+    "@markup-carve/carve": "github:markup-carve/carve-js#9fbaed4d54437d02dd7f9a367cd12fac6771fb7d",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,8 +24,5 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-53-table-doubled-alignment-marker  carve#1344: doubled markers other than `~~` now fall back visibly instead of consuming a valid prefix; the pinned reader implements the retired single-marker rule.
-370-table-columns-carry-alignment-vertical-alignment-and-widths  carve#1344: the pinned reader does not yet consume positional table attributes or emit vertical alignment and column widths.
-371-a-table-alignment-run-carries-two-independent-axes  carve#1344: the pinned reader does not yet recognize two-axis table alignment runs or vertical cell alignment.
 369-a-quote-is-reached-by-its-marker-and-a-column-never-reaches-into-one  carve#1384: the pin DROPS the definition-shaped line written at a block quote's content column with no quote marker on it, so it renders nothing and defines nothing - the outcome carve#624 forbids. PART 1 S4's A QUOTE IS REACHED BY ITS MARKER, AND A COLUMN NEVER REACHES INTO ONE is the fix: the line reaches the quote only through S4's lazy fold, so it continues the deepest open paragraph and renders where it was written. carve-rs already answers it. The paragraph-body control (-3) and the marker control (-4) both reproduce, which is what makes the set discriminating: the pin gets both shapes where the answer never depended on the quote's body right, and only the two where it did wrong.
 369-a-quote-is-reached-by-its-marker-and-a-column-never-reaches-into-one-2  carve#1384: the same shape one container deeper, which is the spelling the ticket reported and the one that shows the outer item does not change the answer either.

--- a/tests/lint-rule-table-claims.test.mjs
+++ b/tests/lint-rule-table-claims.test.mjs
@@ -90,6 +90,10 @@ const TRIGGERS = {
   // leading `|` with no closing one is a paragraph, and there is no cell for
   // the block to be misplaced in.
   'table-cell-attribute-before-marker': '|{#x}< content |\n',
+  'table-alignment-run-padding': '|>text |\n',
+  'table-column-arity': '{aligns="left"}\n| a | b |\n',
+  'table-column-overlap': '{aligns="left"}\n|=> H |\n',
+  'table-width-total': '{widths="60,50"}\n| a | b |\n',
   // `kbd`, not `cite`: PART 9 §10 moved `samp`, `var`, `cite` and `dfn` into the
   // SemanticSpan extension, so in a core lint they are ordinary attributes and
   // provoke nothing. `kbd` is one of the three names core still reserves, which
@@ -133,10 +137,6 @@ const UNPRODUCIBLE_IN_BUILD = new Set(['portable-quote-marker-space'])
  *   - listed here and absent from the page -> a declaration about nothing.
  */
 const NOT_IN_THE_PIN_YET = new Map([
-  ['table-alignment-run-padding', 'specified by markup-carve/carve#1344; no engine implements it yet'],
-  ['table-column-arity', 'specified by markup-carve/carve#1344; no engine implements it yet'],
-  ['table-column-overlap', 'specified by markup-carve/carve#1344; no engine implements it yet'],
-  ['table-width-total', 'specified by markup-carve/carve#1344; no engine implements it yet'],
   [
     'unattached-block-attribute',
     'specified by markup-carve/carve#1281; no engine implements it yet',

--- a/tests/schema-fields-are-produced.test.mjs
+++ b/tests/schema-fields-are-produced.test.mjs
@@ -65,10 +65,6 @@ const OPT_IN_ONLY = {
 const ENGINE_ROLLOUT_PENDING = {
   'figure.shortCaption': 'structural publishing field: Carve 0.1 source has no spelling; produced only by AST/Pandoc consumers',
   'table.shortCaption': 'structural publishing field: Carve 0.1 source has no spelling; produced only by AST/Pandoc consumers',
-  'table.columns':
-    'table-column feature rollout (PART 12 §19): declared for the coordinated engine implementation; removed when the conformance corpus produces it',
-  'table_cell.valign':
-    'vertical-alignment rollout (PART 12 §20): declared for the coordinated engine implementation; removed when the conformance corpus produces it',
   'table.rowGroups':
     'structural exchange field (PART 12 §15): Carve 0.1 source has no spelling for a head/body/foot partition, and absent already means the implicit one, so a parser never synthesizes it; produced only by AST/format-bridge consumers',
 }


### PR DESCRIPTION
Follow-up to #1391 after all coordinated table implementations landed.

- pins the reference build to merged carve-js correction `9fbaed4d54437d02dd7f9a367cd12fac6771fb7d`
- removes the three now-stale #1344 engine-drift declarations
- leaves only the unrelated #1384 quote drift on current main

Verification:
- `npm run engine:report -- --check`: 1,274/1,276 reproduce; both remaining mismatches are declared #1384 inputs
- `npm run core:check`: 1,276 conformant, 0 defects
- `npm test`
- `git diff --check`