### PR TITLE
test: the example-page manifests are checked where npm test can see them

### DIFF
--- a/scripts/generate-example-pages.mjs
+++ b/scripts/generate-example-pages.mjs
@@ -2,7 +2,8 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, posix, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { exampleFiles, numberExamples, readExampleFiles, scanExampleSource, slugify } from './lib/example-sections.mjs'
+import { slugify } from './lib/example-sections.mjs'
+import { collectSections, headerOnlyPages, parseOptionalPages, parsePages, routePages, scanPageSources, unroutedFixtures } from './lib/example-page-manifest.mjs'
 import { optionalFeatureTitles } from './lib/optional-feature-titles.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -18,48 +19,12 @@ const fail = (message) => {
   process.exit(1)
 }
 
-const parsePages = (source) => {
-  const pages = []
-  const seenSlugs = new Set()
-  let current = null
-  for (const [index, line] of source.split('\n').entries()) {
-    if (line.trim() === '' || line.startsWith('#')) continue
-    const heading = /^\[([^\]]+)\]\s+(.+)$/.exec(line)
-    if (heading) {
-      current = { id: heading[1], title: heading[2], description: null, out: null, index: null, source: null, order: 0, level: 2, slugs: [] }
-      pages.push(current)
-      continue
-    }
-    if (line.startsWith('> ')) {
-      if (!current) fail(`line ${index + 1} gives a description before any page; without a page identity its cases have no reader.`)
-      current.description = line.slice(2)
-      continue
-    }
-    const key = /^(out|index|source|order|level):\s*(.+)$/.exec(line)
-    if (key) {
-      if (!current) fail(`line ${index + 1} gives ${key[1]} before any page; the destination would have no page identity.`)
-      const value = key[2].trim()
-      current[key[1]] = key[1] === 'order' || key[1] === 'level' ? Number(value) : value
-      continue
-    }
-    if (line.startsWith('  ')) {
-      if (!current) fail(`line ${index + 1} assigns a case before any page; a corpus case with no page has no reader.`)
-      const slug = line.slice(2).trim()
-      if (seenSlugs.has(slug)) fail(`duplicate entry "${slug}" in the page file; one corpus pair cannot have two reading locations.`)
-      seenSlugs.add(slug)
-      current.slugs.push(slug)
-      continue
-    }
-    fail(`line ${index + 1} has invalid page syntax; ignoring it could leave a corpus case on no page with no reader.`)
-  }
-  for (const page of pages) {
-    if (!page.description) fail(`page "${page.id}" has no description; its generated page would give readers no topical context.`)
-    if (!page.out) fail(`page "${page.id}" has no out: path; its sections would have no generated reading location.`)
-    if (!page.out.endsWith('.md')) fail(`page "${page.id}" has out: "${page.out}" which does not end in .md; VitePress needs a Markdown page.`)
-    if (!Number.isInteger(page.order)) fail(`page "${page.id}" has a non-integer order; block ordering must be deterministic.`)
-    if (![2, 3].includes(page.level)) fail(`page "${page.id}" has level: "${page.level}"; section headings can only be level 2 or 3.`)
-  }
-  return pages
+/* Every structural claim about the two manifests now lives in
+ * scripts/lib/example-page-manifest.mjs so tests/no-orphan-pages.test.mjs can
+ * make it too; this script keeps failing on the first complaint, as it did
+ * when the checks were written out here (carve#1492). */
+const failOn = (complaints) => {
+  if (complaints.length > 0) fail(complaints[0])
 }
 
 /*
@@ -111,69 +76,20 @@ const githubAnchor = (title) => slugify(title)
  * no intentional markup, only element names being talked about.
  */
 const asProse = (text) => text.replace(/</g, '&lt;').replace(/>/g, '&gt;')
-const combinedScan = scanExampleSource(readExampleFiles(repoRoot).split('\n'))
-numberExamples(combinedScan)
-const numberedBySlug = new Map(combinedScan.sections.map((section) => [section.slug, section]))
-const sectionsBySlug = new Map()
-for (const sourceName of exampleFiles) {
-  const sourcePath = resolve(repoRoot, 'resources/examples', `${sourceName}.md`)
-  for (const section of scanExampleSource(readFileSync(sourcePath, 'utf8').split('\n')).sections) {
-    if (sectionsBySlug.has(section.slug)) fail(`source slug "${section.slug}" is duplicated; a page entry could not identify exactly one section.`)
-    const numbered = numberedBySlug.get(section.slug)
-    for (let i = 0; i < section.segments.length; i++) {
-      section.segments[i].corpusName = numbered?.segments[i]?.corpusName
-    }
-    sectionsBySlug.set(section.slug, { ...section, sourceName })
-  }
-}
+const { sectionsBySlug, segmentsByName, complaints: sectionComplaints } = collectSections(repoRoot)
+failOn(sectionComplaints)
 
