### PR TITLE
chore: the two math-import drift lines report stale, and come out

### DIFF
--- a/resources/converter-drift.txt
+++ b/resources/converter-drift.txt
@@ -73,6 +73,24 @@
 # unimplemented under markup-carve/carve-rs#1222 pending this ruling.
 #
 # Each line goes in the commit that lands the fix for that engine.
-
-php/33-html-block-math-imports-as-the-core-form  Writes the ``` math ``` extension fence where PART 9 section 18 requires the core $$ form.
-rust/33-html-block-math-imports-as-the-core-form  Leaves <div class="math display"> as a generic div; PART 9 section 18's core $$ form is unimplemented (markup-carve/carve-rs#1222).
+#
+# AND BOTH LANDED, on the same day the clause did: carve-php took the core form
+# in markup-carve/carve-php#1561, and carve-rs rewrote the placeholder test that
+# held its gap open in markup-carve/carve-rs#1236. So both lines reported STALE
+# and are deleted here.
+#
+# The deletion is a MEASUREMENT, not an inference from the merges. Run against
+# the three merged mains - carve-js 93d469d, carve-php fc568db, carve-rs c7cee5a
+# - `npm run compare:convert` reported case 33 passing for every engine and
+# named exactly these two lines as the reason it failed:
+#
+#     rust: convert_pass=31/31 declared_drift=0 mismatch=0 error=0 skipped=2
+#     js:   convert_pass=31/31 declared_drift=0 mismatch=0 error=0 skipped=2
+#     php:  convert_pass=33/33 declared_drift=0 mismatch=0 error=0 skipped=0
+#     cross_convert_diffs=0
+#
+# That is the shape a stale ledger line has, and the reason the gate checks BOTH
+# directions: an undeclared divergence and a declaration nothing diverges on are
+# the same defect, and only one of them announces itself.
+#
+# THIS FILE IS EMPTY OF DECLARATIONS AGAIN, which is the intended end state.


### PR DESCRIPTION
`resources/converter-drift.txt` declared two lines for the block-math import
case:

````
php/33-html-block-math-imports-as-the-core-form   Writes the ``` math ``` extension fence ...
rust/33-html-block-math-imports-as-the-core-form  Leaves <div class="math display"> as a generic div ...
````

Both engines have since landed PART 9 §18: markup-carve/carve-php#1561 took the
core `$$` form, and markup-carve/carve-rs#1236 rewrote the placeholder test that
held its gap open. So both lines are now declarations that nothing diverges on.

They could not come out with those fixes - the ledger lives in this repo and the
fixes in theirs, so no single commit could hold both halves.

## Measured, not inferred from the merges

`compare-impls.mjs` drives **live sibling checkouts**, so the three merged mains
were fetched and built and the gate run against them: carve-js `93d469d`,
carve-php `fc568db`, carve-rs `c7cee5a`.

| ledger | `npm run compare:convert` |
| --- | --- |
| with the two lines | **exit 1** - and the only two failures are `converter-drift.txt declares php/33 ... delete the STALE line`, and the same for `rust/33` |
| without them | **exit 0** |

The summary is byte-identical either way, which is the point - case 33 already
passes for every engine:

```
rust: convert_pass=31/31 declared_drift=0 mismatch=0 error=0 skipped=2
js:   convert_pass=31/31 declared_drift=0 mismatch=0 error=0 skipped=2
php:  convert_pass=33/33 declared_drift=0 mismatch=0 error=0 skipped=0
cross_convert_diffs=0
```

Re-run after rebasing onto current `main`, so the reading describes the pushed
commit rather than the tree it was written on.

## What the comment block does

Rewritten rather than deleted, the way the flatten rows were when they closed in
#1393: it records that both engines landed, what was measured and against which
commits, and that the file is empty of declarations again - the intended end
state, not a missing section. A ledger line removed on the strength of a merge
would be the same defect as one left behind, so the measurement is written where
the next reader will be standing.

Only `resources/converter-drift.txt` is touched - no overlap with
`resources/ast-span-divergence.txt` or the PART 12 NUL clause work in flight.

No CHANGELOG entry: a drift-ledger line is not consumer-visible.
