### PR TITLE
Specify ListTable local headers and body groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ tested against, and the design rationale behind each decision.
 | | |
 |---|---|
 | **Specification** | 0.1. Tier-1 core and Tier-2 standard extensions are normative and stable; Tier-3 app-level extensions ship but evolve. See [VERSIONING.md](VERSIONING.md). |
-| **Conformance** | Over 1,250 corpus examples pinning exact HTML output, plus 44 optional-corpus examples for host-dependent extensions. |
+| **Conformance** | Over 1,250 corpus examples pinning exact HTML output, plus 45 optional-corpus examples for host-dependent extensions. |
 | **Engines** | [carve-js](https://github.com/markup-carve/carve-js) (TypeScript, reference), [carve-php](https://github.com/markup-carve/carve-php), [carve-rs](https://github.com/markup-carve/carve-rs) - all three run the same corpus, with no open or intentional divergences ([tracker](MAINTAINING.md#known-cross-impl-divergences)). |
 | **Bindings** | Python, Ruby, Go, and WebAssembly, all over carve-rs. |
 | **Tooling** | Language server, tree-sitter grammar, formatter and linter (`carve fmt` / `carve lint`), converters from Markdown, HTML, Djot, and BBCode. |

--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -86,8 +86,10 @@ It holds **counts, never rows**: the counts consume `rows` in order and have to
 account for every row exactly once, so the grouping can never contradict the
 table's content. `rows` stays the one sequence every consumer reads. Absent
 means the implicit structure renderers already derive - a leading run of header
-rows as the head, everything after it as one body, no foot - so a parser never
-synthesizes the field and no existing tree changes shape. Like `shortCaption`,
+rows as the head, everything after it as one body, no foot. Core pipe-table
+parsers do not synthesize the field; ListTable-aware converters may synthesize
+the head, header-led body groups, foot and row-header columns its attributes
+spell. Partitions without those landmarks remain interchange-only. Like `shortCaption`,
 it exists so a richer table model (several `tbody` groups, a group's own
 intermediate header rows, a foot, a count of leading row-header columns)
 survives a format bridge; HTML, plain and ANSI output ignore it and keep

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -542,6 +542,14 @@ and carve-rs; off by default, enable per processor.
   row-header `<th>` (default 0).
 - `{footer-rows=N}` makes the final N rows a table foot. Header and footer
   counts together may not exceed the row count.
+- A boolean `{header-row}` attribute abutting the first inner cell marker
+  (`- -{header-row} Cell`) starts a body group whose leading marked rows are column
+  headers. The marker travels with the row, so inserting rows cannot silently
+  retarget it. Consecutive marked rows form one group's header; a later marked
+  row starts the next `<tbody>`.
+- A boolean `{header}` on an inner cell marker (`  -{header} Cell`)
+  promotes that individual cell to `<th>`. A body-row header defaults to
+  `scope="row"`; a cell in a header row defaults to `scope="col"`.
 - `{aligns="left,right"}`, `{valigns="top,bottom"}`, and `{widths="30,70"}`
   use the same positional,
   comma-separated column lists as core pipe tables. Empty entries are unset;
@@ -566,7 +574,8 @@ and carve-rs; off by default, enable per processor.
   `rowspan`/`colspan` wins over an author-written one.
 - The `<table>` output matches the equivalent pipe table's span markup.
 - A foot renders as `<tfoot>` and maps to `rowGroups.footRows` in the exchange
-  AST. Column alignment resolves into cell styles and
+  AST. Intermediate marked headers map to `rowGroups.bodies[].headRows`, and
+  explicitly marked cells map to `table_cell.header`. Column alignment resolves into cell styles and
   widths render through `<colgroup>`/`<col>` before the row groups.
 - Multiple body groups remain exchange-AST metadata. ListTable has one body
   list, so a canonical source writer flattens `rowGroups.bodies` into that body
@@ -582,18 +591,17 @@ byte-identical to the plain div.
 
 ### 5.4 Conformance (`tests/corpus-optional`)
 
-Tier-2, so not in the mandatory corpus: case `26-list-table-caption-inline` pins
-the caption's inline markup in `tests/corpus-optional`, run per §3 whenever the
-feature is enabled. The rest of the contract is cross-impl parity: for a
-given input the three implementations produce the same `<table>`, and spans match
-the equivalent pipe table. Each implementation pins that in its own test suite
-(block cells, caption, header rows/cols, spans, escape, ragged padding, the
-no-cell-row defer, and the thead/tbody rowspan clamp).
+Tier-2, so not in the mandatory corpus. The shared optional corpus pins the
+caption (case 26), leading header rows/columns (42), column metadata and the
+foot (44), and local row/cell headers (45); run it per §3 whenever the feature
+is enabled. The three implementations additionally pin malformed degradation,
+spans, ragged padding, and row-group boundary clamping in their own suites.
 
 ### 5.5 Out of scope (impls MAY differ)
 
-- Multiple independently authored body groups remain exchange-AST-only; no
-  ListTable source spelling is defined for them.
+- Empty body-group boundaries with no header row remain exchange-AST-only;
+  `{header-row}` spells the useful independently authored groups that begin with
+  one or more intermediate header rows.
 - Deeply ambiguous overlapping-span soup (a marker glued to another, or a `^`
   inside the interior of an existing merged rectangle) resolves however the
   native pipe-table grid walk resolves it; not pinned.

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -814,7 +814,7 @@ came to say 4 when the corpus held 33.
 
 ```text
 Implementation summary
-profile=optional/opt-in corpus=optional corpus_pairs=42 targets=html,markdown,plain,ansi
+profile=optional/opt-in corpus=optional corpus_pairs=43 targets=html,markdown,plain,ansi
 rust: pass=12/12 mismatch=0 error=0 skipped=29 runs=12 avg_ms=5.21
 js: pass=42/42 mismatch=0 error=0 skipped=0 runs=42 avg_ms=157.43
 php: pass=39/39 mismatch=0 error=0 skipped=2 runs=39 avg_ms=103.44

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#447e5770d549e9dc4395ff220008e0c83b588a11",
+        "@markup-carve/carve": "github:markup-carve/carve-js#329a1492d40bdcd28cecafbfb35584dcd5e25ff4",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#447e5770d549e9dc4395ff220008e0c83b588a11",
-      "integrity": "sha512-pgba9E3YDOlRGSVCbESyu7pg9x6BFoivfuytvWn71z1FwB7lvjzwjNMxYYLbhiKE102PxJ1VWRjb7R/nYpOPnw==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#329a1492d40bdcd28cecafbfb35584dcd5e25ff4",
+      "integrity": "sha512-5xkdB207hgMxoKlVy/GlKGKcNnUb05oq0dVvKmXp9jd7f2FmmVyod8s6u+zQTw76wmaFCAq8oHYrxNCT0XjpAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#447e5770d549e9dc4395ff220008e0c83b588a11",
+    "@markup-carve/carve": "github:markup-carve/carve-js#329a1492d40bdcd28cecafbfb35584dcd5e25ff4",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -2750,7 +2750,7 @@
         },
         "columns": {
           "type": "array",
-          "description": "Optional positional column metadata imported from or destined for a richer table model. Entry N describes column N; the array MAY be shorter than the widest row. A cell's explicit value wins over the corresponding column value. Carve 0.1 source has no spelling for this field, so source parsers do not synthesize it.",
+          "description": "Optional positional column metadata imported from, authored through table-level aligns/valigns/widths attributes, or destined for a richer table model. Entry N describes column N; the array MAY be shorter than the widest row. A cell's explicit value wins over the corresponding column value.",
           "items": {
             "type": "object",
             "properties": {
@@ -2782,7 +2782,7 @@
         },
         "rowGroups": {
           "type": "object",
-          "description": "Optional explicit head/body/foot partition of `rows`, imported from or destined for a format whose table model has one. It PARTITIONS `rows` and never repeats them: the counts consume `rows` in order, head first, then each body, then the foot, and they MUST account for every row exactly once. Carve 0.1 source has no spelling for this field; absent means the implicit structure every renderer already derives - the leading run of header rows as the head, everything after it as one body, no foot, no row-head columns. HTML, plain and ANSI output ignore it.",
+          "description": "Optional explicit head/body/foot partition of `rows`, imported from or destined for a format whose table model has one. It PARTITIONS `rows` and never repeats them: the counts consume `rows` in order, head first, then each body, then the foot, and they MUST account for every row exactly once. ListTable can author a leading head, header-led body groups, a foot, and leading row-header columns; partitions without those source landmarks remain interchange-only. Absent means the implicit structure every renderer already derives.",
           "required": [
             "headRows",
             "bodies",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,4 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-375-a-table-cell-can-inherit-horizontal-alignment  the pinned carve-js build predates the horizontal-inheritance placeholder

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -10384,9 +10384,10 @@ EOF = (* end of file *) ;
       a table whose rows are all head and foot is a partition like any other,
       and refusing it would make a head-only table the one shape the field
       cannot describe. It is the representation of a
-      table model richer than the one Carve source can spell: several body
+      table model richer than a core pipe table can spell: several body
       groups, a group's own intermediate header rows, a foot, and a count of
-      leading row-header columns per group.
+      leading row-header columns per group. The standard ListTable extension
+      spells the useful header-led groups, foot and leading row headers.
 
       IT PARTITIONS `rows`; IT DOES NOT REPEAT THEM. `rowGroups` holds counts,
       never row nodes. The counts consume `rows` in order -- `headRows` first,
@@ -10418,16 +10419,15 @@ EOF = (* end of file *) ;
       ABSENT MEANS TODAY'S STRUCTURE, and this is why the field breaks nothing:
       a table without `rowGroups` has the implicit partition every renderer
       already derives -- the leading run of header rows as the head, everything
-      after it as one body, no foot, no row-head columns. A parser therefore
-      never synthesizes the field, since Carve 0.1 source has no spelling that
-      would distinguish those cases, and it need not: the implicit reading is
-      already correct for every table a source document can produce.
+      after it as one body, no foot, no row-head columns. A CORE PIPE-TABLE
+      parser therefore never synthesizes the field; a ListTable-aware converter
+      MAY synthesize the explicit partition its extension attributes spell.
 
-      CARVE 0.1 SOURCE HAS NO SPELLING FOR THIS FIELD. Like `shortCaption` in
-      §14, it enters a tree through an AST consumer or a format bridge and
-      survives AST encode/decode by §6. Being able to REPRESENT a grouping is
-      not being able to AUTHOR one: core pipe tables do not grow a second
-      separator language for it.
+      CORE PIPE-TABLE SOURCE HAS NO SPELLING FOR THIS FIELD. Like
+      `shortCaption` in §14, richer partitions may enter through an AST consumer
+      or format bridge and survive AST encode/decode by §6. The ListTable
+      extension authors a leading head, header-led body groups, a foot and
+      leading row-header columns; empty group boundaries remain interchange-only.
 
       ORDINARY HTML, PLAIN AND ANSI OUTPUT IGNORE `rowGroups`. They keep
       rendering the flat `rows` exactly as they do now, which flattens the

--- a/resources/optional-example-pages.txt
+++ b/resources/optional-example-pages.txt
@@ -13,6 +13,7 @@ order: 1
   details
   list-table
   list-table-columns-1344
+  list-table-local-headers-1248
   spoiler
   tabs
   semantic-span

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -221,6 +221,7 @@ const PLAIN_EXTENSION_FEATURES = {
   spoiler: { js: 'spoiler', php: 'SpoilerExtension' },
   tabs: { js: 'tabs', php: 'TabsExtension' },
   'list-table': { js: 'listTable', php: 'ListTableExtension' },
+  'list-table-local-headers-1248': { js: 'listTable', php: 'ListTableExtension' },
   // PART 9 §10. Registered by name here so the adapter check can see it; the
   // engines do not ship it yet, so the run reports it unreached rather than
   // silently skipping a feature nobody declared.

--- a/scripts/generate-example-pages.mjs
+++ b/scripts/generate-example-pages.mjs
@@ -273,6 +273,7 @@ const optionalTitle = new Map([
   ['details', 'Details'],
   ['list-table', 'ListTable'],
   ['list-table-columns-1344', 'ListTable column metadata and footer rows'],
+  ['list-table-local-headers-1248', 'ListTable local headers and body groups'],
   ['spoiler', 'Spoiler'],
   ['tabs', 'Tabs'],
   ['semantic-span', 'SemanticSpan'],

--- a/tests/corpus-optional/45-list-table-local-headers.crv
+++ b/tests/corpus-optional/45-list-table-local-headers.crv
@@ -1,0 +1,10 @@
+::: list-table
+- -{header-row} Name
+  - Value
+- - Alpha
+  - 1
+- -{header-row} Name again
+  - Value again
+- - Beta
+  -{header} Total
+:::

--- a/tests/corpus-optional/45-list-table-local-headers.html
+++ b/tests/corpus-optional/45-list-table-local-headers.html
@@ -1,0 +1,10 @@
+<table>
+  <tbody>
+    <tr><th scope="col">Name</th><th scope="col">Value</th></tr>
+    <tr><td>Alpha</td><td>1</td></tr>
+  </tbody>
+  <tbody>
+    <tr><th scope="col">Name again</th><th scope="col">Value again</th></tr>
+    <tr><td>Beta</td><th scope="row">Total</th></tr>
+  </tbody>
+</table>

--- a/tests/corpus-optional/manifest.json
+++ b/tests/corpus-optional/manifest.json
@@ -228,6 +228,11 @@
       "slug": "44-list-table-columns-and-foot",
       "feature": "list-table-columns-1344",
       "description": "ListTable shares the core positional column attributes and adds footer-rows; alignment, widths and the head/body/foot partition survive together."
+    },
+    {
+      "slug": "45-list-table-local-headers",
+      "feature": "list-table-local-headers-1248",
+      "description": "A header-row attribute on a row's first cell starts a body group with an intermediate column-header row; a header attribute promotes only its own cell."
     }
   ]
 }

--- a/tests/optional-corpus.test.mjs
+++ b/tests/optional-corpus.test.mjs
@@ -122,6 +122,7 @@ const featureRunners = {
   'code-callouts': (source, render) => render(source, { extensions: [codeCallouts()] }),
   details: (source, render) => render(source, { extensions: [details()] }),
   'list-table': (source, render) => render(source, { extensions: [listTable()] }),
+  'list-table-local-headers-1248': (source, render) => render(source, { extensions: [listTable()] }),
   'semantic-span': (source, render) => render(source, { extensions: [semanticSpan()] }),
   spoiler: (source, render) => render(source, { extensions: [spoiler()] }),
   tabs: (source, render) => render(source, { extensions: [tabs()] }),

--- a/tests/optional-feature-adapters.test.mjs
+++ b/tests/optional-feature-adapters.test.mjs
@@ -123,6 +123,7 @@ const DECLARED_UNREACHABLE = {
   'rust:code-callouts': 'no CLI flag for the code-callouts extension',
   'rust:details': 'no CLI flag for the details extension',
   'rust:list-table': 'no CLI flag for the list-table extension',
+  'rust:list-table-local-headers-1248': 'no CLI flag for the list-table extension',
   'rust:semantic-span': 'no CLI flag for the semantic-span extension',
   'rust:spoiler': 'no CLI flag for the spoiler extension',
   'rust:tabs': 'no CLI flag for the tabs extension',


### PR DESCRIPTION
## Summary

- define `header-row` on the first ListTable cell as a header-led body-group boundary
- define `header` on an individual ListTable cell as a local row header
- require structural markers to be bare and consume them during rendering
- clamp row spans at every table section and body-group boundary
- correct stale schema, grammar, and AST documentation that still described implemented table metadata as source-unspellable
- add an optional conformance case covering two body groups and a local header cell

## Implementations

- JavaScript: markup-carve/carve-js#1220
- PHP: markup-carve/carve-php#1479
- Rust: markup-carve/carve-rs#1130
- Pandoc bridge: markup-carve/pandoc-carve#115

Closes #1248.
Closes #1337.
