### PR TITLE
Require horizontal-first table alignment pairs

### DIFF
--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,3 +24,4 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
+373-a-vertical-table-marker-needs-a-horizontal-partner  the pinned carve-js build still accepts reverse-order vertical-horizontal table alignment pairs

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -24318,8 +24318,8 @@ markers remain more specific than these defaults.
 
 ## A table alignment run carries two independent axes
 
-The horizontal and vertical markers may be authored in either order. The
-canonical order is horizontal then vertical, and rendered CSS always writes
+The horizontal marker comes first and the optional vertical marker follows it.
+Rendered CSS likewise writes
 `text-align` before `vertical-align`. A header-cell run supplies column defaults;
 a body-cell run overrides only that cell.
 
@@ -24382,9 +24382,9 @@ silently changing layout. The order of a valid pair remains author-independent.
 
 ```html
 <table>
-  <thead><tr><th scope="col">^ Top</th><th scope="col">v Bottom</th><th scope="col" style="text-align: left; vertical-align: top;">Paired</th><th scope="col" style="text-align: right; vertical-align: bottom;">Reverse</th><th scope="col" style="text-align: right; vertical-align: middle;">Middle</th></tr></thead>
+  <thead><tr><th scope="col">^ Top</th><th scope="col">v Bottom</th><th scope="col" style="text-align: left; vertical-align: top;">Paired</th><th scope="col">v&gt; Reverse</th><th scope="col">~&gt; Middle</th></tr></thead>
   <tbody>
-    <tr><td>a</td><td>b</td><td style="text-align: left; vertical-align: top;">c</td><td style="text-align: right; vertical-align: bottom;">d</td><td style="text-align: right; vertical-align: middle;">e</td></tr>
+    <tr><td>a</td><td>b</td><td style="text-align: left; vertical-align: top;">c</td><td>d</td><td>e</td></tr>
   </tbody>
 </table>
 ```

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1553,17 +1553,16 @@ colspan_marker = {space}, '<', {space} ;
    (carve#904, applying carve#901). What counts as an EMPTY cell is a
    separate question and is unchanged here. *)
 
-alignment_run = horizontal_alignment, [vertical_alignment]
-              | vertical_alignment, horizontal_alignment ;
+alignment_run = horizontal_alignment, [vertical_alignment] ;
 horizontal_alignment = '<' | '>' | '~' ;  (* left, right, center *)
 vertical_alignment = '^' | '~' | 'v' ;    (* top, middle, bottom *)
 cell_padding = space | (* empty only when no alignment_run is present *) ;
