### PR TITLE
spec: the table-of-contents nav says what it is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The table-of-contents nav carries an accessible name** (carve#1509).
+  `<nav class="toc">` takes an `aria-label` from a new `tocNav` label
+  (default `Table of contents`), read by both TOC extensions so their navs stay
+  byte-identical; an authored `aria-label` outranks it. Extensions §8b.1, §1.5.
 - **Table column metadata and two-axis cell alignment** (carve#1344).
   `table.columns[]` carries a horizontal alignment, a vertical alignment and a
   fractional width, `table_cell` gains `valign`, positional `aligns`, `valigns`

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -221,6 +221,7 @@ language.
 | `indexBackref` | `Back to` | Index (§8.2) |
 | `tabsGroup` | `Tabs` | Tabs (§13.4) |
 | `codeGroup` | `Code examples` | CodeGroup (§13.4) |
+| `tocNav` | `Table of contents` | TocPlacement / TableOfContents (§8b.1) |
 
 These are the extension-written keys, not the whole map: PART 9 §16a lists the
 ten core writes, and the two tables together are every key an engine honors.
@@ -246,12 +247,21 @@ spellings where the extension already had one. Measured on the pinned build:
 `labels: { headingPermalink: 'PERM' }` changes nothing, while
 `tableOfContents({ summary: 'INHALT' })` reaches the `<summary>`.
 
+The table-of-contents NAV's name is a different string and does get a key
+(`tocNav`, §8b.1). `summary` is VISIBLE text in a `<details>` disclosure, and
+the collapsible shape renders that `<details>` *instead of* the `<nav>` - so the
+two never appear in one document and neither can stand in for the other. Their
+near-identical defaults are a coincidence of English, not one string with two
+homes.
+
 **The rule for a new one.** An extension-written string with a fixed English
 default gets a `labels` key **unless** the extension already exposes it as an
 option, and it does not get both. Decide it once, when the string is added: the
 map is for strings that would otherwise have nowhere to be set, and an option is
-already somewhere. The three keys in the table above predate this rule and each
-carries an option as well, arbitrated by the precedence order stated here.
+already somewhere. The first three keys in the table above predate this rule and
+each carries an option as well, arbitrated by the precedence order stated here.
+`tocNav` is the first admitted under the rule, and it has no option: the
+extensions that write it expose nothing that names the nav (§8b.1).
 
 **Why this is not localization.** There is no locale name and no built-in
 translation table, for the reason §16a gives: a locale table is data every
@@ -339,7 +349,7 @@ from disagree whenever a render option reaches inline rendering. Given
 and a symbols map of `ok` to `OK`, a hook rendering with defaults produces
 
 ```html
-<nav class="toc">
+<nav class="toc" aria-label="Table of contents">
 <ul>
 <li><a href="#h">:ok: h</a></li>
 </ul>
@@ -1014,6 +1024,55 @@ preceding attribute line, never inline on the opener):
 - The nested `<ul>` HTML is byte-identical to the standalone TOC extension
   (one tag per line).
 
+**The nav carries an accessible name** (carve#1509). `<nav>` is a navigation
+landmark unconditionally - unlike `<section>`, which maps to `generic` until it
+is named - so an unnamed one is an entry in every landmark list reading only
+"navigation". That is the argument PART 9 §16a accepted for
+`<section role="doc-endnotes">` and §1.5 accepted for an untitled admonition,
+and it is worse here, because a page can hold **more than one**: the table below
+renders two navs when both extensions are registered, a document may write
+`::: toc` more than once, and a surrounding site template's own nav makes it
+three. Indistinguishable entries are the defect; a single anonymous one is only
+how it starts.
+
+The `<nav>` takes `aria-label`, the string is the `tocNav` label (§1.5), and it
+is escaped the way every label is:
+
+```html
+<nav class="toc" aria-label="Table of contents">
+```
+
+**Both extensions read the same key.** `TocPlacement` and `TableOfContents`
+render the same nav, and §8b.3 makes that byte-identical fragment the cross-impl
+contract - so a name chosen per-extension would be the one change that breaks
+it.
+
+**A name the author wrote outranks the label**, by §1.5's precedence, and the
+seam already exists: `{#id .class}` is carried onto the `<nav>`, so an
+`aria-label` written on the attribute line is kept and NO label is added beside
+it. The match is on the attribute name, case-insensitively, as §16a already
+rules for the shapes carve#1468 closed - an author who writes `ARIA-LABEL` has
+named the nav.
+
+**The `collapsible` shape has no landmark to name.** With `collapsible` on, the
+standalone extension renders `<details class="toc">` with a `<summary>` and no
+`<nav>` at all, so nothing there takes this label; `TocPlacement` has no such
+option and always renders the nav. This is also why the name and the `summary`
+string are not one string with two spellings (§1.5): the shapes are mutually
+exclusive, one is a landmark's accessible name and the other is visible text.
+
+**Why a key rather than an option.** §1.5 admits an extension-written string
+with a fixed English default unless the extension already exposes it as an
+option. Nothing exposes this one - no configuration puts an `aria-label` on the
+nav in any engine - so the "unless" does not fire, and the map is exactly where
+a string with nowhere else to be set belongs. Nor is this the class-word case
+that keeps a diagram fence's name an option: `mermaid` is the thing's own name
+and has no translation, whereas a landmark entry reading "toc" is an
+abbreviation a reader hears spelled out, and "Table of contents" is ordinary
+English that a host's catalog already holds. The map is the seam to that
+catalog, and it is the one seam all three engines already honor - which matters
+because the engines do not agree on this extension's options at all.
+
 **Two extensions produce a table of contents, and they are not
 interchangeable.** `TocPlacement` implements this directive. `TableOfContents`
 is the standalone injector on the Tier-3 catalog row: it puts one nav at the top
@@ -1036,8 +1095,8 @@ Intro paragraph.
 
 | registered | what renders |
 |---|---|
-| `TocPlacement` | `<nav class="toc">` where the directive is written |
-| `TableOfContents` | `<nav class="toc">` at the top (or bottom), **plus** an empty `<div class="toc">` where the directive is written |
+| `TocPlacement` | `<nav class="toc">` (named, above) where the directive is written |
+| `TableOfContents` | `<nav class="toc">` (named, above) at the top (or bottom), **plus** an empty `<div class="toc">` where the directive is written |
 | both | two navs - one injected, one in place |
 | neither | the empty `<div class="toc">` only, and no nav anywhere |
 
@@ -1047,7 +1106,7 @@ an author a table of contents in a place they did not choose beside an empty
 element where they did choose:
 
 ```html
-<nav class="toc">
+<nav class="toc" aria-label="Table of contents">
 <ul>
 <li><a href="#One">One</a>
 <ul>

--- a/resources/examples-tier3.md
+++ b/resources/examples-tier3.md
@@ -155,7 +155,7 @@ Not enabled on this site, so the output is shown rather than rendered.
 ```
 
 ```html
-<nav class="toc">
+<nav class="toc" aria-label="Table of contents">
 <ul>
 <li><a href="#Alpha">Alpha</a></li>
 <li><a href="#Beta">Beta</a></li>

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -7383,7 +7383,11 @@ EOF = (* end of file *) ;
    EXTENSION contributes to it, and those keys are part of the same map a host
    passes once. So the list above is what CORE defines and not the whole map an
    engine honors -- measured against the pinned build, `indexBackref`,
-   `tabsGroup` and `codeGroup` are honored beside the ten. A host translating a
+   `tabsGroup` and `codeGroup` are honored beside the ten. A fourth,
+   `tocNav` (Extensions SS8b.1, carve#1509), is STATED and not yet honored by
+   any engine: the table-of-contents nav is a navigation landmark and carries an
+   accessible name, and until an engine ships it the key is declared ahead of
+   the pin rather than measured. A host translating a
    document therefore sets ONE map, which is the whole reason the map exists
    rather than a per-construct option.
 
@@ -7398,7 +7402,9 @@ EOF = (* end of file *) ;
    AN EXTENSION MAY read the map for a string it shares with core; it MUST NOT
    require the host to configure the same text twice. Two extension-written
    strings have no key and are options only -- the heading-permalink label and
-   the table-of-contents summary (carve-js `ariaLabel` / `summary`, carve-php
+   the table-of-contents summary (which is the `<details>` disclosure's VISIBLE
+   text, and not the nav's name: that one is the `tocNav` key above, on a shape
+   the summary never shares) (carve-js `ariaLabel` / `summary`, carve-php
    `$ariaLabel`, carve-rs `aria_label`). That is now the RULE and not merely the
    state (carve#1510): a string the extension already exposes as an option is
    configured there, and §1.5's admission sentence has been narrowed to say so

--- a/tests/every-labels-key-reaches-the-output.test.mjs
+++ b/tests/every-labels-key-reaches-the-output.test.mjs
@@ -35,7 +35,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { carveToHtml, codeGroup, headingPermalinks, index, tableOfContents, tabs } from '@markup-carve/carve'
+import { carveToHtml, codeGroup, headingPermalinks, index, tableOfContents, tabs, tocPlacement } from '@markup-carve/carve'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const grammar = readFileSync(resolve(root, 'resources/grammar.ebnf'), 'utf8')
@@ -127,6 +127,33 @@ const probes = {
     options: { extensions: [codeGroup()] },
     find: (html) => /<div class="code-group" role="group" aria-label="([^"]*)"/.exec(html)?.[1],
   },
+  tocNav: {
+    source: '::: toc\n:::\n\n# One\n',
+    options: { extensions: [tocPlacement()] },
+    find: (html) => /<nav class="toc" aria-label="([^"]*)"/.exec(html)?.[1],
+  },
+}
+
+/*
+ * Keys the SPEC states and the PINNED build has not shipped.
+ *
+ * Without this window the only way to land a labels ruling was to leave the key
+ * out of the two tables until an engine caught up - and a key nobody documents
+ * is a key nobody implements, which is how a ruling goes quiet. The same shape
+ * as `AHEAD_OF_PIN` in tests/examples-tier3.test.mjs and
+ * `resources/engine-pin-drift.txt` for the core corpus.
+ *
+ * The check is INVERTED, so an entry cannot rot into coverage: a declared key
+ * must still be MISSING from the output. The commit that moves the pin past one
+ * deletes its entry, because leaving it there fails.
+ */
+const AHEAD_OF_PIN = {
+  tocNav: {
+    reason:
+      'carve#1509 Extensions §8b.1 - the table-of-contents nav is a navigation landmark ' +
+      'and carries an accessible name; the pinned build leaves every <nav class="toc"> ' +
+      'anonymous and exposes no option that would name one',
+  },
 }
 
 test('the two tables and the probes name the same keys', () => {
@@ -145,12 +172,41 @@ test('the two tables and the probes name the same keys', () => {
  */
 test('both tables were actually read', () => {
   assert.equal(coreKeys().size, 10, 'PART 9 §16a states ten core keys')
-  assert.equal(extensionKeys().size, 3, 'Extensions §1.5 states three extension keys')
+  assert.equal(extensionKeys().size, 4, 'Extensions §1.5 states four extension keys')
+})
+
+/*
+ * The ledger's own liveness. An entry naming a key no table documents declares
+ * nothing - its key is never reached by the loop below, so the entry can never
+ * be deleted by a bump because no check consults it.
+ */
+test('every ahead-of-pin entry names a documented key with a probe', () => {
+  for (const key of Object.keys(AHEAD_OF_PIN)) {
+    assert.ok(documented.has(key), `AHEAD_OF_PIN declares ${key}, which neither table documents`)
+    assert.ok(probes[key], `AHEAD_OF_PIN declares ${key}, which has no probe here`)
+    assert.ok(AHEAD_OF_PIN[key].reason, `AHEAD_OF_PIN.${key} carries no reason`)
+  }
 })
 
 for (const [key, documentedDefault] of documented) {
   const probe = probes[key]
   if (!probe) continue
+
+  const ahead = AHEAD_OF_PIN[key]
+  if (ahead) {
+    test(`${key} is declared ahead of the pinned build`, () => {
+      // Inverted on purpose. The day the build writes this string, this fails
+      // and the entry above comes out in the same commit that moves the pin.
+      const found = probe.find(carveToHtml(probe.source, probe.options))
+      assert.equal(
+        found,
+        undefined,
+        `${key} is declared ahead of the pin (${ahead.reason}), but the pinned build now ` +
+          `renders "${found}". Delete the AHEAD_OF_PIN entry so the key is checked for real.`,
+      )
+    })
+    continue
+  }
 
   test(`${key} renders its documented default`, () => {
     const found = probe.find(carveToHtml(probe.source, probe.options))

--- a/tests/examples-tier3.test.mjs
+++ b/tests/examples-tier3.test.mjs
@@ -53,6 +53,13 @@ const AHEAD_OF_PIN = {
       ['<div class="code-group-panel" role="group" aria-label="Python">', '<div class="code-group-panel">'],
     ],
   },
+  TableOfContents: {
+    reason:
+      'carve#1509 Extensions §8b.1 - <nav> is a navigation landmark unconditionally, and a ' +
+      'page can hold more than one table-of-contents nav, so it carries an accessible name ' +
+      'from the tocNav label; the pinned build leaves every one of them anonymous',
+    pinned: [['<nav class="toc" aria-label="Table of contents">', '<nav class="toc">']],
+  },
 }
 
 const scan = scanExampleSource(readFileSync(resolve(__dirname, '../resources/examples-tier3.md'), 'utf8').split('\n'))


### PR DESCRIPTION
Closes #1509

`<nav>` is a navigation landmark unconditionally - unlike `<section>`, which
maps to `generic` until it is named - so a table-of-contents nav with no
accessible name is an entry in every landmark list reading only "navigation".

Measured on the pinned build rather than taken from the report, and it is worse
than one anonymous entry. Registering both extensions renders **two navs that
are byte-identical, including their absence of a name**:

```html
<nav class="toc">
<ul>
<li><a href="#One">One</a></li>
</ul>
</nav>
<nav class="toc">
<ul>
<li><a href="#One">One</a></li>
</ul>
</nav>
```

A document may also write `::: toc` more than once, and a surrounding site
template contributes its own nav. Indistinguishable entries are the defect; a
single anonymous one is only how it starts.

## Derived or authored: authored, so it gets a key

This is the decision the ticket asks for, and §1.5 states the test. Three
buckets, and the nav lands in the third:

- **Derived from the document** - a tab's `[label]`, an admonition title, a task
  item's own text. Not this: the directive's content is empty and nothing on the
  page names the nav, so there is no string to derive from.
- **No fixed English default** - a diagram fence defaults to its own class word,
  so it stays an option. Not this either, and the near miss is worth stating
  because `toc` *is* this extension's class word: an abbreviation a reader hears
  spelled out is a worse landmark entry than the prose it abbreviates, and
  "Table of contents" is ordinary English a host's catalog already holds.
- **A fixed English default the extension does not already expose as an
  option** - which gets a `labels` key. Measured: no configuration puts an
  `aria-label` on the nav in any engine, so §1.5's "unless" does not fire.

So: **a new `labels` key `tocNav`, default `Table of contents`** - and no option,
which is the half §1.5 says must not be doubled.

### It is not the `summary` string wearing a second hat

That objection is the reason to measure rather than reason. `collapsible` turns
the standalone extension's output into `<details class="toc">` with a
`<summary>` and **no `<nav>` at all**:

```html
<details class="toc">
<summary>Table of Contents</summary>
<ul>
<li><a href="#One">One</a></li>
</ul>
</details>
```

The two shapes are mutually exclusive, one string is a landmark's accessible
name and the other is visible text in a disclosure widget, and `TocPlacement`
has no such option and always renders the nav. So `summary` stays option-only
under carve#1510 and this key does not collide with it. §1.5 now says so
directly, because the near-identical defaults otherwise read as a contradiction.

The map is also the one seam all three engines already honor, which matters
here: `markup-carve/carve-rs` has neither `collapsible` nor `summary`
(`markup-carve/carve-rs#1243`), so routing the name through an extension option
would mean inventing an option in an engine that has none.

## Both extensions, and the author still wins

`TocPlacement` and `TableOfContents` read the same key, so the navs stay
byte-identical - the contract §8b.3 names. And §8b.1 already carries the
author's `{#id .class}` onto the `<nav>`, so an authored `aria-label` is simply
kept with no label added beside it, by §1.5's existing precedence. That needed
only to be stated - it is already the behavior, verbatim from the pinned build:

```html
<nav class="toc wide" id="nav1" aria-label="Chapters">
```

The match is on the attribute name **case-insensitively**, as §16a already rules
for the shapes carve#1468 closed. Worth pinning, because an author writing
`ARIA-LABEL` currently has it echoed through in that spelling.

## No corpus case, and why

§8b.3 states it: `::: toc` is Tier-3, its embedded output carries
per-implementation block indentation, and it is **not** corpus-pinned - the
cross-impl contract is the nav fragment itself. A corpus case here would be
three declared skips, which is the silence the repo's own adapter test exists to
prevent. The pins are instead:

- `tests/every-labels-key-reaches-the-output.test.mjs` - the key is read off the
  §1.5 table, so a row with no probe (or a probe with no row) fails.
- `resources/examples-tier3.md` - the fence IS the expectation and is compared
  live against the pinned build.

## The key is declared ahead of the pin, not asserted into silence

No engine writes this string yet, so both pins would go red. `examples-tier3`
already has `AHEAD_OF_PIN` for exactly this; the labels test had no such window,
which meant the only way to land a labels ruling was to leave the key out of the
tables until an engine caught up - and a key nobody documents is a key nobody
implements.

So the same window is added there, **inverted** the way the Tier-3 ledger is: a
declared key must still be MISSING from the output, so the commit that moves the
pin deletes the entry because leaving it fails. Its own liveness case rejects an
entry naming a key no table documents or no probe reaches, which is the
carve#755 shape this repo keeps finding.
