### PR TITLE
spec: define every optional source-layout fact, and gate the ones without a definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The source-layout sidecar defines every optional fact it declares** (carve#1431,
+  PART 12 §13 F1-F9). Twelve of the thirteen optional `nodeLayout` properties now say
+  what they measure and in which unit; `paddingRaw` stays declared and undefined with
+  its open question recorded. The columns are zero-based per PART 9 §24, so the schema
+  minimum moves from 1 to 0, an unterminated fence is an EMPTY `closerRaw` rather than
+  an omitted one, and the fence pair is `dependentRequired`. Version stays 1: all three
+  engines emit only `path`, `startByte` and `endByte`, so no sidecar in existence
+  carries a field whose meaning moved.
 - **A vertical table-cell marker requires a horizontal partner.** `|^ x` and `|v x` remain visible content; paired runs such as `|<^`, `|~~`, and `|v>` carry both axes. Corpus 373.
 - **A collected definition closes the item paragraph, and only a comment keeps
   the below-column path open** (carve#1376). Item prose reopens at the content

--- a/docs/ast-source-layout.md
+++ b/docs/ast-source-layout.md
@@ -17,9 +17,26 @@ ranges address the original UTF-8 input, start-inclusive and end-exclusive.
 Entries are sorted by path and ranges must not exceed the UTF-8 source length.
 
 Version 1 carries the original source, BOM and line-ending facts, plus ranges
-for every honestly positioned node. Optional facts cover markers, content
-columns, continuation style, blank lines, fences, attachments, and table
-spelling. Missing means unknown, never a guessed default.
+for every honestly positioned node. Everything else a node may carry is an
+optional measured fact. Missing means unknown, never a guessed default: a
+producer that did not measure a fact omits it, and a consumer must not read an
+omission as a default value.
+
+| fact | clause | what it measures |
+| --- | --- | --- |
+| `markerRaw` | §13 F1 | the marker that opened the node, as authored, separator excluded |
+| `markerColumn` | §13 F2 | zero-based visual column of the marker, in PART 9 §24 C1 arithmetic - not `pos.startColumn`, which is 1-based and counts codepoints |
+| `contentColumn` | §13 F3 | `content_column(node)` per PART 9 §24 C3, same zero-based arithmetic, so `- ` is 2 |
+| `continuationStyle` | §13 F4 | how later lines reached the node, one value by precedence `explicit` > `lazy` (below the content column) > `indent` (reaching it) > `marker_line` > `none` |
+| `blankLinesBefore`, `blankLinesAfter` | §13 F5 | authored count of whitespace-only lines around the node, inside its container |
+| `openerRaw`, `closerRaw` | §13 F6 | the fence delimiter runs as authored. An unterminated block is `closerRaw` present and empty, never `closerRaw` omitted |
+| `metadataSeparatorRaw` | §13 F7 | the separator run between a label or term and its body, whitespace included |
+| `leadingPipe`, `trailingPipe` | §13 F8 | whether the row was authored with the optional pipes |
+| `attachment` | §13 F9 | how the node reached its host: `preceding`, `continuation`, `detached`, `none` |
+
+`paddingRaw` is declared by the schema and deliberately left undefined: one
+string cannot hold both of a table cell's whitespace runs, and which run it
+names has not been ruled (carve#1431). No producer emits it.
 
 All producers consume the shared cases in
 [`resources/ast-source-layout-fixtures.json`](https://github.com/markup-carve/carve/blob/main/resources/ast-source-layout-fixtures.json).

--- a/docs/public/ast-source-layout-schema.json
+++ b/docs/public/ast-source-layout-schema.json
@@ -21,21 +21,22 @@
         "path": { "type": "string", "pattern": "^(?:|(?:/(?:[^~/]|~[01])*)+)$" },
         "startByte": { "type": "integer", "minimum": 0 },
         "endByte": { "type": "integer", "minimum": 0 },
-        "markerRaw": { "type": "string" },
-        "markerColumn": { "type": "integer", "minimum": 1 },
-        "contentColumn": { "type": "integer", "minimum": 1 },
-        "continuationStyle": { "enum": ["none", "indent", "explicit", "lazy", "marker_line"] },
-        "blankLinesBefore": { "type": "integer", "minimum": 0 },
-        "blankLinesAfter": { "type": "integer", "minimum": 0 },
-        "openerRaw": { "type": "string" },
-        "closerRaw": { "type": "string" },
-        "metadataSeparatorRaw": { "type": "string" },
-        "leadingPipe": { "type": "boolean" },
-        "trailingPipe": { "type": "boolean" },
+        "markerRaw": { "type": "string", "description": "PART 12 §13 F1: the marker that opened the node, as authored, separator excluded." },
+        "markerColumn": { "type": "integer", "minimum": 0, "description": "PART 12 §13 F2: zero-based visual column of the marker, in PART 9 §24 C1 arithmetic - not pos.startColumn, which is 1-based." },
+        "contentColumn": { "type": "integer", "minimum": 0, "description": "PART 12 §13 F3: content_column(node) per PART 9 §24 C3, same zero-based arithmetic as markerColumn." },
+        "continuationStyle": { "enum": ["none", "indent", "explicit", "lazy", "marker_line"], "description": "PART 12 §13 F4: how the node's later lines reached it, one value by precedence explicit > lazy > indent > marker_line > none." },
+        "blankLinesBefore": { "type": "integer", "minimum": 0, "description": "PART 12 §13 F5: authored count of whitespace-only lines immediately before the node, within its container." },
+        "blankLinesAfter": { "type": "integer", "minimum": 0, "description": "PART 12 §13 F5: authored count of whitespace-only lines immediately after the node, within its container." },
+        "openerRaw": { "type": "string", "minLength": 1, "description": "PART 12 §13 F6: the opening delimiter run as authored, info string excluded. Never empty." },
+        "closerRaw": { "type": "string", "description": "PART 12 §13 F6: the closing delimiter run as authored, EMPTY where the block was unterminated. Absent means unmeasured, as for every other fact." },
+        "metadataSeparatorRaw": { "type": "string", "description": "PART 12 §13 F7: the separator run between a label or term and its body, whitespace included." },
+        "leadingPipe": { "type": "boolean", "description": "PART 12 §13 F8: whether the row was authored with the optional leading pipe." },
+        "trailingPipe": { "type": "boolean", "description": "PART 12 §13 F8: whether the row was authored with the optional trailing pipe." },
         "paddingRaw": { "type": "string" },
-        "attachment": { "enum": ["none", "preceding", "continuation", "detached"] }
+        "attachment": { "enum": ["none", "preceding", "continuation", "detached"], "description": "PART 12 §13 F9: how the node reached its host. detached records an attachable position the spelling separated (PART 9 §4)." }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "dependentRequired": { "openerRaw": ["closerRaw"], "closerRaw": ["openerRaw"] }
     }
   }
 }