-(* An alignment run is a horizontal marker, optionally paired with a vertical
-   marker in either authored order, and MUST be followed by one space after an
+(* An alignment run is a horizontal marker, optionally followed by a vertical
+   marker, and MUST be followed by one space after an
    optional attached attribute block. A vertical marker therefore never stands
    alone: `|^ x` and `|v x` keep `^`/`v` as visible content.
-   Duplicate axes are invalid, except `~~`, whose first marker is horizontal
-   center and second is vertical middle. `fmt` writes horizontal then vertical.
+   Reverse-order pairs are invalid. Duplicate axes are invalid, except `~~`,
+   whose first marker is horizontal center and second is vertical middle.
    A lone `~` is horizontal center; no vertical value has a one-marker spelling.
    With no alignment run the old unpadded cell spelling remains valid. *)
 

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -989,12 +989,12 @@ function parseCell(seg) {
     const marks = [...run[1]]
     let horizontal = null
     let vertical = null
-    for (let mi = 0; mi < marks.length; mi++) {
-      const mark = marks[mi]
-      const verticalFirstMiddle = mark === '~' && mi === 0 &&
-        (marks[1] === '<' || marks[1] === '>')
-      const useHorizontal = !verticalFirstMiddle && (mark === '<' || mark === '>' ||
-        (mark === '~' && (marks.length === 1 || horizontal === null)))
+    const reverseOrder = marks.length === 2 &&
+      (marks[0] === '^' || marks[0] === 'v' ||
+        (marks[0] === '~' && (marks[1] === '<' || marks[1] === '>')))
+    for (const mark of reverseOrder ? [] : marks) {
+      const useHorizontal = mark === '<' || mark === '>' ||
+        (mark === '~' && (marks.length === 1 || horizontal === null))
       if (useHorizontal) {
         if (horizontal !== null) { horizontal = null; vertical = null; break }
         horizontal = mark === '<' ? 'left' : mark === '>' ? 'right' : 'center'

--- a/tests/corpus/373-a-vertical-table-marker-needs-a-horizontal-partner.html
+++ b/tests/corpus/373-a-vertical-table-marker-needs-a-horizontal-partner.html
@@ -1,6 +1,6 @@
 <table>
-  <thead><tr><th scope="col">^ Top</th><th scope="col">v Bottom</th><th scope="col" style="text-align: left; vertical-align: top;">Paired</th><th scope="col" style="text-align: right; vertical-align: bottom;">Reverse</th><th scope="col" style="text-align: right; vertical-align: middle;">Middle</th></tr></thead>
+  <thead><tr><th scope="col">^ Top</th><th scope="col">v Bottom</th><th scope="col" style="text-align: left; vertical-align: top;">Paired</th><th scope="col">v&gt; Reverse</th><th scope="col">~&gt; Middle</th></tr></thead>
   <tbody>
-    <tr><td>a</td><td>b</td><td style="text-align: left; vertical-align: top;">c</td><td style="text-align: right; vertical-align: bottom;">d</td><td style="text-align: right; vertical-align: middle;">e</td></tr>
+    <tr><td>a</td><td>b</td><td style="text-align: left; vertical-align: top;">c</td><td>d</td><td>e</td></tr>
   </tbody>
 </table>

--- a/tests/spec/373-a-vertical-table-marker-needs-a-horizontal-partner.test
+++ b/tests/spec/373-a-vertical-table-marker-needs-a-horizontal-partner.test
@@ -5,9 +5,9 @@ A vertical table marker needs a horizontal partner
 | a | b | c | d | e |
 .
 <table>
-  <thead><tr><th scope="col">^ Top</th><th scope="col">v Bottom</th><th scope="col" style="text-align: left; vertical-align: top;">Paired</th><th scope="col" style="text-align: right; vertical-align: bottom;">Reverse</th><th scope="col" style="text-align: right; vertical-align: middle;">Middle</th></tr></thead>
+  <thead><tr><th scope="col">^ Top</th><th scope="col">v Bottom</th><th scope="col" style="text-align: left; vertical-align: top;">Paired</th><th scope="col">v&gt; Reverse</th><th scope="col">~&gt; Middle</th></tr></thead>
   <tbody>
-    <tr><td>a</td><td>b</td><td style="text-align: left; vertical-align: top;">c</td><td style="text-align: right; vertical-align: bottom;">d</td><td style="text-align: right; vertical-align: middle;">e</td></tr>
+    <tr><td>a</td><td>b</td><td style="text-align: left; vertical-align: top;">c</td><td>d</td><td>e</td></tr>
   </tbody>
 </table>
 ```


### PR DESCRIPTION
## Summary

- require the horizontal table-cell alignment marker to precede the optional vertical marker
- keep lone vertical markers and reverse-order pairs as visible cell content
- update the executable specification and conformance case 373
- temporarily declare the reference-engine drift until the JavaScript implementation is updated

## Canonical forms

Valid paired forms are `<^`, `<~`, `<v`, `~^`, `~~`, `~v`, `>^`, `>~`, and `>v`. Reverse forms such as `v>` and `~>` are not alignment runs.

## Verification

- `npm run core:check` — 1,278/1,278 conformant, zero defects
- `npm run engine:report -- --check` — the single expected case-373 drift is declared
