### PR TITLE
spec: ASCII-folding is available in all three engines, in two modes

### DIFF
--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -61,7 +61,7 @@ write references in whatever case they like.
 ASCII fragments remain available as opt-in, orthogonal options
 (`lowercaseHeadingIds`, `asciiHeadingIds` in carve-js; the
 `LowercaseHeadingIdsExtension` / `AsciiHeadingIdsExtension` in carve-php; the
-`lowercase_heading_ids` option in carve-rs):
+`lowercase_heading_ids` and `ascii_heading_ids` options in carve-rs):
 
 | `lowercase` | `asciiFold` | `# Über uns` → |
 |:-:|:-:|---|
@@ -70,9 +70,15 @@ ASCII fragments remain available as opt-in, orthogonal options
 | off | on | `Uber-uns` (ascii, case kept) |
 | on | on | `uber-uns` (share-safe) |
 
-ASCII-folding is not available in carve-rs (it would require a transliteration
-table, which the zero-dependency Rust crate avoids); attach an explicit `{#id}`
-there when an ASCII fragment is required.
+ASCII-folding has two modes, because the transliteration table covers Latin,
+IPA, combining marks, Cyrillic, punctuation and currency - and not Greek, CJK or
+Arabic. Best-effort (carve-js `'fold'`, carve-rs `AsciiHeadingIds::Fold`) keeps
+what it cannot map, so `Ωmega` stays `Ωmega` and the heading keeps a usable
+anchor; strict (carve-js `'strict'`, carve-rs `AsciiHeadingIds::Strict`, and what
+carve-php's extension does) drops it, so `Ωmega` becomes `mega` and the id is
+guaranteed to match `[0-9A-Za-z-]`. All three engines carry the same table, so a
+folded id is byte-identical across them; carve-rs bakes it rather than taking a
+dependency.
 
 Smart-typography substitutions are also reversed to their ASCII source before
 the id is computed, so an id never depends on presentational typography:

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -953,8 +953,15 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
    OPT-IN, orthogonal transforms: lowercasing (carve-js `lowercaseHeadingIds`;
    carve-php `LowercaseHeadingIdsExtension`; carve-rs `lowercase_heading_ids`) and
    ASCII-folding for URL/CSS-fragment portability (carve-js `asciiHeadingIds`;
-   carve-php `AsciiHeadingIdsExtension`; not available in carve-rs). Neither is the
-   default. NOTE: carve PRESERVES case, matching djot.js / djot-php per #393;
+   carve-php `AsciiHeadingIdsExtension`; carve-rs `ascii_heading_ids`). Neither is
+   the default. ASCII-folding has TWO modes, because a transliteration table
+   covers some scripts and not others: BEST-EFFORT keeps what it cannot map, so a
+   CJK heading still has a usable and unique anchor, and STRICT drops that residue
+   so the id is guaranteed to match `[0-9A-Za-z-]`. carve-js spells them `'fold'`
+   and `'strict'`, carve-rs `AsciiHeadingIds::Fold` and `::Strict`; carve-php's
+   extension is the STRICT one. The table itself is not normative -- what is, is
+   that the three engines carry the SAME table, so a folded id is byte-identical
+   across them. NOTE: carve PRESERVES case, matching djot.js / djot-php per #393;
    cross-references resolve case-insensitively against the case-preserved id table. *)
 
 (* --- Thematic Breaks --- *)


### PR DESCRIPTION
The heading-id clause said ASCII-folding was "not available in carve-rs", and the divergence page gave the reason: it would need a transliteration table, which the zero-dependency crate avoids. markup-carve/carve-rs#1182 carries that table now - ported from carve-php's rather than authored, and verified byte-identical to carve-js's - so the claim and its rationale both go.

What replaces them is the part that was never written down: **the folding has two modes**, and the two engines that already offered it do not mean the same one.

A table covers some scripts and not others, so an engine has to answer for the residue:

- best effort keeps it - carve-js `'fold'`, carve-rs `AsciiHeadingIds::Fold` - so a CJK heading keeps a usable, unique anchor;
- strict drops it - carve-js `'strict'`, carve-rs `AsciiHeadingIds::Strict`, and what carve-php's extension does - so the id is guaranteed to match `[0-9A-Za-z-]`, at the price of `Ωmega` becoming `mega`.

The table itself is deliberately NOT normative. What is normative is that the three engines carry the SAME one, which is what makes a folded id byte-identical across them. Measured over 26 inputs spanning Latin, Cyrillic, Greek and CJK, in every mode: no mismatch, and carve-php agrees with carve-js `strict` on all of them.

### Sequencing

This is prose about what the engines offer, and nothing in the corpus or the claims tests measures it, so it is green either way. It should land AFTER markup-carve/carve-rs#1182, so the page is not describing an option that has not shipped.