### PR TITLE
test: a corpus fixture with no docs page now fails npm test

### DIFF
--- a/tests/no-orphan-pages.test.mjs
+++ b/tests/no-orphan-pages.test.mjs
@@ -9,7 +9,9 @@
  * question nobody asked.
  *
  * A page with no route is the same defect as a corpus fixture with no page: a
- * thing that exists and has no reader. This test asks the question.
+ * thing that exists and has no reader. This test asks BOTH questions - see the
+ * second block below for the fixture direction, which this file named and then
+ * did not check.
  *
  * To retire a page deliberately, delete it. To keep one out of the nav on
  * purpose, add it to UNROUTED with the reason - that turns an oversight into a
@@ -21,6 +23,7 @@ import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { numberExamples, readExampleFiles, scanExampleSource } from '../scripts/lib/example-sections.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, '..')
@@ -95,4 +98,112 @@ test('every UNROUTED waiver still names a real page', () => {
    * same name. */
   const stale = [...UNROUTED.keys()].filter((path) => !tracked.includes(path))
   assert.deepEqual(stale, [], `these waivers name pages that no longer exist: ${stale.join(', ')}`)
+})
+
+/*
+ * THE SECOND DIRECTION: every corpus fixture must be routed to a docs page.
+ *
+ * WHY. The docstring above named this exact defect - "a corpus fixture with no
+ * page" - and then only checked the sibling. The question is asked, but in
+ * `scripts/generate-example-pages.mjs` ("fixture ... is routed to no page"),
+ * which is reached through `docs:pages` and so runs only under `docs:dev` and
+ * `docs:build`. Corpus 394 was added in carve#1482, reached CI unrouted, and
+ * the whole local suite passed; the signal arrived from a later job, after the
+ * point where a contributor is still looking.
+ *
+ * The reason it could not be asked here is real, and it is why this block does
+ * not go looking for a page. `docs/examples/` is generated and gitignored, so
+ * when this test runs there is no generated page on disk to find a fixture in.
+ * It does not need one: the ROUTE is tracked. `resources/example-pages.txt` is
+ * the manifest the generator reads, and `scripts/lib/example-sections.mjs` is
+ * the naming operation both sides already share, so the manifest answers the
+ * question without a build.
+ */
+const exampleScan = scanExampleSource(readExampleFiles(repoRoot).split('\n'))
+numberExamples(exampleScan)
+const sectionSlugByFixture = new Map(exampleScan.examples.map((example) => [example.corpusName, example.slug]))
+const sectionSlugs = new Set(exampleScan.sections.map((section) => section.slug))
+
+/* The census is the fixtures a contributor actually commits, not the scanner's
+ * own account of what it extracted - the same reason scripts/lib/example-pair-
+ * census.mjs exists. `corpus:build` unlinks every .crv before regenerating, so
+ * the two agree by construction, and the guard below fails loudly if they stop. */
+const corpusFixtures = execFileSync('git', ['ls-files', 'tests/corpus'], { cwd: repoRoot, encoding: 'utf8' })
+  .split('\n')
+  .filter((path) => path.endsWith('.crv'))
+  .map((path) => path.slice('tests/corpus/'.length, -'.crv'.length))
+
+/* A route entry is the only kind of line in the page file that is indented;
+ * page ids, `key:` lines, descriptions and comments all start at column zero.
+ * This mirrors parsePages in the generator, which reads an indented line as an
+ * entry after every other form has failed to match. */
+const routeEntries = new Set(
+  readFileSync(resolve(repoRoot, 'resources/example-pages.txt'), 'utf8')
+    .split('\n')
+    .filter((line) => line.startsWith('  ') && line.trim() !== '')
+    .map((line) => line.trim()),
+)
+
+test('the corpus census agrees with the example source', () => {
+  /* Either list arriving empty - a failed git call, a moved source file - would
+   * make the routing assertion below pass over nothing. */
+  assert.ok(corpusFixtures.length > 1000, `expected the tracked corpus fixtures, found ${corpusFixtures.length}`)
+  const unsourced = corpusFixtures.filter((name) => !sectionSlugByFixture.has(name))
+  const unwritten = [...sectionSlugByFixture.keys()].filter((name) => !corpusFixtures.includes(name))
+  assert.deepEqual(
+    { unsourced, unwritten },
+    { unsourced: [], unwritten: [] },
+    'tests/corpus and resources/examples/ disagree about which fixtures exist - run `npm run corpus:build`',
+  )
+})
+
+test('every corpus fixture is routed to a docs page', () => {
+  /* An entry names either a section slug, which routes every pair in that
+   * section, or one fixture name, which routes that pair alone. */
+  const unrouted = corpusFixtures.filter(
+    (name) => !routeEntries.has(name) && !routeEntries.has(sectionSlugByFixture.get(name)),
+  )
+  assert.deepEqual(
+    unrouted,
+    [],
+    'these corpus fixtures are on no docs page, so nothing explains them to a reader -\n' +
+      'add the fixture name, or its section slug, to resources/example-pages.txt:\n' + unrouted.join('\n'),
+  )
+})
+
+test('every route entry names a section or fixture that exists', () => {
+  /* Without this, a typo in the manifest reports as the FIXTURE being
+   * unrouted, which sends the reader to the corpus instead of to the line that
+   * is actually wrong. */
+  const dangling = [...routeEntries].filter((entry) => !sectionSlugs.has(entry) && !sectionSlugByFixture.has(entry))
+  assert.deepEqual(
+    dangling,
+    [],
+    'these resources/example-pages.txt entries match no section slug and no fixture name:\n' + dangling.join('\n'),
+  )
+})
+
+/*
+ * The optional corpus has the same shape and the same gap. Its generator check
+ * is per FEATURE, not per case, so a new case under a feature that already has
+ * a page is routed the moment it is added - but a new feature is not, and that
+ * too was only visible at `docs:build`.
+ */
+test('every optional-corpus feature is routed to a docs page', () => {
+  const manifest = JSON.parse(readFileSync(resolve(repoRoot, 'tests/corpus-optional/manifest.json'), 'utf8'))
+  const features = [...new Set(manifest.cases.map((item) => item.feature))]
+  assert.ok(features.length > 10, `expected the optional-corpus features, found ${features.length}`)
+  const assigned = new Set(
+    readFileSync(resolve(repoRoot, 'resources/optional-example-pages.txt'), 'utf8')
+      .split('\n')
+      .filter((line) => line.startsWith('  ') && line.trim() !== '')
+      .map((line) => line.trim()),
+  )
+  const unrouted = features.filter((feature) => !assigned.has(feature))
+  assert.deepEqual(
+    unrouted,
+    [],
+    'these manifest features appear on no optional page, so the behavior they pin has no reader -\n' +
+      'add them to resources/optional-example-pages.txt:\n' + unrouted.join('\n'),
+  )
 })