-const pages = parsePages(readFileSync(pagesSource, 'utf8'))
-const segmentsByName = new Map([...sectionsBySlug.values()].flatMap((section) =>
-  section.segments.map((segment) => [segment.corpusName, { section, segment }])))
-const routedSegments = new Map()
-const allEntries = new Set(pages.flatMap((page) => page.slugs))
-for (const entry of allEntries) {
-  const fixture = segmentsByName.get(entry)
-  /* A whole-section route already includes every fixture in that section.
-   * Also naming one fixture obscures whether the author meant an override or
-   * duplication, so reject that ambiguity even when the names are on pages. */
-  if (fixture && allEntries.has(fixture.section.slug)) fail(`the page file names both section "${fixture.section.slug}" and fixture "${entry}" from that section; the intent for section "${fixture.section.slug}" is ambiguous.`)
-}
-for (const page of pages) {
-  const sectionEntries = new Set(page.slugs.filter((entry) => sectionsBySlug.has(entry)))
-  for (const entry of page.slugs) {
-    const fixture = segmentsByName.get(entry)
-    /* A misspelled fixture otherwise disappears from the output while looking
-     * like a deliberate fine-grained route in review. */
-    if (!sectionsBySlug.has(entry) && !fixture) fail(`page-file entry "${entry}" matches no source section or fixture; readers would be sent to a pair that does not exist.`)
-    if (fixture && sectionEntries.has(fixture.section.slug)) {
-      /* Naming a category and one of its fixtures makes it impossible to tell
-       * whether duplication was deliberate. Reject it before one rule gains
-       * two apparently authoritative reading locations. */
-      fail(`page "${page.id}" names both section "${fixture.section.slug}" and fixture "${entry}" from that section; the intent for section "${fixture.section.slug}" is ambiguous.`)
-    }
-    const selected = sectionsBySlug.has(entry) ? sectionsBySlug.get(entry).segments : [fixture.segment]
-    for (const segment of selected) {
-      /* Two destinations let surrounding prose turn one corpus pair into two
-       * different apparent rules, so ownership must remain singular. */
-      if (routedSegments.has(segment.corpusName)) fail(`fixture "${segment.corpusName}" is routed to both page "${routedSegments.get(segment.corpusName)}" and page "${page.id}"; it would read as two different rules.`)
-      routedSegments.set(segment.corpusName, page.id)
-    }
-  }
-}
-for (const fixture of segmentsByName.keys()) {
-  /* A generated corpus pair without documentation has no reader, which is the
-   * invariant this routing manifest exists to enforce at pair granularity. */
-  if (!routedSegments.has(fixture)) fail(`fixture "${fixture}" is routed to no page; this corpus fixture would have no reader.`)
-}
+const { pages, complaints: pageComplaints } = parsePages(readFileSync(pagesSource, 'utf8'))
+failOn(pageComplaints)
+const { routedSegments, complaints: routeComplaints } = routePages({ pages, sectionsBySlug, segmentsByName })
+failOn(routeComplaints)
+/* A generated corpus pair without documentation has no reader, which is the
+ * invariant this routing manifest exists to enforce at pair granularity. */
+failOn(unroutedFixtures({ routedSegments, segmentsByName }))
 
-for (const page of pages.filter((candidate) => candidate.source)) {
-  const sourcePath = resolve(repoRoot, 'resources', page.source)
-  if (!existsSync(sourcePath)) fail(`page "${page.id}" names missing source "${page.source}"; its examples could not be generated.`)
-  const scan = scanExampleSource(readFileSync(sourcePath, 'utf8').split('\n'))
-  if (scan.sections.length === 0) fail(`page "${page.id}" source has no sections; its generated page would be empty.`)
-  page.standaloneSections = scan.sections
-}
+const { sectionsByPage, complaints: sourceComplaints } = scanPageSources(pages, repoRoot)
+failOn(sourceComplaints)
+for (const page of pages) page.standaloneSections = sectionsByPage.get(page)
 
 const corpusUrl = (name) => `https://github.com/markup-carve/carve/blob/main/tests/corpus/${name}.crv`
 const sourceLink = (name) => `[\`resources/examples/${name}.md\`](https://github.com/markup-carve/carve/blob/main/resources/examples/${name}.md)`
@@ -289,42 +205,9 @@ for (const item of manifest.cases) {
   if (!casesByFeature.has(item.feature)) casesByFeature.set(item.feature, [])
   casesByFeature.get(item.feature).push(item)
 }
