### PR TITLE
Require horizontal partners for vertical table markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A vertical table-cell marker requires a horizontal partner.** `|^ x` and `|v x` remain visible content; paired runs such as `|<^`, `|~~`, and `|v>` carry both axes. Corpus 373.
 - **A quote is reached by its marker, and a column never reaches into one** (carve#1384). A line writing no `>` is in no quote whatever column it lands on; it folds into the deepest open paragraph, renders where it was written, and registers nothing. Corpus 369.
 - **An unterminated fence at a container's content column opens no block** (carve#1387). Section 10 I4 asks for a closer; without one the line is paragraph text, the paragraph stays open, and a flush-left line below folds into it. Corpus 367.
 - **A raw block keeps the blank line at the end of its payload** (carve#1389). The payload is every line between the delimiters; the container and whether the closer was written are not parameters. Corpus 366.

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -149,8 +149,9 @@ with a space.
 
 ### Alignment
 
-`<` left, `~` center, `>` right; `^` top, `~` middle, `v` bottom. A one- or
-two-axis run is glued to the pipe and terminated by a space. On `|=` it sets
+`<` left, `~` center, `>` right; paired `^` top, `~` middle, `v` bottom. A
+horizontal marker may stand alone; a vertical marker always needs a horizontal
+partner. The run is glued to the pipe and terminated by a space. On `|=` it sets
 column defaults; on a plain `|` it overrides that cell. Table attributes can
 set headerless defaults: `{aligns="right,center" valigns="top," widths="30,70"}`.
 

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -21,15 +21,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>709 / 709</strong>
+    <strong>709 / 710</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>709 / 709</strong>
+    <strong>709 / 710</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>709 / 709</strong>
+    <strong>709 / 710</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -40,9 +40,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `709 / 709` | `0` | `0` | `3.01` |
-| JS | `8105210` | `709 / 709` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `709 / 709` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `709 / 710` | `0` | `0` | `3.01` |
+| JS | `8105210` | `709 / 710` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `709 / 710` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 
@@ -752,7 +752,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=709 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=710 targets=html,markdown,plain,carve,ansi
 rust: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=3.01
   mismatching documents: 0
 js: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=76.02

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1277 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1278 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,3 +24,4 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
+373-a-vertical-table-marker-needs-a-horizontal-partner  the pinned carve-js build predates the rule that a vertical marker requires a horizontal partner

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -197,6 +197,7 @@ index: examples/edge-cases/index.md
   table-doubled-alignment-marker
   table-columns-carry-alignment-vertical-alignment-and-widths
   a-table-alignment-run-carries-two-independent-axes
+  a-vertical-table-marker-needs-a-horizontal-partner
   table-cell-escaped-pipe
   table-cell-pipe-inside-code-span
   an-unclosed-verbatim-run-in-a-row-stops-at-the-closing-pipe

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -24366,3 +24366,27 @@ after
 ````
 
 :::
+
+## A vertical table marker needs a horizontal partner
+
+Horizontal alignment may stand alone. Vertical alignment is meaningful only as
+the second axis of a paired run, so a lone `^` or `v` stays visible instead of
+silently changing layout. The order of a valid pair remains author-independent.
+
+::: compare
+
+```carve
+|=^ Top |=v Bottom |=<^ Paired |=v> Reverse |=~> Middle |
+| a | b | c | d | e |
+```
+
+```html
+<table>
+  <thead><tr><th scope="col">^ Top</th><th scope="col">v Bottom</th><th scope="col" style="text-align: left; vertical-align: top;">Paired</th><th scope="col" style="text-align: right; vertical-align: bottom;">Reverse</th><th scope="col" style="text-align: right; vertical-align: middle;">Middle</th></tr></thead>
+  <tbody>
+    <tr><td>a</td><td>b</td><td style="text-align: left; vertical-align: top;">c</td><td style="text-align: right; vertical-align: bottom;">d</td><td style="text-align: right; vertical-align: middle;">e</td></tr>
+  </tbody>
+</table>
+```
+
+:::

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1554,15 +1554,17 @@ colspan_marker = {space}, '<', {space} ;
    separate question and is unchanged here. *)
 
 alignment_run = horizontal_alignment, [vertical_alignment]
-              | vertical_alignment, [horizontal_alignment] ;
+              | vertical_alignment, horizontal_alignment ;
 horizontal_alignment = '<' | '>' | '~' ;  (* left, right, center *)
 vertical_alignment = '^' | '~' | 'v' ;    (* top, middle, bottom *)
 cell_padding = space | (* empty only when no alignment_run is present *) ;
-(* An alignment run is a one- or two-marker SET, in either authored order, and
-   MUST be followed by one space after an optional attached attribute block.
+(* An alignment run is a horizontal marker, optionally paired with a vertical
+   marker in either authored order, and MUST be followed by one space after an
+   optional attached attribute block. A vertical marker therefore never stands
+   alone: `|^ x` and `|v x` keep `^`/`v` as visible content.
    Duplicate axes are invalid, except `~~`, whose first marker is horizontal
    center and second is vertical middle. `fmt` writes horizontal then vertical.
-   A lone `~` is horizontal center; middle-only has no one-marker spelling.
+   A lone `~` is horizontal center; no vertical value has a one-marker spelling.
    With no alignment run the old unpadded cell spelling remains valid. *)
 
 cell_content = inline_content ;
@@ -10633,13 +10635,14 @@ EOF = (* end of file *) ;
       alignment run is glued to its opening pipe, after an optional `=` kind
       marker, and is terminated by exactly one space after an optional glued
       attribute block. Horizontal markers are `<`, `~`, `>`; vertical markers
-      are `^`, `~`, `v` for top, middle and bottom. A run may carry either axis
-      or both, in either order. `~~` means center plus middle. Any other
+      are `^`, `~`, `v` for top, middle and bottom. A horizontal marker may
+      stand alone; a vertical marker MUST be paired with a horizontal marker,
+      in either order. `~~` means center plus middle. Any other
       duplicate axis is invalid and falls back visibly rather than consuming
       a prefix. `fmt` normalizes both axes to horizontal then vertical.
 
-      A lone `~` is horizontal center. To request middle while preserving a
-      chosen horizontal value, spell that value too. A header-cell run supplies
+      A lone `~` is horizontal center. Every vertical value spells its chosen
+      horizontal value too. A header-cell run supplies
       column defaults; a body-cell run supplies only that cell. A run with no
       following space is not alignment: this deliberately changes the glued
       `|>text` family so marker runs have an unambiguous terminator. `lint`

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -981,8 +981,9 @@ function parseCell(seg) {
   } else if (s.startsWith('\\=')) {
     s = '\\=' + s.slice(2) // literal `=` data cell; unescaped by inline pass
   }
-  // A one/two-axis run is committed only when its optional attribute block is
-  // followed by the required space. Invalid duplicate axes consume nothing.
+  // A horizontal-only or paired run is committed only when its optional
+  // attribute block is followed by the required space. A lone vertical marker
+  // and invalid duplicate axes consume nothing.
   const run = new RegExp(`^([<>~^v]{1,2})(?=(?:\\{${ATTR_PAYLOAD}\\})? )`).exec(s)
   if (run) {
     const marks = [...run[1]]
@@ -990,8 +991,10 @@ function parseCell(seg) {
     let vertical = null
     for (let mi = 0; mi < marks.length; mi++) {
       const mark = marks[mi]
-      const useHorizontal = mark === '<' || mark === '>' ||
-        (mark === '~' && (marks.length === 1 || horizontal === null))
+      const verticalFirstMiddle = mark === '~' && mi === 0 &&
+        (marks[1] === '<' || marks[1] === '>')
+      const useHorizontal = !verticalFirstMiddle && (mark === '<' || mark === '>' ||
+        (mark === '~' && (marks.length === 1 || horizontal === null)))
       if (useHorizontal) {
         if (horizontal !== null) { horizontal = null; vertical = null; break }
         horizontal = mark === '<' ? 'left' : mark === '>' ? 'right' : 'center'
@@ -1000,7 +1003,7 @@ function parseCell(seg) {
         vertical = mark === '^' ? 'top' : mark === 'v' ? 'bottom' : 'middle'
       }
     }
-    if (horizontal !== null || vertical !== null) {
+    if (horizontal !== null && (vertical !== null || run[1].length === 1)) {
       cell.align = horizontal
       cell.valign = vertical
       s = s.slice(run[1].length)

--- a/tests/corpus/373-a-vertical-table-marker-needs-a-horizontal-partner.crv
+++ b/tests/corpus/373-a-vertical-table-marker-needs-a-horizontal-partner.crv
@@ -1,0 +1,2 @@
+|=^ Top |=v Bottom |=<^ Paired |=v> Reverse |=~> Middle |
+| a | b | c | d | e |

--- a/tests/corpus/373-a-vertical-table-marker-needs-a-horizontal-partner.html
+++ b/tests/corpus/373-a-vertical-table-marker-needs-a-horizontal-partner.html
@@ -1,0 +1,6 @@
+<table>
+  <thead><tr><th scope="col">^ Top</th><th scope="col">v Bottom</th><th scope="col" style="text-align: left; vertical-align: top;">Paired</th><th scope="col" style="text-align: right; vertical-align: bottom;">Reverse</th><th scope="col" style="text-align: right; vertical-align: middle;">Middle</th></tr></thead>
+  <tbody>
+    <tr><td>a</td><td>b</td><td style="text-align: left; vertical-align: top;">c</td><td style="text-align: right; vertical-align: bottom;">d</td><td style="text-align: right; vertical-align: middle;">e</td></tr>
+  </tbody>
+</table>

--- a/tests/spec/373-a-vertical-table-marker-needs-a-horizontal-partner.test
+++ b/tests/spec/373-a-vertical-table-marker-needs-a-horizontal-partner.test
@@ -1,0 +1,13 @@
+A vertical table marker needs a horizontal partner
+
+```
+|=^ Top |=v Bottom |=<^ Paired |=v> Reverse |=~> Middle |
+| a | b | c | d | e |
+.
+<table>
+  <thead><tr><th scope="col">^ Top</th><th scope="col">v Bottom</th><th scope="col" style="text-align: left; vertical-align: top;">Paired</th><th scope="col" style="text-align: right; vertical-align: bottom;">Reverse</th><th scope="col" style="text-align: right; vertical-align: middle;">Middle</th></tr></thead>
+  <tbody>
+    <tr><td>a</td><td>b</td><td style="text-align: left; vertical-align: top;">c</td><td style="text-align: right; vertical-align: bottom;">d</td><td style="text-align: right; vertical-align: middle;">e</td></tr>
+  </tbody>
+</table>
+```


### PR DESCRIPTION
## Summary

- require every vertical table-cell alignment marker to be paired with a horizontal marker
- keep lone `^` and `v` prefixes as visible cell content
- retain either authored order for valid pairs, with horizontal-first as the canonical form
- document only concise valid forms in the cheatsheet and place invalid forms in the edge-case corpus

## Contract

Horizontal-only runs remain valid (`|<`, `|~`, `|>`). Vertical values require both axes (`|<^`, `|~~`, `|>v`), and reverse authored pairs such as `|v>` and `|~>` remain accepted. Corpus 373 pins both the negative cases and reverse-order parsing.

## Verification

- `npm run corpus:build`
- `node --test tests/corpus.test.mjs tests/examples.test.mjs tests/normativity.test.mjs` (1293 passed)
- full spec suite (2546 passed, 2 skipped before the final generated category; targeted corpus suite rerun after generation)

The VitePress build also reached the existing Shiki failure in `docs/ast-json.md` (`startIndex`), unrelated to these table changes.
