### PR TITLE
test: a manifest feature with no authored title fails npm test

### DIFF
--- a/scripts/generate-example-pages.mjs
+++ b/scripts/generate-example-pages.mjs
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import { dirname, posix, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { exampleFiles, numberExamples, readExampleFiles, scanExampleSource, slugify } from './lib/example-sections.mjs'
+import { optionalFeatureTitles } from './lib/optional-feature-titles.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, '..')
@@ -260,39 +261,15 @@ for (const page of pages) {
 
 
 /*
- * Every manifest feature needs an authored heading. Title-casing the id
- * produces "Bare Url Autolink" and "Ansi Typography Source" - a slug wearing
- * capitals, not a name a reader recognizes. Making the map REQUIRED (see the
- * fail below) means a new manifest feature stops the build until someone names
- * it, instead of shipping the slug-cased fallback nobody would notice.
+ * The authored headings live in scripts/lib/optional-feature-titles.mjs so
+ * that tests/no-orphan-pages.test.mjs can assert both directions of the map.
+ * They used to sit here, where only docs:pages/docs:dev/docs:build reached
+ * them, so a feature added without a title passed npm test and failed in a
+ * later job (carve#1490).
  */
-const optionalTitle = new Map([
-  ['citations-numbered', 'Citations, numbered'],
-  ['citations-author-date', 'Citations, author-date'],
-  ['code-callouts', 'CodeCallouts'],
-  ['details', 'Details'],
-  ['list-table', 'ListTable'],
-  ['list-table-columns-1344', 'ListTable column metadata and footer rows'],
-  ['list-table-local-headers-1248', 'ListTable local headers and body groups'],
-  ['spoiler', 'Spoiler'],
-  ['tabs', 'Tabs'],
-  ['tabs-aria', 'Tabs in aria mode'],
-  ['semantic-span', 'SemanticSpan'],
-  ['social-link-templates', 'Mention and tag URL templates'],
-  ['symbol-map', 'Symbol map'],
-  ['smart-quotes-locale-de', 'Smart quotes (de locale)'],
-  ['bare-url-autolink', 'Bare-URL autolinking'],
-  ['smart-typography-off', 'Smart typography off'],
-  ['smart-typography-default', 'Smart typography at default (control)'],
-  ['section-wrapper-off', 'Section wrapper off'],
-  ['source-line-after-generated-id', 'Source-line annotation order'],
-  ['markdown-typography-source', 'Markdown target, source typography'],
-  ['plain-typography-source', 'Plain-text target, source typography'],
-  ['ansi-typography-source', 'ANSI target, source typography'],
-])
 const featureTitle = (feature) => {
-  const title = optionalTitle.get(feature)
-  if (!title) fail(`manifest feature "${feature}" has no authored title in optionalTitle; a slug-cased heading reads as a filename, not a feature.`)
+  const title = optionalFeatureTitles.get(feature)
+  if (!title) fail(`manifest feature "${feature}" has no authored title in scripts/lib/optional-feature-titles.mjs; a slug-cased heading reads as a filename, not a feature.`)
   return title
 }
 const languageByExtension = new Map([

--- a/scripts/lib/optional-feature-titles.mjs
+++ b/scripts/lib/optional-feature-titles.mjs
@@ -1,0 +1,42 @@
+/*
+ * The authored heading for every optional-corpus manifest feature.
+ *
+ * REQUIRED, not a fallback. Title-casing the id produces "Bare Url Autolink"
+ * and "Ansi Typography Source" - a slug wearing capitals, not a name a reader
+ * recognizes. Making the map required means a new manifest feature stops the
+ * build until someone names it, instead of shipping the slug-cased fallback
+ * nobody would notice.
+ *
+ * WHY THIS IS ITS OWN MODULE. The requirement used to live inside
+ * `scripts/generate-example-pages.mjs`, which only `docs:pages`, `docs:dev`
+ * and `docs:build` invoke - so a feature added without a title passed the
+ * whole local suite and failed in a later job, after the contributor had moved
+ * on. That is what carve#1490 was filed for, and it is the same boundary
+ * carve#1483 moved for the routing direction. A script that generates files as
+ * a side effect of import cannot be read by a test, so the table moves here
+ * and `tests/no-orphan-pages.test.mjs` asserts both directions of it.
+ */
+export const optionalFeatureTitles = new Map([
+  ['citations-numbered', 'Citations, numbered'],
+  ['citations-author-date', 'Citations, author-date'],
+  ['code-callouts', 'CodeCallouts'],
+  ['details', 'Details'],
+  ['list-table', 'ListTable'],
+  ['list-table-columns-1344', 'ListTable column metadata and footer rows'],
+  ['list-table-local-headers-1248', 'ListTable local headers and body groups'],
+  ['spoiler', 'Spoiler'],
+  ['tabs', 'Tabs'],
+  ['tabs-aria', 'Tabs in aria mode'],
+  ['semantic-span', 'SemanticSpan'],
+  ['social-link-templates', 'Mention and tag URL templates'],
+  ['symbol-map', 'Symbol map'],
+  ['smart-quotes-locale-de', 'Smart quotes (de locale)'],
+  ['bare-url-autolink', 'Bare-URL autolinking'],
+  ['smart-typography-off', 'Smart typography off'],
+  ['smart-typography-default', 'Smart typography at default (control)'],
+  ['section-wrapper-off', 'Section wrapper off'],
+  ['source-line-after-generated-id', 'Source-line annotation order'],
+  ['markdown-typography-source', 'Markdown target, source typography'],
+  ['plain-typography-source', 'Plain-text target, source typography'],
+  ['ansi-typography-source', 'ANSI target, source typography'],
+])

--- a/tests/no-orphan-pages.test.mjs
+++ b/tests/no-orphan-pages.test.mjs
@@ -24,6 +24,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { numberExamples, readExampleFiles, scanExampleSource } from '../scripts/lib/example-sections.mjs'
+import { optionalFeatureTitles } from '../scripts/lib/optional-feature-titles.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, '..')
@@ -137,12 +138,11 @@ const corpusFixtures = execFileSync('git', ['ls-files', 'tests/corpus'], { cwd: 
  * page ids, `key:` lines, descriptions and comments all start at column zero.
  * This mirrors parsePages in the generator, which reads an indented line as an
  * entry after every other form has failed to match. */
-const routeEntries = new Set(
-  readFileSync(resolve(repoRoot, 'resources/example-pages.txt'), 'utf8')
-    .split('\n')
-    .filter((line) => line.startsWith('  ') && line.trim() !== '')
-    .map((line) => line.trim()),
-)
+const routeEntryLines = readFileSync(resolve(repoRoot, 'resources/example-pages.txt'), 'utf8')
+  .split('\n')
+  .filter((line) => line.startsWith('  ') && line.trim() !== '')
+  .map((line) => line.trim())
+const routeEntries = new Set(routeEntryLines)
 
 test('the corpus census agrees with the example source', () => {
   /* Either list arriving empty - a failed git call, a moved source file - would
@@ -189,21 +189,100 @@ test('every route entry names a section or fixture that exists', () => {
  * a page is routed the moment it is added - but a new feature is not, and that
  * too was only visible at `docs:build`.
  */
+const manifestFeatures = [...new Set(
+  JSON.parse(readFileSync(resolve(repoRoot, 'tests/corpus-optional/manifest.json'), 'utf8')).cases.map((item) => item.feature),
+)]
+const assignedFeatures = new Set(
+  readFileSync(resolve(repoRoot, 'resources/optional-example-pages.txt'), 'utf8')
+    .split('\n')
+    .filter((line) => line.startsWith('  ') && line.trim() !== '')
+    .map((line) => line.trim()),
+)
+
+test('the optional-corpus feature census is not empty', () => {
+  /* Either list arriving empty would make every assertion below pass over
+   * nothing - the same liveness floor the corpus census carries. */
+  assert.ok(manifestFeatures.length > 10, `expected the optional-corpus features, found ${manifestFeatures.length}`)
+  assert.ok(assignedFeatures.size > 10, `expected the optional page assignments, found ${assignedFeatures.size}`)
+})
+
 test('every optional-corpus feature is routed to a docs page', () => {
-  const manifest = JSON.parse(readFileSync(resolve(repoRoot, 'tests/corpus-optional/manifest.json'), 'utf8'))
-  const features = [...new Set(manifest.cases.map((item) => item.feature))]
-  assert.ok(features.length > 10, `expected the optional-corpus features, found ${features.length}`)
-  const assigned = new Set(
-    readFileSync(resolve(repoRoot, 'resources/optional-example-pages.txt'), 'utf8')
-      .split('\n')
-      .filter((line) => line.startsWith('  ') && line.trim() !== '')
-      .map((line) => line.trim()),
-  )
-  const unrouted = features.filter((feature) => !assigned.has(feature))
+  const unrouted = manifestFeatures.filter((feature) => !assignedFeatures.has(feature))
   assert.deepEqual(
     unrouted,
     [],
     'these manifest features appear on no optional page, so the behavior they pin has no reader -\n' +
       'add them to resources/optional-example-pages.txt:\n' + unrouted.join('\n'),
+  )
+})
+
+/*
+ * THE REVERSE DIRECTION of the same manifest. A page naming a feature the
+ * manifest does not have generates a heading with nothing under it, and the
+ * generator says so ("readers would see a nonexistent behavior") - but only
+ * under `docs:build`. Both populations are already read above, so asking is
+ * free, and the failure names the line that is actually wrong instead of
+ * reporting the feature as merely unrouted.
+ */
+test('every optional page names a feature the manifest still has', () => {
+  const dangling = [...assignedFeatures].filter((feature) => !manifestFeatures.includes(feature))
+  assert.deepEqual(
+    dangling,
+    [],
+    'these resources/optional-example-pages.txt entries name no manifest feature -\n' +
+      'the page would introduce a behavior nothing pins:\n' + dangling.join('\n'),
+  )
+})
+
+/*
+ * THE TITLE, which is a second and independent claim about the same features.
+ *
+ * WHY. `scripts/generate-example-pages.mjs` requires an authored heading for
+ * every manifest feature - deliberately, because title-casing the id yields
+ * "Bare Url Autolink", a slug wearing capitals. But the requirement lived
+ * inside that script, which only `docs:pages`, `docs:dev` and `docs:build`
+ * reach, so a feature added without a title passed the entire local suite and
+ * went red in a later job (carve#1490, hit for real while landing carve#1489).
+ * Being routed to a page and being NAMED on it are different questions; the
+ * routing check above cannot answer the second one.
+ *
+ * The map is now scripts/lib/optional-feature-titles.mjs, imported by the
+ * generator and by this test, so the two cannot drift.
+ */
+test('every optional-corpus feature has an authored title', () => {
+  const unnamed = manifestFeatures.filter((feature) => !optionalFeatureTitles.get(feature))
+  assert.deepEqual(
+    unnamed,
+    [],
+    'these manifest features have no authored title, so their generated heading would be a slug -\n' +
+      'name them in scripts/lib/optional-feature-titles.mjs:\n' + unnamed.join('\n'),
+  )
+})
+
+test('every authored title names a feature the manifest still has', () => {
+  /* A title outliving its feature would silently name a future feature that
+   * happens to reuse the slug - the same hazard the UNROUTED waivers carry. */
+  const stale = [...optionalFeatureTitles.keys()].filter((feature) => !manifestFeatures.includes(feature))
+  assert.deepEqual(
+    stale,
+    [],
+    'these scripts/lib/optional-feature-titles.mjs entries name no manifest feature:\n' + stale.join('\n'),
+  )
+})
+
+/*
+ * One route entry, one reading location. The generator rejects a duplicate
+ * ("one corpus pair cannot have two reading locations") and this file collects
+ * the entries into a Set, which is exactly where a duplicate disappears - so
+ * the raw lines are kept above and counted here.
+ */
+test('no corpus pair is routed twice from the page file', () => {
+  const seen = new Set()
+  const duplicated = routeEntryLines.filter((entry) => seen.size === seen.add(entry).size)
+  assert.deepEqual(
+    duplicated,
+    [],
+    'these resources/example-pages.txt entries appear more than once -\n' +
+      'one corpus pair cannot have two reading locations:\n' + duplicated.join('\n'),
   )
 })


### PR DESCRIPTION
`scripts/generate-example-pages.mjs` requires an authored heading for every optional-corpus manifest feature, and only `docs:pages`, `docs:dev` and `docs:build` reach that code. So a feature added without a title passed the entire local suite and went red later, in a different job, after the contributor had moved on. That is not hypothetical - it happened while landing markup-carve/carve#1489.

This is the second direction of the boundary markup-carve/carve#1483 opened. That PR moved the *routing* claim into `npm test`: a corpus fixture with no docs route now fails locally. Being routed to a page and being NAMED on it are different questions, and the suite could still answer only the first.

## The reproduction

Deleting one entry from the title map, on `origin/main` at 1fd179e2:

- `npm test` - exit 0, 2649 tests, 0 fail
- `npm run docs:pages` - exit 1:

```
generate-example-pages: manifest feature "spoiler" has no authored title in optionalTitle; a slug-cased heading reads as a filename, not a feature.
```

That contrast is the whole ticket.

## Why the map had to move

The generator cannot be imported by a test. At module scope it removes and rewrites `docs/examples/` and calls `process.exit(1)` on failure, so there is no way to pull a value out of it. The table moves to `scripts/lib/optional-feature-titles.mjs`, which the generator and the test both import - the same split `scripts/lib/example-sections.mjs` already carries, and the same move that let carve#1483 assert routing without a build.

The extraction is behavior-preserving: running the pre-change generator and the post-change generator over the same tree produces byte-identical output for all 16 generated pages and the sidebar JSON.

## What is now asserted

Four assertions in `tests/no-orphan-pages.test.mjs`, which already owns the question of whether a thing that exists has a reader:

- every manifest feature has an authored title
- every authored title still names a feature the manifest has, so a title cannot outlive its feature and silently name a future one that reuses the slug
- every optional page names a feature the manifest still has - the reverse direction of a routing check that until now only asked one way
- no corpus pair is routed twice from the page file; the entries were collected into a `Set`, which is exactly where a duplicate disappeared

Each was watched failing before being trusted, since a complete tree makes a new assertion look green whether or not it works. Removing a title, adding a stale title, naming an absent feature on a page, and duplicating a route entry each fail exactly one of the four, and each failure names the offending entry rather than reporting a downstream symptom.

## One note on reproducing this

Renaming a manifest feature to simulate a new one is noisier than it looks: it also trips six assertions about per-engine adapters and the vendored runner. Those are a different obligation - a new feature needs adapters - and they are already visible to `npm test`. Removing the title alone isolates this claim.

## The wider question

The ticket asked whether anything else in the generator is reachable only from `docs:build`. Auditing all of it: four claims are asserted where `npm test` reaches them, and twenty-two are not - essentially every structural claim about the two page manifests, because the test reads only their indented lines, plus the routing-ambiguity claims that a `Set` erases. Two of those are worse than unchecked: an entry above the first page id is collected into the route set and *satisfies* the routing assertions instead of failing them. That is markup-carve/carve#1492, which proposes extracting `parsePages` and `parseOptionalPages` the same way rather than continuing one clause at a time.

No CHANGELOG entry: nothing under the shipped source changed, and test tooling is not consumer-visible.

Validated with the targeted tests, the four mutation proofs, `npm test` and `docs:build` locally; the full gate set runs in CI.
