### PR TITLE
spec: a css-mode tabs panel is named, and code-group grows the same mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the guard off wherever an extension exists.
 - **A block matcher's coordinates are local, not absolute** (carve#1437, R1b).
   A matcher reads positions against its own container rather than the document.
+- **Tabs and code-group panels get an accessible name, and code-group gets a
+  mode** (carve#1468, extensions §13). `css` stays the default mode in both; a
+  `css`-mode panel takes `role="group"` named by its tab's own label, while an
+  `aria`-mode panel stays bound by `aria-labelledby` and takes neither.
+  CodeGroup grows the `mode: 'css' | 'aria'` option Tabs already has. Optional
+  corpus 46, 47.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ tested against, and the design rationale behind each decision.
 | | |
 |---|---|
 | **Specification** | 0.1. Tier-1 core and Tier-2 standard extensions are normative and stable; Tier-3 app-level extensions ship but evolve. See [VERSIONING.md](VERSIONING.md). |
-| **Conformance** | Over 1,250 corpus examples pinning exact HTML output, plus 45 optional-corpus examples for host-dependent extensions. |
+| **Conformance** | Over 1,250 corpus examples pinning exact HTML output, plus 47 optional-corpus examples for host-dependent extensions. |
 | **Engines** | [carve-js](https://github.com/markup-carve/carve-js) (TypeScript, reference), [carve-php](https://github.com/markup-carve/carve-php), [carve-rs](https://github.com/markup-carve/carve-rs) - all three run the same corpus, with no open or intentional divergences ([tracker](MAINTAINING.md#known-cross-impl-divergences)). |
 | **Bindings** | Python, Ruby, Go, and WebAssembly, all over carve-rs. |
 | **Tooling** | Language server, tree-sitter grammar, formatter and linter (`carve fmt` / `carve lint`), converters from Markdown, HTML, Djot, and BBCode. |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -216,13 +216,14 @@ language.
 | Key | Default | Written by |
 |-----|---------|-----------|
 | `indexBackref` | `Back to` | Index (§8.2) |
-| `tabsGroup` | `Tabs` | Tabs (§4.20) |
-| `codeGroup` | `Code examples` | CodeGroup |
+| `tabsGroup` | `Tabs` | Tabs (§13.4) |
+| `codeGroup` | `Code examples` | CodeGroup (§13.4) |
 
 **What does NOT get a key.** A string with no fixed English default is not in
 the map, because there is nothing to translate: a diagram fence's name defaults
 to the *extension's own class word* (`mermaid`, `d2`, and `graphviz` for the
-`dot` fence it claims), so it stays an option on the extension. Neither is a string the author already wrote - a tab's `[label]`, an
+`dot` fence it claims), so it stays an option on the extension. Neither is a string the author already wrote - a tab's `[label]`, which
+also names its panel (§13.2), an
 index term, an admonition title. Those are named by DERIVING from the document,
 so a translated document translates them exactly once, in the document.
 
@@ -1375,3 +1376,143 @@ render degrades to the literal source text rather than inventing a URL. A site
 layer that knows which pages exist can walk the AST, match `ref` against its own
 index and fill `href` in - which is the same division of labor Wikilinks makes
 explicit through its URL generator.
