### PR TITLE
spec: settle definition continuation columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **A vertical table-cell marker requires a horizontal partner.** `|^ x` and `|v x` remain visible content; paired runs such as `|<^`, `|~~`, and `|v>` carry both axes. Corpus 373.
+- **A collected definition closes the item paragraph, and only a comment keeps
+  the below-column path open** (carve#1376). Item prose reopens at the content
+  column; a footnote body starts two columns beyond its definition; bare `. `
+  and `- ` have the same content column. Corpus 374.
 - **A quote is reached by its marker, and a column never reaches into one** (carve#1384). A line writing no `>` is in no quote whatever column it lands on; it folds into the deepest open paragraph, renders where it was written, and registers nothing. Corpus 369.
 - **An unterminated fence at a container's content column opens no block** (carve#1387). Section 10 I4 asks for a closer; without one the line is paragraph text, the paragraph stays open, and a flush-left line below folds into it. Corpus 367.
 - **A raw block keeps the blank line at the end of its payload** (carve#1389). The payload is every line between the delimiters; the container and whether the closer was written are not parameters. Corpus 366.

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -158,7 +158,8 @@ under the same semantic-span rule,
 `366-a-raw-block-keeps-the-blank-line-at-the-end-of-its-payload-too`,
 `367-an-unterminated-fence-at-a-content-column-opens-no-block-so-the-paragraph-stays-open`,
 `369-a-quote-is-reached-by-its-marker-and-a-column-never-reaches-into-one`,
-`372-an-all-blank-raw-payload-still-emits-its-line`.
+`372-an-all-blank-raw-payload-still-emits-its-line`,
+`374-a-collected-definition-closes-the-item-paragraph`.
 
 Every category up to and including `334` landed on a host that could not retake
 the run above, so its numbers describe the corpus WITHOUT them. The alternative

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1278 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1282 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#a29dc11fffa8667e91ca16d556d01e5e88346db1",
+        "@markup-carve/carve": "github:markup-carve/carve-js#e46188aa5b17f169027c79d7ff4736dbce62b0e9",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#a29dc11fffa8667e91ca16d556d01e5e88346db1",
-      "integrity": "sha512-+WcEj2GCfAcx0qdUOJ7RetVI3dcflN3Q/B950Fs0svo3TPsf5CJzCslWYUExve5S1D6OeVc5nDSqf6vZW/yxPA==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#e46188aa5b17f169027c79d7ff4736dbce62b0e9",
+      "integrity": "sha512-kbHBj8HcKndoenXUVoqL2od+Aw6cT0RAE2oRhB2w5OLWevAdUsCwiVcf5j/iigMo7t55V57qYNMxiMKm+0L9lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#a29dc11fffa8667e91ca16d556d01e5e88346db1",
+    "@markup-carve/carve": "github:markup-carve/carve-js#e46188aa5b17f169027c79d7ff4736dbce62b0e9",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -351,6 +351,7 @@ index: examples/edge-cases/index.md
   a-block-at-a-container-s-content-column-ends-the-paragraph-whatever-it-renders
   what-a-content-column-block-does-not-reach
   a-footnote-definition-s-block-runs-to-the-end-of-its-body
+  a-collected-definition-closes-the-item-paragraph
   a-definition-behind-an-alternating-container-prefix-registers-at-the-innermost-content-column
   41-line-blocks-8
   12-inline-code-5

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -24390,3 +24390,108 @@ silently changing layout. The order of a valid pair remains author-independent.
 ```
 
 :::
+
+## A collected definition closes the item paragraph
+
+A link or footnote definition at an item's content column is an I5 block and
+ends the paragraph above it. A following nonzero line below that column has no
+paragraph to continue, so the item closes; §24 C3 reserves that path for a
+comment. Here column 1 is below the bullet's content column 2.
+
+::: compare
+
+```carve
+- a
+  [r]: /u
+ more
+tail
+```
+
+```html
+<ul>
+  <li>a</li>
+</ul>
+<p>more
+tail</p>
+```
+
+:::
+
+The bare decimal-dot marker claims the same two columns as the bullet, so it
+has the same boundary rather than the three-column boundary of `1. `.
+
+::: compare
+
+```carve
+. a
+  [r]: /u
+ more
+tail
+```
+
+```html
+<ol>
+  <li>a</li>
+</ol>
+<p>more
+tail</p>
+```
+
+:::
+
+A footnote body begins two columns beyond its definition. For `1. ` the
+definition is at column 3 and its body at column 5; column 4 is item prose, so
+it reopens the paragraph and the flush-left line folds into it.
+
+::: compare
+
+```carve
+1. a
+   [^f]: note
+    more
+tail
+```
+
+```html
+<ol>
+  <li>a
+    more
+tail
+  </li>
+</ol>
+```
+
+:::
+
+At the body column the line remains part of the footnote block and opens no
+item paragraph. The flush-left line is consequently outside the item.
+
+::: compare
+
+```carve
+- a
+  [^f]: note
+    more
+tail
+
+see[^f]
+```
+
+```html
+<ul>
+  <li>a</li>
+</ul>
+<p>tail</p>
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note
+more<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+:::

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -4683,6 +4683,16 @@ EOF = (* end of file *) ;
          exception in §24 C3: their invisibility is accepted independently of
          column and they do not by themselves close the item. Pinned by corpus
          287-a-column-zero-definition-ends-an-open-list-item (carve#1045).
+
+         A DEFINITION COLLECTED AT content_column ENDS THE ITEM'S OPEN
+         PARAGRAPH. The next nonblank line therefore stays in the item only if
+         it reaches content_column and opens item prose, except that a footnote
+         line reaching content_column + 2 belongs to the definition body and
+         leaves no item paragraph open. A line one column short of that body is
+         item prose. The comment exception above does not extend to definitions.
+         The bare decimal-dot marker `. ` claims one marker column and one
+         separator column, so its content_column is the same as `- `. Pinned
+         by corpus 374 (carve#1376).
       I6 SCOPE + THE HEADING EXCEPTION. The relation applies to EVERY open
          paragraph, including a blockquote's lazy continuation: "> quoted
          \n - item" folds into ONE quote whose paragraph is

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -3406,11 +3406,16 @@ function collectItems(lines, i, list, state, ind, meas) {
          * ended the item and `- a` / `  [^f]: t` / `    more` / `tail` folded.
          * carve-rs answers both the same; carve-js and carve-php answer neither.
          *
-         * `defBodyIndent` is the definition line's own column, so a line at or
-         * below it is a sibling of the definition rather than its body and
-         * takes the branches above instead.
+         * `defBodyIndent` is the definition line's own column. The footnote
+         * body's column is two columns beyond it, so a line in the intervening
+         * band is the item's prose rather than definition content
+         * (markup-carve/carve#1376).
          */
-        else if (defBody !== null && dmeas.col > defBody && dmeas.rest !== '') {
+        else if (
+          defBody !== null &&
+          dmeas.col >= defBody + FOOTNOTE_BODY_COLUMN &&
+          dmeas.rest !== ''
+        ) {
           closePara()
           defBodyIndent = defBody
         }

--- a/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-2.crv
+++ b/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-2.crv
@@ -1,0 +1,4 @@
+. a
+  [r]: /u
+ more
+tail

--- a/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-2.html
+++ b/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-2.html
@@ -1,0 +1,5 @@
+<ol>
+  <li>a</li>
+</ol>
+<p>more
+tail</p>

--- a/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-3.crv
+++ b/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-3.crv
@@ -1,0 +1,4 @@
+1. a
+   [^f]: note
+    more
+tail

--- a/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-3.html
+++ b/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-3.html
@@ -1,0 +1,6 @@
+<ol>
+  <li>a
+    more
+tail
+  </li>
+</ol>

--- a/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-4.crv
+++ b/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-4.crv
@@ -1,0 +1,6 @@
+- a
+  [^f]: note
+    more
+tail
+
+see[^f]

--- a/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-4.html
+++ b/tests/corpus/374-a-collected-definition-closes-the-item-paragraph-4.html
@@ -1,0 +1,14 @@
+<ul>
+  <li>a</li>
+</ul>
+<p>tail</p>
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note
+more<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>

--- a/tests/corpus/374-a-collected-definition-closes-the-item-paragraph.crv
+++ b/tests/corpus/374-a-collected-definition-closes-the-item-paragraph.crv
@@ -1,0 +1,4 @@
+- a
+  [r]: /u
+ more
+tail

--- a/tests/corpus/374-a-collected-definition-closes-the-item-paragraph.html
+++ b/tests/corpus/374-a-collected-definition-closes-the-item-paragraph.html
@@ -1,0 +1,5 @@
+<ul>
+  <li>a</li>
+</ul>
+<p>more
+tail</p>

--- a/tests/spec/374-a-collected-definition-closes-the-item-paragraph.test
+++ b/tests/spec/374-a-collected-definition-closes-the-item-paragraph.test
@@ -1,0 +1,65 @@
+A collected definition closes the item paragraph
+
+```
+- a
+  [r]: /u
+ more
+tail
+.
+<ul>
+  <li>a</li>
+</ul>
+<p>more
+tail</p>
+```
+
+```
+. a
+  [r]: /u
+ more
+tail
+.
+<ol>
+  <li>a</li>
+</ol>
+<p>more
+tail</p>
+```
+
+```
+1. a
+   [^f]: note
+    more
+tail
+.
+<ol>
+  <li>a
+    more
+tail
+  </li>
+</ol>
+```
+
+```
+- a
+  [^f]: note
+    more
+tail
+
+see[^f]
+.
+<ul>
+  <li>a</li>
+</ul>
+<p>tail</p>
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a></p>
+<section role="doc-endnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>note
+more<a href="#fnref1" role="doc-backlink">↩</a></p>
+    </li>
+  </ol>
+</section>
+```


### PR DESCRIPTION
Closes #1376.

## Ruling

- a definition collected at an item content column ends the open item paragraph
- only comments retain the nonzero below-column continuation exception
- item prose reopens at the content column; a footnote body starts two columns beyond its definition
- the bare decimal-dot marker has the same content column as a bullet

## Coverage

Corpus 374 adds four discriminating cases. The executable spec reproduces all 1,282 corpus pairs, and the merged carve-js pin reproduces every new #1376 case. The one aggregate engine-report mismatch is the pre-existing corpus 373/table-alignment coordination currently tracked by carve-js #1219.

Implementations merged in markup-carve/carve-js#1217, markup-carve/carve-php#1476, and markup-carve/carve-rs#1128.