### PR TITLE
docs: a string an extension exposes as an option gets no labels key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The `labels` admission rule stops reading on two strings that have no key**
+  (carve#1510, Extensions §1.5, PART 9 §16a). The heading-permalink label and
+  the table-of-contents summary stay options on the extensions that write
+  them; the map carries the strings that have no other home, and a string an
+  extension already exposes as an option does not get a key as well.
 - **An HTML import of block math writes the core `$$` form** (carve#1514,
   PART 9 §18). The ```` ```math ```` fence is an extension and degrades to a
   `language-math` code block wherever it is not loaded, so an importer that

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -188,9 +188,12 @@ words. PART 9 §16a governs the same question for core, and its rule binds here:
 > An extension MAY read the map for a string it shares with core; it MUST NOT
 > require the host to configure the same text twice.
 
-**One `labels` map localizes a whole document.** Every extension-written string
-that has a fixed English default has a key in the render's `labels` map, and the
-extension reads it. A host translating a document sets `labels` **once**:
+**One `labels` map localizes a whole document.** The map carries the
+extension-written strings that have no other home: an extension-written string
+with a fixed English default has a key here, and the extension reads it, **unless
+the extension already exposes that string as an option of its own** - in which
+case the option is where it is configured and the map has no key for it. A host
+translating a document sets `labels` **once** for everything in the map:
 
 ```js
 carveToHtml(src, {
@@ -232,6 +235,23 @@ to the *extension's own class word* (`mermaid`, `d2`, and `graphviz` for the
 also names its panel (§13.2), an
 index term, an admonition title. Those are named by DERIVING from the document,
 so a translated document translates them exactly once, in the document.
+
+**Nor does a string the extension already exposes as an option** (carve#1510).
+The heading-permalink label (default `Permalink`) and the table-of-contents
+`summary` (default `Table of Contents`, visible whenever `collapsible` is on)
+both have a fixed English default and neither is in the map. They are configured
+on the extensions that write them - `headingPermalinks({ ariaLabel })` and
+`tableOfContents({ summary })` - and adding a key would give one string two
+spellings where the extension already had one. Measured on the pinned build:
+`labels: { headingPermalink: 'PERM' }` changes nothing, while
+`tableOfContents({ summary: 'INHALT' })` reaches the `<summary>`.
+
+**The rule for a new one.** An extension-written string with a fixed English
+default gets a `labels` key **unless** the extension already exposes it as an
+option, and it does not get both. Decide it once, when the string is added: the
+map is for strings that would otherwise have nowhere to be set, and an option is
+already somewhere. The three keys in the table above predate this rule and each
+carries an option as well, arbitrated by the precedence order stated here.
 
 **Why this is not localization.** There is no locale name and no built-in
 translation table, for the reason §16a gives: a locale table is data every

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -7328,11 +7328,13 @@ EOF = (* end of file *) ;
 
    AN EXTENSION MAY read the map for a string it shares with core; it MUST NOT
    require the host to configure the same text twice. Two extension-written
-   strings still have no key and are options only -- the heading-permalink
-   label and the table-of-contents summary (carve-js `ariaLabel` / `summary`,
-   carve-php `$ariaLabel`, carve-rs `aria_label`). That is the state, not a
-   rule: §1.5's admission sentence reads on both of them, and whether they
-   join the map is carve#1510.
+   strings have no key and are options only -- the heading-permalink label and
+   the table-of-contents summary (carve-js `ariaLabel` / `summary`, carve-php
+   `$ariaLabel`, carve-rs `aria_label`). That is now the RULE and not merely the
+   state (carve#1510): a string the extension already exposes as an option is
+   configured there, and §1.5's admission sentence has been narrowed to say so
+   instead of reading on these two. Adding a key would give one string two
+   spellings where the extension already had one.
 
    EVERY DOCUMENTED KEY REACHES THE OUTPUT, and that is checked rather than
    asserted (carve#1508). No fixture in the spec repo renders with a non-default

--- a/tests/every-labels-key-reaches-the-output.test.mjs
+++ b/tests/every-labels-key-reaches-the-output.test.mjs
@@ -35,7 +35,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { carveToHtml, codeGroup, index, tabs } from '@markup-carve/carve'
+import { carveToHtml, codeGroup, headingPermalinks, index, tableOfContents, tabs } from '@markup-carve/carve'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const grammar = readFileSync(resolve(root, 'resources/grammar.ebnf'), 'utf8')
@@ -186,4 +186,72 @@ test('a key the map does not define changes nothing', () => {
     labels: { admonitionNotUsed: 'SentinelUnusedValue' },
   })
   assert.equal(withBogus, plain)
+})
+
+/*
+ * THE OTHER HALF OF THE ADMISSION RULE (carve#1510).
+ *
+ * Everything above checks that a DOCUMENTED key reaches the output. This
+ * checks the opposite direction: a string the extension already exposes as an
+ * OPTION has no key, and the option is what configures it. Extensions §1.5's
+ * admission sentence used to read on these two - both have a fixed English
+ * default - and neither honored it, so the spec promised a host something two
+ * strings did not do.
+ *
+ * Asserting the ABSENCE alone would be a check that cannot fail for the right
+ * reason: a key nothing implements is absent from the output whether the rule
+ * is honored or an engine simply forgot the string. So each row asserts three
+ * things - the documented default renders, the map key does NOT reach it, and
+ * the extension option DOES. Only the third distinguishes "configured
+ * elsewhere" from "not configurable at all".
+ */
+const optionOnly = {
+  headingPermalink: {
+    source: '# One\n\nbody\n',
+    extension: (opts) => headingPermalinks(opts),
+    option: (value) => ({ ariaLabel: value }),
+    default: 'Permalink',
+    find: (html) => /class="permalink" aria-label="([^"]*)"/.exec(html)?.[1],
+  },
+  tocSummary: {
+    source: '::: toc\n:::\n\n# One\n\nbody\n',
+    extension: (opts) => tableOfContents({ collapsible: true, ...opts }),
+    option: (value) => ({ summary: value }),
+    default: 'Table of Contents',
+    find: (html) => /<summary>([^<]*)<\/summary>/.exec(html)?.[1],
+  },
+}
+
+for (const [key, row] of Object.entries(optionOnly)) {
+  test(`${key} is not a labels key, and its extension option is`, () => {
+    const render = (extensionOptions, renderOptions) =>
+      row.find(carveToHtml(row.source, { extensions: [row.extension(extensionOptions)], ...renderOptions }))
+
+    assert.equal(render({}, {}), row.default, `${key}: the probe did not find the documented default`)
+
+    assert.equal(
+      render({}, { labels: { [key]: `Sentinel${key}Value` } }),
+      row.default,
+      `${key} is not in the labels map (Extensions §1.5, PART 9 §16a), so setting it must change ` +
+        'nothing. A map key that works here is a key the two tables do not document.',
+    )
+
+    assert.equal(
+      render(row.option(`Option${key}Value`), {}),
+      `Option${key}Value`,
+      `${key}: the extension option did not reach the output, so the string is configurable ` +
+        'nowhere - which is the state §1.5 says it must not be in.',
+    )
+  })
+}
+
+test('neither option-only string is documented as a key', () => {
+  const both = [...documented.keys()]
+  for (const key of Object.keys(optionOnly)) {
+    assert.ok(
+      !both.includes(key),
+      `${key} is documented as a labels key in PART 9 §16a or Extensions §1.5, and §1.5 says a ` +
+        'string the extension exposes as an option does not get one. Remove the table row or the option.',
+    )
+  }
 })


### PR DESCRIPTION
Extensions §1.5 said:

> Every extension-written string that has a fixed English default has a key in
> the render's `labels` map, and the extension reads it.

Two strings satisfy that sentence and have no key: the heading-permalink label
(default `Permalink`) and the table-of-contents `summary` (default
`Table of Contents`, visible whenever `collapsible` is on). So the spec promised
a host something two strings did not honor, and a host translating a document
set `labels` once for thirteen strings and then had to remember two more places
with nothing telling it to.

## Re-measured on the pinned build

```js
// changes nothing - the heading still renders aria-label="Permalink"
carveToHtml(src, { extensions: [headingPermalinks()], labels: { headingPermalink: 'PERM' } })

// reaches it
carveToHtml(src, { extensions: [headingPermalinks({ ariaLabel: 'OPT' })] })
```

Same shape for the summary: the map key is inert, `tableOfContents({ summary:
'INHALT' })` reaches the `<summary>`.

## The fix is the sentence, not the map

Both strings are already options on the extensions that write them, and adding
a key would give one string two spellings where the extension already had one.
§1.5's admission sentence now says what is true - the map carries the strings
that have no other home - and PART 9 §16a's note recording the open question
becomes the rule.

The rule a future extension author needs is stated with it: an
extension-written string with a fixed English default gets a `labels` key
**unless** the extension already exposes it as an option, and it does not get
both. The three keys in §1.5's table predate that rule and each carries an
option too, arbitrated by the precedence order the same section states, so the
rule is written for the next string rather than applied backwards to them.

## The check

It goes where carve#1511's key sweep already is, and it is three assertions per
row rather than one. Asserting only that the map key is inert cannot fail for
the right reason - a key nothing implements is inert whether the rule is
honored or an engine simply forgot the string - so each row also requires the
documented default to render and the extension option to reach the output.

All three were proved to fail: a wrong documented default, a wrong option name,
and a row added for a real map key (`indexBackref`) each turn it red.

No engine change follows from this one - it records what all three already do.

Closes #1510
