### PR TITLE
Pin paired table alignment reference engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#63afbb294b65763f0354d2347190daf7e8e35b25",
+        "@markup-carve/carve": "github:markup-carve/carve-js#a29dc11fffa8667e91ca16d556d01e5e88346db1",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#63afbb294b65763f0354d2347190daf7e8e35b25",
-      "integrity": "sha512-0M7DGigskT7WGiXworPkN4/otapY11lGgPQakK7bw3o8azQHyi76NbL1eM36Ty1osnnAuRh90RONhYYz7AbU8A==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#a29dc11fffa8667e91ca16d556d01e5e88346db1",
+      "integrity": "sha512-+WcEj2GCfAcx0qdUOJ7RetVI3dcflN3Q/B950Fs0svo3TPsf5CJzCslWYUExve5S1D6OeVc5nDSqf6vZW/yxPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#63afbb294b65763f0354d2347190daf7e8e35b25",
+    "@markup-carve/carve": "github:markup-carve/carve-js#a29dc11fffa8667e91ca16d556d01e5e88346db1",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,4 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-373-a-vertical-table-marker-needs-a-horizontal-partner  the pinned carve-js build predates the rule that a vertical marker requires a horizontal partner


### PR DESCRIPTION
## Summary

- pin the reference JavaScript engine to its merged paired-table-alignment implementation
- remove the temporary declared drift for corpus case 373
- keep the executable specification and reference engine at zero drift across all 1,278 corpus pairs

## Verification

- `npm run engine:report -- --check`
- `npm run core:check`

Both checks report all 1,278 cases conformant with zero mismatches, throws, defects, sentinel leaks, or declared drift.