-const parseOptionalPages = (source) => {
-  const parsed = []
-  let current = null
-  for (const [index, line] of source.split('\n').entries()) {
-    if (line.trim() === '' || line.startsWith('#')) continue
-    const heading = /^\[([^\]]+)\]\s+(.+)$/.exec(line)
-    if (heading) {
-      current = { id: heading[1], title: heading[2], description: null, kind: null, out: null, order: 0, features: [], line: index + 1 }
-      parsed.push(current)
-      continue
-    }
-    if (!current) fail(`optional page line ${index + 1} has content before a page; a pinned behavior would have no reader.`)
-    if (line.startsWith('> ')) current.description = line.slice(2)
-    else if (/^(kind|out|order):\s*/.test(line)) {
-      const [, key, value] = /^(kind|out|order):\s*(.+)$/.exec(line)
-      current[key] = key === 'order' ? Number(value) : value
-    } else if (line.startsWith('  ')) current.features.push(line.trim())
-    else fail(`optional page line ${index + 1} has invalid syntax; ignoring it could leave a pinned behavior with no reader.`)
-  }
-  const kinds = new Set(['extensions-enable', 'core-configured', 'processor-options'])
-  for (let i = 0; i < parsed.length; i++) {
-    const page = parsed[i]
-    if (!page.description || !page.out || !kinds.has(page.kind)) fail(`optional page "${page.id}" needs a description, out, and classified kind; readers must know what activates it.`)
-    if (!Number.isInteger(page.order)) fail(`optional page "${page.id}" has a non-integer order; block ordering must be deterministic.`)
-  }
-  return parsed
-}
-const optionalPages = parseOptionalPages(readFileSync(optionalPagesSource, 'utf8'))
-const outputCounts = new Map()
-for (const entry of [...pages, ...optionalPages]) outputCounts.set(entry.out, (outputCounts.get(entry.out) ?? 0) + 1)
-for (const page of pages) {
-  /* A header-only block can own shared frontmatter and introductory prose,
-   * including when its companions come from the optional-page file. An
-   * unshared empty page would publish no examples at all. */
-  if (page.slugs.length === 0 && !page.source && outputCounts.get(page.out) === 1) fail(`page "${page.id}" has zero slugs and no source; that is allowed only when another entry shares its out: path as a legitimate header-only owner.`)
-}
+const { pages: optionalPages, complaints: optionalComplaints } = parseOptionalPages(readFileSync(optionalPagesSource, 'utf8'))
+failOn(optionalComplaints)
+failOn(headerOnlyPages(pages, optionalPages))
 const optionalAssigned = new Set(optionalPages.flatMap((page) => page.features))
 for (const feature of casesByFeature.keys()) {
   if (!optionalAssigned.has(feature)) fail(`manifest feature "${feature}" appears on no optional page; this pinned behavior has no reader.`)

--- a/scripts/lib/example-page-manifest.mjs
+++ b/scripts/lib/example-page-manifest.mjs
@@ -1,0 +1,267 @@
+/*
+ * Reading and validating the two example-page manifests.
+ *
+ * WHY THIS IS ITS OWN MODULE. Every structural claim about
+ * `resources/example-pages.txt` and `resources/optional-example-pages.txt`
+ * used to live inside `scripts/generate-example-pages.mjs`, which only
+ * `docs:pages`, `docs:dev` and `docs:build` invoke. That script removes and
+ * rewrites `docs/examples/` at module scope and calls `process.exit(1)` on the
+ * first problem, so a test cannot import it - which is why the suite instead
+ * approximated the manifest with a one-line filter:
+ *
+ *     .filter((line) => line.startsWith('  ') && line.trim() !== '')
+ *
+ * A filter that keeps only INDENTED lines cannot see a `[id]` heading, a
+ * `> description` or a `key:` line, so none of the claims about them were
+ * reachable from `npm test`. Two of them were worse than unchecked: a route
+ * entry sitting above the first `[id]` was still collected, so it SATISFIED
+ * the routing assertions instead of failing them, and a malformed line at
+ * column zero was skipped in silence (carve#1492).
+ *
+ * So the parsing moves here and both sides call it. Nothing in this module
+ * exits or throws on bad input: each function returns the parsed manifest plus
+ * a list of complaints, the generator fails on the first one exactly as it did
+ * before, and the test asserts the list is empty. Same split as
+ * `example-sections.mjs`, `corpus-targets.mjs` and
+ * `optional-feature-titles.mjs`.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { exampleFiles, numberExamples, readExampleFiles, scanExampleSource } from './example-sections.mjs'
+
+/*
+ * A page id line opens a page; everything after it belongs to that page until
+ * the next one. A line arriving before the first `[id]` therefore has no page
+ * to attach to, which is the case the indented-line filter used to swallow.
+ */
+const pageHeading = /^\[([^\]]+)\]\s+(.+)$/
+
+export const parsePages = (source) => {
+  const pages = []
+  const complaints = []
+  const seenSlugs = new Set()
+  let current = null
+  for (const [index, line] of source.split('\n').entries()) {
+    if (line.trim() === '' || line.startsWith('#')) continue
+    const heading = pageHeading.exec(line)
+    if (heading) {
+      current = { id: heading[1], title: heading[2], description: null, out: null, index: null, source: null, order: 0, level: 2, slugs: [] }
+      pages.push(current)
+      continue
+    }
+    if (line.startsWith('> ')) {
+      if (!current) {
+        complaints.push(`line ${index + 1} gives a description before any page; without a page identity its cases have no reader.`)
+        continue
+      }
+      current.description = line.slice(2)
+      continue
+    }
+    const key = /^(out|index|source|order|level):\s*(.+)$/.exec(line)
+    if (key) {
+      if (!current) {
+        complaints.push(`line ${index + 1} gives ${key[1]} before any page; the destination would have no page identity.`)
+        continue
+      }
+      const value = key[2].trim()
+      current[key[1]] = key[1] === 'order' || key[1] === 'level' ? Number(value) : value
+      continue
+    }
+    if (line.startsWith('  ')) {
+      if (!current) {
+        complaints.push(`line ${index + 1} assigns a case before any page; a corpus case with no page has no reader.`)
+        continue
+      }
+      const slug = line.slice(2).trim()
+      if (seenSlugs.has(slug)) {
+        complaints.push(`duplicate entry "${slug}" in the page file; one corpus pair cannot have two reading locations.`)
+        continue
+      }
+      seenSlugs.add(slug)
+      current.slugs.push(slug)
+      continue
+    }
+    complaints.push(`line ${index + 1} has invalid page syntax; ignoring it could leave a corpus case on no page with no reader.`)
+  }
+  for (const page of pages) {
+    if (!page.description) complaints.push(`page "${page.id}" has no description; its generated page would give readers no topical context.`)
+    if (!page.out) complaints.push(`page "${page.id}" has no out: path; its sections would have no generated reading location.`)
+    else if (!page.out.endsWith('.md')) complaints.push(`page "${page.id}" has out: "${page.out}" which does not end in .md; VitePress needs a Markdown page.`)
+    if (!Number.isInteger(page.order)) complaints.push(`page "${page.id}" has a non-integer order; block ordering must be deterministic.`)
+    if (![2, 3].includes(page.level)) complaints.push(`page "${page.id}" has level: "${page.level}"; section headings can only be level 2 or 3.`)
+  }
+  return { pages, complaints }
+}
+
+/* The three things a reader must be told to switch on before an optional
+ * example applies. A fourth value would generate a page that describes no
+ * activation the docs explain anywhere. */
+const optionalKinds = new Set(['extensions-enable', 'core-configured', 'processor-options'])
+
+export const parseOptionalPages = (source) => {
+  const pages = []
+  const complaints = []
+  let current = null
+  for (const [index, line] of source.split('\n').entries()) {
+    if (line.trim() === '' || line.startsWith('#')) continue
+    const heading = pageHeading.exec(line)
+    if (heading) {
+      current = { id: heading[1], title: heading[2], description: null, kind: null, out: null, order: 0, features: [], line: index + 1 }
+      pages.push(current)
+      continue
+    }
+    if (!current) {
+      complaints.push(`optional page line ${index + 1} has content before a page; a pinned behavior would have no reader.`)
+      continue
+    }
+    /*
+     * ONE regex, matched once. Testing `^(kind|out|order):` and then execing a
+     * second pattern that also requires a value made `kind:` with nothing after
+     * it a TypeError at module scope instead of a complaint naming the line.
+     */
+    const key = /^(kind|out|order):\s*(.+)$/.exec(line)
+    if (line.startsWith('> ')) current.description = line.slice(2)
+    else if (key) current[key[1]] = key[1] === 'order' ? Number(key[2]) : key[2]
+    else if (line.startsWith('  ')) current.features.push(line.trim())
+    else complaints.push(`optional page line ${index + 1} has invalid syntax; ignoring it could leave a pinned behavior with no reader.`)
+  }
+  for (const page of pages) {
+    if (!page.description || !page.out || !optionalKinds.has(page.kind)) complaints.push(`optional page "${page.id}" needs a description, out, and classified kind; readers must know what activates it.`)
+    if (!Number.isInteger(page.order)) complaints.push(`optional page "${page.id}" has a non-integer order; block ordering must be deterministic.`)
+  }
+  return { pages, complaints }
+}
+
+/*
+ * The sections a page entry may name, keyed by slug, and the corpus pairs those
+ * sections hold, keyed by fixture name. Numbering comes from the CONCATENATION
+ * of the three example files - that is what `generate-corpus.mjs` numbers by -
+ * while `sourceName` comes from the file a section actually sits in, so a page
+ * can name its provenance. Both are needed to resolve a route, which is why
+ * they are built together here rather than reconstructed on each side.
+ */
+export const collectSections = (repoRoot) => {
+  const complaints = []
+  const combinedScan = scanExampleSource(readExampleFiles(repoRoot).split('\n'))
+  numberExamples(combinedScan)
+  const numberedBySlug = new Map(combinedScan.sections.map((section) => [section.slug, section]))
+  const sectionsBySlug = new Map()
+  for (const sourceName of exampleFiles) {
+    const sourcePath = resolve(repoRoot, 'resources/examples', `${sourceName}.md`)
+    for (const section of scanExampleSource(readFileSync(sourcePath, 'utf8').split('\n')).sections) {
+      /* `scanExampleSource` already throws on two identical section TITLES.
+       * Two DIFFERENT titles that slugify to one slug reach here instead, and
+       * a page entry naming that slug could not say which one it meant. */
+      if (sectionsBySlug.has(section.slug)) {
+        complaints.push(`source slug "${section.slug}" is duplicated; a page entry could not identify exactly one section.`)
+        continue
+      }
+      const numbered = numberedBySlug.get(section.slug)
+      for (let i = 0; i < section.segments.length; i++) {
+        section.segments[i].corpusName = numbered?.segments[i]?.corpusName
+      }
+      sectionsBySlug.set(section.slug, { ...section, sourceName })
+    }
+  }
+  const segmentsByName = new Map([...sectionsBySlug.values()].flatMap((section) =>
+    section.segments.map((segment) => [segment.corpusName, { section, segment }])))
+  return { sectionsBySlug, segmentsByName, complaints }
+}
+
+/*
+ * Resolve every page entry to the corpus pairs it routes, and report the ways
+ * that resolution can be ambiguous. Ambiguity is the whole point of this pass:
+ * a manifest with two apparently authoritative reading locations for one rule
+ * still generates two readable pages, so nothing downstream notices.
+ */
+export const routePages = ({ pages, sectionsBySlug, segmentsByName }) => {
+  const complaints = []
+  const routedSegments = new Map()
+  const allEntries = new Set(pages.flatMap((page) => page.slugs))
+  for (const entry of allEntries) {
+    const fixture = segmentsByName.get(entry)
+    /* A whole-section route already includes every fixture in that section.
+     * Also naming one fixture obscures whether the author meant an override or
+     * duplication, so reject that ambiguity even when the names are on pages. */
+    if (fixture && allEntries.has(fixture.section.slug)) complaints.push(`the page file names both section "${fixture.section.slug}" and fixture "${entry}" from that section; the intent for section "${fixture.section.slug}" is ambiguous.`)
+  }
+  for (const page of pages) {
+    const sectionEntries = new Set(page.slugs.filter((entry) => sectionsBySlug.has(entry)))
+    for (const entry of page.slugs) {
+      const fixture = segmentsByName.get(entry)
+      /* A misspelled fixture otherwise disappears from the output while looking
+       * like a deliberate fine-grained route in review. */
+      if (!sectionsBySlug.has(entry) && !fixture) {
+        complaints.push(`page-file entry "${entry}" matches no source section or fixture; readers would be sent to a pair that does not exist.`)
+        continue
+      }
+      if (fixture && sectionEntries.has(fixture.section.slug)) {
+        /* Naming a category and one of its fixtures makes it impossible to tell
+         * whether duplication was deliberate. Reject it before one rule gains
+         * two apparently authoritative reading locations. */
+        complaints.push(`page "${page.id}" names both section "${fixture.section.slug}" and fixture "${entry}" from that section; the intent for section "${fixture.section.slug}" is ambiguous.`)
+      }
+      const selected = sectionsBySlug.has(entry) ? sectionsBySlug.get(entry).segments : [fixture.segment]
+      for (const segment of selected) {
+        /* Two destinations let surrounding prose turn one corpus pair into two
+         * different apparent rules, so ownership must remain singular. */
+        if (routedSegments.has(segment.corpusName)) {
+          complaints.push(`fixture "${segment.corpusName}" is routed to both page "${routedSegments.get(segment.corpusName)}" and page "${page.id}"; it would read as two different rules.`)
+          continue
+        }
+        routedSegments.set(segment.corpusName, page.id)
+      }
+    }
+  }
+  return { routedSegments, complaints }
+}
+
+/*
+ * The other direction, kept separate because the suite already asks it of the
+ * TRACKED fixtures - `git ls-files tests/corpus` - which is the population a
+ * contributor actually commits. The generator asks it of the scanner's own
+ * account, and `tests/no-orphan-pages.test.mjs` pins that the two agree.
+ */
+export const unroutedFixtures = ({ routedSegments, segmentsByName }) =>
+  [...segmentsByName.keys()]
+    .filter((fixture) => !routedSegments.has(fixture))
+    .map((fixture) => `fixture "${fixture}" is routed to no page; this corpus fixture would have no reader.`)
+
+/* A page may name a hand-written source instead of, or alongside, corpus
+ * sections. Only `examples-tier3.md` does today, and only because
+ * `tests/examples-tier3.test.mjs` happens to read that one file at module
+ * scope were these two claims reachable at all. */
+export const scanPageSources = (pages, repoRoot) => {
+  const complaints = []
+  /* Keyed by the PAGE OBJECT, not by `page.id`. Nothing rejects two entries
+   * sharing an id - `out:` is what decides where a page lands - so an id key
+   * would hand both of them the last one's sections. */
+  const sectionsByPage = new Map()
+  for (const page of pages.filter((candidate) => candidate.source)) {
+    const sourcePath = resolve(repoRoot, 'resources', page.source)
+    if (!existsSync(sourcePath)) {
+      complaints.push(`page "${page.id}" names missing source "${page.source}"; its examples could not be generated.`)
+      continue
+    }
+    const scan = scanExampleSource(readFileSync(sourcePath, 'utf8').split('\n'))
+    if (scan.sections.length === 0) {
+      complaints.push(`page "${page.id}" source has no sections; its generated page would be empty.`)
+      continue
+    }
+    sectionsByPage.set(page, scan.sections)
+  }
+  return { sectionsByPage, complaints }
+}
+
+/*
+ * A header-only block can own shared frontmatter and introductory prose,
+ * including when its companions come from the optional-page file. An unshared
+ * empty page would publish no examples at all.
+ */
+export const headerOnlyPages = (pages, optionalPages) => {
+  const outputCounts = new Map()
+  for (const entry of [...pages, ...optionalPages]) outputCounts.set(entry.out, (outputCounts.get(entry.out) ?? 0) + 1)
+  return pages
+    .filter((page) => page.slugs.length === 0 && !page.source && outputCounts.get(page.out) === 1)
+    .map((page) => `page "${page.id}" has zero slugs and no source; that is allowed only when another entry shares its out: path as a legitimate header-only owner.`)
+}

