### PR TITLE
chore: move the reference build past the lazy marker-line definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#84aaab607f1b00f376d34b312aed40e739b35333",
+        "@markup-carve/carve": "github:markup-carve/carve-js#a18107812cceb57e7996191f4ac0660c880b8747",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#84aaab607f1b00f376d34b312aed40e739b35333",
-      "integrity": "sha512-Jt0bF9oNVunNYdCxBxaMourJDz1NLaKtx7/982Kc1jUog+CbohSz3HulDf/ZYSld985Xkenf66xjBshXXXF2Bg==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#a18107812cceb57e7996191f4ac0660c880b8747",
+      "integrity": "sha512-c7Ja4B1Xi1BSZ4CorNSRF330K7A14oBGr1YihCm5V9BNOWj345m+1Fn1MiK8A/ArwCOQIYwbaGs43Wv9Y+8S7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#84aaab607f1b00f376d34b312aed40e739b35333",
+    "@markup-carve/carve": "github:markup-carve/carve-js#a18107812cceb57e7996191f4ac0660c880b8747",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,5 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-383-a-lazy-marker-line-s-definition-defines-nothing-in-any-container  carve-js#1229 still registers a lazy marker line's definition, so the reference resolves
-383-a-lazy-marker-line-s-definition-defines-nothing-in-any-container-2  carve-js#1229, the div spelling of the same defect


### PR DESCRIPTION
Follow-up to #1429, doing what its comment said had to happen.

The pinned carve-js build predated markup-carve/carve-js#1230, so the two corpus pairs pinning the container spellings were declared in `resources/engine-pin-drift.txt` when they landed. The new pin carries the fix, so both lines are stale and are deleted here - in the commit that makes them stale, which is what the file requires and what `engine:report --check` enforces in both directions.

```
pinned reference build:  github:markup-carve/carve-js#a1810781
corpus pairs:            1308
reproduced:              1308
mismatched:              0
threw:                   0
declared drift:          0
```

No corpus, example or docs content changes - the pin and the now-empty drift declaration only.