### PR TITLE
fix: two example-page generator guards check what they claim

### DIFF
--- a/scripts/generate-example-pages.mjs
+++ b/scripts/generate-example-pages.mjs
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import { dirname, posix, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { slugify } from './lib/example-sections.mjs'
-import { collectSections, headerOnlyPages, parseOptionalPages, parsePages, routePages, scanPageSources, unroutedFixtures } from './lib/example-page-manifest.mjs'
+import { SECTION_HEADING_PREFIX, collectSections, headerOnlyPages, nonHeadingSections, optionalCaseFences, parseOptionalPages, parsePages, routePages, scanPageSources, unroutedFixtures } from './lib/example-page-manifest.mjs'
 import { optionalFeatureTitles } from './lib/optional-feature-titles.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -91,6 +91,12 @@ const { sectionsByPage, complaints: sourceComplaints } = scanPageSources(pages, 
 failOn(sourceComplaints)
 for (const page of pages) page.standaloneSections = sectionsByPage.get(page)
 
+/* Asked of both populations that reach `sectionLines` below, before anything is
+ * generated: the scanner guarantees a section opens at `##`, not what separates
+ * it from the title, and the separator is re-emitted verbatim (carve#1496). */
+failOn(nonHeadingSections([...sectionsBySlug.values()], 'resources/examples/*.md'))
+for (const [page, sections] of sectionsByPage) failOn(nonHeadingSections(sections, `page "${page.id}" source resources/${page.source}`))
+
 const corpusUrl = (name) => `https://github.com/markup-carve/carve/blob/main/tests/corpus/${name}.crv`
 const sourceLink = (name) => `[\`resources/examples/${name}.md\`](https://github.com/markup-carve/carve/blob/main/resources/examples/${name}.md)`
 /*
@@ -104,15 +110,21 @@ const banner = (sourceNames) => {
   const list = links.length === 1 ? links[0] : `${links.slice(0, -1).join(', ')} and ${links.at(-1)}`
   return `Generated from ${list} - edit the cases there, not here. Each case links the conformance fixture it produces.`
 }
-const sectionLines = (section, level, context) => {
+/*
+ * Re-emitting the heading at the page's level is a slice, not a reparse: the two
+ * `#`s go, everything after them travels verbatim. Both claims that used to be
+ * checked here are settled before this point (carve#1496). `scanExampleSource`
+ * opens a section only on `/^##\s+/`, so `bodyLines[0]` exists and begins at
+ * level 2 - a `###` line never opens a section, which is why the `### ` clause
+ * that lived here could not fire. What the separator may be is not guaranteed by
+ * that regex, so `nonHeadingSections` in scripts/lib/example-page-manifest.mjs
+ * asks it of both populations above, where a test can ask it too.
+ */
+const sectionLines = (section, level) => {
   const [heading, ...body] = rewriteProseLinks(section.bodyLines)
-  /* Generated nesting is only safe when the authored section starts at the
-   * documented ## boundary; accepting another level would silently corrupt
-   * both the outline and VitePress's stable anchor text. */
-  if (!heading?.startsWith('## ') || heading.startsWith('### ')) fail(`${context} section heading "${heading ?? ''}" is not ##; generated sections must begin at level 2 before nesting.`)
   return [`${'#'.repeat(level)}${heading.slice(2)}`, ...body]
 }
-const sectionHeading = (section, level, context) => sectionLines({ bodyLines: [section.bodyLines[0]] }, level, context)[0]
+const sectionHeading = (section, level) => sectionLines({ bodyLines: [section.bodyLines[0]] }, level)[0]
 const segmentLines = (segment) => rewriteProseLinks(segment.bodyLines)
 const blocksByOutput = new Map()
 let declarationIndex = 0
@@ -138,7 +150,7 @@ for (const page of pages) {
     bySection.get(section.slug).segments.push(...segments)
   }
   for (const { section, segments } of bySection.values()) {
-    lines.push(sectionHeading(section, page.level, `page "${page.id}"`))
+    lines.push(sectionHeading(section, page.level))
     /*
      * ONE collapsed list per section, not a citation line per pair. The
      * fixture name serves one flow - a maintainer asking which fixture pins a
@@ -170,7 +182,7 @@ for (const page of pages) {
   }
   if (page.source) {
     lines.push(`Hand-written source: [\`resources/${page.source}\`](https://github.com/markup-carve/carve/blob/main/resources/${page.source}).`, '')
-    for (const section of page.standaloneSections) lines.push(...sectionLines(section, page.level, `page "${page.id}"`))
+    for (const section of page.standaloneSections) lines.push(...sectionLines(section, page.level))
   }
   addBlock(page.out, { order: page.order, title: page.title, description: page.description, lines })
 }
@@ -188,12 +200,6 @@ const featureTitle = (feature) => {
   if (!title) fail(`manifest feature "${feature}" has no authored title in scripts/lib/optional-feature-titles.mjs; a slug-cased heading reads as a filename, not a feature.`)
   return title
 }
-const languageByExtension = new Map([
-  ['.html', 'html'],
-  ['.md', 'markdown'],
-  ['.txt', 'text'],
-  ['.ansi', 'ansi'],
-])
 const fenced = (language, content) => {
   const longest = Math.max(0, ...[...content.matchAll(/`+/g)].map((match) => match[0].length))
   const marker = '`'.repeat(Math.max(3, longest + 1))
@@ -205,6 +211,13 @@ for (const item of manifest.cases) {
   if (!casesByFeature.has(item.feature)) casesByFeature.set(item.feature, [])
   casesByFeature.get(item.feature).push(item)
 }
+/* The expected-output extension and its fence language both come from the
+ * case's `target`, through the map every other reader of this manifest uses.
+ * Resolved for the whole manifest up front so a target nobody implements is
+ * named as such, rather than defaulting to HTML - which pinned the wrong file
+ * silently wherever an `.html` happened to exist (carve#1496). */
+const { fences, complaints: fenceComplaints } = optionalCaseFences(manifest.cases)
+failOn(fenceComplaints)
 const { pages: optionalPages, complaints: optionalComplaints } = parseOptionalPages(readFileSync(optionalPagesSource, 'utf8'))
 failOn(optionalComplaints)
 failOn(headerOnlyPages(pages, optionalPages))
@@ -239,11 +252,9 @@ for (const page of optionalPages) {
     )
     for (const item of featureCases) {
       const sourcePath = resolve(optionalCorpusDir, `${item.slug}.crv`)
-      const targetExtension = item.target === 'markdown' ? '.md' : item.target === 'plain' ? '.txt' : item.target === 'ansi' ? '.ansi' : '.html'
+      const { extension: targetExtension, language } = fences.get(item)
       const targetPath = resolve(optionalCorpusDir, `${item.slug}${targetExtension}`)
       if (!existsSync(sourcePath) || !existsSync(targetPath)) fail(`optional case "${item.slug}" is missing its .crv or ${targetExtension} target; the generated comparison would be unverifiable.`)
-      const language = languageByExtension.get(targetExtension)
-      if (!language) fail(`optional case "${item.slug}" has unknown target extension "${targetExtension}"; the generator cannot choose a truthful fence language.`)
       /* These renders depend on configuration the docs page does not apply; live rendering would contradict the pinned output. */
       const carve = readFileSync(sourcePath, 'utf8').replace(/\n$/, '')
       const target = readFileSync(targetPath, 'utf8').replace(/\n$/, '')
@@ -277,7 +288,10 @@ for (const [out, blocks] of blocksByOutput) {
      * group boundary for every non-owner block, including a header-only owner. */
     if (blocks.length > 1 && block !== owner) parts.push(`## ${block.title}`, '', asProse(block.description), '')
     const nested = blocks.length > 1 && block !== owner
-      ? block.lines.map((line) => line.startsWith('## ') ? `###${line.slice(2)}` : line)
+      /* Same prefix `nonHeadingSections` guards, imported rather than respelled:
+       * a heading it let through with a different separator would silently stay
+       * at level 2 while its page-mates moved to level 3 (carve#1496). */
+      ? block.lines.map((line) => line.startsWith(SECTION_HEADING_PREFIX) ? `###${line.slice(2)}` : line)
       : block.lines
     parts.push(...nested)
   }

--- a/scripts/lib/example-page-manifest.mjs
+++ b/scripts/lib/example-page-manifest.mjs
@@ -27,6 +27,7 @@
  */
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { TARGET_EXTENSIONS, targetNames, targetOf } from './corpus-targets.mjs'
 import { exampleFiles, numberExamples, readExampleFiles, scanExampleSource } from './example-sections.mjs'
 
 /*
@@ -133,6 +134,48 @@ export const parseOptionalPages = (source) => {
 }
 
 /*
+ * Sections whose heading would not survive being generated.
+ *
+ * `scripts/generate-example-pages.mjs` re-emits a section heading at the page's
+ * own level by slicing off the two `#`s and keeping the rest verbatim, so the
+ * character between `##` and the title travels into the generated page.
+ * `scanExampleSource` opens a section on `/^##\s+/`, and `\s` is not only the
+ * space. Two different things go wrong, which is why the rule is the space and
+ * not "ATX whitespace". Measured through VitePress's own renderer:
+ *
+ *     "## Title"       ->  <h2 id="title">Title</h2>
+ *     "##<TAB>Title"   ->  <h2 id="title">Title</h2>
+ *     "##<U+00A0>Title" ->  <p>## Title</p>
+ *
+ * U+00A0 (and U+000B, U+000C) is not ATX whitespace, so the generated line
+ * renders as a PARAGRAPH: a section that quietly stops being a heading, loses
+ * the anchor every in-page link to it needs, and still owns its corpus
+ * fixtures. A tab does render as a heading - but the generator pushes a shared
+ * output's non-owner blocks down a level by matching
+ * `SECTION_HEADING_PREFIX` literally, so a tab-separated heading would sit at
+ * level 2 among page-mates that all moved to level 3. Both sides use the
+ * constant below so the guard and that rewrite cannot drift apart.
+ *
+ * The LEVEL needs no check. `/^##\s/` is the only way a section opens, so a
+ * `###` line is never a section heading and can never reach `bodyLines[0]`;
+ * the generator carried a `startsWith('### ')` clause that therefore could not
+ * fire and implied a guard that does not exist (carve#1496).
+ */
+export const SECTION_HEADING_PREFIX = '## '
+export const nonHeadingSections = (sections, context) =>
+  sections
+    .filter((section) => !section.bodyLines[0].startsWith(SECTION_HEADING_PREFIX))
+    .map((section) => {
+      const heading = section.bodyLines[0]
+      /* Name the CODE POINT. Every character this can report is invisible in a
+       * terminal, so a message that only quotes the line shows the reader a
+       * heading that looks perfectly correct. `##` plus one character is the
+       * shortest heading the scanner can open a section on, so index 2 exists. */
+      const separator = `U+${heading.codePointAt(2).toString(16).toUpperCase().padStart(4, '0')}`
+      return `${context} heading "${heading}" separates "##" from its title with ${separator} instead of a space; the separator is re-emitted verbatim, and only a space is read as a heading by VitePress AND recognized by the rewrite that pushes a shared page's sections to level 3.`
+    })
+
+/*
  * The sections a page entry may name, keyed by slug, and the corpus pairs those
  * sections hold, keyed by fixture name. Numbering comes from the CONCATENATION
  * of the three example files - that is what `generate-corpus.mjs` numbers by -
@@ -148,7 +191,8 @@ export const collectSections = (repoRoot) => {
   const sectionsBySlug = new Map()
   for (const sourceName of exampleFiles) {
     const sourcePath = resolve(repoRoot, 'resources/examples', `${sourceName}.md`)
-    for (const section of scanExampleSource(readFileSync(sourcePath, 'utf8').split('\n')).sections) {
+    const { sections } = scanExampleSource(readFileSync(sourcePath, 'utf8').split('\n'))
+    for (const section of sections) {
       /* `scanExampleSource` already throws on two identical section TITLES.
        * Two DIFFERENT titles that slugify to one slug reach here instead, and
        * a page entry naming that slug could not say which one it meant. */
@@ -264,4 +308,64 @@ export const headerOnlyPages = (pages, optionalPages) => {
   return pages
     .filter((page) => page.slugs.length === 0 && !page.source && outputCounts.get(page.out) === 1)
     .map((page) => `page "${page.id}" has zero slugs and no source; that is allowed only when another entry shares its out: path as a legitimate header-only owner.`)
+}
+
+/*
+ * The fence language an optional case's expected output is shown in, keyed by
+ * TARGET - the same key `scripts/lib/corpus-targets.mjs` names its extensions
+ * by, so one target vocabulary serves both halves of a generated comparison.
+ *
+ * WHY KEYED BY TARGET. The generator used to derive the extension from a closed
+ * four-arm ternary (`markdown` -> .md, `plain` -> .txt, `ansi` -> .ansi,
+ * ANYTHING ELSE -> .html) and then look the language up by extension. That made
+ * the language lookup unable to miss - a `fail()` call that could not fire -
+ * while the arm that actually mattered was the silent default: `carve` has been
+ * a legal target with a `.fmt` expected file, honored by
+ * `tests/optional-corpus.test.mjs`, `tests/corpus-targets.test.mjs` and
+ * `scripts/compare-impls.mjs`, and the ternary called it HTML. Measured: with
+ * one manifest case switched to `target: "carve"`, the old generator did not
+ * fail at all - it paired the case with the `.html` file it also happens to have
+ * and labeled the fence `html`, publishing an HTML expectation for a case pinned
+ * on Carve output. Where no `.html` exists it failed one step later naming the
+ * wrong file (carve#1496).
+ *
+ * Now an unknown target is caught by the extension map, which CAN miss, and a
+ * target added to `TARGET_EXTENSIONS` with no fence language is caught here.
+ * `tests/no-orphan-pages.test.mjs` asserts both directions of this map, the
+ * shape carve#1490 gave `optional-feature-titles.mjs`.
+ */
+export const fenceLanguages = new Map([
+  ['html', 'html'],
+  ['markdown', 'markdown'],
+  ['plain', 'text'],
+  ['ansi', 'ansi'],
+  ['carve', 'carve'],
+])
+
+/*
+ * Resolve every optional-corpus case to the expected-file extension and fence
+ * language its generated comparison needs.
+ *
+ * Keyed by the CASE OBJECT, not by `item.slug`. Nothing in this repo rejects
+ * two manifest entries sharing a slug, and a slug key would hand both of them
+ * the last one's target - the same keying trap `scanPageSources` documents.
+ */
+export const optionalCaseFences = (cases) => {
+  const fences = new Map()
+  const complaints = []
+  for (const item of cases) {
+    const target = targetOf(item)
+    const extension = TARGET_EXTENSIONS[target]
+    if (!extension) {
+      complaints.push(`optional case "${item.slug}" names target "${target}", which is not one of ${targetNames().join(', ')}; its expected output has no filename, so the generated comparison would pin nothing.`)
+      continue
+    }
+    const language = fenceLanguages.get(target)
+    if (!language) {
+      complaints.push(`optional case "${item.slug}" names target "${target}", which has no fence language in scripts/lib/example-page-manifest.mjs; the generator cannot label its expected output truthfully.`)
+      continue
+    }
+    fences.set(item, { extension: `.${extension}`, language })
+  }
+  return { fences, complaints }
 }

--- a/tests/no-orphan-pages.test.mjs
+++ b/tests/no-orphan-pages.test.mjs
@@ -24,7 +24,8 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { numberExamples, readExampleFiles, scanExampleSource } from '../scripts/lib/example-sections.mjs'
-import { collectSections, headerOnlyPages, parseOptionalPages, parsePages, routePages, scanPageSources } from '../scripts/lib/example-page-manifest.mjs'
+import { SECTION_HEADING_PREFIX, collectSections, fenceLanguages, headerOnlyPages, nonHeadingSections, optionalCaseFences, parseOptionalPages, parsePages, routePages, scanPageSources } from '../scripts/lib/example-page-manifest.mjs'
+import { TARGET_EXTENSIONS, targetNames } from '../scripts/lib/corpus-targets.mjs'
 import { optionalFeatureTitles } from '../scripts/lib/optional-feature-titles.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -234,6 +235,72 @@ test('every page naming a hand-written source can read it', () => {
   )
 })
 
