### PR TITLE
docs: list Docusaurus, webpack, and Obsidian integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ tested against, and the design rationale behind each decision.
 | **Bindings** | Python, Ruby, Go, and WebAssembly, all over carve-rs. |
 | **Tooling** | Language server, tree-sitter grammar, formatter and linter (`carve fmt` / `carve lint`), converters from Markdown, HTML, Djot, and BBCode. |
 | **Editors** | VS Code, JetBrains, Sublime Text, Vim/Neovim, Emacs, Zed, Helix. |
-| **Integrations** | Laravel, Symfony, WordPress, Shopware, Hugo, Astro, Eleventy, Jekyll, and a Pandoc bridge to LaTeX, Typst, DOCX, and PDF. |
+| **Integrations** | Laravel, Symfony, WordPress, Shopware, Hugo, Astro, Eleventy, Jekyll, Docusaurus, webpack/Next.js, Obsidian, and a Pandoc bridge to LaTeX, Typst, DOCX, and PDF. |
 
 Pre-1.0, a minor release may still change the grammar; the stability tiers and
 the release lockstep between the spec and the engines are defined in

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -63,6 +63,9 @@ Carve embedded in another tool or framework.
 | [eleventy-carve](https://github.com/markup-carve/eleventy-carve) | Eleventy (11ty) | Plugin for processing Carve source files. |
 | [astro-carve](https://github.com/markup-carve/astro-carve) | Astro | Integration for importing `.crv` pages. |
 | [hugo-carve](https://github.com/markup-carve/hugo-carve) | Hugo | Preprocessor that converts `.crv` content to HTML, via carve-go. |
+| [docusaurus-carve](https://github.com/markup-carve/docusaurus-carve) | Docusaurus | Docs plugin: converts `.crv` pages and delegates routes, sidebars, and metadata to Docusaurus. |
+| [webpack-loader-carve](https://github.com/markup-carve/webpack-loader-carve) | webpack / Next.js | Build-time loader for importing `.crv` as rendered HTML modules. |
+| [obsidian-carve](https://github.com/markup-carve/obsidian-carve) | Obsidian | Community plugin with source and reading views for `.crv` notes. |
 | [symfony-carve](https://github.com/markup-carve/symfony-carve) | Symfony | Bundle to render Carve markup to HTML via carve-php. |
 | [symfony-carve-demo](https://github.com/markup-carve/symfony-carve-demo) | Symfony | Demo app showcasing the symfony-carve bundle. |
 | [laravel-carve](https://github.com/markup-carve/laravel-carve) | Laravel | Integration with Blade directives, services, validation, and caching. |


### PR DESCRIPTION
## Summary

- list the new Docusaurus docs plugin
- list the webpack/Next.js loader
- list the Obsidian source and reading-view plugin
- update the README integration overview

## Verification

- `node --test tests/no-orphan-pages.test.mjs tests/repo-links.test.mjs`
- all three linked repositories have host-level build or renderer tests