### PR TITLE
fix: a first-party git dependency names the commit it installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
       "devDependencies": {
         "@djot/djot": "^0.3.2",
         "@markup-carve/carve": "github:markup-carve/carve-js#d9cb2c717dd2a47fa44a76d9004e33628b65a956",
-        "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
-        "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
+        "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
+        "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
         "@mermaid-lint/cli": "^0.53.1",
         "ajv": "^8.20.0",
         "markdown-it-container": "^4.0.0",
@@ -1009,15 +1009,22 @@
       }
     },
     "node_modules/@markup-carve/carve-grammars": {
-      "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-grammars.git#83b1872991090b7f8e6840e51a4c4c75ce7e611d",
+      "version": "0.1.4",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-grammars.git#086d9603736466092c4517e76513b4915c1f94a7",
+      "integrity": "sha512-/i+9FIe2wPPeQoSNXD3GEAfceoSnCmZaxTxQrXSpcrHS8XdYVvNe2PSLuSrmxzUjjr5ZcIrWHybbV46ZRMHmaQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@markup-carve/carve": "^0.1.4"
+      },
       "peerDependencies": {
         "@shikijs/themes": "^2 || ^3",
-        "@tiptap/core": "^2",
-        "@tiptap/extension-underline": "^2",
-        "@tiptap/starter-kit": "^2",
+        "@terrastruct/d2": "^0.1",
+        "@tiptap/core": "^2 || ^3",
+        "@tiptap/extension-heading": "^2 || ^3",
+        "@tiptap/extension-underline": "^2 || ^3",
+        "@tiptap/starter-kit": "^2 || ^3",
+        "@viz-js/viz": "^3",
         "highlight.js": "^11",
         "prismjs": "^1"
       },
@@ -1025,13 +1032,22 @@
         "@shikijs/themes": {
           "optional": true
         },
+        "@terrastruct/d2": {
+          "optional": true
+        },
         "@tiptap/core": {
+          "optional": true
+        },
+        "@tiptap/extension-heading": {
           "optional": true
         },
         "@tiptap/extension-underline": {
           "optional": true
         },
         "@tiptap/starter-kit": {
+          "optional": true
+        },
+        "@viz-js/viz": {
           "optional": true
         },
         "highlight.js": {
@@ -1044,11 +1060,12 @@
     },
     "node_modules/@markup-carve/vite-plugin-carve": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/markup-carve/vite-plugin-carve.git#8b2ae32f3a8ee2b4430e18f714d84111b60dbdb1",