+/*
+ * THE SECTION HEADING ITSELF, which the generator used to check where nothing
+ * could reach it - and where one half of the check could not fire at all.
+ *
+ * WHY. `scripts/generate-example-pages.mjs` re-emits a section heading at the
+ * page's level by slicing off the two `#`s and keeping the rest verbatim. It
+ * guarded that with `!heading.startsWith('## ') || heading.startsWith('### ')`.
+ * The second half is unreachable by construction: `scanExampleSource` opens a
+ * section only on `/^##\s+/`, so a `###` line never becomes `bodyLines[0]`, and
+ * the clause implied a level guard the scanner already makes impossible
+ * (carve#1496). The first half is NOT unreachable - `\s` is not only the space,
+ * and `##` followed by U+00A0 opens a section whose generated line VitePress
+ * renders as a paragraph, losing the heading and its anchor while the section
+ * keeps its corpus fixtures. A tab renders as a heading but is rejected for the
+ * other reason the lib records: the rewrite that pushes a shared page's
+ * sections to level 3 matches `SECTION_HEADING_PREFIX` literally.
+ *
+ * So the live half moved into the manifest lib, and it is asked here of the two
+ * populations the generator generates from.
+ */
+test('every routed section heading survives being generated', () => {
+  const complaints = nonHeadingSections([...sectionsBySlug.values()], 'resources/examples/*.md')
+  assert.deepEqual(
+    complaints,
+    [],
+    'these resources/examples/*.md headings would stop being headings once generated:\n' + complaints.join('\n'),
+  )
+})
+
+test('every hand-written source heading survives being generated', () => {
+  const { sectionsByPage } = scanPageSources(pages, repoRoot)
+  const complaints = [...sectionsByPage].flatMap(([page, sections]) =>
+    nonHeadingSections(sections, `page "${page.id}" source resources/${page.source}`))
+  assert.deepEqual(
+    complaints,
+    [],
+    'these source: headings would stop being headings once generated:\n' + complaints.join('\n'),
+  )
+})
+
+test('a heading whose separator is not a space is reported', () => {
+  /*
+   * The reachability proof. Without it the two assertions above pass for a
+   * check that cannot fail, which is the defect carve#1496 is about - so every
+   * separator the scanner's `/^##\s+/` CAN produce is asserted here, in both
+   * directions.
+   */
+  const sections = (heading) => [{ bodyLines: [heading] }]
+  assert.deepEqual(nonHeadingSections(sections('## Title'), 'ctx'), [])
+  for (const [label, separator] of [['tab', '\t'], ['U+00A0', '\u00a0'], ['form feed', '\u000c'], ['vertical tab', '\u000b']]) {
+    const complaints = nonHeadingSections(sections(`##${separator}Title`), 'ctx')
+    assert.equal(complaints.length, 1, `a ${label} after ## must be reported`)
+    assert.match(complaints[0], /^ctx heading .* separates "##" from its title with U\+[0-9A-F]{4} instead of a space/,
+      'the offending character is invisible, so the message has to name its code point')
+  }
+  assert.match(nonHeadingSections(sections('##\u00a0Title'), 'ctx')[0], /U\+00A0/)
+})
+
+test('the guard and the level rewrite share one heading prefix', () => {
+  /* The rewrite in scripts/generate-example-pages.mjs that pushes a shared
+   * page's non-owner sections to level 3 matches this exact prefix. A guard
+   * that accepted a heading the rewrite does not recognize would leave that
+   * section at level 2 among page-mates that all moved down. */
+  assert.equal(SECTION_HEADING_PREFIX, '## ')
+})
+
 test('no page is an unshared header-only page', () => {
   /* A page with no entries and no source is legitimate only as the frontmatter
    * owner of an out: path another entry also writes to. Alone, it publishes a
@@ -279,9 +346,8 @@ test('every corpus fixture is routed to a docs page', () => {
  * a page is routed the moment it is added - but a new feature is not, and that
  * too was only visible at `docs:build`.
  */
-const manifestFeatures = [...new Set(
-  JSON.parse(readFileSync(resolve(repoRoot, 'tests/corpus-optional/manifest.json'), 'utf8')).cases.map((item) => item.feature),
-)]
+const optionalCases = JSON.parse(readFileSync(resolve(repoRoot, 'tests/corpus-optional/manifest.json'), 'utf8')).cases
+const manifestFeatures = [...new Set(optionalCases.map((item) => item.feature))]
 const assignedFeatures = new Set(optionalPages.flatMap((page) => page.features))
 
 test('the optional-corpus feature census is not empty', () => {
@@ -362,3 +428,57 @@ test('every authored title names a feature the manifest still has', () => {
  * `duplicate entry` complaint, the second as `matches no source section or
  * fixture` - with the generator's own wording, so they are not repeated here.
  */
+
+/*
+ * THE TARGET each optional case pins, and the fence language its expected
+ * output is shown in.
+ *
+ * WHY. The generator derived the extension from a closed four-arm ternary
+ * (`markdown` -> .md, `plain` -> .txt, `ansi` -> .ansi, anything else -> .html)
+ * and then looked the language up by extension, so its
+ * `unknown target extension` failure could not fire over that range - while the
+ * default arm quietly claimed HTML for `carve`, a target that has had a `.fmt`
+ * expected file since `TARGET_EXTENSIONS` grew it and that every other reader of
+ * this manifest honors. Measured on the old generator: a `target: "carve"` case
+ * did not fail, it published the case's `.html` file under an `html` fence -
+ * an HTML expectation for a case pinned on Carve output (carve#1496). Both maps
+ * are keyed by target now, and both directions are asserted, the shape
+ * carve#1490 gave the feature titles.
+ */
+test('every optional-corpus case resolves an expected file and a fence language', () => {
+  const { fences, complaints } = optionalCaseFences(optionalCases)
+  assert.deepEqual(
+    complaints,
+    [],
+    'these tests/corpus-optional/manifest.json cases would stop `npm run docs:build`:\n' + complaints.join('\n'),
+  )
+  assert.equal(fences.size, optionalCases.length, 'every case must resolve exactly one fence')
+})
+
+test('a case naming a target nobody implements is reported', () => {
+  /* The reachability proof for the guard that replaced the closed ternary: the
+   * complaint names the TARGET, which is the wrong thing in the manifest, and
+   * not a derived `.html` filename that was never asked for. */
+  const { fences, complaints } = optionalCaseFences([{ slug: '99-invented', feature: 'x', target: 'pdf' }])
+  assert.equal(complaints.length, 1)
+  assert.match(complaints[0], /names target "pdf"/)
+  assert.match(complaints[0], new RegExp(targetNames().join(', ')))
+  assert.equal(fences.size, 0)
+})
+
+test('a case with no target pins the default HTML pairing', () => {
+  const { fences } = optionalCaseFences([{ slug: '01-plain', feature: 'x' }, { slug: '02-fmt', feature: 'x', target: 'carve' }])
+  assert.deepEqual([...fences.values()], [
+    { extension: '.html', language: 'html' },
+    /* The case the ternary got wrong. */
+    { extension: '.fmt', language: 'carve' },
+  ])
+})
+
+test('every corpus target has a fence language, and every fence language a target', () => {
+  /* A sixth target added to scripts/lib/corpus-targets.mjs with no fence
+   * language would otherwise reach the generator, which is the only place that
+   * pairing is needed - and the generator is what `npm test` does not run. */
+  assert.deepEqual(targetNames().filter((target) => !fenceLanguages.has(target)), [])
+  assert.deepEqual([...fenceLanguages.keys()].filter((target) => !Object.hasOwn(TARGET_EXTENSIONS, target)), [])
+})


### PR DESCRIPTION
Closes #1496.

Two `fail()` calls in `scripts/generate-example-pages.mjs` could not fire, which is why carve#1494 could move the other 27 checks into `npm test` and not these. Re-measuring both before deciding their fate found **one of the two claims half wrong, and the other one covering a live defect** - so one is deleted and the rest are made reachable rather than removed.

### The target extension: reachable now, and it was hiding a real gap

The extension came from a closed four-arm ternary (`markdown` -> `.md`, `plain` -> `.txt`, `ansi` -> `.ansi`, **anything else** -> `.html`) and the fence language was then looked up by extension over a map holding exactly those four. The language lookup therefore could not miss - while the arm that mattered was the silent default:

| `item.target` | old ternary | `TARGET_EXTENSIONS` | agree |
|---|---|---|---|
| `html` / `markdown` / `plain` / `ansi` | `.html` / `.md` / `.txt` / `.ansi` | same | yes |
| `carve` | `.html` | `.fmt` | **no** |
| anything else | `.html` | (none - a manifest error) | **no** |

`carve` has been a legal target with a `.fmt` expected file since `TARGET_EXTENSIONS` grew it, and `tests/optional-corpus.test.mjs`, `tests/corpus-targets.test.mjs` and `scripts/compare-impls.mjs` all honor it. Measured by switching one manifest case to `target: "carve"`: the old generator **did not fail at all**. It paired the case with the `.html` file it also happens to have, labeled the fence `html`, and published an HTML expectation for a case pinned on Carve output. Only a case with no `.html` would have failed, one step later, naming the wrong file.

Both halves now come from the target: the extension through `TARGET_EXTENSIONS`, which *can* miss, and the fence language through a map keyed the same way. The complaint names the bad target instead of a derived filename nobody asked for, and both directions of the target/language map are asserted so a sixth target cannot arrive without one.

### The section heading: one half dead, one half alive

`!heading.startsWith('## ') || heading.startsWith('### ')` is two claims.

- `startsWith('### ')` is **unreachable by construction**: `scanExampleSource` opens a section only on `/^##\s+/`, so a `###` line never becomes `bodyLines[0]`. It also implied a level guard the scanner already makes impossible. **Deleted**, with the invariant recorded where it stood.
- `!startsWith('## ')` is **not** unreachable, which is where the ticket's premise was wrong: `\s` is not only the space. Measured through VitePress's own renderer:

| heading | renders as |
|---|---|
| `## Title` | `<h2 id="title">` |
| `##` + TAB + `Title` | `<h2 id="title">` |
| `##` + U+00A0 + `Title` | `<p>## Title</p>` |

U+00A0 (and U+000B, U+000C) opens a section whose generated line is a **paragraph** - a section that stops being a heading, loses the anchor every in-page link to it needs, and still owns its corpus fixtures. Deleting that guard would have removed a defense that exists and fires.

So it **stays**, moves to `nonHeadingSections` in `scripts/lib/example-page-manifest.mjs` where a test can make the same claim, and is worded for what it actually detects. It names the offending code point, because every character it can report is invisible in a terminal - the old message quoted a heading that looked perfectly correct.

A tab renders as a heading but is still rejected, for a second reason found while reading the file: the rewrite that pushes a shared output's non-owner sections to level 3 matches `'## '` **literally**, so a tab-separated heading would sit at level 2 among page-mates that all moved down. The guard and that rewrite now share one exported prefix constant so they cannot drift.

### Reachability, proved rather than assumed

A mutation that changes nothing here proves nothing - that is the shape of the original defect. So each new check was proved against the input it is about:

- `resources/examples/core.md`'s `## Emphasis` separator replaced with U+00A0: generator exits 1 with the new message naming `U+00A0`, and `every routed section heading survives being generated` reddens. Same with a tab, naming `U+0009`.
- one manifest case given `target: "pdf"`: generator exits 1 naming the target and the five it could have been, and `every optional-corpus case resolves an expected file and a fence language` reddens.
- the same case given `target: "carve"`: new generator names the missing `.fmt`; the version on `main` generated all 16 pages without complaint.

Sources and manifest were restored from `cp` backups and confirmed byte-identical to `HEAD`.

### Scope

All 16 generated pages and `docs/.vitepress/generated-examples.json` are byte-identical before and after (`sha256` of the file list unchanged), so no docs output moves. No CHANGELOG entry: nothing shipped in the package changed.

Validated locally on the targeted files - `tests/no-orphan-pages.test.mjs` plus every test importing the touched modules (106 pass, 1 pre-existing skip) - and one full `npm run docs:build`, which is what exercises the generator. The full 2,650-case suite is CI's run against the pushed commit, not a local one; the baseline `gate-run` on this checkout reports `partial`, with `ast:check`, `claims:check`, `degradation:check` and `fmt:check` unrunnable here for missing sibling engine checkouts.
