### PR TITLE
chore: retire the span rows the carve-js offset-to-line fix closed

### DIFF
--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -550,9 +550,70 @@
 # scripts/ast-conformance.mjs is carve-js, carve-rs and carve-php, because
 # carve-rb serializes carve-rs's tree rather than deriving its own spans.
 
-list (extent) 1
-list_item (extent) 1
-paragraph (extent) 2
+
+# AND THE POST-FIX MEASUREMENT, 2026-08-23, from FRESH CLONES of every main
+# taken after markup-carve/carve-js#1318 merged: carve-js cc5726c, carve-rs
+# 6f36d9d and carve-php d21336c, against carve 8dfa9261, over 1356 corpus
+# documents plus 3 synthetic samples. Of 27,915 comparable spans - the same
+# number as the block above, because this fix moved where spans SIT and not how
+# many there are - TWO rows disagree across ONE document.
+#
+#   list (extent)        1 -> 0   AGREED, and the line is deleted.
+#   list_item (extent)   1 -> 0   AGREED, and the line is deleted.
+#   soft_break (extent)  1 -> 0   AGREED, and the line is deleted.
+#   text (extent)        1 -> 0   AGREED, and the line is deleted.
+#   paragraph (extent)   2 -> 1   the surviving document is `380-...`;
+#                                 `384-...-6` no longer disagrees.
+#   code (extent)        1 -> 1   unchanged, and on the same document.
+#
+# `384-a-continuation-marker-attaches-only-a-flush-left-block-6` IS GONE FROM
+# THE PANEL ENTIRELY, which is what retires four of the six rows at once. It
+# was never a disagreement about where a construct ends: all three engines
+# published the same OFFSETS on it throughout, and carve-js was inconsistent
+# with ITSELF - naming line 3 column 3 for offset 16, where line 3 column 3 is
+# offset 12. A `+` continuation marker's own line is consumed before the item's
+# text is scanned, so the joined text holds one newline where the source holds
+# two, and a line derived by counting newlines in that text ran one short for
+# every offset after the removal. markup-carve/carve-js#1318 gave every line
+# anchor its source line number, and the anchor's line now wins as its offset
+# and column already did.
+#
+# WHAT SURVIVES IS ONE DOCUMENT AND ONE ENGINE.
+# `380-a-terminal-comment-line-still-leaves-an-empty-verse-line` still parts
+# carve-php from the other two on `paragraph` and `code`, and it now parts it
+# on LINE AND COLUMN ALONE: all three publish `6..8`, carve-js and carve-rs
+# name that end line 3 column 1, and carve-php names it line 2 column 3 - a
+# column line 2 does not have. That is markup-carve/carve-php#1457, the same
+# defect on the same kind of removed comment line it was always attributed to,
+# and deleting these two lines is the closing step of THAT issue rather than
+# of anything carve-js owes.
+#
+# THE ROW COUNT DID NOT SEPARATE THE TWO DEFECTS ON `380`, which is the reading
+# to keep. Before #1318 all three engines differed on that document: carve-js
+# ended the span at offset 9 - the second `%` of a comment marker the block
+# layer removed - while carve-rs ended it at 8 and carve-php agreed on 8 and
+# named it wrongly. One key, `paragraph (extent)`, covered an OFFSET defect in
+# one engine and a LINE-AND-COLUMN defect in another, and the count moved by
+# neither when the first was fixed. A key says which type moved; it does not
+# say how many faults are standing behind it.
+#
+# THE CORPUS CARRIES THE CONTINUATION SHAPE ONCE, and that is a floor rather
+# than a size. Measured on carve-js before the fix, every `+` spelling drifted
+# - two markers in one item (drifting by two), an ordered list, one nested in a
+# quote, a definition body, a run crossing emphasis - and the corpus happens to
+# hold exactly one of them. The removals that turned out NOT to be affected are
+# the ones that leave a `comment` node behind and so SPLIT the paragraph rather
+# than being crossed by an inline run: a comment line in a paragraph, in a list
+# item, in a definition body, or inside a line block that is not its last line.
+# Collected link, footnote and abbreviation definitions, hoisted definitions,
+# the BOM strip and the CR/CRLF fold, and PART 0's NUL replacement were all
+# unanimous before and after - the replacement because it swaps one codepoint
+# for one codepoint, so no codepoint offset moves.
+#
+# EVERY ENGINE'S OWN §4 REPORT IS IDENTICAL AND CLEAN: 55 findings, 3 distinct,
+# 55 waived, 0 outstanding on each of the three, so
+# resources/ast-position-waivers.txt owes nothing. Shape is unanimous over all
+# 1359 documents and the value panel declares nothing that still diverges.
+
+paragraph (extent) 1
 code (extent) 1
-soft_break (extent) 1
-text (extent) 1

