### PR TITLE
Pin horizontal-first reference engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#e46188aa5b17f169027c79d7ff4736dbce62b0e9",
+        "@markup-carve/carve": "github:markup-carve/carve-js#447e5770d549e9dc4395ff220008e0c83b588a11",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#e46188aa5b17f169027c79d7ff4736dbce62b0e9",
-      "integrity": "sha512-kbHBj8HcKndoenXUVoqL2od+Aw6cT0RAE2oRhB2w5OLWevAdUsCwiVcf5j/iigMo7t55V57qYNMxiMKm+0L9lA==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#447e5770d549e9dc4395ff220008e0c83b588a11",
+      "integrity": "sha512-pgba9E3YDOlRGSVCbESyu7pg9x6BFoivfuytvWn71z1FwB7lvjzwjNMxYYLbhiKE102PxJ1VWRjb7R/nYpOPnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#e46188aa5b17f169027c79d7ff4736dbce62b0e9",
+    "@markup-carve/carve": "github:markup-carve/carve-js#447e5770d549e9dc4395ff220008e0c83b588a11",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,4 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-373-a-vertical-table-marker-needs-a-horizontal-partner  the pinned carve-js build still accepts reverse-order vertical-horizontal table alignment pairs


### PR DESCRIPTION
## Summary

- pin the merged JavaScript implementation of horizontal-first table alignment pairs
- remove the now-stale temporary drift declaration for corpus case 373

## Verification

- `npm run engine:report -- --check` — 1,282/1,282 reproduced, zero drift
- `npm run core:check` — 1,282/1,282 conformant, zero defects