--- a/resources/ast-source-layout-schema.json
+++ b/resources/ast-source-layout-schema.json
@@ -21,21 +21,22 @@
         "path": { "type": "string", "pattern": "^(?:|(?:/(?:[^~/]|~[01])*)+)$" },
         "startByte": { "type": "integer", "minimum": 0 },
         "endByte": { "type": "integer", "minimum": 0 },
-        "markerRaw": { "type": "string" },
-        "markerColumn": { "type": "integer", "minimum": 1 },
-        "contentColumn": { "type": "integer", "minimum": 1 },
-        "continuationStyle": { "enum": ["none", "indent", "explicit", "lazy", "marker_line"] },
-        "blankLinesBefore": { "type": "integer", "minimum": 0 },
-        "blankLinesAfter": { "type": "integer", "minimum": 0 },
-        "openerRaw": { "type": "string" },
-        "closerRaw": { "type": "string" },
-        "metadataSeparatorRaw": { "type": "string" },
-        "leadingPipe": { "type": "boolean" },
-        "trailingPipe": { "type": "boolean" },
+        "markerRaw": { "type": "string", "description": "PART 12 §13 F1: the marker that opened the node, as authored, separator excluded." },
+        "markerColumn": { "type": "integer", "minimum": 0, "description": "PART 12 §13 F2: zero-based visual column of the marker, in PART 9 §24 C1 arithmetic - not pos.startColumn, which is 1-based." },
+        "contentColumn": { "type": "integer", "minimum": 0, "description": "PART 12 §13 F3: content_column(node) per PART 9 §24 C3, same zero-based arithmetic as markerColumn." },
+        "continuationStyle": { "enum": ["none", "indent", "explicit", "lazy", "marker_line"], "description": "PART 12 §13 F4: how the node's later lines reached it, one value by precedence explicit > lazy > indent > marker_line > none." },
+        "blankLinesBefore": { "type": "integer", "minimum": 0, "description": "PART 12 §13 F5: authored count of whitespace-only lines immediately before the node, within its container." },
+        "blankLinesAfter": { "type": "integer", "minimum": 0, "description": "PART 12 §13 F5: authored count of whitespace-only lines immediately after the node, within its container." },
+        "openerRaw": { "type": "string", "minLength": 1, "description": "PART 12 §13 F6: the opening delimiter run as authored, info string excluded. Never empty." },
+        "closerRaw": { "type": "string", "description": "PART 12 §13 F6: the closing delimiter run as authored, EMPTY where the block was unterminated. Absent means unmeasured, as for every other fact." },
+        "metadataSeparatorRaw": { "type": "string", "description": "PART 12 §13 F7: the separator run between a label or term and its body, whitespace included." },
+        "leadingPipe": { "type": "boolean", "description": "PART 12 §13 F8: whether the row was authored with the optional leading pipe." },
+        "trailingPipe": { "type": "boolean", "description": "PART 12 §13 F8: whether the row was authored with the optional trailing pipe." },
         "paddingRaw": { "type": "string" },
