### PR TITLE
docs: reconcile the unreleased changelog with every merge since 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Table column metadata and two-axis cell alignment** (carve#1344).
+  `table.columns[]` carries a horizontal alignment, a vertical alignment and a
+  fractional width, `table_cell` gains `valign`, positional `aligns`, `valigns`
+  and `widths` table attributes set them, and a cell marker run may write both
+  axes (`|>^`, `|<v`). HTML gains cell styles and `colgroup` widths, and
+  `table-column-arity`, `table-column-overlap` and `table-width-total` lint the
+  result. Corpus 370, 371.
+- **A table cell can inherit its column's horizontal alignment** (carve#1408).
+  `?^`, `?~` and `?v` keep the column's horizontal alignment while setting the
+  cell's vertical one; a lone `?`, a reversed `v?` and a two-horizontal `?<`
+  stay literal content. Corpus 375.
+- **A pipe table can state its head and foot row counts** (carve#1413).
+  `header-rows=N` and `footer-rows=N` partition the table into `thead`, `tbody`
+  and `tfoot`; an explicit head cell becomes a column header and `|=` stays
+  valid in a body row. A ListTable cell's own `align`/`valign` outranks its
+  column's. Corpus 376.
+- **ListTable declares local headers and body row groups** (carve#1248,
+  carve#1337). A body group may carry its own header row, and a row group's
+  span boundaries are defined. Optional corpus 45.
+- **An extension block matcher is a pure predicate, and a definition probe may
+  ask it** (carve#1432, R1a). An engine deciding whether a definition line folds
+  into an open paragraph may consult a registered matcher instead of switching
+  the guard off wherever an extension exists.
+- **A block matcher's coordinates are local, not absolute** (carve#1437, R1b).
+  A matcher reads positions against its own container rather than the document.
+
 ### Fixed
 
 - **The index back-link says where it goes, and the extension-written strings
@@ -50,9 +78,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the next block instead of folding in as literal text. The layout pass
   already read the other two correctly in that position. Corpus 391.
 
-- **The AST span-divergence ledger now records the current zero-difference
-  baseline.** The last `hard_break` extent disagreement cleared across all
-  three engines and its regression test now pins an empty ledger (carve#1414).
+- **The footnote backlink says where it goes, and the engine's own words are an
+  option** (carve#1457, PART 9 §16). `role="doc-backlink"` carried no accessible
+  name, so a reader announced the `↩` glyph. A lone backlink is now named by its
+  label, the k-th of several renders `↩<sup>k</sup>` and is named for that
+  reference ordinal, and the English string is a render option rather than a
+  fixed word.
+
+- **A continuation marker attaches only a flush-left block** (carve#1436,
+  carve#1437, §17 L3). The clause always said flush-left and no reader
+  implemented it, so a `+` marker attached the following block at any
+  indentation. Corpus 384.
+
+- **The hyphen-run flanking test reads PART 7's spaces, not the host
+  language's** (carve#1448). It was spelled with JavaScript's `\s`, which takes a
+  vertical tab and a form feed; Carve reads both as content, so two documents
+  that should agree answered differently.
 
 ### Changed
 
@@ -82,7 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an omitted one, and the fence pair is `dependentRequired`. Version stays 1: all three
   engines emit only `path`, `startByte` and `endByte`, so no sidecar in existence
   carries a field whose meaning moved.
-- **A vertical table-cell marker requires a horizontal partner.** `|^ x` and `|v x` remain visible content; paired runs such as `|<^`, `|~~`, and `|v>` carry both axes. Corpus 373.
+- **A vertical table-cell marker requires a horizontal partner, written first** (carve#1405, carve#1407). `|^ x` and `|v x` remain visible content, and so does a reversed pair such as `|v>`; a horizontal-first run such as `|<^` or `|>^` carries both axes. Corpus 373.
 - **A collected definition closes the item paragraph, and only a comment keeps
   the below-column path open** (carve#1376). Item prose reopens at the content
   column; a footnote body starts two columns beyond its definition; bare `. `
@@ -90,6 +131,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A quote is reached by its marker, and a column never reaches into one** (carve#1384). A line writing no `>` is in no quote whatever column it lands on; it folds into the deepest open paragraph, renders where it was written, and registers nothing. Corpus 369.
 - **An unterminated fence at a container's content column opens no block** (carve#1387). Section 10 I4 asks for a closer; without one the line is paragraph text, the paragraph stays open, and a flush-left line below folds into it. Corpus 367.
 - **A raw block keeps the blank line at the end of its payload** (carve#1389). The payload is every line between the delimiters; the container and whether the closer was written are not parameters. Corpus 366.
+- **A heading at an item's content column leaves no paragraph open**
+  (carve#1377). A heading is the visible control: at the content column it ends
+  the item's paragraph, and an enclosing item's paragraph survives past a nested
+  heading. Corpus 368.
+- **An all-blank raw payload still emits its line** (carve#1401). Corpus 372.
+- **A resumed lazy run belongs to the innermost marker-line item** (carve#1424).
+  Corpus 381.
+- **A marker-line link definition is collected where no paragraph is open**
+  (carve#1425). A definition written directly after a list marker is metadata;
+  with a paragraph open above it the marker line is lazy text and the definition
+  defines nothing. Corpus 382.
+- **A lazy marker line's definition defines nothing, in any container**
+  (carve#1428). The corpus said this only at the document level, so the quote
+  and div spellings had three answers across the engines. Corpus 383.
+- **A hyphen run opening a word after whitespace is a flag, not a dash**
+  (carve#1443). `--oneline` and `--force-with-lease` stay literal; `1--10`,
+  `Mon--Fri` and a spaced `--` still convert. Corpus 385.
+- **The doubled run is the canonical arrow, in both families** (carve#1442).
+  `<--`, `-->`, `<-->` and the `=` family are canonical; the single-hyphen
+  spellings are deprecated and still render. Corpus 386.
+- **A row is a row, in every table section** (carve#1459). `thead`, `tbody` and
+  `tfoot` all write one row per line; a head and a foot used to be compact while
+  a body was expanded, so the same element had two layouts and no stated reason.
+- **`table-marker-run-padding` is one lint id for the whole marker run**
+  (carve#1464, PART 9 §5 T11). It names the kind marker as well as the alignment
+  run and the attribute block, and supersedes `table-alignment-run-padding`,
+  which named only the middle part; `fmt --migrate` inserts the missing space.
+- **ASCII-folding is available in all three engines, in two modes**
+  (carve#1470). Best-effort keeps what the transliteration table cannot map,
+  strict drops it so an id matches `[0-9A-Za-z-]`; carve-rs gains
+  `ascii_heading_ids`, and all three carry the same table, so a folded id is
+  byte-identical across them.
 
 ## [0.1.3] - 2026-08-18
 


### PR DESCRIPTION
Reconciles the `[Unreleased]` section against the merge list rather than reading it for completeness. 77 commits landed since `0.1.3` across 51 pull requests. 14 were already described, 17 are tooling or docs and correctly carry no entry, 19 consumer-visible changes had no entry at all, and one existing entry described behavior that never shipped.

## The gap

The whole table-column feature was undescribed, together with the table row partitions, the marker-line definition family, the hyphen-run and arrow rulings, the footnote backlink name, the table section layout, the new lint id and the ASCII-folding modes.

## One entry contradicted the corpus

The vertical-marker entry listed `|v>` among the pairs that carry both axes. A reversed pair has been literal content since the horizontal-first rule landed in #1407, and corpus 373 pins it as a data cell whose text is `=v&gt; Reverse`. The entry now names the order requirement and cites both PRs.

## One entry removed, deliberately

The AST span-divergence ledger entry (from #1417) is gone. That PR changed `resources/ast-span-divergence.txt` and `tests/ast-spans.test.mjs`: a regression test now pins an empty ledger. The behavior convergence it reports happened in the engine repositories, and belongs in their changelogs. Nothing a reader of this specification can observe moved, so it fails the consumer test. Easy to revert if you disagree.

## Reconciliation

| PR | Subject | Entry | Why not |
| --- | --- | --- | --- |
| #1391 | define table column metadata and two-axis alignment (carve#1344) | added | |
| #1392 | a heading at an item's content column leaves no paragraph open (carve#1377) | added | |
| #1397 | a citation broken by a line wrap escapes the citation gate | no | normativity gate; `scripts/` and `tests/` only |
| #1398 | a raw block keeps the blank line at the end of its payload | described | |
| #1399 | an unterminated fence at a content column opens no block | described | |
| #1400 | a quote is reached by its marker | described | |
| #1402 | finalize table engine pin | no | engine pin |
| #1404 | define all-blank raw payload output (carve#1401) | added | |
| #1405 | require horizontal partners for vertical table markers | described | |
| #1406 | pin paired table alignment engine | no | engine pin |
| #1407 | require horizontal-first table alignment pairs | corrected | existing entry said `\|v>` carries both axes; it is literal content |
| #1408 | define inherited table alignment | added | |
| #1409 | settle definition continuation columns | described | |
| #1410 | pin horizontal-first reference engine | no | engine pin |
| #1411 | normalize list-table row-group formatting | no | serialization only, superseded by the carve#1459 entry |
| #1412 | specify ListTable local headers and body groups (carve#1248, carve#1337) | added | |
| #1413 | semantic table row partitions | added | |
| #1417 | retire the final AST span divergence | no | test ledger; see above, existing entry removed |
| #1422 | sweep combinatorial seam families weekly | no | test harness |
| #1423 | close combinatorial parser findings | no | corpus documents under `tests/` only, no rule moved |
| #1426 | specify nested marker-line lazy resume (carve#1424) | added | |
| #1427 | a marker-line link definition is collected (carve#1425) | added | |
| #1429 | a lazy marker line's definition defines nothing (carve#1428) | added | |
| #1433 | define every optional source-layout fact | described | |
| #1434 | move the reference build past the lazy marker-line definition | no | engine pin |
| #1435 | a matcher is a pure predicate (carve#1432) | added | |
| #1438 | a continuation marker attaches only a flush-left block (carve#1436) | added | |
| #1439 | a block matcher's coordinates are local (carve#1437) | added | |
| #1445 | a hyphen run opening a word after whitespace is a flag (carve#1443) | added | |
| #1446 | the doubled run is the canonical arrow (carve#1442) | added | |
| #1448 | the hyphen-run flanking test reads PART 7's spaces | added | |
| #1449 | an empty brace pair is text, a braced hyphen pair is an en dash | described | |
| #1452 | a boolean attribute does not start with an underscore | described | |
| #1453 | name the corpus numbers the empty-brace rule landed on | no | corrects numbers inside entries already present |
| #1457 | the footnote backlink says where it goes | added | |
| #1458 | show the inherit-horizontal marker in the cheatsheet | no | docs; the behavior is the carve#1408 entry |
| #1460 | a table cell's marker run ends at a space | described | |
| #1461 | a row is a row, in every table section (carve#1459) | added | |
| #1462 | the convert corpus takes the table layout too | no | fixture regeneration for carve#1459 |
| #1465 | an attributed cell keeps its attributes | described | |
| #1466 | an attribute line below a list item interrupts it | described | |
| #1467 | the marker run gets one lint id (carve#1464) | added | |
| #1470 | ASCII-folding is available in all three engines, in two modes | added | |
| #1471 | four engine-written shapes say what they are called | described | |
| #1473 | the binding-parity gate no longer deletes carve-php from the run | no | `scripts/ast-conformance.mjs` and its test |
| #1475 | the home page and README say tables align on two axes | no | docs; the behavior is the carve#1344 entry |
| #1477 | the index back-link is named | described | |
| #1478 | bump the pinned engine and clear the declared drift | no | engine pin |
| #1480 | a duplicate key in a drift ledger fails | no | ledger tooling |
| #1481 | a first-party git dependency names the commit it installs | no | dependency tooling |
| #1482 | the writer's two disputed spellings were already decided | described | |
