### PR TITLE
docs: the syntax reference teaches the arrow family the language actually has

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -1306,16 +1306,40 @@ On by default in the conformant core; a processor MAY disable it
 | `(c)`       | ©      | Copyright        |
 | `(r)`       | ®      | Registered       |
 | `(tm)`      | ™      | Trademark        |
-| `->`        | →      | Right arrow      |
-| `<-`        | ←      | Left arrow       |
-| `<->`       | ↔      | Bi-arrow         |
-| `=>`        | ⇒      | Double arrow     |
+| `-->`       | →      | Right arrow      |
+| `<--`       | ←      | Left arrow       |
+| `<-->`      | ↔      | Bi-arrow         |
+| `==>`       | ⇒      | Right double arrow |
+| `<==`       | ⇐      | Left double arrow |
+| `<=>`       | ⇔      | Bi double arrow  |
 | `!=`        | ≠      | Not equal        |
 | `<=`        | ≤      | Less or equal    |
 | `>=`        | ≥      | Greater or equal |
 | `+-`        | ±      | Plus/minus       |
 
-Escape with backslash: `\->` = literal `->`.
+**The doubled run is the canonical arrow in both families** (PART 9 §8). Runs
+are matched longest-first, so `<==` beats `<=` and `-->` beats the hyphen run.
+
+`->`, `<-` and `<->` are **deprecated but still rendered** - a document written
+before the doubled forms landed goes on working, and they are what an author
+should stop writing rather than what a processor may stop reading.
+
+`=>` is **removed**, not deprecated, and that one is a behavior change. It was
+the form that was actively harmful rather than merely non-canonical: every
+`key => value`, `x => x + 1` and `Some(x) => x` is ordinary prose about code,
+and every one of them silently became ⇒. It now renders as the two characters
+written.
+
+The double family is asymmetric on purpose. `<=` keeps its comparison meaning,
+so the left double arrow has to grow a character - and the bi-arrow is `<=>`,
+not `<==>`. `<==>` is read longest-first as `<==` followed by `>` and renders
+`⇐>`, which is correct rather than a bug.
+
+Escape with backslash: `\->` = literal `->`. A backslash breaks the run it
+starts, so escaping a DOUBLED arrow takes the escape one character in: `-\->`
+is a literal `-->`, while `\-->` leaves `-` followed by a live `->`. The
+double-line family has no such split - `\==>` is a literal `==>` - because `=`
+converts to nothing on its own.
 
 Single quotes are contextual (matching djot): a `'` is an apostrophe /
 closing quote `’` when the preceding character is alphanumeric (`it's`,

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -45,7 +45,7 @@ make every line prose. For the working version of a notation block, see
 | `:youtube[ID]` ✦ | extension | `:type[content]{attrs}` — syntax is core; the handler is opt-in |
 | `@user` `#tag` | mention / tag | social conventions |
 | `\*literal\*` | escape | backslash + any ASCII punctuation |
-| `--` `---` `...` `->` `(c)` | – — … → © | smart typography; a run with a space before it and a non-space after it is a CLI flag and stays literal |
+| `--` `---` `...` `-->` `==>` `(c)` | – — … → ⇒ © | smart typography; a bare HYPHEN RUN with a space before it and a non-space after it is a CLI flag and stays literal (`x --next`) - the arrows are matched before that guard and still convert there (`x -->next` is `x →next`) |
 | `{--}` | – | braced en dash — converts in the flag position the bare run refuses |
 | `\` at end of line | hard break | `\ ` is a hard break here too — the trailing space is stripped before the escape is read |
 | `\ ` mid-line | no-break space | backslash-space; in the last column it is the hard break above |

--- a/docs/parsing-ambiguities.md
+++ b/docs/parsing-ambiguities.md
@@ -125,13 +125,14 @@ braced `| {^2^} |`.
 | Context | Meaning | Example |
 |---------|---------|---------|
 | Table cell | Colspan | `\| < \|` |
-| Inline | Smart typography | `<-` → ← |
+| Inline | Smart typography | `<--` → ← |
 | Autolinks | URL wrapper | `<https://...>` |
 
 **Resolution rules:**
 1. **Colspan:** `<` as sole content of a table cell
 2. **Autolink:** `<` followed by URL scheme or email pattern
-3. **Smart typography:** `<-`, `<->`, `<=` patterns
+3. **Smart typography:** `<--`, `<-->`, `<==`, `<=>`, `<=` patterns (and the
+   deprecated `<-` / `<->`), matched longest-first
 4. **Literal:** Everything else
 
 **Examples:**
@@ -140,7 +141,7 @@ braced `| {^2^} |`.
 
 <https://example.com>          # Autolink
 
-The arrow points <- that way   # Smart typography (←)
+The arrow points <-- that way  # Smart typography (←)
 
 if (x < 5)                     # Literal <
 ```
@@ -453,11 +454,17 @@ Inside code spans, backslash is literal:
 | `--` | – (en-dash) | Strikethrough delimiter start? No, `~` is used |
 | `---` | — (em-dash) | Horizontal rule? Only at line start alone |
 | `...` | … (ellipsis) | Nothing |
-| `->` | → | Nothing |
-| `<-` | ← | Less-than? Requires full pattern |
+| `-->` | → | Nothing |
+| `<--` | ← | Less-than? Requires full pattern |
+| `==>` | ⇒ | Nothing |
+| `<==` | ⇐ | `<=`? Yes - the longer run wins, so `<==` is the arrow and a bare `<=` stays ≤ |
+| `<=>` | ⇔ | `<=`? Same rule. `<==>` is `<==` then `>`, and renders `⇐>` |
 | `<=` | ≤ | Less-than-equal? Yes, context-dependent |
 
-**Resolution:** Smart typography only applies to specific patterns, not partial matches.
+**Resolution:** Smart typography only applies to specific patterns, not partial
+matches, and a longer pattern is matched before a shorter one it contains. The
+single-hyphen `->` / `<-` / `<->` still render and are deprecated; `=>` was
+removed and renders literally, because `key => value` is prose about code.
 
 ---
 
@@ -594,6 +601,6 @@ When multiple interpretations are possible, use this order:
 5. **Autolinks** - `<url>` pattern
 6. **Links/Images** - `[text](url)`, `![alt](src)`
 7. **Emphasis** - `/italic/`, `*bold*`, etc.
-8. **Smart typography** - `--`, `->`, etc.
+8. **Smart typography** - `--`, `-->`, etc.
 9. **Extensions** - `@mention`, `#tag`, `:type[content]`
 10. **Plain text** - Everything else


### PR DESCRIPTION
Closes #1506

`docs/case-study/syntax.md` listed `=>` as producing ⇒. It does not, and it was
removed on purpose - the reasoning is in `resources/examples/edge-cases.md`:
`key => value` and `Some(x) => x` are ordinary prose about code, and every one
of them silently became ⇒. So the reference recommended the exact spelling the
language dropped because it corrupted code.

The table was wrong a second way too. The whole doubled family was absent, and
so was the canonical single-line family - it listed only the deprecated forms.

## What the table says now

| form | renders | status |
| --- | --- | --- |
| `-->` `<--` `<-->` | → ← ↔ | canonical |
| `==>` `<==` `<=>` | ⇒ ⇐ ⇔ | canonical |
| `->` `<-` `<->` | → ← ↔ | deprecated, still rendered |
| `=>` | literal `=>` | removed |

Measured on carve-js at `f00b986`, which reproduces the normative compare block
byte for byte - docs-only.

The asymmetry is now stated rather than left to be filed as a bug: the bi-arrow
is `<=>` and not `<==>`, because `<=` keeps its comparison meaning, so `<==>`
reads longest-first as `<==` then `>` and renders `⇐>`.

## The escape changed with the canonical form, and nothing said so

`\->` was the documented escape and still works. The canonical `-->` does not
escape the same way - a backslash breaks the run it starts, so the escape has to
go one character in. Measured on all three engines (carve-js `f00b986`,
carve-php `3a06c99`, carve-rs `1149591`), which agree:

```
a \--> b   ->  <p>a -→ b</p>
a -\-> b   ->  <p>a --&gt; b</p>
a \==> b   ->  <p>a ==&gt; b</p>
```

The double-line family has no such split, because `=` converts to nothing on its
own.

## docs/parsing-ambiguities.md

It discusses `<-` and `<->` as ambiguity cases rather than recommending them, so
the framing stays and the doubled family is added beside them - in the
less-than-overloading resolution list, in section 15's conflict table, and in the
example line. The one genuinely ambiguous interaction was missing entirely and is
now the point of two of those rows: `<=` is the comparison, `<==` is the arrow,
and longest-first is what separates them.

## docs/cheatsheet.md

Its typography row named `->` as the arrow to know; it now names `-->` and
`==>`. The row's CLI-flag note is narrowed in the same edit, because adding
`-->` to a row whose note said a space-then-non-space run stays literal would
have been a new wrong claim - the guard covers a bare hyphen run (`x --next`
stays literal), and an arrow is matched before it (`x -->next` is `x →next`).
