### PR TITLE
docs: the home page and README say tables align on two axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ TABLES
   | Cell    | Cell    |
   ^ Table caption
 
+  |=> Right |=>^ Top  |      (< ~ > horizontal, ^ ~ v vertical)
+  |<v Cell  |?~ Cell  |      (?  keeps the column's horizontal)
+
   | ^       | ...     |      (^ rowspan)
   | ...     | <       |      (< colspan)
   + continuation      |      (+ multiline)
@@ -285,7 +288,7 @@ the [Case Study](https://markup-carve.github.io/carve/case-study/) and the
 | Definition lists | n/a | `: term` + indented def | `:: term` / `:  def` |
 | Ordered list dialects | `1.` / `1)` (decimal only) | decimal/alpha/roman; `.` `)` `(1)` delimiters | decimal/alpha/roman; `.` `)` delimiters (`(1)` deliberately omitted — prose-ambiguity) |
 | Table headers | `\|---\|` separator (GFM) | `\|---\|` separator | `\|=` prefix |
-| Table alignment | `:--` / `--:` (GFM) | `:--` / `--:` separator | `\|=<` / `\|=>` / `\|=~` (column), `\|<` / `\|>` / `\|~` (cell) |
+| Table alignment | `:--` / `--:` (GFM), horizontal only | `:--` / `--:` separator, horizontal only | horizontal `\|=<` / `\|=>` / `\|=~` (column) and `\|<` / `\|>` / `\|~` (cell), plus a vertical axis on a second marker: `\|=>^` right+top, `\|<v` left+bottom, `\|?~` middle keeping the column's horizontal value. A marker run is glued to the pipe and ends at a space |
 | Headerless tables | n/a (header + separator required) | n/a (header + separator required) | omit `\|=` |
 | Table rowspan | n/a (raw HTML only) | n/a (raw HTML only) | `^` marker |
 | Table colspan | n/a (raw HTML only) | n/a (raw HTML only) | `<` marker |

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,15 +50,16 @@ underscores sit below, tildes run through:
 H{,2,}O and E=mc{^2^}
 ```
 
-Tables without a separator row. `|=` marks a header cell, `|=>` aligns that
-column right, a bare `|>` aligns a single body cell, and one `^` line captions
-the whole thing:
+Tables without a separator row. `|=` marks a header cell and `|=>` aligns that
+column right; a bare `|>` aligns one body cell. Every marker run is glued to the
+pipe and ends at a space, and a second marker adds the vertical axis - `|=>^` is
+right and top, `|<v` left and bottom. One `^` line captions the whole thing:
 
 ```carve
-|= Fruit  |=> Price |
-| Apple    | $1      |
-| Pear     | $2      |
-|~ Total  |< $3     |
+|= Fruit  |=>^ Price |
+| Apple    | $1       |
+| Pear     | $2       |
+|~ Total   |<v $3     |
 ^ Table 1: no separator row needed
 ```
 


### PR DESCRIPTION
Addresses the **first** checklist item of markup-carve/carve#1403, "Fix up docs about vertical alignment in tables". The second item, deprecating `|=` in favor of `|#`, is a syntax deprecation and a maintainer call - it is untouched here and the ticket stays open for it. A `needs-decision` comment stating that question follows on the ticket.

## The defect was a deleted sentence, not a wrong one

#1391 gave tables an independent vertical axis and made a marker run end at a required space, and it rewrote the table teaser on the home page to say both:

````
-Tables without a separator row. `|=` marks a header cell, `|=>` aligns that
-column right, a bare `|>` aligns a single body cell, and one `^` line captions
+Tables without a separator row. `|=` marks a header cell, `|=> ` aligns that
+column right, a bare `|> ` aligns a single body cell, two-axis runs such as
+`|>^ ` add vertical alignment, and one `^` line captions
````

Merge commit `791d3594`, later on #1391's own branch, resolved that hunk back to the pre-#1391 text. It landed inside the #1391 merge, so the deletion never appeared in a reviewable diff, and `git log -S` does not surface it either because it skips merges by default. The follow-ups that corrected the rest of the docs (#1405, #1408, #1458, #1460) all edited the cheatsheet and the comparison page; none of them looked at the home page, because nothing there looked broken. It just described a language one axis smaller than the grammar does.

## Why the missing terminator sentence matters

A run with no following space is not a run. The `>` becomes the cell's text - and because the column's own marker still applies, the cell is still right-aligned, so the output looks almost right:

Input:

````
|=> Price |
|>9 |
````

Output:

````html
<table>
  <thead><tr><th scope="col" style="text-align: right;">Price</th></tr></thead>
  <tbody>
    <tr><td style="text-align: right;">&gt;9</td></tr>
  </tbody>
</table>
````

PART 9 §5 T11: "A cell carrying ANY of the three must follow the run with one literal space. Without it there is no run at all, and every character of it is ordinary cell content." The two-axis rule itself is PART 12 §20.

## What changed

`docs/index.md` - the teaser states the terminator and the vertical axis again, and the sample now renders a `vertical-align` so the claim above it is checkable:

Input:

````
|= Fruit  |=>^ Price |
| Apple    | $1       |
| Pear     | $2       |
|~ Total   |<v $3     |
^ Table 1: no separator row needed
````

Output:

````html
<table>
  <caption>Table 1: no separator row needed</caption>
  <thead><tr><th scope="col">Fruit</th><th scope="col" style="text-align: right; vertical-align: top;">Price</th></tr></thead>
  <tbody>
    <tr><td>Apple</td><td style="text-align: right; vertical-align: top;">$1</td></tr>
    <tr><td>Pear</td><td style="text-align: right; vertical-align: top;">$2</td></tr>
    <tr><td style="text-align: center;">Total</td><td style="text-align: left; vertical-align: bottom;">$3</td></tr>
  </tbody>
</table>
````

`README.md` - the "Table alignment" comparison row carried the same one-axis claim, in the row whose whole job is to say what Carve has that Markdown and Djot do not. A vertical axis is exactly that and it was missing. The quick-reference block gains the four spellings, including `?`, which keeps the column's horizontal value while setting only the vertical one:

Input:

````
|=> Right |=>^ Top  |
|<v Cell  |?~ Cell  |
````

Output:

````html
<table>
  <thead><tr><th scope="col" style="text-align: right;">Right</th><th scope="col" style="text-align: right; vertical-align: top;">Top</th></tr></thead>
  <tbody>
    <tr><td style="text-align: left; vertical-align: bottom;">Cell</td><td style="text-align: right; vertical-align: middle;">Cell</td></tr>
  </tbody>
</table>
````

Every spelling written in this PR was rendered through the carve-js build this repo pins (`a1810781`) before it went in.

No CHANGELOG entry: docs-only, no product behavior moved.

## Deliberately not touched

`docs/case-study/syntax.md` still describes one axis, and still says a repeated marker such as `|=<<` is content, which `~~` now contradicts. The page carries an explicit "Historical document / not kept in lockstep with the language" banner, so it is out of scope by its own terms rather than by oversight.

`docs/cheatsheet.md`, `docs/ast-json.md`, `docs/extensions.md`, `docs/versioning.md` and `docs/validation.md` were each checked and are already correct; the cheatsheet's alignment example renders exactly what it claims.

## Baseline

The gate baseline on this branch's base is `red` on one gate:

````
{"outcome":"red","failed":["npm run combinatorial:check"],"unrunnable":[{"gate":"npm run ast:check","reason":"a dependency outside the repository is missing: /tmp/carve-js/dist"},{"gate":"npm run claims:check","reason":"engine-claims: need all three engines, found 0 (none)."},{"gate":"npm run degradation:check","reason":"degradation-claims: need all three engines, found 0 (none)."},{"gate":"npm run fmt:check","reason":"fmt-fixture-claims: need all three engines, found 0 (none)."}]}
````

`combinatorial:check` is weekly/dispatch-only in the AST-conformance workflow, and its 18 undeclared divergences are all the pinned engine lacking the `role="math"` and `aria-label` output that #1471 landed hours ago. Pre-existing on the base commit, unrelated to prose, and inside the territory #1451 is being worked in. Every other runnable gate is green, including the full `npm test` (2626 passing), whose `doc-carve-samples` suite parses every fenced Carve block under `docs/`.

## Concurrency

`draft-check` is WARN, not block. Open drafts #1026 (`docs/quoted-admonition-titles`, the CarvePress-cutover prose sweep) and #291 (`spec/includes-section-19`) both touch `docs/index.md`. Neither does alignment work; expect a rebase against whichever lands first.

## Found while measuring, not fixed here

- `docs/html-import.md` names `text-align`, `font-weight`, `font-style` and `text-decoration` as the CSS declarations an importer may map. `vertical-align` now has a stable Carve spelling and is absent, so an imported `<td style="vertical-align: middle">` reports `style-unmapped` for something the language can express. That is a normative claim, not prose, so it wants its own ticket.
- `docs/migrate-from-markdown.md` covers the GFM delimiter row but never says what the alignment colons become in either direction.
- The one-axis claim is likely repeated in the carve-js, carve-php and carve-rs READMEs and in the editor integrations. Not measured from this repo; flagged so it gets swept.
