### PR TITLE
test: retire the final AST span divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The AST span-divergence ledger now records the current zero-difference
+  baseline.** The last `hard_break` extent disagreement cleared across all
+  three engines and its regression test now pins an empty ledger (carve#1414).
+
 ### Changed
 
 - **A vertical table-cell marker requires a horizontal partner.** `|^ x` and `|v x` remain visible content; paired runs such as `|<^`, `|~~`, and `|v>` carry both axes. Corpus 373.

--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -280,5 +280,3 @@
 # DECLARED rather than tolerated, on the same terms as every block above: the row
 # fails this run the moment carve-php agrees, which is what makes deleting it the
 # closing step of that issue rather than a chore nobody is holding.
-
-hard_break (extent) 1

--- a/tests/ast-spans.test.mjs
+++ b/tests/ast-spans.test.mjs
@@ -249,7 +249,9 @@ test('a malformed declaration line is an error, never a silent skip', () => {
  * one taken because the previous one had stopped being true, and a seventh the
  * next day that replaced the surviving row with a different one.
  */
-const LAST_MEASURED = new Map([['hard_break (extent)', 1]])
+// The 2026-08-19 post-fix run compared 26,301 spans and all three engines
+// placed every node identically, retiring the final hard_break row.
+const LAST_MEASURED = new Map()
 
 const asMeasured = (counts) =>
   new Map(


### PR DESCRIPTION
## Summary

- remove the final `hard_break (extent)` entry from the AST span-divergence ledger
- update the ledger regression fixture to pin zero span divergences
- record the measured 26,301-span agreement in the changelog and test

## Evidence

Post-merge AST conformance run 32242974791 reported that all three engines place every node identically and explicitly instructed removal of the stale `hard_break` row. The same run compared 26,301 spans.

## Verification

- `node --test tests/ast-spans.test.mjs` — 15/15 pass

Follow-up for #1414. The scheduled workflow owns closure of that issue.
