### PR TITLE
spec: a tab control is a button, and two marked items select one tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A tab control is `type="button"`, and two marked items select one tab**
+  (carve#1537, extensions §13.3 and §13.5). A generated control with no `type`
+  is a submit button, so a tab set inside a `<form>` submitted the form instead
+  of switching panels; and several `{selected}` items each got their own
+  selection, which a single-select `tablist` has no state for. The first mark
+  wins and later ones are ignored, in both modes and both constructs. Optional
+  corpus 47, 48, 49.
 - **The index back-link says where it goes, and the extension-written strings
   get one map** (carve#1469, carve#1468). The Index extension's own rendering rule mandated a bare `↩`, which
   a reader announces as "leftwards arrow with hook" or skips - the sentence

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ tested against, and the design rationale behind each decision.
 | | |
 |---|---|
 | **Specification** | 0.1. Tier-1 core and Tier-2 standard extensions are normative and stable; Tier-3 app-level extensions ship but evolve. See [VERSIONING.md](VERSIONING.md). |
-| **Conformance** | Over 1,250 corpus examples pinning exact HTML output, plus 47 optional-corpus examples for host-dependent extensions. |
+| **Conformance** | Over 1,250 corpus examples pinning exact HTML output, plus 49 optional-corpus examples for host-dependent extensions. |
 | **Engines** | [carve-js](https://github.com/markup-carve/carve-js) (TypeScript, reference), [carve-php](https://github.com/markup-carve/carve-php), [carve-rs](https://github.com/markup-carve/carve-rs) - all three run the same corpus, with no open or intentional divergences ([tracker](MAINTAINING.md#known-cross-impl-divergences)). |
 | **Bindings** | Python, Ruby, Go, and WebAssembly, all over carve-rs. |
 | **Tooling** | Language server, tree-sitter grammar, formatter and linter (`carve fmt` / `carve lint`), converters from Markdown, HTML, Djot, and BBCode. |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1471,7 +1471,7 @@ Both extensions carry a `mode` option with exactly two values:
 | `mode` | How a panel is revealed | Needs a client script |
 |---|---|---|
 | `css` (default) | one `<input type="radio">` per tab plus a sibling `<label for=…>`; a stylesheet reveals the checked panel | no |
-| `aria` | a `<button role="tab">` per tab and `role="tabpanel"` panels; every non-selected panel carries `hidden` | yes |
+| `aria` | a `<button type="button" role="tab">` per tab and `role="tabpanel"` panels; every non-selected panel carries `hidden` | yes |
 
 `css` is the default in both, and an implementation MUST NOT ship `aria` as the
 default. That is a consequence of the §2.5 rule rather than of compatibility:
@@ -1546,13 +1546,13 @@ tab name where one was written, otherwise the language word.
 
 In `aria` mode the association already exists, so the panel takes **neither**
 `role="group"` **nor** an `aria-label`. It stays `role="tabpanel"`, bound by
-`aria-labelledby` to its `<button role="tab">`, and every non-selected panel
+`aria-labelledby` to its `<button type="button" role="tab">`, and every non-selected panel
 carries `hidden`:
 
 ```html
 <div class="tabs" role="tablist" aria-label="Tabs">
-<button role="tab" id="tabset-1-tab-1" aria-selected="true" aria-controls="tabset-1-panel-1" class="tabs-label">First</button>
-<button role="tab" id="tabset-1-tab-2" aria-selected="false" aria-controls="tabset-1-panel-2" class="tabs-label" tabindex="-1">Second</button>
+<button type="button" role="tab" id="tabset-1-tab-1" aria-selected="true" aria-controls="tabset-1-panel-1" class="tabs-label">First</button>
+<button type="button" role="tab" id="tabset-1-tab-2" aria-selected="false" aria-controls="tabset-1-panel-2" class="tabs-label" tabindex="-1">Second</button>
 <div role="tabpanel" id="tabset-1-panel-1" aria-labelledby="tabset-1-tab-1" class="tabs-panel">
 <p>Content one.</p>
 </div>
@@ -1565,6 +1565,18 @@ carries `hidden`:
 Naming it as well would give one element two accessible names and pull it out of
 the `tablist` relationship that is the only reason to be in this mode. So the
 rule in §13.2 is a `css`-mode rule specifically, not "every panel gets a name".
+
+**The control is `type="button"`, not the implicit `submit`.** A `<button>` with
+no `type` is a submit button, so a tab set rendered inside a `<form>` submitted
+the form when a tab was activated, instead of switching panels: the one
+interaction this mode exists to provide, traded for the one thing the page never
+asked for. The attribute is not a style choice and an implementation MUST write
+it, on every generated control in BOTH constructs. `css` mode is unaffected -
+its control is an `<input type="radio">`, which already says what it is.
+
+Nothing here is an invitation to write other attributes on the control. The
+`tabindex="-1"` on every non-selected tab is the roving-tabindex the `tablist`
+pattern requires, and it and `type` are the whole list.
 
 ### 13.4 The set's own name
 
@@ -1582,12 +1594,67 @@ container outranks both - naming two tab sets on one page apart is the author's
 job. In `aria` mode the tabs wrapper is `role="tablist"` instead and keeps the
 same name.
 
-### 13.5 Conformance
+### 13.5 Exactly one item is selected, and the first mark wins
+
+An item marked `{selected}` opens the set. Where the document marks none, the
+FIRST item opens it, in both modes and in both constructs. Where the document
+marks several, the first mark wins and the later ones are ignored:
+
+```
+:::: tabs
+::: tab [First]
+Content one.
+:::
+
+{selected}
+::: tab [Second]
+Content two.
+:::
+
+{selected}
+::: tab [Third]
+Content three.
+:::
+::::
+```
+
+Only `Second` is selected: not `First`, which is what the default would have
+chosen, and not `Third`, which is what a last-wins rule would.
+
+**Why first-wins and not last-wins.** The `css` mode is a radio group, and a
+radio group cannot have two checked members - the browser resolves it to one and
+the document's intent is already lost either way. `aria` mode emitting two
+`aria-selected="true"` tabs is not more expressive, it is a shape a
+single-select `tablist` has no state for: two panels are revealed, both take a
+normal tab stop, and no assistive technology can report which tab the set is on.
+So the only question is which single item the rule keeps, and first-wins is what
+the `css` default already does with `checked`. That makes the two modes agree,
+which is the whole point of this section binding both.
+
+Last-wins would mean an author scrolling a long tab set and marking the item in
+front of them silently unselects one above, with nothing in the rendered page
+saying so.
+
+**Over-specifying is not an error.** An implementation MUST NOT emit a
+diagnostic for a document that marks several items: the document is redundant,
+not wrong, and this section has no diagnostic channel. The same holds for a
+document that marks the first item explicitly, which asks for exactly what it
+would have got.
+
+### 13.6 Conformance
 
 Tabs is pinned in `tests/corpus-optional`. Feature `tabs` covers the `css`
 panel name (cases 28 and 46); feature `tabs-aria` covers §13.3 - the
 `tabpanel` / `aria-labelledby` binding, the `hidden` reveal that §13.1 turns on,
-and the absence of `role="group"` there (case 47).
+the absence of `role="group"` there, and the control's `type="button"`
+(case 47).
+
+§13.5 is pinned twice on one document, because a rule that says the two modes
+agree is not pinned by either mode alone: case 48 is the `aria` render under
+`tabs-aria` and case 49 the `css` render under `tabs`. Both mark the second and
+third items, so a fixture that selected the first would be reading the default
+rather than the rule, and one that selected the third would be reading
+last-wins.
 
 CodeGroup is Tier-3 and NOT corpus-pinned; `resources/examples-tier3.md` is its
 only verifier in this repo. Its `mode` option, its panel naming and its

--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -825,14 +825,16 @@ Optional raw output:
 
 Optional corpus added since this run: `42-list-table-header-rows-cols`,
 `43-citations-at-label-in-reference-position`, `46-tabs-css-panel-name`,
-`47-tabs-aria-panel-binding`.
+`47-tabs-aria-panel-binding`, `48-tabs-aria-single-selection`,
+`49-tabs-css-single-selection`.
 
 The first pins `{header-rows}` / `{header-cols}` on a list table; the second is
 the citations-side control for the core rule that a label beginning with an at
-sign is not a reference label. The last two are the two halves of extensions
+sign is not a reference label. The next two are the two halves of extensions
 §13.2 and §13.3 - a `css`-mode panel named by its tab, and an `aria`-mode panel
-bound rather than named. All four landed after the run above was taken, so
-the corpus is four cases ahead of it. The
+bound rather than named. The last two are §13.5 under both modes: two marked
+items select one tab, and the same one in each. All six landed after the run
+above was taken, so the corpus is six cases ahead of it. The
 declaration is the same device the core block uses: it names the cases and
 carries no count, so there is nothing in it to fabricate, and
 `tests/implementation-comparison-counts.test.mjs` fails both when a named case

--- a/tests/corpus-optional/47-tabs-aria-panel-binding.html
+++ b/tests/corpus-optional/47-tabs-aria-panel-binding.html
@@ -1,6 +1,6 @@
 <div class="tabs" role="tablist" aria-label="Tabs">
-<button role="tab" id="tabset-1-tab-1" aria-selected="true" aria-controls="tabset-1-panel-1" class="tabs-label">First</button>
-<button role="tab" id="tabset-1-tab-2" aria-selected="false" aria-controls="tabset-1-panel-2" class="tabs-label" tabindex="-1">R&amp;D "core" &lt;x&gt;</button>
+<button type="button" role="tab" id="tabset-1-tab-1" aria-selected="true" aria-controls="tabset-1-panel-1" class="tabs-label">First</button>
+<button type="button" role="tab" id="tabset-1-tab-2" aria-selected="false" aria-controls="tabset-1-panel-2" class="tabs-label" tabindex="-1">R&amp;D "core" &lt;x&gt;</button>
 <div role="tabpanel" id="tabset-1-panel-1" aria-labelledby="tabset-1-tab-1" class="tabs-panel">
 <p>Content one.</p>
 </div>

--- a/tests/corpus-optional/48-tabs-aria-single-selection.crv
+++ b/tests/corpus-optional/48-tabs-aria-single-selection.crv
@@ -1,0 +1,15 @@
+:::: tabs
+::: tab [First]
+Content one.
+:::
+
+{selected}
+::: tab [Second]
+Content two.
+:::
+
+{selected}
+::: tab [Third]
+Content three.
+:::
+::::

--- a/tests/corpus-optional/48-tabs-aria-single-selection.html
+++ b/tests/corpus-optional/48-tabs-aria-single-selection.html
@@ -1,0 +1,14 @@
+<div class="tabs" role="tablist" aria-label="Tabs">
+<button type="button" role="tab" id="tabset-1-tab-1" aria-selected="false" aria-controls="tabset-1-panel-1" class="tabs-label" tabindex="-1">First</button>
+<button type="button" role="tab" id="tabset-1-tab-2" aria-selected="true" aria-controls="tabset-1-panel-2" class="tabs-label">Second</button>
+<button type="button" role="tab" id="tabset-1-tab-3" aria-selected="false" aria-controls="tabset-1-panel-3" class="tabs-label" tabindex="-1">Third</button>
+<div role="tabpanel" id="tabset-1-panel-1" aria-labelledby="tabset-1-tab-1" class="tabs-panel" hidden>
+<p>Content one.</p>
+</div>
+<div role="tabpanel" id="tabset-1-panel-2" aria-labelledby="tabset-1-tab-2" class="tabs-panel">
+<p>Content two.</p>
+</div>
+<div role="tabpanel" id="tabset-1-panel-3" aria-labelledby="tabset-1-tab-3" class="tabs-panel" hidden>
+<p>Content three.</p>
+</div>
+</div>

--- a/tests/corpus-optional/49-tabs-css-single-selection.crv
+++ b/tests/corpus-optional/49-tabs-css-single-selection.crv
@@ -1,0 +1,15 @@
+:::: tabs
+::: tab [First]
+Content one.
+:::
+
+{selected}
+::: tab [Second]
+Content two.
+:::
+
+{selected}
+::: tab [Third]
+Content three.
+:::
+::::

--- a/tests/corpus-optional/49-tabs-css-single-selection.html
+++ b/tests/corpus-optional/49-tabs-css-single-selection.html
@@ -1,0 +1,17 @@
+<div class="tabs" role="group" aria-label="Tabs">
+<input type="radio" name="tabset-1" id="tabset-1-tab-1" class="tabs-radio">
+<label for="tabset-1-tab-1" class="tabs-label">First</label>
+<input type="radio" name="tabset-1" id="tabset-1-tab-2" class="tabs-radio" checked>
+<label for="tabset-1-tab-2" class="tabs-label">Second</label>
+<input type="radio" name="tabset-1" id="tabset-1-tab-3" class="tabs-radio">
+<label for="tabset-1-tab-3" class="tabs-label">Third</label>
+<div class="tabs-panel" role="group" aria-label="First">
+<p>Content one.</p>
+</div>
+<div class="tabs-panel" role="group" aria-label="Second">
+<p>Content two.</p>
+</div>
+<div class="tabs-panel" role="group" aria-label="Third">
+<p>Content three.</p>
+</div>
+</div>

--- a/tests/corpus-optional/manifest.json
+++ b/tests/corpus-optional/manifest.json
@@ -242,7 +242,17 @@
     {
       "slug": "47-tabs-aria-panel-binding",
       "feature": "tabs-aria",
-      "description": "In aria mode a panel is bound rather than named: role=\"tabpanel\" with aria-labelledby and hidden on every non-selected panel, and no role=\"group\"."
+      "description": "In aria mode a panel is bound rather than named: role=\"tabpanel\" with aria-labelledby and hidden on every non-selected panel, and no role=\"group\". The control is type=\"button\", not the implicit submit."
+    },
+    {
+      "slug": "48-tabs-aria-single-selection",
+      "feature": "tabs-aria",
+      "description": "Two marked items select one tab: the FIRST mark wins and later ones are ignored, so neither the default first item nor the last mark is selected."
+    },
+    {
+      "slug": "49-tabs-css-single-selection",
+      "feature": "tabs",
+      "description": "The same document under css: one radio carries checked, on the first marked item, so both modes select the same tab."
     }
   ]
 }

--- a/tests/optional-corpus.test.mjs
+++ b/tests/optional-corpus.test.mjs
@@ -164,6 +164,12 @@ const AHEAD_OF_PIN = {
   '28-tabs-panel-title':
     'carve#1468 §13.2 - the css-mode panel takes role="group" and its tab\'s label; no engine emits it yet',
   '46-tabs-css-panel-name': 'carve#1468 §13.2 - same rule, with the attribute-escaping case',
+  '47-tabs-aria-panel-binding':
+    'carve#1537 §13.3 - the tab control is type="button"; a bare <button> submits the form it sits in, and no engine writes the attribute yet',
+  '48-tabs-aria-single-selection':
+    'carve#1537 §13.5 - the first {selected} wins and later ones are ignored; every engine still emits one aria-selected="true" per mark',
+  '49-tabs-css-single-selection':
+    'carve#1537 §13.5 - the same rule in css mode, where every mark still gets its own checked',
 }
 
 /*


### PR DESCRIPTION
Two rules for Extensions §13, both binding Tabs and CodeGroup alike. Ruled on markup-carve/carve-php#1537.

## §13.3 - the control is `type="button"`

A generated tab control carried no `type`, and a `<button>` with no `type` is a submit button. A tab set rendered inside a `<form>` therefore submitted the form when a tab was activated, instead of switching panels - the one interaction the `aria` mode exists to provide, traded for the one thing the page never asked for.

`css` mode is unaffected: its control is an `<input type="radio">`, which already says what it is.

Case 47 pinned the bytes as they were, which is why the fixture moves here first and the three engines follow. This is the whole content of the sequencing: an engine that adds the attribute against the old fixture goes out of conformance with a fixture that is itself wrong.

Before:

```html
<button role="tab" id="tabset-1-tab-1" aria-selected="true" aria-controls="tabset-1-panel-1" class="tabs-label">First</button>
```

After:

```html
<button type="button" role="tab" id="tabset-1-tab-1" aria-selected="true" aria-controls="tabset-1-panel-1" class="tabs-label">First</button>
```

## §13.5 - exactly one item is selected, and the first mark wins

Both constructs defaulted the first item when the document marked none, and left every mark alone when it marked several. So `aria` mode emitted several `aria-selected="true"` tabs: two panels revealed, both taking a normal tab stop, and nothing able to report which tab a single-select `tablist` is on. `css` mode is a radio group, which the browser resolves to one checked member whatever the markup says, so the document's intent was already lost there too.

The only question is which single item the rule keeps. First-wins is what the `css` default already does with `checked`, so the two modes agree - the point of §13 mirroring them. Not last-wins: an author scrolling a long set and marking the item in front of them should not silently unselect one above. And over-specifying gets **no diagnostic**: the document is redundant, not wrong, and §13 has no diagnostic channel.

Input, cases 48 and 49 (one document, both modes):

```
:::: tabs
::: tab [First]
Content one.
:::

{selected}
::: tab [Second]
Content two.
:::

{selected}
::: tab [Third]
Content three.
:::
::::
```

The second and third are marked on purpose. A fixture selecting `First` would be reading the default rather than the rule; one selecting `Third` would be reading last-wins. Only `Second` distinguishes the ruling from both.

Case 48, `aria`:

```html
<div class="tabs" role="tablist" aria-label="Tabs">
<button type="button" role="tab" id="tabset-1-tab-1" aria-selected="false" aria-controls="tabset-1-panel-1" class="tabs-label" tabindex="-1">First</button>
<button type="button" role="tab" id="tabset-1-tab-2" aria-selected="true" aria-controls="tabset-1-panel-2" class="tabs-label">Second</button>
<button type="button" role="tab" id="tabset-1-tab-3" aria-selected="false" aria-controls="tabset-1-panel-3" class="tabs-label" tabindex="-1">Third</button>
<div role="tabpanel" id="tabset-1-panel-1" aria-labelledby="tabset-1-tab-1" class="tabs-panel" hidden>
<p>Content one.</p>
</div>
<div role="tabpanel" id="tabset-1-panel-2" aria-labelledby="tabset-1-tab-2" class="tabs-panel">
<p>Content two.</p>
</div>
<div role="tabpanel" id="tabset-1-panel-3" aria-labelledby="tabset-1-tab-3" class="tabs-panel" hidden>
<p>Content three.</p>
</div>
</div>
```

Case 49, `css` - the same tab, one `checked`:

```html
<div class="tabs" role="group" aria-label="Tabs">
<input type="radio" name="tabset-1" id="tabset-1-tab-1" class="tabs-radio">
<label for="tabset-1-tab-1" class="tabs-label">First</label>
<input type="radio" name="tabset-1" id="tabset-1-tab-2" class="tabs-radio" checked>
<label for="tabset-1-tab-2" class="tabs-label">Second</label>
<input type="radio" name="tabset-1" id="tabset-1-tab-3" class="tabs-radio">
<label for="tabset-1-tab-3" class="tabs-label">Third</label>
<div class="tabs-panel" role="group" aria-label="First">
<p>Content one.</p>
</div>
<div class="tabs-panel" role="group" aria-label="Second">
<p>Content two.</p>
</div>
<div class="tabs-panel" role="group" aria-label="Third">
<p>Content three.</p>
</div>
</div>
```

## Numbering

The new clause is §13.5 and Conformance moves to §13.6, so the only cited number in §13 (§13.4, "The set's own name", referenced from the §1.5 labels table) does not move. §13.1 through §13.4 are unchanged, and those are the numbers the engines quote in their own source.

## Sequencing

Cases 47, 48 and 49 all enter `AHEAD_OF_PIN` in `tests/optional-corpus.test.mjs`: no engine writes either rule yet. Each entry is deleted by the pin bump that catches up with it - the ledger fails an entry whose case already matches, so a stale one cannot sit there.

The engine ports follow this PR:

- carve-php: markup-carve/carve-php#1537, PR to follow.
- carve-js: measured identical at `8fb450d8` on both defects, follow-up ticket filed.
- carve-rs: not measured, follow-up ticket filed.