--- a/tests/no-orphan-pages.test.mjs
+++ b/tests/no-orphan-pages.test.mjs
@@ -24,6 +24,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { numberExamples, readExampleFiles, scanExampleSource } from '../scripts/lib/example-sections.mjs'
+import { collectSections, headerOnlyPages, parseOptionalPages, parsePages, routePages, scanPageSources } from '../scripts/lib/example-page-manifest.mjs'
 import { optionalFeatureTitles } from '../scripts/lib/optional-feature-titles.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -123,7 +124,6 @@ test('every UNROUTED waiver still names a real page', () => {
 const exampleScan = scanExampleSource(readExampleFiles(repoRoot).split('\n'))
 numberExamples(exampleScan)
 const sectionSlugByFixture = new Map(exampleScan.examples.map((example) => [example.corpusName, example.slug]))
-const sectionSlugs = new Set(exampleScan.sections.map((section) => section.slug))
 
 /* The census is the fixtures a contributor actually commits, not the scanner's
  * own account of what it extracted - the same reason scripts/lib/example-pair-
@@ -134,15 +134,117 @@ const corpusFixtures = execFileSync('git', ['ls-files', 'tests/corpus'], { cwd: 
   .filter((path) => path.endsWith('.crv'))
   .map((path) => path.slice('tests/corpus/'.length, -'.crv'.length))
 
-/* A route entry is the only kind of line in the page file that is indented;
- * page ids, `key:` lines, descriptions and comments all start at column zero.
- * This mirrors parsePages in the generator, which reads an indented line as an
- * entry after every other form has failed to match. */
-const routeEntryLines = readFileSync(resolve(repoRoot, 'resources/example-pages.txt'), 'utf8')
-  .split('\n')
-  .filter((line) => line.startsWith('  ') && line.trim() !== '')
-  .map((line) => line.trim())
-const routeEntries = new Set(routeEntryLines)
+/*
+ * THE MANIFEST ITSELF, read by the generator's own parser.
+ *
+ * This block used to approximate the page file with a filter that kept only
+ * INDENTED lines, on the reasoning that a route entry is the only indented
+ * form. It is - but a filter that keeps only indented lines cannot see a
+ * `[id]` heading, a `> description` or a `key:` line, so every claim the
+ * generator makes about those was unreachable from `npm test`, and two of them
+ * were worse than unchecked: an entry sitting ABOVE the first `[id]` still
+ * landed in the route set below, so it SATISFIED the routing assertions
+ * instead of failing them, and a malformed line at column zero was dropped in
+ * silence (carve#1492).
+ *
+ * So the parsing now lives in scripts/lib/example-page-manifest.mjs and this
+ * file calls it. The generator calls the same functions and fails on the first
+ * complaint, which is why the assertions below can be `deepEqual` against an
+ * empty list: an empty complaint list is exactly the condition under which
+ * `docs:build` proceeds.
+ */
+const { pages, complaints: pageComplaints } = parsePages(
+  readFileSync(resolve(repoRoot, 'resources/example-pages.txt'), 'utf8'))
+const { pages: optionalPages, complaints: optionalPageComplaints } = parseOptionalPages(
+  readFileSync(resolve(repoRoot, 'resources/optional-example-pages.txt'), 'utf8'))
+const { sectionsBySlug, segmentsByName, complaints: sectionComplaints } = collectSections(repoRoot)
+/*
+ * FAIL-FAST ORDER, mirroring the generator, which exits on the section
+ * complaints before it resolves a single route. Two section titles that
+ * slugify to one slug also cost that slug's fixtures their names, so routing
+ * would report every entry naming one of them as dangling - a consequence of
+ * the collision, reported in the generator's voice for a run the generator
+ * never performs. The collision itself is asserted just below.
+ */
+const { complaints: routeComplaints } = sectionComplaints.length === 0
+  ? routePages({ pages, sectionsBySlug, segmentsByName })
+  : { complaints: [] }
+const routeEntries = new Set(pages.flatMap((page) => page.slugs))
+
+test('both page manifests parsed something', () => {
+  /* A parser returning nothing would make every assertion below pass over an
+   * empty manifest - the same liveness floor the corpus census carries. */
+  assert.ok(pages.length > 5, `expected the configured example pages, found ${pages.length}`)
+  assert.ok(optionalPages.length > 1, `expected the optional example pages, found ${optionalPages.length}`)
+  assert.ok(sectionsBySlug.size > 20, `expected the example source sections, found ${sectionsBySlug.size}`)
+})
+
+test('the page manifest has no structural complaint', () => {
+  assert.deepEqual(
+    pageComplaints,
+    [],
+    'resources/example-pages.txt would stop `npm run docs:build` for these reasons:\n' + pageComplaints.join('\n'),
+  )
+})
+
+test('the optional page manifest has no structural complaint', () => {
+  assert.deepEqual(
+    optionalPageComplaints,
+    [],
+    'resources/optional-example-pages.txt would stop `npm run docs:build` for these reasons:\n' +
+      optionalPageComplaints.join('\n'),
+  )
+})
+
+test('every example source section has a slug of its own', () => {
+  /* scanExampleSource throws on two identical section TITLES. Two different
+   * titles that slugify to one slug arrive here instead, where a page entry
+   * naming that slug could no longer say which section it meant. */
+  assert.deepEqual(
+    sectionComplaints,
+    [],
+    'resources/examples/*.md sections collide after slugification:\n' + sectionComplaints.join('\n'),
+  )
+})
+
+test('every page-file entry resolves to exactly one reading location', () => {
+  /*
+   * The routing AMBIGUITIES, which a Set of entry names cannot hold: a page
+   * naming both a section and one of that section's own fixtures, the same
+   * pairing spread across two pages, and one fixture reached from two pages.
+   * Each of those generates two readable pages, so nothing downstream ever
+   * notices that one rule acquired two apparently authoritative homes.
+   */
+  assert.deepEqual(
+    routeComplaints,
+    [],
+    'resources/example-pages.txt routes ambiguously:\n' + routeComplaints.join('\n'),
+  )
+})
+
+test('every page naming a hand-written source can read it', () => {
+  /* Reachable for `examples-tier3.md` alone before this, and only because
+   * tests/examples-tier3.test.mjs happens to read that one file at module
+   * scope. A second `source:` value would have inherited nothing. */
+  const { complaints } = scanPageSources(pages, repoRoot)
+  assert.deepEqual(
+    complaints,
+    [],
+    'these resources/example-pages.txt source: values cannot be generated from:\n' + complaints.join('\n'),
+  )
+})
+
+test('no page is an unshared header-only page', () => {
+  /* A page with no entries and no source is legitimate only as the frontmatter
+   * owner of an out: path another entry also writes to. Alone, it publishes a
+   * heading and no examples. */
+  const complaints = headerOnlyPages(pages, optionalPages)
+  assert.deepEqual(
+    complaints,
+    [],
+    'these resources/example-pages.txt entries would publish no examples:\n' + complaints.join('\n'),
+  )
+})
 
 test('the corpus census agrees with the example source', () => {
   /* Either list arriving empty - a failed git call, a moved source file - would
@@ -171,18 +273,6 @@ test('every corpus fixture is routed to a docs page', () => {
   )
 })
 
-test('every route entry names a section or fixture that exists', () => {
-  /* Without this, a typo in the manifest reports as the FIXTURE being
-   * unrouted, which sends the reader to the corpus instead of to the line that
-   * is actually wrong. */
-  const dangling = [...routeEntries].filter((entry) => !sectionSlugs.has(entry) && !sectionSlugByFixture.has(entry))
-  assert.deepEqual(
-    dangling,
-    [],
-    'these resources/example-pages.txt entries match no section slug and no fixture name:\n' + dangling.join('\n'),
-  )
-})
-
 /*
  * The optional corpus has the same shape and the same gap. Its generator check
  * is per FEATURE, not per case, so a new case under a feature that already has
@@ -192,12 +282,7 @@ test('every route entry names a section or fixture that exists', () => {
 const manifestFeatures = [...new Set(
   JSON.parse(readFileSync(resolve(repoRoot, 'tests/corpus-optional/manifest.json'), 'utf8')).cases.map((item) => item.feature),
 )]
-const assignedFeatures = new Set(
-  readFileSync(resolve(repoRoot, 'resources/optional-example-pages.txt'), 'utf8')
-    .split('\n')
-    .filter((line) => line.startsWith('  ') && line.trim() !== '')
-    .map((line) => line.trim()),
-)
+const assignedFeatures = new Set(optionalPages.flatMap((page) => page.features))
 
 test('the optional-corpus feature census is not empty', () => {
   /* Either list arriving empty would make every assertion below pass over
@@ -271,18 +356,9 @@ test('every authored title names a feature the manifest still has', () => {
 })
 
 /*
- * One route entry, one reading location. The generator rejects a duplicate
- * ("one corpus pair cannot have two reading locations") and this file collects
- * the entries into a Set, which is exactly where a duplicate disappears - so
- * the raw lines are kept above and counted here.
+ * A duplicate route entry, and an entry naming no section or fixture at all,
+ * each had a test of their own here, derived from the raw indented lines. Both
+ * claims are now made by the shared parser and router above - the first as a
+ * `duplicate entry` complaint, the second as `matches no source section or
+ * fixture` - with the generator's own wording, so they are not repeated here.
  */
