### PR TITLE
docs: say which table-of-contents extension handles the directive

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -56,7 +56,7 @@ PART 9 §19); Tier-2 / Tier-3 are off until enabled.
 | ListTable (§5), Details, Spoiler, Tabs — shipped in all three engines and pinned in `tests/corpus-optional` | <Badge type="info" text="standard" /> | off | — |
 | Mermaid / FencedRender, MathBlock, Glossary, Index, HeadingNumbers, CodeGroup | <Badge type="warning" text="extension" /> | off | — |
 | Bibliography (§6) — an **option on Citations**, not a separate registration: the host passes a CSL-JSON pool to the Citations extension | <Badge type="warning" text="extension" /> | off | — |
-| TableOfContents, HeadingPermalinks / LevelShift, ExternalLinks, Wikilinks and HeadingReference (§12), ColorSwatch, Lowercase/AsciiHeadingIds | <Badge type="warning" text="extension" /> | off | — |
+| TableOfContents and TocPlacement (§8b.1 - the injector and the `::: toc` directive; not interchangeable), HeadingPermalinks / LevelShift, ExternalLinks, Wikilinks and HeadingReference (§12), ColorSwatch, Lowercase/AsciiHeadingIds | <Badge type="warning" text="extension" /> | off | — |
 | Semantic span attributes — `[x]{kbd}`, `[HTML]{abbr="…"}`, `[now]{time="…"}` (three names; PART 9 §9) | <Badge type="tip" text="core" /> | on | no |
 | SemanticSpan — the four names core does not reserve (`samp`, `var`, `cite`, `dfn`), plus the soft-deprecated `:name[…]` spelling for all seven | <Badge type="info" text="standard" /> | off | — |
 | [ImgFence](/svg-images) (sanitized SVG `img` fence — sandboxed by default) | <Badge type="warning" text="extension" /> | off | — |
@@ -977,6 +977,73 @@ preceding attribute line, never inline on the opener):
   the TOC faithfully reflects each engine's parse.)
 - The nested `<ul>` HTML is byte-identical to the standalone TOC extension
   (one tag per line).
+
+**Two extensions produce a table of contents, and they are not
+interchangeable.** `TocPlacement` implements this directive. `TableOfContents`
+is the standalone injector on the Tier-3 catalog row: it puts one nav at the top
+or the bottom of every document and never looks at `::: toc`. Registering the
+wrong one is not an error and fails quietly, so it is worth knowing what each
+combination renders.
+
+For this document:
+
+```
+Intro paragraph.
+
+::: toc
+:::
+
+# One
+
+## One A
+```
+
+| registered | what renders |
+|---|---|
+| `TocPlacement` | `<nav class="toc">` where the directive is written |
+| `TableOfContents` | `<nav class="toc">` at the top (or bottom), **plus** an empty `<div class="toc">` where the directive is written |
+| both | two navs - one injected, one in place |
+| neither | the empty `<div class="toc">` only, and no nav anywhere |
+
+The `<div class="toc">` in rows two and four is the §8b.3 degradation floor for
+an unhandled directive, not a defect. Registering `TableOfContents` alone gives
+an author a table of contents in a place they did not choose beside an empty
+element where they did choose:
+
+```html
+<nav class="toc">
+<ul>
+<li><a href="#One">One</a>
+<ul>
+<li><a href="#One-A">One A</a></li>
+</ul>
+</li>
+</ul>
+</nav>
+<p>Intro paragraph.</p>
+<div class="toc">
+
+</div>
+```
+
+The two also differ on a document with **no** directive: `TocPlacement` renders
+nothing at all, `TableOfContents` still injects its nav. So the choice is
+between letting each document say where its contents go and letting the site
+decide once for all of them. Registering both is supported and renders both.
+
+All three engines ship both, under parallel names:
+
+```js
+carveToHtml(src, { extensions: [tocPlacement()] })
+```
+
+```php
+new TocPlacementExtension();
+```
+
+```rust
+TocPlacement::new()
+```
 
 ### 8b.2 `::: footnotes` — endnotes placement
 


