### PR TITLE
spec: the convert corpus takes the table layout too

### DIFF
--- a/tests/corpus-convert.test.mjs
+++ b/tests/corpus-convert.test.mjs
@@ -145,7 +145,10 @@ const PINNED_UNIMPLEMENTED = {
  * that starts matching fails as STALE until the entry is deleted in the commit
  * that moves the pin, and the meaning assertion still runs regardless.
  */
-const PINNED_DRIFT = {}
+const PINNED_DRIFT = {
+  '18-markdown-a-gfm-table-survives':
+    'carve#1459 gives every row its own line in thead/tfoot too; the pinned build still writes the section on one line',
+}
 
 /**
  * The visible text of an HTML fragment.

--- a/tests/corpus-convert/18-markdown-a-gfm-table-survives/expected.html
+++ b/tests/corpus-convert/18-markdown-a-gfm-table-survives/expected.html
@@ -1,5 +1,7 @@
 <table>
-  <thead><tr><th scope="col">Name</th><th scope="col">Age</th></tr></thead>
+  <thead>
+    <tr><th scope="col">Name</th><th scope="col">Age</th></tr>
+  </thead>
   <tbody>
     <tr><td>Ann</td><td>30</td></tr>
   </tbody>


### PR DESCRIPTION
#1461 gave every table section one row per line and regenerated the core corpus, the optional corpus and the authored examples - and missed `tests/corpus-convert`, whose fixtures are rendered HTML of the same kind.

carve-php caught it: its converter suite renders the converted document and compares against that fixture, so the sweep left one document behind and the next engine to implement the layout failed on it.

The fixture is regenerated, and the case is declared in `PINNED_DRIFT` - the ledger this file already keeps for expectations the pinned build has not shipped - because that build still writes the section on one line. The entry fails as stale once the pin moves.

Follow-up to #1461, part of #1459.