+      "resolved": "git+ssh://git@github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
+      "integrity": "sha512-tiFEggk5o6mQQEBcqWgy8o24TZ+vS1ELYVcCxalB49LJfI20aBU+LxGm8ar66p8eiR8mrRXv150kNhwzLltKEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@markup-carve/carve": "git+https://github.com/markup-carve/carve-js.git"
+        "@markup-carve/carve": "^0.1.4"
       },
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0"

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "devDependencies": {
     "@djot/djot": "^0.3.2",
     "@markup-carve/carve": "github:markup-carve/carve-js#d9cb2c717dd2a47fa44a76d9004e33628b65a956",
-    "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars",
-    "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git",
+    "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
+    "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
     "@mermaid-lint/cli": "^0.53.1",
     "ajv": "^8.20.0",
     "markdown-it-container": "^4.0.0",

--- a/tests/engine-pin-matches-the-lock.test.mjs
+++ b/tests/engine-pin-matches-the-lock.test.mjs
@@ -1,5 +1,6 @@
 /*
- * The reference-build pin means one thing.
+ * A first-party git dependency names one commit, and it is the commit that gets
+ * installed.
  *
  * `package.json` names the `@markup-carve/carve` commit this repo measures
  * against, and every human-readable claim about "the pinned build" reads that
@@ -13,6 +14,20 @@
  * and then PRINTS "Now run: npm install". Skip that line - or land the bump
  * without committing the regenerated lock - and the two part company silently.
  * Found 16 commits apart (carve#661).
+ *
+ * There is a second way to have no pin at all, and it went unnoticed for longer
+ * because it does not look like a mismatch. A git dependency written with NO
+ * ref means "whatever tip is at install time", so the manifest and the lock
+ * disagree about what the dependency even is: a fresh install takes tip, an
+ * `npm ci` takes whatever the lock happened to capture. carve#1476 found
+ * carve-grammars that way, resolved to a build 201 commits behind its own main,
+ * and vite-plugin-carve alongside it - which the survey that filed the issue had
+ * missed, because it was spelled `git+https://` rather than `github:`.
+ *
+ * So this checks the dependency for what it IS - a git URL pointing into this
+ * org - rather than for how it happens to be spelled, and it checks EVERY one
+ * rather than the reference build alone. A check that only knew the two
+ * spellings in front of it would be exactly as blind as the survey was.
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
@@ -25,25 +40,96 @@ const pkg = JSON.parse(readFileSync(resolve(repo, 'package.json'), 'utf8'))
 const lock = JSON.parse(readFileSync(resolve(repo, 'package-lock.json'), 'utf8'))
 
 const SHA = /[0-9a-f]{40}/
+const ORG = 'markup-carve'
 
-test('the carve-js pin in package.json is the one the lockfile installs', () => {
-  const declared = pkg.devDependencies['@markup-carve/carve'] ?? pkg.dependencies['@markup-carve/carve']
-  assert.ok(declared, 'no @markup-carve/carve dependency in package.json')
+/*
+ * Anything that names a repository in this org, however it is spelled.
+ *
+ * Deliberately not a list of the spellings currently in use. npm accepts
+ * `github:owner/repo`, a bare `owner/repo` shorthand, `git@github.com:owner/repo.git`
+ * and five `git+<protocol>://` forms, and this repo already uses two of them.
+ * A matcher keyed on the prefix would have to grow a case per spelling, and a
+ * dependency added in a spelling nobody thought of would pass the check by not
+ * being seen - the failure this whole test exists to stop.
+ *
+ * So the org name is the signal. The exclusions are the specs that legitimately
+ * name no commit: `npm:` is a registry alias, and `file:`/`link:`/`workspace:`
+ * are local paths.
+ */
+const NAMES_THIS_ORG = new RegExp(String.raw`(^|[^@\w.-])${ORG}/`)
+const isFirstPartyGit = (spec) => !/^(npm|file|link|workspace):/.test(spec) && NAMES_THIS_ORG.test(spec)
 
-  const entry = lock.packages?.['node_modules/@markup-carve/carve']
-  assert.ok(entry, 'no @markup-carve/carve entry in package-lock.json')
+const firstPartyGitDependencies = Object.entries({
+  ...(pkg.dependencies ?? {}),
+  ...(pkg.devDependencies ?? {}),
+}).filter(([, spec]) => isFirstPartyGit(spec))
 
-  const declaredSha = declared.match(SHA)?.[0]
-  const lockedSha = String(entry.resolved ?? '').match(SHA)?.[0]
-
-  assert.ok(declaredSha, `package.json pin has no commit: ${declared}`)
-  assert.ok(lockedSha, `lockfile resolution has no commit: ${entry.resolved}`)
-  assert.equal(
-    lockedSha,
-    declaredSha,
-    'package.json and package-lock.json name DIFFERENT carve-js commits. ' +
-      'CI installs the lockfile one, so the report and the drift file describe ' +
-      'that build while the repo declares the other. Run `npm install` after ' +
-      '`npm run bump-carve-pin` and commit the lockfile with it.',
+test('every first-party git dependency names a commit, and the lock installs that commit', () => {
+  // The scan IS the check, so a scan that matched nothing would pass for the
+  // wrong reason - which is how the survey behind carve#1476 concluded there
+  // was one unpinned dependency when there were two.
+  assert.ok(
+    firstPartyGitDependencies.length >= 3,
+    `expected the first-party git dependencies to be found, matched ${firstPartyGitDependencies.length}`,
   )
+
+  for (const [name, spec] of firstPartyGitDependencies) {
+    const declaredSha = spec.match(SHA)?.[0]
+    assert.ok(
+      declaredSha,
+      `${name} is a git dependency with no commit: ${spec}\n` +
+        'That means "whatever tip is at install time", so a fresh install and an ' +
+        '`npm ci` can get different code. Pin it at a merged commit on the ' +
+        "dependency's main and commit the regenerated lockfile with it.",
+    )
+
+    const entry = lock.packages?.[`node_modules/${name}`]
+    assert.ok(entry, `no ${name} entry in package-lock.json`)
+    const lockedSha = String(entry.resolved ?? '').match(SHA)?.[0]
+    assert.ok(lockedSha, `lockfile resolution for ${name} has no commit: ${entry.resolved}`)
+
+    assert.equal(
+      lockedSha,
+      declaredSha,
+      `package.json and package-lock.json name DIFFERENT ${name} commits. ` +
+        'CI installs the lockfile one, so every claim made about the declared ' +
+        'commit describes some other build. Run `npm install` after moving the ' +
+        'pin and commit the lockfile with it.',
+    )
+  }
+})
+
+test('the reference build is one of them', () => {
+  // Named on its own because it is the pin the report, the drift ledger and the
+  // corpus all measure against: losing it entirely would leave the loop above
+  // with nothing to say.
+  const declared = pkg.devDependencies?.['@markup-carve/carve'] ?? pkg.dependencies?.['@markup-carve/carve']
+  assert.ok(declared, 'no @markup-carve/carve dependency in package.json')
+  assert.ok(isFirstPartyGit(declared), `the reference build is not a first-party git pin: ${declared}`)
+})
+
+/*
+ * The matcher's own coverage, because "it matches on the org rather than the
+ * spelling" is a claim about a regular expression and claims about regular
+ * expressions are worth checking. Both columns matter: a matcher that returned
+ * true for everything would pass the first list and fail the second.
+ */
+test('every spelling npm accepts for a repository in this org is recognized', () => {
+  for (const spec of [
+    'github:markup-carve/x',
+    'git+https://github.com/markup-carve/x.git',
+    'git+ssh://git@github.com/markup-carve/x.git',
+    'git+ssh://git@github.com:markup-carve/x.git',
+    'git://github.com/markup-carve/x.git',
+    'git@github.com:markup-carve/x.git',
+    'https://github.com/markup-carve/x/archive/refs/heads/main.tar.gz',
+    'markup-carve/x',
+    'markup-carve/x#semver:^1',
+  ]) {
+    assert.ok(isFirstPartyGit(spec), `not recognized as a first-party git dependency: ${spec}`)
+  }
+
+  for (const spec of ['^0.1.4', '~2.0.0', 'npm:@markup-carve/carve@^0.1.4', 'file:../markup-carve/x', 'github:other-org/x']) {
+    assert.ok(!isFirstPartyGit(spec), `wrongly treated as a first-party git dependency: ${spec}`)
+  }
 })


### PR DESCRIPTION
Closes #1476

Two first-party git dependencies named no commit, so the manifest meant "whatever tip is at
install time" while the committed lock delivered whatever it had once captured. Which of the
two a checkout got depended entirely on whether its lockfile was honored.

| dependency | before | lock resolved | after |
| --- | --- | --- | --- |
| carve-grammars | `github:markup-carve/carve-grammars` | `83b1872` (0.1.2, 2026-07-14) | `#086d9603` (0.1.4, 2026-08-20) |
| vite-plugin-carve | `git+https://…/vite-plugin-carve.git` | `8b2ae32f` (0.1.0, 2026-06-01) | `#0b355241` (0.1.0, 2026-08-18) |

`git rev-list --count 83b1872..086d9603` in carve-grammars is **201**, matching the issue.
Both new pins are the current head of their repo's `main`.

The issue says carve-grammars was the only unpinned first-party dependency here. It was not.
vite-plugin-carve is spelled `git+https://` rather than `github:`, which is presumably why
the survey missed it, and that is the thing the guard below has to be built around.

## The installed tree, not the manifest

`npm install` after the pin, then read the file the bump is supposed to have moved -
the installed grammars package's `textmate/carve.tmLanguage.json`:

```
version in node_modules/@markup-carve/carve-grammars/package.json:  0.1.4   (was 0.1.2)
tmLanguage repository rules:                                        79      (was 57)
  literal_inline                present  (absent at 0.1.2)
  callout_marker                present  (absent at 0.1.2)
  citation                      present  (absent at 0.1.2)
  block_comment_on_marker_line  present  (absent at 0.1.2)
  extension_block               absent   (present at 0.1.2)
```

Those rules did not exist in the 0.1.2 build under any name, so the tree on disk is the new
one and not a manifest edit that changed nothing. A `diagrams/` directory appeared too, which
0.1.2 did not ship.

For vite-plugin-carve the thing to check is different: it declares `prepare: npm run build`
and does not track `dist/`, which is exactly the shape that bit the carve-js bump earlier
tonight. the installed vite-plugin-carve `dist/` holds `index.js`, `index.d.ts`
and `index.js.map`, freshly written, so the prepare script did run rather than being skipped.

## Nothing moved, and here is why that is the correct outcome rather than a missed check

No test changed, no snapshot moved, `npm run docs:build` is green and regenerates no tracked
file. Jumping 201 commits usually moves output, so the absence needs an account rather than a
shrug.

This repo reads exactly three things out of carve-grammars:

| consumer | file | across the 201 commits |
| --- | --- | --- |
| `docs/.vitepress/config.ts` | `shiki/index.js` | byte-identical (sha256 `034c173aa4799246` both sides) |
| `docs/.vitepress/theme/index.ts` | `shiki/carve.css` | byte-identical (sha256 `d41a68edc5bc3267` both sides) |
| `docs/.vitepress/theme/components/Playground.vue` | `textmate/carve.tmLanguage.json` | rewritten, 1742 insertions / 922 deletions |

Of the 201 commits, 2733 changed files are under `tests/`, 38 under `tiptap/` and one under
`textmate/`. The only consumed file that moved is the TextMate grammar, and it is loaded at
runtime in the browser by the playground - no gate reads it, and it is not a committed
artifact here. So there is no snapshot to attribute, and no line was regenerated.

The rule changes visible in that grammar all correspond to landed work: `citation`,
`literal_inline`, `callout_marker` / `callout_annotation`, the `block_comment_*` family and
the `*_in_container` rules are highlighting for syntax this repo already specifies, and
`extension_block` is gone because that spelling no longer exists. Nothing in the set is a
rule this repo does not have.

## The guard

`tests/engine-pin-matches-the-lock.test.mjs` covered the carve-js pin alone. It now covers
every first-party git dependency: each must name a commit, and the lock must resolve to that
same commit.

It replaces the carve-js-specific assertion rather than sitting beside it - a second spelling
of "declared sha equals locked sha" is precisely the defect `#1479` closed an hour ago.

It matches on the org name rather than a list of URL prefixes. npm accepts a bare
`owner/repo` shorthand and a bare scp-style SSH URL alongside the two forms in
use here, and a prefix list would let a dependency written either of those ways pass by not
being seen - the same blindness that produced the issue's "only one" claim. Registry aliases
and local paths are excluded, since they name no commit and want none. The matcher's coverage
is pinned by a table of spellings rather than asserted in prose, and the scan asserts it
matched something, so it cannot pass by finding nothing.

## The guard fails on the cases it claims to

Each mutation applied after the fix was committed, then restored with
`git restore --source=HEAD --staged --worktree package.json`.

**1. The `github:` form with its `#sha` stripped** - the exact pre-fix state:

```
AssertionError [ERR_ASSERTION]: @markup-carve/carve-grammars is a git dependency with no commit: github:markup-carve/carve-grammars
That means "whatever tip is at install time", so a fresh install and an `npm ci` can get different code. Pin it at a merged commit on the dependency's main and commit the regenerated lockfile with it.
exit=1
```

**2. The `git+https://` form with its `#sha` stripped** - the spelling the issue's survey
missed:

```
AssertionError [ERR_ASSERTION]: @markup-carve/vite-plugin-carve is a git dependency with no commit: git+https://github.com/markup-carve/vite-plugin-carve.git
exit=1
```

**3. The bare `owner/repo` shorthand** - the spelling a prefix-matching guard would have
walked straight past:

```
AssertionError [ERR_ASSERTION]: @markup-carve/carve-grammars is a git dependency with no commit: markup-carve/carve-grammars
exit=1
```

**4. Manifest and lock naming different commits**, the carve#661 shape:

```
AssertionError [ERR_ASSERTION]: package.json and package-lock.json name DIFFERENT @markup-carve/carve-grammars commits. CI installs the lockfile one, so every claim made about the declared commit describes some other build. Run `npm install` after moving the pin and commit the lockfile with it.
+ '086d9603736466092c4517e76513b4915c1f94a7'
- '83b1872991090b7f8e6840e51a4c4c75ce7e611d'
exit=1
```

After each restore, `grep -n "carve-grammars" package.json` prints the pinned line back and
the file runs green (`exit=0`), with `git status --porcelain` empty.

## Gate

`partial`, nothing failed. Ran: `npm test`, `combinatorial:check` (0 declared, 0 undeclared),
`core:check`, `escape:check`, `html-import:check`, `links:check`, `property:check`,
`test:conformance`. Plus `npm run docs:build`, which is the only consumer of the bumped
dependency and is not part of the detected gate set.

Four gates were unrunnable on this host for missing sibling engine checkouts, verbatim:

```
npm run ast:check          a dependency outside the repository is missing: /tmp/carve-js/dist
npm run claims:check       engine-claims: need all three engines, found 0 (none).
npm run degradation:check  degradation-claims: need all three engines, found 0 (none).
npm run fmt:check          fmt-fixture-claims: need all three engines, found 0 (none).
```

No CHANGELOG entry: nothing here changes what the language or any shipped renderer does.

`resources/examples-tier3.md` did not move, so the peer session on
`spec/1468-tier3-accessible-names` is unaffected. Draft `#291` also touches `package.json`.