### PR DESCRIPTION
`tests/no-orphan-pages.test.mjs` checked one direction: every docs page is reachable. Its own docstring named the other one - "a corpus fixture with no page" - and then did not check it. Corpus 394 reached CI unrouted and the whole local suite passed; only `docs:build` noticed, which is a different and later job.

The question was already being asked, in `scripts/generate-example-pages.mjs`:

```
for (const fixture of segmentsByName.keys()) {
  if (!routedSegments.has(fixture)) fail(`fixture "${fixture}" is routed to no page; ...`)
}
```

That is reached through `docs:pages`, which only `docs:dev` and `docs:build` call. Nothing under `npm test` runs it.

### Why the test could not ask it before

A real reason, and it shapes the fix. `docs/examples/` and `docs/.vitepress/generated-examples.json` are gitignored, and the existing test deliberately restricts itself to tracked pages - so when it runs there is no generated page on disk to look a fixture up in. "Which page did fixture 394 land on" is genuinely unanswerable there.

It does not need the output. The route is tracked: `resources/example-pages.txt` is the manifest the generator reads, and `scripts/lib/example-sections.mjs` is the naming operation both sides already share (a test already imports its sibling `example-pair-census.mjs`). So the manifest answers the question with no build.

### What lands

Four assertions in the same file:

| assertion | catches |
| --- | --- |
| every corpus fixture is routed to a docs page | the reported defect, over the 1342 tracked `.crv` files |
| every route entry names a section or fixture that exists | a typo, which otherwise reports as the FIXTURE being unrouted and sends the reader to the corpus instead of the wrong manifest line |
| the corpus census agrees with the example source | a failed `git ls-files` or a moved source file making the routing assertion pass over nothing |
| every optional-corpus feature is routed to a docs page | the same gap at feature granularity - `manifest feature "X" appears on no optional page` was equally invisible to `npm test` |

The census is the tracked `tests/corpus/*.crv` files rather than the scanner's own account of what it extracted, for the reason `scripts/lib/example-pair-census.mjs` gives: a check that asks the extractor how many things it extracted cannot fail. Measured on `ab844f87`, the two agree exactly - 1342 each way, 0 unsourced, 0 unwritten.

### Proof the assertions can fail

394 is routed, so it could not serve as the failing case on its own. Each assertion was driven red by unrouting something, then restored from a `cp` backup and re-verified by checksum and grep:

```
unroute corpus 394 (its section slug)   -> fail 1: 394-a-leading-escaped-caret-keeps-its-escape
unroute one fixture entry 01-emphasis-4 -> fail 1: 01-emphasis-4
add a typo'd entry 01-emfasis-9         -> fail 1: 01-emfasis-9
unroute the optional feature `spoiler`  -> fail 1: spoiler
stage a corpus file with no section     -> fail 2: 999-orphan-probe, census and routing both
```

Restored state re-measured green, 8 of 8.

No CHANGELOG entry - test tooling, nothing a consumer of the spec sees.
