### PR TITLE
Specify semantic table row partitions

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -86,14 +86,15 @@ It holds **counts, never rows**: the counts consume `rows` in order and have to
 account for every row exactly once, so the grouping can never contradict the
 table's content. `rows` stays the one sequence every consumer reads. Absent
 means the implicit structure renderers already derive - a leading run of header
-rows as the head, everything after it as one body, no foot. Core pipe-table
-parsers do not synthesize the field; ListTable-aware converters may synthesize
-the head, header-led body groups, foot and row-header columns its attributes
-spell. Partitions without those landmarks remain interchange-only. Like `shortCaption`,
+rows as the head, everything after it as one body, no foot. Pipe-table parsers
+synthesize the simple partition spelled by `header-rows` / `footer-rows`, and
+ListTable-aware converters may additionally synthesize header-led body groups
+and row-header columns. Partitions without those landmarks remain
+interchange-only. Like `shortCaption`,
 it exists so a richer table model (several `tbody` groups, a group's own
 intermediate header rows, a foot, a count of leading row-header columns)
-survives a format bridge; HTML, plain and ANSI output ignore it and keep
-flattening the table on the way out.
+survives a format bridge. HTML renders source-spelled head/foot ranges;
+plain and ANSI keep flattening the table.
 
 A `table` may also carry an optional positional `columns` array (§19). Each
 entry describes the corresponding column and may hold `align` (`left`, `right`

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -154,6 +154,8 @@ horizontal marker may stand alone; a vertical marker always needs a horizontal
 partner. The run is glued to the pipe and terminated by a space. On `|=` it sets
 column defaults; on a plain `|` it overrides that cell. Table attributes can
 set headerless defaults: `{aligns="right,center" valigns="top," widths="30,70"}`.
+Use `{header-rows=N footer-rows=N}` before a pipe table for explicit
+`thead`/`tfoot` ranges; `|=` header cells still work in the body.
 
 ```carve
 |=~ Item |=>^ Qty |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -556,6 +556,11 @@ and carve-rs; off by default, enable per processor.
   too many entries is an error, while a short list renders with an unset tail
   and produces a lint diagnostic. Widths are percentages in source and
   fractional values in the exchange AST.
+- A cell marker may carry `align=left|right|center` and/or
+  `valign=top|middle|bottom` (for example,
+  `-{align=center valign=middle} Cell`). Each cell value overrides the matching
+  positional column value independently and is consumed rather than emitted as
+  a legacy HTML attribute.
 - Spans reuse the pipe-table span markers: a cell whose sole content is a lone
   `^` merges with the cell above (rowspan); a lone `<` merges with the cell to
   the left (colspan); continuation-style (`colspan=3` is two `<`, `rowspan=N` is

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -21,15 +21,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>709 / 711</strong>
+    <strong>710 / 712</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>709 / 711</strong>
+    <strong>710 / 712</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>709 / 711</strong>
+    <strong>710 / 712</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -40,9 +40,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `709 / 711` | `0` | `0` | `3.01` |
-| JS | `8105210` | `709 / 711` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `709 / 711` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `710 / 712` | `0` | `0` | `3.01` |
+| JS | `8105210` | `710 / 712` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `710 / 712` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 
@@ -753,7 +753,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=711 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=712 targets=html,markdown,plain,carve,ansi
 rust: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=3.01
   mismatching documents: 0
 js: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=76.02

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1283 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1284 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -231,7 +231,8 @@ carve-js pins carve-php's exact bytes as test fixtures.
 - [addition] Tables gain independent horizontal and vertical cell/column
   alignment, positional `aligns`/`valigns`/`widths` attributes, and an exchange
   AST `columns` model. ListTable gains the same column attributes plus
-  `footer-rows`.
+  per-cell `align`/`valign` and `footer-rows`; pipe tables gain explicit
+  `header-rows` / `footer-rows` partitioning.
 
 ### 0.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#329a1492d40bdcd28cecafbfb35584dcd5e25ff4",
+        "@markup-carve/carve": "github:markup-carve/carve-js#81a9ba1494c0809f38b813cfed0e612e8413d185",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#329a1492d40bdcd28cecafbfb35584dcd5e25ff4",
-      "integrity": "sha512-5xkdB207hgMxoKlVy/GlKGKcNnUb05oq0dVvKmXp9jd7f2FmmVyod8s6u+zQTw76wmaFCAq8oHYrxNCT0XjpAg==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#81a9ba1494c0809f38b813cfed0e612e8413d185",
+      "integrity": "sha512-S5egYPHUItQrWyiUmNLTy3Hag3FTP4F+XWCQ9fBORE53/Rt77yMVpMA6AeUjmzwpUmUMPGGOmeUcm5LoV5nGrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#81a9ba1494c0809f38b813cfed0e612e8413d185",
+        "@markup-carve/carve": "github:markup-carve/carve-js#1cc133662c5799ada5d12c3516a73e801505da97",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#81a9ba1494c0809f38b813cfed0e612e8413d185",
-      "integrity": "sha512-S5egYPHUItQrWyiUmNLTy3Hag3FTP4F+XWCQ9fBORE53/Rt77yMVpMA6AeUjmzwpUmUMPGGOmeUcm5LoV5nGrw==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#1cc133662c5799ada5d12c3516a73e801505da97",
+      "integrity": "sha512-kjXefQL1Xe6OqW2qw7+OAPEjkEktNrxImKqE4emAHH0ACBFDZ5uO2Mi1gpDiOUaBV8cw1wuz+b6H4mxVwJvOYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#329a1492d40bdcd28cecafbfb35584dcd5e25ff4",
+    "@markup-carve/carve": "github:markup-carve/carve-js#81a9ba1494c0809f38b813cfed0e612e8413d185",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#81a9ba1494c0809f38b813cfed0e612e8413d185",
+    "@markup-carve/carve": "github:markup-carve/carve-js#1cc133662c5799ada5d12c3516a73e801505da97",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -199,6 +199,7 @@ index: examples/edge-cases/index.md
   a-table-alignment-run-carries-two-independent-axes
   a-vertical-table-marker-needs-a-horizontal-partner
   a-table-cell-can-inherit-horizontal-alignment
+  pipe-tables-can-state-head-and-foot-row-counts
   table-cell-escaped-pipe
   table-cell-pipe-inside-code-span
   an-unclosed-verbatim-run-in-a-row-stops-at-the-closing-pipe

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -24526,3 +24526,30 @@ marker of `?^`, `?~`, or `?v`; every other use stays visible content.
 ```
 
 :::
+
+## Pipe tables can state head and foot row counts
+
+The explicit counts partition the rows. Rows in the explicit head are promoted
+to column headers; a native `|=` cell in the body remains a row header.
+
+::: compare
+
+```carve
+{header-rows=2 footer-rows=1}
+| Region | Q1 |
+| Detail | EUR |
+|= North | 11 |
+| All | 33 |
+```
+
+```html
+<table>
+  <thead><tr><th scope="col">Region</th><th scope="col">Q1</th></tr><tr><th scope="col">Detail</th><th scope="col">EUR</th></tr></thead>
+  <tbody>
+    <tr><th scope="row">North</th><td>11</td></tr>
+  </tbody>
+  <tfoot><tr><td>All</td><td>33</td></tr></tfoot>
+</table>
+```
+
+:::

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -10419,24 +10419,30 @@ EOF = (* end of file *) ;
       ABSENT MEANS TODAY'S STRUCTURE, and this is why the field breaks nothing:
       a table without `rowGroups` has the implicit partition every renderer
       already derives -- the leading run of header rows as the head, everything
-      after it as one body, no foot, no row-head columns. A CORE PIPE-TABLE
-      parser therefore never synthesizes the field; a ListTable-aware converter
-      MAY synthesize the explicit partition its extension attributes spell.
+      after it as one body, no foot, no row-head columns.
 
-      CORE PIPE-TABLE SOURCE HAS NO SPELLING FOR THIS FIELD. Like
-      `shortCaption` in §14, richer partitions may enter through an AST consumer
-      or format bridge and survive AST encode/decode by §6. The ListTable
+      A pipe table's preceding block-attribute line MAY carry
+      `header-rows=N` and/or `footer-rows=N`. An empty boolean value means one;
+      otherwise N MUST be a non-negative decimal integer, and the two counts
+      MUST NOT exceed the number of rows. The parser synthesizes one body group
+      holding all rows between them. Explicit header rows promote every cell in
+      those rows to a column-header cell; native `|=` cells outside that head
+      remain header cells and default to row scope. The attributes are consumed
+      in HTML, where the three ranges render as `thead`, `tbody`, and `tfoot`.
+
+      CORE PIPE-TABLE SOURCE CANNOT SPELL multiple bodies, intermediate body
+      headers, or per-group row-head counts. Those richer partitions may enter
+      through an AST consumer or format bridge and survive AST encode/decode by
+      §6. The ListTable
       extension authors a leading head, header-led body groups, a foot and
       leading row-header columns; empty group boundaries remain interchange-only.
 
-      ORDINARY HTML, PLAIN AND ANSI OUTPUT IGNORE `rowGroups`. They keep
-      rendering the flat `rows` exactly as they do now, which flattens the
-      grouping on the way out; that degradation is deliberate and is the point
-      of holding the structure in the model rather than in the output. A
-      structured exporter MAY map the partition to its target's equivalent. A
-      canonical Carve source writer MUST omit the field, MUST NOT invent source
-      syntax for it, and MUST NOT drop or reorder rows to suit it. A bridge or
-      API which exposes conversion diagnostics SHOULD report the loss.
+      HTML maps a source-spelled head and foot to their native row-group
+      elements. Plain and ANSI keep rendering the flat rows. A structured
+      exporter MAY map the full partition to its target's equivalent. A
+      canonical Carve source writer retains `header-rows` / `footer-rows` when
+      they are present in table attributes; it MUST NOT invent a spelling for
+      richer grouping or drop/reorder rows to suit it.
 
    16. A COMPOSITE FIGURE IS ITS OWN NODE TYPE -- NORMATIVE (PART 9 §4c;
       carve#1122). The type is `figure_group`, and the wire shape:
@@ -10634,6 +10640,13 @@ EOF = (* end of file *) ;
       then unset. Supplying two column-level spellings for one field lints and
       the in-table spelling wins. Existing header markers and delimiter colons
       keep their tree and output; attributes fill only facts they do not state.
+
+      LISTTABLE CELL SPELLING. Because a ListTable cell is a list item, its
+      marker attribute MAY carry `align=left|right|center` and/or
+      `valign=top|middle|bottom`. These values populate the corresponding
+      `table_cell` fields and override the positional column value independently.
+      They are consumed as semantics and MUST NOT also appear as literal HTML
+      `align` or `valign` attributes.
 
       THE WRITER RETAINS THE MOST LOCAL AVAILABLE SPELLING. A headed table
       keeps native column markers. A headerless aligned table emits `aligns`.

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -221,6 +221,7 @@ const PLAIN_EXTENSION_FEATURES = {
   spoiler: { js: 'spoiler', php: 'SpoilerExtension' },
   tabs: { js: 'tabs', php: 'TabsExtension' },
   'list-table': { js: 'listTable', php: 'ListTableExtension' },
+  'list-table-columns-1344': { js: 'listTable', php: 'ListTableExtension' },
   'list-table-local-headers-1248': { js: 'listTable', php: 'ListTableExtension' },
   // PART 9 §10. Registered by name here so the adapter check can see it; the
   // engines do not ship it yet, so the run reports it unreached rather than
@@ -258,8 +259,6 @@ const PLAIN_EXTENSION_FEATURES = {
  * (carve#535).
  */
 const UNREACHABLE_REASONS = {
-  'list-table-columns-1344':
-    'carve#1344 column metadata and footer rows are specified ahead of all three engine implementations',
 }
 
 // Cases that ask an engine for the author's source runs instead of the glyph.

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -330,6 +330,9 @@ const impls = [
       if (SOURCE_TYPOGRAPHY_FEATURES.has(feature)) {
         return [...rustBaseCommand, '--smart-typography', 'source', ...flags]
       }
+      if (feature === 'list-table-columns-1344') {
+        return [...rustBaseCommand, '--extensions', ...flags]
+      }
       return null
     },
     hooks: [

--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -639,7 +639,7 @@ function renderTable(node, depth, ctx) {
   for (const list of node.battrs ?? []) {
     const keep = []
     for (const attr of list) {
-      if (attr[0] === 'kv' && ['aligns', 'valigns', 'widths'].includes(attr[1])) tableKeys.set(attr[1], attr[2])
+      if (attr[0] === 'kv' && ['aligns', 'valigns', 'widths', 'header-rows', 'footer-rows'].includes(attr[1])) tableKeys.set(attr[1], attr[2])
       else keep.push(attr)
     }
     if (keep.length) ordinaryAttrs.push(keep)
@@ -699,10 +699,24 @@ function renderTable(node, depth, ctx) {
       colValign[ci] = c.valign ?? colValign[ci] ?? null
     })
   }
-  let headCount = 0
-  while (headCount < rows.length && rows[headCount].isHead) headCount++
+  const rowCount = (key) => {
+    if (!tableKeys.has(key)) return 0
+    const value = String(tableKeys.get(key)).trim()
+    if (value === '') return 1
+    if (!/^\d+$/.test(value)) throw new Refuse(`invalid ${key} table attribute`)
+    return Number(value)
+  }
+  const explicitPartition = tableKeys.has('header-rows') || tableKeys.has('footer-rows')
+  let headCount = rowCount('header-rows')
+  const footCount = rowCount('footer-rows')
+  if (headCount + footCount > rows.length) throw new Refuse('table header and footer rows overlap')
+  if (!explicitPartition) {
+    while (headCount < rows.length && rows[headCount].isHead) headCount++
+  }
+  const footStart = rows.length - footCount
   const renderCell = (cell, r, c) => {
-    const tag = cell.header ? 'th' : 'td'
+    const isHeader = cell.header || r < headCount
+    const tag = isHeader ? 'th' : 'td'
     let a = ''
     // The cell's own block is parsed FIRST, only to see whether it names
     // `scope`. Emitting the default unconditionally and letting the authored
@@ -721,7 +735,7 @@ function renderTable(node, depth, ctx) {
     // attribute names are not, so emitting the default beside it produces two
     // `scope`s as far as any consumer is concerned. The test is about avoiding
     // that collision, not about folding the author's name.
-    if (cell.header && !/ scope="/i.test(parsed)) {
+    if (isHeader && !/ scope="/i.test(parsed)) {
       a += r < headCount ? ' scope="col"' : ' scope="row"'
     }
     if (cell.rowspan) a += ` rowspan="${cell.rowspan}"`
@@ -771,10 +785,14 @@ function renderTable(node, depth, ctx) {
     const headRows = rows.slice(0, headCount).map((row, r) => renderRow(row, r)).join('')
     out.push(`${pad}  <thead>${headRows}</thead>`)
   }
-  if (rows.length > bodyStart) {
+  if (footStart > bodyStart) {
     out.push(`${pad}  <tbody>`)
-    for (let r = bodyStart; r < rows.length; r++) out.push(`${pad}    ${renderRow(rows[r], r)}`)
+    for (let r = bodyStart; r < footStart; r++) out.push(`${pad}    ${renderRow(rows[r], r)}`)
     out.push(`${pad}  </tbody>`)
+  }
+  if (footStart < rows.length) {
+    const footRows = rows.slice(footStart).map((row, offset) => renderRow(row, footStart + offset)).join('')
+    out.push(`${pad}  <tfoot>${footRows}</tfoot>`)
   }
   out.push(`${pad}</table>`)
   return out.join('\n')

--- a/tests/corpus-optional/44-list-table-columns-and-foot.crv
+++ b/tests/corpus-optional/44-list-table-columns-and-foot.crv
@@ -2,7 +2,7 @@
 ::: list-table
 - - Region
   - Total
-- - North
+- -{align=center valign=middle} North
   - 11
 - - All
   - 33

--- a/tests/corpus-optional/44-list-table-columns-and-foot.html
+++ b/tests/corpus-optional/44-list-table-columns-and-foot.html
@@ -5,7 +5,7 @@
   </colgroup>
   <thead><tr><th scope="col" style="text-align: left; vertical-align: top;">Region</th><th scope="col" style="text-align: right; vertical-align: bottom;">Total</th></tr></thead>
   <tbody>
-    <tr><td style="text-align: left; vertical-align: top;">North</td><td style="text-align: right; vertical-align: bottom;">11</td></tr>
+    <tr><td style="text-align: center; vertical-align: middle;">North</td><td style="text-align: right; vertical-align: bottom;">11</td></tr>
   </tbody>
   <tfoot>
     <tr><td style="text-align: left; vertical-align: top;">All</td><td style="text-align: right; vertical-align: bottom;">33</td></tr>

--- a/tests/corpus-optional/manifest.json
+++ b/tests/corpus-optional/manifest.json
@@ -227,7 +227,7 @@
     {
       "slug": "44-list-table-columns-and-foot",
       "feature": "list-table-columns-1344",
-      "description": "ListTable shares the core positional column attributes and adds footer-rows; alignment, widths and the head/body/foot partition survive together."
+      "description": "ListTable shares positional column attributes and adds per-cell align/valign overrides; widths and the head/body/foot partition survive together."
     },
     {
       "slug": "45-list-table-local-headers",

--- a/tests/corpus/376-pipe-tables-can-state-head-and-foot-row-counts.crv
+++ b/tests/corpus/376-pipe-tables-can-state-head-and-foot-row-counts.crv
@@ -1,0 +1,5 @@
+{header-rows=2 footer-rows=1}
+| Region | Q1 |
+| Detail | EUR |
+|= North | 11 |
+| All | 33 |

--- a/tests/corpus/376-pipe-tables-can-state-head-and-foot-row-counts.html
+++ b/tests/corpus/376-pipe-tables-can-state-head-and-foot-row-counts.html
@@ -1,0 +1,7 @@
+<table>
+  <thead><tr><th scope="col">Region</th><th scope="col">Q1</th></tr><tr><th scope="col">Detail</th><th scope="col">EUR</th></tr></thead>
+  <tbody>
+    <tr><th scope="row">North</th><td>11</td></tr>
+  </tbody>
+  <tfoot><tr><td>All</td><td>33</td></tr></tfoot>
+</table>

--- a/tests/optional-corpus.test.mjs
+++ b/tests/optional-corpus.test.mjs
@@ -122,6 +122,7 @@ const featureRunners = {
   'code-callouts': (source, render) => render(source, { extensions: [codeCallouts()] }),
   details: (source, render) => render(source, { extensions: [details()] }),
   'list-table': (source, render) => render(source, { extensions: [listTable()] }),
+  'list-table-columns-1344': (source, render) => render(source, { extensions: [listTable()] }),
   'list-table-local-headers-1248': (source, render) => render(source, { extensions: [listTable()] }),
   'semantic-span': (source, render) => render(source, { extensions: [semanticSpan()] }),
   spoiler: (source, render) => render(source, { extensions: [spoiler()] }),
@@ -134,8 +135,6 @@ const featureRunners = {
  * here is a statement about this file, and fails.
  */
 const DECLARED_UNIMPLEMENTED = {
-  'list-table-columns-1344':
-    'markup-carve/carve#1344 column metadata and footer rows have not reached the pinned reference engine yet',
   'smart-quotes-locale-de':
     'locale quote selection is an implementation extension/configuration, not canonical Djot syntax',
 }

--- a/tests/schema-fields-are-produced.test.mjs
+++ b/tests/schema-fields-are-produced.test.mjs
@@ -65,8 +65,6 @@ const OPT_IN_ONLY = {
 const ENGINE_ROLLOUT_PENDING = {
   'figure.shortCaption': 'structural publishing field: Carve 0.1 source has no spelling; produced only by AST/Pandoc consumers',
   'table.shortCaption': 'structural publishing field: Carve 0.1 source has no spelling; produced only by AST/Pandoc consumers',
-  'table.rowGroups':
-    'structural exchange field (PART 12 §15): Carve 0.1 source has no spelling for a head/body/foot partition, and absent already means the implicit one, so a parser never synthesizes it; produced only by AST/format-bridge consumers',
 }
 
 /**

--- a/tests/spec/376-pipe-tables-can-state-head-and-foot-row-counts.test
+++ b/tests/spec/376-pipe-tables-can-state-head-and-foot-row-counts.test
@@ -1,0 +1,17 @@
+Pipe tables can state head and foot row counts
+
+```
+{header-rows=2 footer-rows=1}
+| Region | Q1 |
+| Detail | EUR |
+|= North | 11 |
+| All | 33 |
+.
+<table>
+  <thead><tr><th scope="col">Region</th><th scope="col">Q1</th></tr><tr><th scope="col">Detail</th><th scope="col">EUR</th></tr></thead>
+  <tbody>
+    <tr><th scope="row">North</th><td>11</td></tr>
+  </tbody>
+  <tfoot><tr><td>All</td><td>33</td></tr></tfoot>
+</table>
+```


### PR DESCRIPTION
Coordinates the new table semantics across the spec and executable corpus:

- ListTable per-cell `align` / `valign`, with cell-over-column precedence
- pipe-table `header-rows=N` and `footer-rows=N`
- explicit head cells become column headers; native `|=` remains valid in body rows
- core corpus case 376 and expanded optional ListTable case 44

Implementation dependencies:
- markup-carve/carve-js#1223
- markup-carve/carve-php#1482
- markup-carve/carve-rs#1135

Draft until the implementation PRs merge and the reference-engine pin can be advanced to merged `carve-js` main.