-        "attachment": { "enum": ["none", "preceding", "continuation", "detached"] }
+        "attachment": { "enum": ["none", "preceding", "continuation", "detached"], "description": "PART 12 §13 F9: how the node reached its host. detached records an attachable position the spelling separated (PART 9 §4)." }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "dependentRequired": { "openerRaw": ["closerRaw"], "closerRaw": ["openerRaw"] }
     }
   }
 }

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -10345,9 +10345,64 @@ EOF = (* end of file *) ;
       exclusive in the ORIGINAL input, including BOM and CRLF bytes. Entries
       are sorted by path; a producer MUST NOT invent an unplaceable range.
 
-      Original source and byte ranges are the portable minimum. Optional
-      measured facts carry markers and columns, continuation style, blank
-      lines, fences, attachment and table spelling. Absent means unknown.
+      Original source and byte ranges are the portable minimum. Every OTHER
+      property the schema declares is an optional MEASURED FACT, and each one
+      is defined below. ABSENT MEANS UNKNOWN, per field: a producer that did
+      not measure a fact omits it, a producer MUST NOT emit a fact it did not
+      measure, and a consumer MUST NOT read an omission as a default value.
+
+      F1 `markerRaw` -- the exact source text of the marker that opened the
+         node, WITHOUT the separator that follows it (PART 9 §24 C2). `-`,
+         `*`, `1.`, `1)`, `iv.` for a list item; the `::` of a definition
+         term.
+      F2 `markerColumn` -- the visual column the marker's first character
+         sits at, in PART 9 §24 C1's arithmetic and therefore ZERO-BASED: a
+         marker at the left margin is 0, and a marker after one leading tab is
+         4. It is NOT `pos.startColumn`, which is 1-based and counts
+         codepoints; the two disagree on every node.
+      F3 `contentColumn` -- content_column(node) exactly as PART 9 §24 C3
+         defines it, in the same zero-based arithmetic as F2, so `- ` is 2 and
+         `10. ` is 4.
+      F4 `continuationStyle` -- how the node's later lines reached it. One
+         value, chosen by PRECEDENCE, because a node may be written in more
+         than one of these ways at once: `explicit` if any line was reached
+         through the `+` continuation marker (PART 9 §17 L3/L4), else `lazy`
+         if any paragraph line sits BELOW the content column, else `indent` if
+         any later line REACHES the content column -- at it or past it, since
+         PART 9 §24 C3 asks a child to reach the column, not to land on it --
+         else `marker_line` if all
+         content is on the marker line, else `none` where the node takes no
+         continuation. The order is the order a writer must respect: the
+         spellings that cannot be re-derived from the tree win over the ones
+         that can.
+      F5 `blankLinesBefore`, `blankLinesAfter` -- how many lines holding
+         nothing but PART 2 `whitespace` sit immediately before and after the
+         node's range within its own container. The count is the AUTHORED one,
+         which is what makes it a fact rather than a re-derivation: the parse
+         reads a longer run and a single blank the same way in most positions.
+      F6 `openerRaw`, `closerRaw` -- the exact source text of the delimiter
+         run that opened and closed a fenced node, its info string excluded.
+         ABSENCE STILL MEANS UNKNOWN here, so an unterminated block is not
+         spelled by omitting `closerRaw`: it is `closerRaw` present and EMPTY.
+         A producer that measures fences at all emits both, and `openerRaw` is
+         never empty because a fence cannot open without a delimiter.
+      F7 `metadataSeparatorRaw` -- the exact separator run between a label or
+         term and its body, its whitespace included, for the definition-style
+         openers that take one.
+      F8 `leadingPipe`, `trailingPipe` -- whether the row was AUTHORED with
+         the optional leading and trailing `|`.
+      F9 `attachment` -- how the node reached the host it belongs to.
+         `preceding` for the host immediately above it (a caption slot under
+         its host, PART 9 §4), `continuation` for a `+`-attached block,
+         `detached` where an attachable position was written but the spelling
+         detached it (§4's two blank lines), `none` where the node has no
+         host.
+
+      A DECLARED FACT WITH NO DEFINITION IS A DEFECT, not a reserved slot.
+      `tests/ast-schema.test.mjs` fails when the schema declares an optional
+      property this clause does not define, unless the gap is named there with
+      its open question. That is what stops the sidecar from growing fields no
+      producer can implement (carve#1431).
 
       DEFAULT OUTPUT DOES NOT MOVE. Ordinary parse, AST encoding, CLI JSON and
       rendering retain their existing APIs and shapes. An AST decoder does not

--- a/tests/ast-schema.test.mjs
+++ b/tests/ast-schema.test.mjs
@@ -199,6 +199,130 @@ test('a table cell carries an optional vertical alignment', () => {
   assert.equal(validate(cell('baseline')), false)
 })
 
+/*
+ * The sidecar's OPTIONAL facts, and why a declared one needs a definition.
+ *
+ * `nodeLayout` requires three properties and declares thirteen more. Those
+ * thirteen are the source spellings the canonical AST deliberately drops, so
+ * they are the only thing a formatter or an editor can rebuild an authored
+ * document from - and until carve#1431 not one of them was defined anywhere.
+ * The schema named them, PART 12 §13 described their CATEGORIES in prose, and
+ * no clause said what any single field measures. A producer had nothing to
+ * implement against, and "Absent means unknown" makes emitting none of them
+ * conformant, so the gap could not surface as a failure either.
+ *
+ * This is the guard the node-type tests above apply, one layer up, and the
+ * proxy for "defined" is the same kind of proxy: the field's name appears in
+ * the text of §13. That cannot tell a definition from a mention, which is why
+ * the clause carries F-numbered entries rather than a list of names.
+ *
+ * A fact that genuinely has no answer yet goes in UNDEFINED_FACT with the
+ * question, rather than being named in the clause with nothing behind it.
+ * Emptying this map is the intended end state.
+ */
+const UNDEFINED_FACT = {
+  paddingRaw:
+    "one string cannot hold both of a table cell's whitespace runs, and which run it names is unruled (carve#1431)",
+}
+
+/** The text of PART 12 §13, the clause that defines the sidecar. */
+function sidecarClause() {
+  const grammar = readFileSync(resolve(root, 'resources/grammar.ebnf'), 'utf8')
+  const start = grammar.indexOf('   13. SOURCE LAYOUT IS A SEPARATE OPT-IN SIDECAR')
+  assert.notEqual(start, -1, 'PART 12 §13 is not where this test looks for it')
+  const end = grammar.indexOf('\n   14. ', start)
+  assert.notEqual(end, -1, 'PART 12 §13 has no §14 after it')
+  return grammar.slice(start, end)
+}
+
+/** The sidecar schema, read fresh so a test cannot mutate another's copy. */
+function layoutSchema() {
+  return JSON.parse(readFileSync(resolve(root, 'resources/ast-source-layout-schema.json'), 'utf8'))
+}
+
+/** Every `nodeLayout` property that is not one of the three required ones. */
+function optionalFacts(schemaDoc = layoutSchema()) {
+  const node = schemaDoc.$defs.nodeLayout
+  const required = new Set(node.required)
+  return Object.keys(node.properties).filter((name) => !required.has(name))
+}
+
+/** §13 names a fact in backticks, the way it names every other field. */
+const namedInClause = (clause, name) => clause.includes('`' + name + '`')
+
+test('every optional sidecar fact is defined in PART 12 §13, or named as undefined', () => {
+  const clause = sidecarClause()
+  const undefinedHere = optionalFacts()
+    .filter((name) => !namedInClause(clause, name) && !(name in UNDEFINED_FACT))
+    .sort()
+  assert.deepEqual(
+    undefinedHere,
+    [],
+    `the sidecar schema declares optional fact(s) PART 12 §13 does not define: ${undefinedHere.join(', ')}. ` +
+      'A declared fact with no definition cannot be implemented and cannot be measured. ' +
+      'Define it in §13, or name it in UNDEFINED_FACT with the open question.',
+  )
+})
+
+test('every optional sidecar fact carries a schema description', () => {
+  const properties = layoutSchema().$defs.nodeLayout.properties
+  const bare = optionalFacts()
+    .filter((name) => !(name in UNDEFINED_FACT) && typeof properties[name].description !== 'string')
+    .sort()
+  assert.deepEqual(
+    bare,
+    [],
+    `optional sidecar fact(s) carry no description: ${bare.join(', ')}. ` +
+      'The schema is published on its own, so a consumer reading only the schema needs the pointer to §13.',
+  )
+})
+
+test('the sidecar schema rejects a half-measured fence pair', () => {
+  const validateLayout = new Ajv2020({ strict: true }).compile(layoutSchema())
+  const sidecar = (node) => ({
+    version: 1,
+    encoding: 'utf-8',
+    source: '```\nx\n```\n',
+    lineEndings: 'lf',
+    bom: false,
+    nodes: [{ path: '/children/0', startByte: 0, endByte: 10, ...node }],
+  })
+  // §13 F6 spells an unterminated block as an EMPTY closer, so a producer that
+  // measures fences always has both fields. Omitting one is not "unterminated"
+  // and not "unknown" - it is a producer that measured half a pair, and the
+  // schema has to say so on its own, because a consumer may hold nothing else.
+  assert.equal(validateLayout(sidecar({ openerRaw: '```' })), false, 'an opener with no closer validated')
+  assert.equal(validateLayout(sidecar({ closerRaw: '```' })), false, 'a closer with no opener validated')
+  assert.equal(validateLayout(sidecar({ openerRaw: '```', closerRaw: '```' })), true, 'a measured pair was rejected')
+  assert.equal(validateLayout(sidecar({ openerRaw: '```', closerRaw: '' })), true, 'an unterminated block was rejected')
+  assert.equal(validateLayout(sidecar({})), true, 'an unmeasured node was rejected')
+})
+
+test('every UNDEFINED_FACT entry is still needed', () => {
+  const clause = sidecarClause()
+  const stale = Object.keys(UNDEFINED_FACT)
+    .filter((name) => namedInClause(clause, name))
+    .sort()
+  assert.deepEqual(
+    stale,
+    [],
+    `UNDEFINED_FACT names fact(s) PART 12 §13 now defines: ${stale.join(', ')}. ` +
+      'Delete the entry so the fact is gated like every other one.',
+  )
+})
+
+test('every UNDEFINED_FACT entry names a fact the schema still declares', () => {
+  const declared = new Set(optionalFacts())
+  const unknown = Object.keys(UNDEFINED_FACT)
+    .filter((name) => !declared.has(name))
+    .sort()
+  assert.deepEqual(
+    unknown,
+    [],
+    `UNDEFINED_FACT names fact(s) the sidecar schema no longer declares: ${unknown.join(', ')}.`,
+  )
+})
+
 test('shared source-layout fixtures validate', () => {
   const layoutSchema = JSON.parse(readFileSync(resolve(root, 'resources/ast-source-layout-schema.json'), 'utf8'))
   const validateLayout = new Ajv2020({ strict: true }).compile(layoutSchema)


### PR DESCRIPTION
Closes #1431.

`nodeLayout` required three properties and declared thirteen more. Those thirteen are the
source spellings the canonical AST drops on purpose, so they are the only thing a
formatter or an editor can rebuild an authored document from - and none of them was
defined anywhere. The schema named them, PART 12 §13 described their *categories* in
prose, and no clause said what a single field measures. Nothing produced them either:
carve-js's `SourceLayoutNode`, carve-php's `src/Ast/SourceLayout.php:52` and carve-rs's
`src/source_layout.rs:49` each emit `path`, `startByte`, `endByte` and stop. "Absent means
unknown" made emitting none of them conformant, so the gap could not surface as a failure.

Twelve are defined as F1-F9, each derived from a clause that already exists rather than
invented here. The three that are decisions rather than restatements:

- **Columns are zero-based**, per PART 9 §24 C1/C3 - a left-margin marker is 0 and `- ` is
  2. So `markerColumn` and `contentColumn` are not `pos.startColumn`, which is 1-based and
  counts codepoints, and the schema minimum moves from 1 to 0 because the old bound could
  not express the commonest value.
- **`continuationStyle` takes one value by precedence**, `explicit` > `lazy` > `indent` >
  `marker_line` > `none`, since a node can be written several of those ways at once. The
  order is what a writer must respect: spellings that cannot be re-derived from the tree
  win. A line *past* the content column is `indent`, not `lazy` - §24 C3 asks a child to
  reach the column, not to land on it.
- **An unterminated fence is `closerRaw` present and EMPTY**, never `closerRaw` omitted, so
  absence keeps meaning unmeasured here as everywhere else. The pair is
  `dependentRequired` and a test pins both rejections.

`paddingRaw` stays declared and undefined: one string cannot hold both of a table cell's
whitespace runs, and which run it names is unruled. It sits in `UNDEFINED_FACT` with that
question rather than being named in the clause with nothing behind it.

Four guards keep this honest, modelled on the node-type producibility tests above them:
every optional fact is defined in §13 or named as undefined, every defined fact carries a
schema description, and both directions of the exemption map are checked. Each was
verified to fail under a mutation - stripping a field from the clause, dropping a
description, naming a defined field as undefined, naming a field the schema does not
declare - so none of them is a check that cannot fail.

**Sidecar version stays 1.** No sidecar in existence carries a field whose meaning moved,
because no producer emits one.

**One item from #1431 is deliberately not here.** Step 4 was a fixture group for the
optional tier. A fixture nothing reads is the same defect class this PR is fixing, so it
should land with the first producer (carve-js) rather than ahead of it.
