### PR TITLE
docs: name the corpus numbers the empty-brace rule actually landed on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **An empty brace pair is not a construct** (carve#1447). `{//}`, `{**}`,
   `{__}`, `{~~}`, `{^^}`, `{,,}`, `{==}`, `{++}` and `{##}` render literally;
   every content slot was already a one-or-more repetition. A fully empty
-  substitution is unchanged. Corpus 387.
+  substitution is unchanged. Corpus 388.
 - **`{--}` is an en dash, not an empty deletion** (carve#1447). The string the
   empty deletion freed becomes the braced en dash, which converts in the flag
-  position the bare hyphen run refuses. Corpus 386.
+  position the bare hyphen run refuses. Corpus 387.
 - **The source-layout sidecar defines every optional fact it declares** (carve#1431,
   PART 12 §13 F1-F9). Twelve of the thirteen optional `nodeLayout` properties now say
   what they measure and in which unit; `paddingRaw` stays declared and undefined with

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -21,15 +21,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>727 / 736</strong>
+    <strong>729 / 736</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>727 / 736</strong>
+    <strong>729 / 736</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>727 / 736</strong>
+    <strong>729 / 736</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -40,9 +40,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `727 / 736` | `0` | `0` | `3.01` |
-| JS | `8105210` | `727 / 736` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `727 / 736` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `729 / 736` | `0` | `0` | `3.01` |
+| JS | `8105210` | `729 / 736` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `729 / 736` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 


### PR DESCRIPTION
Follow-up to #1449, which merged while #1446 was landing.

Two numbers in that merge describe the branch rather than what arrived on main.

**The CHANGELOG entries are off by one category.** The arrow ruling took 386, so
the two new categories moved to 387 and 388. The fixtures moved with the merge;
the entries did not, and now point one category short - the en dash entry at the
arrows, the empty-brace entry at the en dash.

**The comparison numerator stayed at 727 while four pairs arrived.** Measured
against carve-php `f30ebd1` and carve-rs main:

| case | php | rs |
| --- | --- | --- |
| `387-a-braced-hyphen-pair-is-an-en-dash` | fail | fail |
| `387-a-braced-hyphen-pair-is-an-en-dash-2` | pass | pass |
| `388-an-empty-brace-pair-is-not-a-construct` | fail | fail |
| `388-an-empty-brace-pair-is-not-a-construct-2` | pass | pass |

So the engines pass two more documents than before, not zero more: `729 / 736`.
The denominator already moved with the merge, and the three rows stay equal
because the two that fail, fail everywhere.