### PR DESCRIPTION
Closes #1488.

`::: toc` is handled by one extension and ignored by the other, and `docs/extensions.md` never said which. §8b.1 hinted at it in a parenthetical - "rather than the top/bottom injection of the standalone TOC extension" - which names neither extension and does not say what registering the other one produces.

## What each one does, measured

Not read off the names. One document, varying only what is registered, rendered through the engine this repo pins in `package.json` (carve-js at 4269ea88):

```
Intro paragraph.

::: toc
:::

# One

## One A
```

| registered | what renders |
|---|---|
| `TocPlacement` | `<nav class="toc">` where the directive is written |
| `TableOfContents` | `<nav class="toc">` at the top, plus an empty `<div class="toc">` where the directive is written |
| both | two navs - one injected, one in place |
| neither | the empty `<div class="toc">` only, and no nav anywhere |

With no `::: toc` in the document at all they differ again: `TocPlacement` renders nothing, `TableOfContents` still injects. So the two are not two placements of one feature - one is directive-driven and silent without a directive, the other is unconditional and never looks at the directive.

## One detail of the ticket was off

The ticket describes the wrong-extension case as "a stray element beside a missing nav". The nav is not missing when `TableOfContents` is registered - `position` defaults to `top`, so it is at the top:

```html
<nav class="toc">
<ul>
<li><a href="#One">One</a>
<ul>
<li><a href="#One-A">One A</a></li>
</ul>
</li>
</ul>
</nav>
<p>Intro paragraph.</p>
<div class="toc">

</div>
```

"No nav anywhere" is the case where NEITHER is registered. They are different symptoms, so both are on the page - an author debugging one should not be reading a description of the other.

## The catalog named only one of the two

The Tier-3 row listed `TableOfContents`. `TocPlacement` was on no tier row, so a reader assembling registrations from the catalog - which is what that table is for - never met the directive's extension. Both names are on the row now.

That also puts `TocPlacement` under `tests/extension-catalog-claims.test.mjs`, which holds every name on those rows to a reference-engine export. Measured in both directions:

- Writing `TocPlacementX` on the row turns that test red: "the page names extension(s) the reference engine does not export".
- Removing `TocPlacement` from the row again leaves every test green.

So the check gates the name now that it is there, and could never have caught its absence - which is why the omission survived. Stated rather than implied, since a check that cannot detect what a reader assumes it detects is worth naming.

## A defect for carve-js, filed separately

`tocPlacement()`'s docblock in carve-js says the block "degrades to a plain `<aside class="admonition toc">` placeholder" when the extension is absent. Measured, the floor is `<div class="toc">`, which is what §8b.3 of this page already specifies. The spec is right; the engine's docblock is stale. Not touched here.

## Verification

Every Carve sample and every HTML block on the page was re-extracted **from the edited file** and re-rendered through the pinned engine, asserting nav count, nav position relative to the intro paragraph, and the presence or absence of the degradation floor for all four registration combinations plus the two no-directive cases. `npm run docs:build` completes and leaves no artifact in the tree.

Targeted tests locally - the catalog, orphan-page, doc-sample, repo-link and normativity suites (112 assertions). The full suite runs in CI. A baseline `gate-run` on the untouched branch was `partial`: `npm test`, `combinatorial:check`, `core:check`, `escape:check`, `html-import:check`, `links:check`, `property:check` and `test:conformance` all green, with four gates correctly classified unrunnable for missing sibling engine checkouts - `ast:check` ("a dependency outside the repository is missing: /tmp/carve-js/dist"), and `claims:check`, `degradation:check` and `fmt:check` ("need all three engines, found 0 (none).").

Draft #1026 also touches `docs/extensions.md`; expect a rebase if it lands first.
