### PR TITLE
spec: the hyphen-run flanking test reads PART 7's spaces, not the host's

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -3309,6 +3309,14 @@ ellipsis = "..." ;    (* → … *)
    shape -- whitespace before, word after -- is the one no dash wants and every
    flag has.
 
+   THE SPACE CLASS IS PART 7'S, and that is not the host language's `\s`. A
+   VERTICAL TAB and a FORM FEED are CONTENT in Carve, so `---<VT>` converts or
+   stays literal exactly as `---!` does; a rule spelled with `\s` answered the
+   two differently, which is the divergence carve-php's whitespace-definition
+   sweep exists to catch. A NO-BREAK SPACE counts as a space here, because the
+   question asked is "does a space stand before this run" - the same question
+   quote flanking asks, and a nbsp is a space to the reader.
+
    ELLIPSIS IS NOT COVERED. `wait... really` is the ordinary use and it is
    word-then-whitespace; an ellipsis terminates a clause where a dash joins two
    things, so their natural positions differ and the rule follows the construct.

--- a/scripts/spec/render.mjs
+++ b/scripts/spec/render.mjs
@@ -622,14 +622,20 @@ const sem = g.createSemantics().addOperation('h', {
     // 19-smart-typography-dashes-and-quotes-7 pins it), as does a trailing
     // dash on an interrupted clause. Requiring matching sides would have
     // broken both.
+    //
+    // The space class is PART 7's, NOT the host language's `\s`: a VERTICAL TAB
+    // and a FORM FEED are CONTENT in Carve, so `---<VT>` has to answer the way
+    // `---!` answers. A NO-BREAK SPACE is included because the question here is
+    // "does a space stand before this run", which is the same question quote
+    // flanking asks, and a nbsp is a space to the reader.
     {
       const src = this.source.sourceString
       const at = this.source.startIdx
       const end = this.source.endIdx
       const prev = at > 0 ? src[at - 1] : ''
       const next = src[end] ?? ''
-      const prevIsSpace = prev === '' || /\s/.test(prev)
-      const nextIsSpace = next === '' || /\s/.test(next)
+      const prevIsSpace = prev === '' || FLANK_SPACE.test(prev)
+      const nextIsSpace = next === '' || FLANK_SPACE.test(next)
       if (prevIsSpace && !nextIsSpace) return escapeHtml(this.sourceString)
     }
     // PART 9 SS8: a run of n hyphens -> em/en dash mix (djot allocateDashes):
@@ -1105,6 +1111,10 @@ export function renderBlockAttrs(lists) {
 // corpus 37-3 pins a line-initial pair as two closers). A single quote
 // directly before a digit is always an apostrophe ('70s, '24).
 const QUOTE_OPEN_PREV = new Set([' ', '\t', '=', ':', '-', '/', '(', '[', '{'])
+// PART 7's whitespace plus the NO-BREAK SPACE, for the hyphen-run flanking
+// test (carve#1443). A vertical tab and a form feed are deliberately OUT:
+// Carve reads both as content, and `\s` takes them.
+const FLANK_SPACE = /[ \t\n\r\u00a0]/
 const QUOTE_CHARS = new Set(['"', "'"])
 // The glyph the previous quote token resolved to, so a quote directly after
 // another one can tell which half it follows: after an OPENING quote it opens


### PR DESCRIPTION
The flanking rule from #1443 was spelled with JavaScript's `\s`, which takes a
VERTICAL TAB and a FORM FEED. Carve reads both as **content**, so the rule
answered two documents that should agree differently:

| source | before this | after this |
| --- | --- | --- |
| `---!` | `---!` (literal) | `---!` |
| `---<VT>` | `—<VT>` (converted) | `---<VT>` |

`---!` is the baseline carve-php's whitespace-definition sweep uses precisely
because `!` is content and not a word character. The sweep feeds every
construct a vertical tab, a form feed and that baseline, and keeps the rows
where the first two do not behave like the third - it caught this while the
rule was being ported to the engines.

## The class

PART 7's four whitespace characters, plus the NO-BREAK SPACE:

```
[ \t\n\r ]
```

The nbsp is deliberate rather than inherited. What the test asks is "does a
space stand before this run", which is the same question quote flanking asks,
and a nbsp is a space to the reader. A vertical tab and a form feed are not
spaces under any reading, and `\s` takes them.

No corpus pair moves - the rule is unchanged for every document that does not
put a vertical tab or a form feed next to a hyphen run. 2600 tests pass.

Follow-up to #1443.
