### PR TITLE
Normalize list-table row-group formatting

### DIFF
--- a/tests/corpus-optional/42-list-table-header-rows-cols.html
+++ b/tests/corpus-optional/42-list-table-header-rows-cols.html
@@ -1,7 +1,5 @@
 <table>
-  <thead>
-    <tr><th scope="col">Region</th><th scope="col">Q1</th></tr>
-  </thead>
+  <thead><tr><th scope="col">Region</th><th scope="col">Q1</th></tr></thead>
   <tbody>
     <tr><th scope="row">EMEA</th><td>10</td></tr>
   </tbody>

--- a/tests/corpus-optional/42-list-table-header-rows-cols.html
+++ b/tests/corpus-optional/42-list-table-header-rows-cols.html
@@ -1,5 +1,7 @@
 <table>
-  <thead><tr><th scope="col">Region</th><th scope="col">Q1</th></tr></thead>
+  <thead>
+    <tr><th scope="col">Region</th><th scope="col">Q1</th></tr>
+  </thead>
   <tbody>
     <tr><th scope="row">EMEA</th><td>10</td></tr>
   </tbody>

--- a/tests/corpus-optional/44-list-table-columns-and-foot.html
+++ b/tests/corpus-optional/44-list-table-columns-and-foot.html
@@ -3,9 +3,13 @@
     <col style="width: 30%;">
     <col style="width: 70%;">
   </colgroup>
-  <thead><tr><th scope="col" style="text-align: left; vertical-align: top;">Region</th><th scope="col" style="text-align: right; vertical-align: bottom;">Total</th></tr></thead>
+  <thead>
+    <tr><th scope="col" style="text-align: left; vertical-align: top;">Region</th><th scope="col" style="text-align: right; vertical-align: bottom;">Total</th></tr>
+  </thead>
   <tbody>
     <tr><td style="text-align: left; vertical-align: top;">North</td><td style="text-align: right; vertical-align: bottom;">11</td></tr>
   </tbody>
-  <tfoot><tr><td style="text-align: left; vertical-align: top;">All</td><td style="text-align: right; vertical-align: bottom;">33</td></tr></tfoot>
+  <tfoot>
+    <tr><td style="text-align: left; vertical-align: top;">All</td><td style="text-align: right; vertical-align: bottom;">33</td></tr>
+  </tfoot>
 </table>

--- a/tests/corpus-optional/44-list-table-columns-and-foot.html
+++ b/tests/corpus-optional/44-list-table-columns-and-foot.html
@@ -3,9 +3,7 @@
     <col style="width: 30%;">
     <col style="width: 70%;">
   </colgroup>
-  <thead>
-    <tr><th scope="col" style="text-align: left; vertical-align: top;">Region</th><th scope="col" style="text-align: right; vertical-align: bottom;">Total</th></tr>
-  </thead>
+  <thead><tr><th scope="col" style="text-align: left; vertical-align: top;">Region</th><th scope="col" style="text-align: right; vertical-align: bottom;">Total</th></tr></thead>
   <tbody>
     <tr><td style="text-align: left; vertical-align: top;">North</td><td style="text-align: right; vertical-align: bottom;">11</td></tr>
   </tbody>


### PR DESCRIPTION
Multi-row list-table footers are currently collapsed onto one long line even though body rows are emitted one per line. This updates the optional corpus fixture so each footer row is indented on its own line.

This branch also incorporates the local ListTable header specification commit already pinned by the merged JS and Rust implementation PRs, so downstream spec pointers have a single descendant commit.

The footer change is serialization-only; the HTML table structure does not change.