### PR TITLE
A blank line between two ordered items loosens the list

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -21,15 +21,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>735 / 749</strong>
+    <strong>735 / 750</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>735 / 749</strong>
+    <strong>735 / 750</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>737 / 749</strong>
+    <strong>737 / 750</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -40,9 +40,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `735 / 749` | `0` | `0` | `3.01` |
-| JS | `8105210` | `735 / 749` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `737 / 749` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `735 / 750` | `0` | `0` | `3.01` |
+| JS | `8105210` | `735 / 750` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `737 / 750` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 
@@ -781,7 +781,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=749 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=750 targets=html,markdown,plain,carve,ansi
 rust: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=3.01
   mismatching documents: 0
 js: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=76.02

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1342 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1343 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -25,3 +25,4 @@
 #
 # Format: <slug><space><space><reason>
 
+05-lists-22  The pinned JS build ends an ordered list at a blank line instead of loosening it (markup-carve/carve-js#1270); remove when the pin advances past the fix.

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -244,6 +244,7 @@ index: examples/edge-cases/index.md
   05-lists-18
   05-lists-20
   05-lists-21
+  05-lists-22
   ordered-marker-vs-prose
   parenthesized-ordered-marker
   list-nesting-and-looseness

--- a/resources/examples/core.md
+++ b/resources/examples/core.md
@@ -994,6 +994,31 @@ lazy</li>
 
 :::
 
+A blank line is not a list boundary, so the ORDERED spelling loosens exactly
+as the bullet one does: the marker after the blank is still a sibling of the
+same list. §11 N1's axes are the bullet character, the ordered-marker
+alternative, the delimiter and plain-vs-task - a blank line is not among them -
+and §17 L1 reads "a blank line before the next sibling marker", which is a
+statement about tightness, not about where the list ends.
+
+::: compare
+
+```carve
+1. apples
+
+2. oranges
+```
+
+```html
+<ol>
+  <li><p>apples</p></li>
+  <li><p>oranges</p></li>
+</ol>
+```
+
+:::
+
+
 ## Task lists
 
 ::: compare

--- a/tests/corpus/05-lists-22.crv
+++ b/tests/corpus/05-lists-22.crv
@@ -1,0 +1,3 @@
+1. apples
+
+2. oranges

--- a/tests/corpus/05-lists-22.html
+++ b/tests/corpus/05-lists-22.html
@@ -1,0 +1,4 @@
+<ol>
+  <li><p>apples</p></li>
+  <li><p>oranges</p></li>
+</ol>

--- a/tests/spec/05-lists.test
+++ b/tests/spec/05-lists.test
@@ -243,3 +243,14 @@ lazy</li>
   </li>
 </ol>
 ```
+
+```
+1. apples
+
+2. oranges
+.
+<ol>
+  <li><p>apples</p></li>
+  <li><p>oranges</p></li>
+</ol>
+```


### PR DESCRIPTION
The corpus pins the bullet spelling of a loose list four times and the ordered
spelling not once. Scanning all 1387 example inputs for an ordered marker at
column 0, a blank line, and another ordered marker at column 0 finds **zero**
cases; the bullet equivalent has four (`05-lists-15`,
`75-list-nesting-and-looseness-2`,
`172-attribute-braces-on-a-list-item-marker-line`,
`290-adjacent-sibling-lists-survive-the-round-trip-3`).

The gap was load-bearing. The three engines disagree on this input while all
passing the corpus:

```
1. apples

2. oranges
```

carve-php `78d9e18`, carve-rs `1e4b5a6` and the oracle:

```html
<ol>
  <li><p>apples</p></li>
  <li><p>oranges</p></li>
</ol>
```

carve-js `d47a579`:

```html
<ol>
  <li>apples</li>
</ol>
<ol start="2">
  <li>oranges</li>
</ol>
```

## Why the two-engine reading is the right one

Not because it is two against one. Because nothing in the grammar makes a blank
line start a list:

- **§11 N1** makes two adjacent items the same list iff they match on the
  bullet character, the ordered-marker alternative, the delimiter and
  plain-vs-task. A blank line is not one of the axes.
- **§11 N2** fixes the dialect and delimiter from the FIRST item. `2.` is
  decimal-with-dot exactly as `1.` is, so it does not leave the list.
- **§17 L1** reads "a blank line before the next **sibling marker**" - the
  marker after the blank belongs to the same list, and the blank decides tight
  versus loose and nothing else.

carve-js also gets the bullet spelling right, so it is applying a different rule
to its own ordered lists than to its bullets. Filed as
markup-carve/carve-js#1270.

## Placement

The example is appended at the END of the Lists section rather than sitting
beside its bullet twin. Numbering is per-section by source order, so inserting
in the middle renumbers every later fixture in that section; appended, it takes
the next free number and nothing moves. Confirmed by the rebuild - one new pair,
no renames.

Note for sequencing: this claims `05-lists-22`, which is the number the `next`
branch used for carve#1430's hard-boundary fixture. Whichever lands second takes
23.

## Consequences

- The pinned JS build does not reproduce this document, so it is declared in
  `resources/engine-pin-drift.txt` rather than tolerated - that file's stated
  purpose.
- `docs/index.md` 1342 to 1343, and the comparison page's DENOMINATORS 749 to
  750. The numerators stay as they are: they are a recorded sweep against the
  engine commits named beside them, and those pins never saw this document.
  Re-running `compare:impls` is a separate job.