--- a/tests/ast-spans.test.mjs
+++ b/tests/ast-spans.test.mjs
@@ -249,31 +249,30 @@ test('a malformed declaration line is an error, never a silent skip', () => {
  * one taken because the previous one had stopped being true, and a seventh the
  * next day that replaced the surviving row with a different one.
  */
-// The POST-FIX run, 2026-08-22, from fresh clones of every main after
-// markup-carve/carve-php#1564 merged: 27,915 spans, SIX rows across TWO
-// documents. `paragraph` fell from 4 to 2, `code` from 2 to 1, and
-// `text (presence)` AGREED and is gone - all three are the NUL fixtures
-// leaving, and nothing else moved. The two surviving documents are the two the
-// previous block predicted would survive.
+// The POST-FIX run, 2026-08-23, from fresh clones of every main after
+// markup-carve/carve-js#1318 merged: carve-js cc5726c, carve-rs 6f36d9d and
+// carve-php d21336c, 27,915 spans, TWO rows across ONE document. `list`,
+// `list_item`, `soft_break` and `text` all AGREED and are gone, and
+// `paragraph` fell from 2 to 1 - one document leaving the panel, and it
+// carried five of the six rows.
 //
-// ONE DEFECT ACCOUNTED FOR EVERY MOVED ROW THIS TIME, which is the unusual
-// outcome here and the reason to say so: subtract its +2, +1 and +1 and the
-// declared counts become the measured ones exactly. The runs above are mostly
-// the other shape, where a row survives with a different document behind it.
+// THE SPAN COUNT DID NOT MOVE, which is the tell for what kind of fix this
+// was: 27,915 before and after. The engine published the same nodes with the
+// same offsets throughout and named the wrong LINE for them, so nothing was
+// added or dropped, only relocated. A run whose total moves is a fix that
+// changed what gets a position; this one is not that.
 //
-// The count also UNDERSTATED the defect rather than sizing it. Both of its
-// symptoms were properties of carve-php's document-wide offset table, so one
-// NUL moved every later offset in its document and cost every later text node
-// its position; the panel saw two documents because those are the only two
-// fixtures with a NUL. This map pins what was measured, and what was measured
-// is a floor - see resources/ast-span-divergence.txt.
+// WHAT SURVIVES IS carve-php ALONE ON `380-a-terminal-comment-line-still-
+// leaves-an-empty-verse-line`, naming line 2 column 3 for an end offset all
+// three agree is 8 - a column that line does not have
+// (markup-carve/carve-php#1457). Before this run the same two keys ALSO
+// covered a carve-js offset defect on the same document, so one key stood for
+// two faults in two engines and its count moved by neither when the first was
+// fixed. A key says which type moved; it does not say how many faults are
+// standing behind it - see resources/ast-span-divergence.txt.
 const LAST_MEASURED = new Map([
-  ['list (extent)', 1],
-  ['list_item (extent)', 1],
-  ['paragraph (extent)', 2],
+  ['paragraph (extent)', 1],
   ['code (extent)', 1],
-  ['soft_break (extent)', 1],
-  ['text (extent)', 1],
 ])
 
 const asMeasured = (counts) =>


### PR DESCRIPTION
The rows markup-carve/carve-js#1318 closed, retired from the span ledger.

Re-measured rather than derived from the merge, from fresh clones of every
main: carve-js `cc5726c`, carve-rs `6f36d9d`, carve-php `d21336c`, against carve
`8dfa9261`, over 1356 corpus documents plus 3 synthetic samples. `ast:check`
named the edit and this PR applies it verbatim:

```
THREE-WAY SPAN COMPARISON does not match resources/ast-span-divergence.txt:
  COUNT      paragraph (extent) declares 2 document(s), measured 1
  AGREED     list (extent) no longer disagrees - delete its line
  AGREED     list_item (extent) no longer disagrees - delete its line
  AGREED     soft_break (extent) no longer disagrees - delete its line
  AGREED     text (extent) no longer disagrees - delete its line
```

`384-a-continuation-marker-attaches-only-a-flush-left-block-6` leaves the panel
entirely, which is what retires four rows at once - it carried five of the six.
It was never a disagreement about where a construct ends: all three engines
published the same offsets on it throughout, and carve-js was inconsistent with
itself, naming line 3 column 3 for offset 16 where line 3 column 3 is offset 12.

What survives is carve-php alone on
`380-a-terminal-comment-line-still-leaves-an-empty-verse-line`, naming line 2
column 3 for an end offset all three now agree is 8 - a column that line does
not have. That is markup-carve/carve-php#1457, already filed and declared, and
deleting the last two lines is the closing step of that issue rather than of
anything carve-js owes.

Worth recording in the ledger prose: before this run those same two keys covered
a carve-js OFFSET defect and a carve-php LINE-AND-COLUMN defect on the same
document, so one key stood for two faults in two engines and its count moved by
neither when the first was fixed.

The span total did not move - 27,915 before and after - which is the tell for
what kind of fix this was: the same nodes with the same offsets, relocated
rather than added or dropped.

## LAST_MEASURED moves with the file

`tests/ast-spans.test.mjs` runs in ordinary CI with no engine checkouts and
reconciles the shipped ledger against the last measurement, so editing one
without the other is red. Confirmed by mutation rather than assumed: leaving
`LAST_MEASURED` at the old six against the edited file reports four `NEW` and
one `COUNT`.

## Failable in both directions

Against what the panel actually measured:

```
as edited                       : reconciles clean
MUTATION drop a disagreeing row : NEW        code (extent) disagrees in 1 document(s) and is not declared
MUTATION keep a retired row     : AGREED     text (extent) no longer disagrees - delete its line
MUTATION wrong count            : COUNT      paragraph (extent) declares 2 document(s), measured 1
```

and end to end through the engine-backed gate: the pre-edit file exits 1 with
the four `AGREED` and the `COUNT` above, deleting the still-disagreeing `code`
row exits 1 with `NEW`, and the file as shipped exits 0.

## Waivers

`resources/ast-position-waivers.txt` owes nothing. All three engines report 55
findings, 3 distinct, 55 waived, 0 outstanding - identical to each other. Shape
is unanimous over all 1359 documents and the value panel declares nothing that
still diverges.