+## 13. Tabs (Tier-2) and CodeGroup (Tier-3)
+
+Two constructs of the same shape. A `:::: tabs` container turns each `::: tab
+[Label]` child into one panel; a `::: code-group` container does the same with
+each fenced code block, taking the fence's `[Label]` as the tab name and its
+language word where none was written. Tabs is Tier-2 and pinned in
+`tests/corpus-optional`; CodeGroup is Tier-3 and is not corpus-pinned. Every
+rule in this section binds BOTH: two constructs of the same shape do not get
+different accessibility ceilings because one of them was written second
+(carve#1468).
+
+### 13.1 Two modes, and why `css` is the default
+
+Both extensions carry a `mode` option with exactly two values:
+
+| `mode` | How a panel is revealed | Needs a client script |
+|---|---|---|
+| `css` (default) | one `<input type="radio">` per tab plus a sibling `<label for=…>`; a stylesheet reveals the checked panel | no |
+| `aria` | a `<button role="tab">` per tab and `role="tabpanel"` panels; every non-selected panel carries `hidden` | yes |
+
+`css` is the default in both, and an implementation MUST NOT ship `aria` as the
+default. That is a consequence of the §2.5 rule rather than of compatibility:
+content is never dropped, only interaction. `aria` mode reveals with `hidden`,
+so a page that registers it and ships no script loses every panel but the first,
+while `css` mode with no stylesheet at all shows every panel. A default whose
+failure mode is missing content is the wrong default, whatever its semantics are
+when it works. The question reopens if `aria` mode stops using `hidden` for the
+reveal.
+
+An unknown `mode` value MUST be rejected rather than guessed, for the reason
+§2.5 gives about render modes: a guess turns a typo into silently different
+output.
+
+A `"static"` render (§2.5) takes neither mode. `renderStatic` flattens the set to
+one `<section>` per panel headed by its `[label]`, where the heading IS the name
+and no interaction survives to bind.
+
+### 13.2 A `css`-mode panel carries its tab's name
+
+Under `css` there are no tab roles, so nothing binds a panel to the control that
+reveals it: all radios and labels are emitted before all panels, and the panel
+itself is anonymous. Each panel therefore takes a role and a name of its own:
+
+```html
+<div class="tabs" role="group" aria-label="Tabs">
+<input type="radio" name="tabset-1" id="tabset-1-tab-1" class="tabs-radio" checked>
+<label for="tabset-1-tab-1" class="tabs-label">First</label>
+<div class="tabs-panel" role="group" aria-label="First">
+<p>Content one.</p>
+</div>
+</div>
+```
+
+- **The name is the tab's own label** - the same string the tab's `<label>`
+  element carries. It is DERIVED from the document, so per
+  [§1.5](#_1-5-the-strings-an-extension-writes-itself) it gets **no `labels`
+  key**, exactly as an admonition title does not: a translated document
+  translates it once, in the document. The name is TEXT and is
+  attribute-escaped.
+- There is no separate attribute for it, and none is introduced: an author
+  renames a panel by renaming its tab.
+- **`role="group"`, not `role="tabpanel"`.** The control that reveals this panel
+  is a `radio`, not a `tab`. `group` is all the CSS mode can honestly claim.
+- **Not `<section>`.** One landmark per panel is N landmarks per tab set, which
+  is the noise §1.5's sibling ruling removed from untitled admonitions.
+- **A bare `aria-labelledby` would not do instead.** ARIA marks `aria-label` and
+  `aria-labelledby` **prohibited** on role `generic`, which a plain `<div>` maps
+  to, so the attribute is ignored where it is not flagged outright - and there
+  is nothing to point one at, since the `<label>` elements carry `for=`, not
+  `id=`.
+
+`code-group` panels take the same treatment, keyed on the panel's own label: the
+tab name where one was written, otherwise the language word.
+
+```html
+<div class="code-group" role="group" aria-label="Code examples">
+<input type="radio" name="codegroup-1" id="codegroup-1-tab-1" class="code-group-radio" checked>
+<label for="codegroup-1-tab-1" class="code-group-label">Node</label>
+<input type="radio" name="codegroup-1" id="codegroup-1-tab-2" class="code-group-radio">
+<label for="codegroup-1-tab-2" class="code-group-label">python</label>
+<div class="code-group-panel" role="group" aria-label="Node"><pre><code class="language-js">console.log(1)
+</code></pre>
+</div>
+<div class="code-group-panel" role="group" aria-label="python"><pre><code class="language-python">print(1)
+</code></pre>
+</div>
+</div>
+```
+
+### 13.3 An `aria`-mode panel is bound, not named
+
+In `aria` mode the association already exists, so the panel takes **neither**
+`role="group"` **nor** an `aria-label`. It stays `role="tabpanel"`, bound by
+`aria-labelledby` to its `<button role="tab">`, and every non-selected panel
+carries `hidden`:
+
+```html
+<div class="tabs" role="tablist" aria-label="Tabs">
+<button role="tab" id="tabset-1-tab-1" aria-selected="true" aria-controls="tabset-1-panel-1" class="tabs-label">First</button>
+<button role="tab" id="tabset-1-tab-2" aria-selected="false" aria-controls="tabset-1-panel-2" class="tabs-label" tabindex="-1">Second</button>
+<div role="tabpanel" id="tabset-1-panel-1" aria-labelledby="tabset-1-tab-1" class="tabs-panel">
+<p>Content one.</p>
+</div>
+<div role="tabpanel" id="tabset-1-panel-2" aria-labelledby="tabset-1-tab-2" class="tabs-panel" hidden>
+<p>Content two.</p>
+</div>
+</div>
+```
+
+Naming it as well would give one element two accessible names and pull it out of
+the `tablist` relationship that is the only reason to be in this mode. So the
+rule in §13.2 is a `css`-mode rule specifically, not "every panel gets a name".
+
+### 13.4 The set's own name
+
+Both wrappers are named already, and unlike a panel name those two strings are
+extension-written with a fixed English default, so both DO have `labels` keys:
+
+```html
+<div class="tabs" role="group" aria-label="Tabs">
+<div class="code-group" role="group" aria-label="Code examples">
+```
+
+`tabsGroup` and `codeGroup` in the §1.5 table carry them, an option on the
+extension overrides the map, and an `aria-label` the author writes on the
+container outranks both - naming two tab sets on one page apart is the author's
+job. In `aria` mode the tabs wrapper is `role="tablist"` instead and keeps the
+same name.
+
+### 13.5 Conformance
+
+Tabs is pinned in `tests/corpus-optional`. Feature `tabs` covers the `css`
+panel name (cases 28 and 46); feature `tabs-aria` covers §13.3 - the
+`tabpanel` / `aria-labelledby` binding, the `hidden` reveal that §13.1 turns on,
+and the absence of `role="group"` there (case 47).
+
+CodeGroup is Tier-3 and NOT corpus-pinned; `resources/examples-tier3.md` is its
+only verifier in this repo. Its `mode` option, its panel naming and its
+rejection of an unknown mode are stated here and pinned by each implementation
+in its own suite, the same division §8.4 describes for Index.

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -824,12 +824,15 @@ rather than a parser one.
 Optional raw output:
 
 Optional corpus added since this run: `42-list-table-header-rows-cols`,
-`43-citations-at-label-in-reference-position`.
+`43-citations-at-label-in-reference-position`, `46-tabs-css-panel-name`,
+`47-tabs-aria-panel-binding`.
 
 The first pins `{header-rows}` / `{header-cols}` on a list table; the second is
 the citations-side control for the core rule that a label beginning with an at
-sign is not a reference label. Both landed after the run above was taken, so
-the corpus is two cases ahead of it. The
+sign is not a reference label. The last two are the two halves of extensions
+§13.2 and §13.3 - a `css`-mode panel named by its tab, and an `aria`-mode panel
+bound rather than named. All four landed after the run above was taken, so
+the corpus is four cases ahead of it. The
 declaration is the same device the core block uses: it names the cases and
 carries no count, so there is nothing in it to fabricate, and
 `tests/implementation-comparison-counts.test.mjs` fails both when a named case

--- a/resources/optional-example-pages.txt
+++ b/resources/optional-example-pages.txt
@@ -16,6 +16,7 @@ order: 1
   list-table-local-headers-1248
   spoiler
   tabs
+  tabs-aria
   semantic-span
 
 [core-configured] Core syntax with configured resolution

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -221,6 +221,15 @@ const PLAIN_EXTENSION_FEATURES = {
   details: { js: 'details', php: 'DetailsExtension' },
   spoiler: { js: 'spoiler', php: 'SpoilerExtension' },
   tabs: { js: 'tabs', php: 'TabsExtension' },
+  // The same extension in its other mode. Not a plain registration for the
+  // same reason `citations-author-date` is not: registering with the default
+  // mode renders the css markup against a fixture that pins the aria one.
+  'tabs-aria': {
+    js: 'tabs',
+    jsOptions: "{ mode: 'aria' }",
+    php: 'TabsExtension',
+    phpArgs: "mode: 'aria'",
+  },
   'list-table': { js: 'listTable', php: 'ListTableExtension' },
   'list-table-columns-1344': { js: 'listTable', php: 'ListTableExtension' },
   'list-table-local-headers-1248': { js: 'listTable', php: 'ListTableExtension' },

--- a/scripts/generate-example-pages.mjs
+++ b/scripts/generate-example-pages.mjs
@@ -276,6 +276,7 @@ const optionalTitle = new Map([
   ['list-table-local-headers-1248', 'ListTable local headers and body groups'],
   ['spoiler', 'Spoiler'],
   ['tabs', 'Tabs'],
+  ['tabs-aria', 'Tabs in aria mode'],
   ['semantic-span', 'SemanticSpan'],
   ['social-link-templates', 'Mention and tag URL templates'],
   ['symbol-map', 'Symbol map'],

--- a/tests/corpus-optional/46-tabs-css-panel-name.crv
+++ b/tests/corpus-optional/46-tabs-css-panel-name.crv
@@ -1,0 +1,8 @@
+:::: tabs
+::: tab [First]
+Content one.
+:::
+::: tab [R&D "core" <x>]
+Content two.
+:::
+::::

--- a/tests/corpus-optional/46-tabs-css-panel-name.html
+++ b/tests/corpus-optional/46-tabs-css-panel-name.html
@@ -1,8 +1,12 @@
 <div class="tabs" role="group" aria-label="Tabs">
 <input type="radio" name="tabset-1" id="tabset-1-tab-1" class="tabs-radio" checked>
 <label for="tabset-1-tab-1" class="tabs-label">First</label>
+<input type="radio" name="tabset-1" id="tabset-1-tab-2" class="tabs-radio">
+<label for="tabset-1-tab-2" class="tabs-label">R&amp;D "core" &lt;x&gt;</label>
 <div class="tabs-panel" role="group" aria-label="First">
-<p class="admonition-title">Inner <strong>Title</strong></p>
 <p>Content one.</p>
+</div>
+<div class="tabs-panel" role="group" aria-label="R&amp;D &quot;core&quot; &lt;x&gt;">
+<p>Content two.</p>
 </div>
 </div>

--- a/tests/corpus-optional/47-tabs-aria-panel-binding.crv
+++ b/tests/corpus-optional/47-tabs-aria-panel-binding.crv
@@ -1,0 +1,8 @@
+:::: tabs
+::: tab [First]
+Content one.
+:::
+::: tab [R&D "core" <x>]
+Content two.
+:::
+::::

--- a/tests/corpus-optional/47-tabs-aria-panel-binding.html
+++ b/tests/corpus-optional/47-tabs-aria-panel-binding.html
@@ -1,0 +1,10 @@
+<div class="tabs" role="tablist" aria-label="Tabs">
+<button role="tab" id="tabset-1-tab-1" aria-selected="true" aria-controls="tabset-1-panel-1" class="tabs-label">First</button>
+<button role="tab" id="tabset-1-tab-2" aria-selected="false" aria-controls="tabset-1-panel-2" class="tabs-label" tabindex="-1">R&amp;D "core" &lt;x&gt;</button>
+<div role="tabpanel" id="tabset-1-panel-1" aria-labelledby="tabset-1-tab-1" class="tabs-panel">
+<p>Content one.</p>
+</div>
+<div role="tabpanel" id="tabset-1-panel-2" aria-labelledby="tabset-1-tab-2" class="tabs-panel" hidden>
+<p>Content two.</p>
+</div>
+</div>

--- a/tests/corpus-optional/manifest.json
+++ b/tests/corpus-optional/manifest.json
@@ -233,6 +233,16 @@
       "slug": "45-list-table-local-headers",
       "feature": "list-table-local-headers-1248",
       "description": "A header-row attribute on a row's first cell starts a body group with an intermediate column-header row; a header attribute promotes only its own cell."
+    },
+    {
+      "slug": "46-tabs-css-panel-name",
+      "feature": "tabs",
+      "description": "Under the css default each tabs panel carries role=\"group\" named by its tab's own label, attribute-escaped."
+    },
+    {
+      "slug": "47-tabs-aria-panel-binding",
+      "feature": "tabs-aria",
+      "description": "In aria mode a panel is bound rather than named: role=\"tabpanel\" with aria-labelledby and hidden on every non-selected panel, and no role=\"group\"."
     }
   ]
 }

--- a/tests/optional-corpus.test.mjs
+++ b/tests/optional-corpus.test.mjs
@@ -127,6 +127,14 @@ const featureRunners = {
   'semantic-span': (source, render) => render(source, { extensions: [semanticSpan()] }),
   spoiler: (source, render) => render(source, { extensions: [spoiler()] }),
   tabs: (source, render) => render(source, { extensions: [tabs()] }),
+  /*
+   * A second feature id rather than a second case under `tabs`, because a
+   * runner is keyed by feature id and this one needs the other mode. The two
+   * cases share one .crv on purpose: the same document under both modes is
+   * what makes the css-only rule (§13.2) legible as a rule about css and not
+   * about panels in general.
+   */
+  'tabs-aria': (source, render) => render(source, { extensions: [tabs({ mode: 'aria' })] }),
 }
 
 /*
@@ -152,7 +160,11 @@ const DECLARED_UNIMPLEMENTED = {
  * An entry is deleted in the commit that moves the pin past it; the check below
  * fails an entry whose case already matches, so a stale one cannot sit here.
  */
-const AHEAD_OF_PIN = {}
+const AHEAD_OF_PIN = {
+  '28-tabs-panel-title':
+    'carve#1468 §13.2 - the css-mode panel takes role="group" and its tab\'s label; no engine emits it yet',
+  '46-tabs-css-panel-name': 'carve#1468 §13.2 - same rule, with the attribute-escaping case',
+}
 
 /*
  * THE RATCHET ON THE EXCUSE, because an entry above can only ever turn a

--- a/tests/optional-feature-adapters.test.mjs
+++ b/tests/optional-feature-adapters.test.mjs
@@ -127,6 +127,7 @@ const DECLARED_UNREACHABLE = {
   'rust:semantic-span': 'no CLI flag for the semantic-span extension',
   'rust:spoiler': 'no CLI flag for the spoiler extension',
   'rust:tabs': 'no CLI flag for the tabs extension',
+  'rust:tabs-aria': 'no CLI flag for the tabs extension, and none for its mode',
   'php:symbol-map': 'the symbol map is not reachable from CarveConverter::create()',
   // "`section-wrapper-off` and `source-line-after-generated-id` reach carve-js
   // and carve-php" - docs/implementation-comparison.md, on the same run.


### PR DESCRIPTION
Implements the still-open half of item 4 in markup-carve/carve#1468, on the maintainer's
ruling of 2026-08-21 ("Ruled: item 4 splits three ways"). Spec side only - the three engine
implementations fan out separately.

## What moved

Tabs and CodeGroup had no clause of their own. They were reachable only through the §1.5
`labels` table, which pointed Tabs at the non-normative narrative (`syntax.md` §4.20) and
CodeGroup at nothing at all, so there was nothing to amend. `docs/extensions.md` gains
**§13. Tabs (Tier-2) and CodeGroup (Tier-3)** carrying the three halves of the ruling.

**§13.1 - `css` stays the default mode in both**, and an implementation MUST NOT ship `aria`
as the default. Stated on the §2.5 ground rather than on compatibility: content is never
dropped, only interaction. `aria` reveals with `hidden`, so a page that registers it and ships
no script loses every panel but the first, while `css` with no stylesheet at all shows every
panel. The clause names the condition that would reopen it - `aria` no longer using `hidden`.
CodeGroup grows the same `mode: 'css' | 'aria'` option under the same name, and an unknown
value MUST be rejected rather than guessed.

**§13.2 - a `css`-mode panel carries its tab's name**: `<div class="tabs-panel" role="group"
aria-label="First">`, the name being the string the tab's own `<label>` carries, attribute-escaped.
Derived from the document, so per §1.5 it gets no `labels` key. Not `role="tabpanel"` (its
controller is a `radio`), not `<section>` (N landmarks per tab set), and not a bare
`aria-labelledby` - ARIA marks both naming attributes prohibited on role `generic`, and the
`<label>` elements carry `for=`, not `id=`. `code-group` panels take the same treatment, keyed
on the panel's own label: the tab name where one was written, otherwise the language word.

**§13.3 - an `aria`-mode panel is bound, not named.** It keeps `role="tabpanel"` and
`aria-labelledby` and takes neither `role="group"` nor an `aria-label`; naming it as well would
give one element two accessible names. So §13.2 is a `css`-mode rule specifically, not
"every panel gets a name".

§13.4 records the set names that already ship and why those two DO have `labels` keys, and §13.5
says where each half is pinned.

## Measured before the clause was written

Against the pinned build (`d9cb2c7`, `@markup-carve/carve` 0.1.4). Two measurements settled points
the ruling does not spell out, so nothing here is a guess:

- A tab's `[label]` is emitted as a plain escaped string rather than inline-parsed - `[*Bold* &
  <chars>]` renders `*Bold* &amp; &lt;chars&gt;` in the `<label>`. So the panel name is that same
  string, needing attribute escaping and no text extraction.
- An attribute block written above a `::: tab` is dropped entirely today, so there is no author
  seam at the panel. The clause introduces none: an author renames a panel by renaming its tab.

## Corpus

| Case | Feature | Pins |
| --- | --- | --- |
| `46-tabs-css-panel-name` | `tabs` | §13.2, with a label needing `&amp;`, `&quot;` and `&lt;` in the attribute |
| `47-tabs-aria-panel-binding` | `tabs-aria` (new) | §13.3 - the binding, the `hidden` reveal §13.1 turns on, and the ABSENCE of `role="group"` |
| `28-tabs-panel-title` | `tabs` | updated so it stops contradicting §13.2 |

The two `css` cases state what no engine emits yet, so they carry `AHEAD_OF_PIN` entries with the
reason and are asserted in both directions - an entry the pin catches up on fails and gets deleted.
Case 47 matches the pinned build today and compares live.

`tabs-aria` is a second feature id rather than a second case under `tabs`, because a runner is keyed
by feature id and this one needs the other mode. It is wired through `PLAIN_EXTENSION_FEATURES`
(`jsOptions` / `phpArgs`, the shape `citations-author-date` already uses), declared unreachable from
the carve-rs adapter for the same reason `tabs` is, and routed in `resources/optional-example-pages.txt`
so the both-directions orphan check passes.

## Mutation proofs

Every new assertion was made to fail on purpose, then restored from a `cp` backup and re-verified by
grep:

1. Dropped `hidden` from an `aria` panel in 47 -> `47-tabs-aria-panel-binding` alone red.
2. Reverted 46 to the pinned shape (panels unnamed) -> its ledger assertion red: "the pinned build
   reproduces this now".
3. Same on 28 -> same failure, on that case alone.
4. **The near-miss**: added `role="group"` plus a name to an `aria` panel in 47 - the reading that
   says "every panel gets a name" - -> red. That is the assertion that makes §13.3 a rule rather
   than a remark.

## Gates

Targeted locally: the optional corpus, the adapter check, both directions of the orphan-page check,
the corpus-target and count checks, `normativity`, `grammar-citations`, `doc-carve-samples`, plus
`combinatorial:check` ("no undeclared divergences"). One baseline `gate-run` over the tree came back
`partial` with `failed: []`; the four gates it could not run are the usual sibling-checkout ones,
verbatim:

- `npm run ast:check` - "a dependency outside the repository is missing: /tmp/carve-js/dist"
- `npm run claims:check` - "engine-claims: need all three engines, found 0 (none)."
- `npm run degradation:check` - "degradation-claims: need all three engines, found 0 (none)."
- `npm run fmt:check` - "fmt-fixture-claims: need all three engines, found 0 (none)."

Every HTML block in §13 was rendered through the pinned engine before it went in: the `aria` block
and the two set-name lines are byte-identical to what it emits, and the two `css` blocks are its
output plus exactly the panel attributes §13.2 adds. No golden was re-snapshotted; the three changed
expected files are the three the clause changes, each named above.

## Not in this PR

The engine work, which markup-carve/carve#1468 stays open for, and the three items its ruling filed
separately - the carve-php `.tabs-radio { display: none; }` recipe, the carve-php group naming, and
the TOC docs note.