-test('no corpus pair is routed twice from the page file', () => {
-  const seen = new Set()
-  const duplicated = routeEntryLines.filter((entry) => seen.size === seen.add(entry).size)
-  assert.deepEqual(
-    duplicated,
-    [],
-    'these resources/example-pages.txt entries appear more than once -\n' +
-      'one corpus pair cannot have two reading locations:\n' + duplicated.join('\n'),
-  )
-})


### PR DESCRIPTION
Closes #1492.

`scripts/generate-example-pages.mjs` holds **29** `fail()` call sites. Before this, **7** were reachable from `npm test`, two more only by accident, and the rest only from `docs:pages` / `docs:dev` / `docs:build` - which is how every one of them has been discovered so far: a contributor pushes, a later job goes red, and the local suite said nothing.

The gap was structural. `tests/no-orphan-pages.test.mjs` read both page manifests through one filter:

```js
.filter((line) => line.startsWith('  ') && line.trim() !== '')
```

A route entry really is the only indented form in those files - but a filter that keeps only indented lines cannot see a `[id]` heading, a `> description` or a `key:` line, so every claim about those was invisible. Two of them were worse than invisible, and both reproduce:

- An entry sitting **above the first `[id]`** was still collected into the test's route set, so it **satisfied** the routing assertions instead of failing them. Moving `01-emphasis-15` above the first page id left the pre-change suite at **13 of 13 passing**.
- A malformed line at column zero was **dropped in silence**. Turning `out: examples/edge-cases/tables.md` into `out examples/edge-cases/tables.md` also left the pre-change suite green.

## The change

The script cannot be imported by a test - it `rmSync`s `docs/examples/` and calls `process.exit` at module scope - so the parsing moves out to `scripts/lib/example-page-manifest.mjs`. Same split `scripts/lib/example-sections.mjs` (#1487) and `scripts/lib/optional-feature-titles.mjs` (#1493) already have.

Nothing in the new module exits or throws on bad input: `parsePages`, `parseOptionalPages`, `collectSections`, `routePages`, `unroutedFixtures`, `scanPageSources` and `headerOnlyPages` each return the parsed manifest plus a list of complaints. The generator calls them at the points it used to run these checks and fails on the first complaint, so its message and its fail-fast order are unchanged. The test calls the same functions and asserts each list is empty - an empty list is exactly the condition under which `docs:build` proceeds.

## Which of the 29 are reachable now

**Reachable after this change: 27.** The 20 that move, by the assertion that now carries them:

| Test | Claims |
| --- | --- |
| the page manifest has no structural complaint | description / `key:` / entry before the first `[id]` (3), invalid page syntax, duplicate entry, missing description, missing `out:`, `out:` not `.md`, non-integer `order:`, `level:` outside {2,3} |
| the optional page manifest has no structural complaint | content before the first `[id]`, invalid syntax, unclassified `kind:` or missing description / `out:`, non-integer `order:` |
| every example source section has a slug of its own | duplicate source slug (two titles, one slug - the scanner already throws on two identical titles) |
| every page-file entry resolves to exactly one reading location | section-and-its-own-fixture named together, globally and per page; one fixture routed from two pages; entry matching no section or fixture |
| every page naming a hand-written source can read it | missing `source:` file, `source:` with no sections |
| no page is an unshared header-only page | zero entries, no `source:`, and no other entry sharing its `out:` |

Already reachable and unchanged: fixture routed to no page, authored title, optional feature routed to no page, optional page naming a feature the manifest lacks, and an optional case missing its `.crv` or target (that last one via `tests/optional-corpus.test.mjs`).

**Not reachable: 2, and neither can be.** Both are dead checks - they cannot fire, so no test could reach them:

- `section heading "..." is not ##`. `scanExampleSource` only opens a section on a line matching `^##\s+`, and a section's `bodyLines` begins at that line, so `bodyLines[0]` always starts with `## `.
- `unknown target extension`. The extension comes from a closed ternary over four literals and the language map holds all four keys.

I have left #1492 for a maintainer to close on merge rather than claiming these two; they are a separate, smaller question (delete them, or make them reachable by widening what the scanner accepts).

## Each assertion watched failing

The tree is complete, so every one of these was a deliberate mutation, restored afterwards. Each reddened **exactly one** test and named the offending entry.

| Mutation | Test that went red | Named |
| --- | --- | --- |
| a fresh entry above the first `[id]` | the page manifest has no structural complaint | `line 29 assigns a case before any page` |
| `out:` colon removed | the page manifest has no structural complaint | `line 193 has invalid page syntax` |
| `> description` line deleted | the page manifest has no structural complaint | `page "edge-tables" has no description` |
| `tables.md` to `tables.mdx` | the page manifest has no structural complaint | `page "edge-tables" has out: "...mdx"` |
| `order: 3` to `order: third` | the page manifest has no structural complaint | `page "tier3" has a non-integer order` |
| `level: 3` to `level: 4` | the page manifest has no structural complaint | `page "tier3" has level: "4"` |
| `kind: core-configured` to `core-configuration` | the optional page manifest has no structural complaint | `optional page "core-configured" needs ... classified kind` |
| `order: 2` to `order: two` | the optional page manifest has no structural complaint | `optional page "core-configured" has a non-integer order` |
| a fresh feature above the first `[id]` | the optional page manifest has no structural complaint | `optional page line 5 has content before a page` |
| `kind:` with no value | the optional page manifest has no structural complaint | `optional page line 34 has invalid syntax` |
| `51-table-without-alignment` added to the page already routing its section | every page-file entry resolves to exactly one reading location | that fixture and section `table-without-alignment`, three complaints |
| the same fixture routed from the lists page instead | every page-file entry resolves to exactly one reading location | `routed to both page "edge-tables" and page "edge-lists"` |
| the header-only `extensions` entry given an `out:` nobody shares | no page is an unshared header-only page | `page "extensions" has zero slugs and no source` |
| `source: examples-tier3.md` to `examples-tier-3.md` | every page naming a hand-written source can read it | `page "tier3" names missing source "examples-tier-3.md"` |
| a second `## Emphasis!` section, no compare block | every example source section has a slug of its own | `source slug "emphasis" is duplicated` |

That last one first reddened two tests: a slug collision also costs that slug's fixtures their names, so routing reported every entry naming one as dangling. The generator never performs that run - it exits on the section complaint first - so the routing complaints are now computed only when the section complaints are empty, mirroring the generator's own order.

## Behavior preserved

Generated output is byte-identical before and after: all 16 pages under `docs/examples/` plus `docs/.vitepress/generated-examples.json`, compared with `diff -r` and by hashing the tree.

Two incidental fixes fell out of the move, both changing behavior only on input that was already broken:

- An optional-page `kind:` with no value matched a presence test and then destructured a null `exec`, so the generator died with `TypeError: object null is not iterable` and named no line. It now reports the line.
- The hand-written `source:` scan is keyed by the page object rather than by `page.id`. Nothing rejects two entries sharing an id, and an id key would have handed both of them the last one's sections.

## Two tests removed, not weakened

`every route entry names a section or fixture that exists` and `no corpus pair is routed twice from the page file` were both derived from the raw indented lines. Both claims are now made by the shared parser and router in the generator's own wording - `matches no source section or fixture` and `duplicate entry` - so keeping them would only mean two tests reddening for one mutation.

Locally: `docs:build` (the job that owns these checks today) and the affected test files. CI runs the full suite against the pushed commit.
