### PR TITLE
spec: PART 11 §2b's idle-escape count becomes a reading at a stated pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,9 +94,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **An escape escalation reaches the block that failed, not the document**
   (carve#1507, PART 11 §2b, §4). All three writers took one needed escape as
   license to escape every candidate in the document, which invented 72 idle
-  escapes across the same 28 corpus documents; 15 of them came from the scope
-  alone, and the engines land at 24 documents / 57 escapes (carve#1532).
-  Corpus 396.
+  escapes across the same 28 corpus documents. Swept as an A/B at one corpus
+  pin, the scope alone owns 4 documents / 17 escapes and the reading lands at
+  25 documents / 59 escapes (carve#1532, carve#1549). Corpus 396.
 - **A hard list boundary is written as exactly three blank lines**
   (carve#1505, PART 11 §10i). All three engines collapse a longer run to
   three when writing and nothing said so, and both pairs carve#1499 added

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -8412,24 +8412,40 @@ EOF = (* end of file *) ;
       MEASURED, AND THE MEASUREMENT IS WHY IT IS A CLAUSE (carve#1507). Three
       independently written writers -- carve-js, carve-php and carve-rs --
       invented 72 idle escapes across the same 28 corpus documents, with the
-      same per-document counts, character for character. Three writers agreeing
-      to the character is not coincidence and not inheritance: each took the
-      scope deliberately, and each took it from §4's own conclusion that a
-      two-render implementation is stuck with it. That conclusion is what this
-      section corrects.
+      same per-document counts, character for character, on the corpus those
+      runs carried at the time. Three writers agreeing to the character is not
+      coincidence and not inheritance: each took the scope deliberately, and
+      each took it from §4's own conclusion that a two-render implementation is
+      stuck with it. That conclusion is what this section corrects.
 
-      NARROWING RETIRES 15 OF THE 72, NOT 67 (carve#1532). The ruling that
-      seeded this section predicted that 26 documents / 67 escapes were the
-      document scope and would retire with it, leaving EXACTLY 2. Implemented,
-      all three engines land at 24 DOCUMENTS / 57 ESCAPES -- character for
-      character again (carve-js#1307, carve-php#1560, carve-rs#1239). The gap
-      is a property of the prediction rather than of a narrowing that stopped
-      short. The seeded split was measured by asking "did the writer return the
-      conservative form?", which is TRUE OF EVERY SINGLE-BLOCK DOCUMENT -- and
-      for a single-block document this section's smallest failing unit IS the
+      NARROWING RETIRES A MINORITY OF THE IDLE ESCAPES, NOT ALL BUT TWO
+      (carve#1532). The ruling that seeded this section predicted that document
+      scope owned 26 documents / 67 escapes and would take them with it,
+      leaving EXACTLY 2. Swept as an A/B at ONE corpus pin -- the same writer
+      without and with the narrowing, carve-js 234fff0 against 8f83eea
+      (carve-js#1307), over the 1362 corpus documents at spec 7cb4769 -- the
+      reading moves from 29 DOCUMENTS / 76 ESCAPES to 25 DOCUMENTS / 59
+      ESCAPES, so document scope owned 4 documents and 17 escapes and those
+      retired. carve-php#1560 and carve-rs#1239 are the same narrowing in the
+      other two writers. The gap against the prediction is a property of the
+      prediction rather than of a narrowing that stopped short: the seeded
+      split was measured by asking "did the writer return the conservative
+      form?", which is TRUE OF EVERY SINGLE-BLOCK DOCUMENT -- and for a
+      single-block document this section's smallest failing unit IS the
       document. `103-heading-marker-column-zero-2` is `  ## H` alone, and it
-      was counted as document scope on exactly that reading. Document scope
-      owned 15 escapes, and those retired.
+      was counted as document scope on exactly that reading.
+
+      A COUNT HERE IS A READING AT A PIN, NOT AN INVARIANT (carve#1549). The
+      corpus grows, so both halves of a difference have to be swept at the SAME
+      corpus pin, with the same writer save the one change under test. This
+      section shipped with "15 of 72 retired", which subtracted a
+      post-narrowing reading from a pre-narrowing one taken on a corpus that
+      did not yet hold corpus 396 -- the document this very clause added, and
+      its own worked example. At one pin the pair is 17 of 76, and 396 itself
+      carries 4 idle escapes before the narrowing and 2 after, which is the
+      paragraph above coming out as it says it does. What is durable here is
+      the CAUSE SPLIT below; a pair of magnitudes is its arithmetic at a stated
+      pin, and stating the pin is the whole of what makes it checkable.
 
       WHAT REMAINS IS THREE CAUSES, AND NONE OF THEM IS THIS SECTION'S.
 
@@ -8442,9 +8458,10 @@ EOF = (* end of file *) ;
                          per-occurrence. Retiring these needs §2's own
                          per-OPENER-OCCURRENCE test, a different mechanism
                          rather than a narrower scope, and out of this
-                         section's scope by design (carve#1533).
+                         section's scope by design (carve#1533). Since taken,
+                         and these retired with it -- see below.
 
-        `opener run`     2 documents, 5 escapes. A FLOOR THE MEASUREMENT CANNOT
+        `opener run`     3 documents, 7 escapes. A FLOOR THE MEASUREMENT CANNOT
                          GO BELOW, AND NOT DEBT. §2's THE UNIT IS THE OPENER
                          requires the whole opener run escaped -- `\#\# H` and
                          never `\## H` -- while the sweep that counts idle
@@ -8452,8 +8469,13 @@ EOF = (* end of file *) ;
                          first still in place no heading forms either way and
                          the sweep reads the rest of a correctly escaped run as
                          idle. Driving these to zero would mean emitting output
-                         §2 forbids. `103-heading-marker-column-zero-2` and
-                         `132-thematic-break-requires-contiguous-markers-3`.
+                         §2 forbids. `103-heading-marker-column-zero-2`,
+                         `132-thematic-break-requires-contiguous-markers-3`
+                         and corpus 396, this section's own worked example.
+                         The third arrived with the CORPUS rather than with a
+                         writer, which is how this row came to name two: the
+                         reading behind it was taken at a pin that predated the
+                         commit adding the document the clause shipped.
 
         `minimal class`  2 documents, 5 escapes. The two the ruling named,
                          unchanged: `72-escape-coverage-2` carries a literal
@@ -8466,6 +8488,15 @@ EOF = (* end of file *) ;
 
       An engine that narrows the scope and does not land at exactly these three
       causes has found something else.
+
+      TWO OF THE THREE ARE WHAT AN ENGINE READS TODAY. All three writers have
+      since taken §2's test per OPENER OCCURRENCE inside the failing unit
+      (carve-js#1327, carve-php#1578, carve-rs#1254), which retires the `unit
+      scope` rows entirely: their ratchets carry the same five slugs with the
+      same counts, 5 DOCUMENTS / 12 ESCAPES, and every one of those is an
+      `opener run` or a `minimal class` row above. That is a §2 mechanism
+      rather than a narrower scope, so nothing this section rules changed with
+      it, and the clause carve#1533 asks for is still open.
 
       THE COMPARISON STAYS DOCUMENT-SCOPED, WHICH IS THE OTHER QUESTION. §4
       rules out re-parsing a LINE on its own, because a line has lost the


### PR DESCRIPTION
Closes #1549.

PART 11 §2b reported the escalation ratchet as "narrowing retires 15 of the 72"
and "all three engines land at 24 documents / 57 escapes". The ticket asked for
25 / 59. Re-derived mechanically, both pairs turn out to be readings taken at
different corpus pins and subtracted from each other, which is the actual
defect: corpus 396 is the document this clause itself added as its worked
example, and the pre-narrowing half of the subtraction was read before it
existed.

## How it was re-derived

The sweep is §2b's own: run the writer, remove each backslash of its output on
its own, and count a backslash whose removal leaves both the render and the
position-free canonical tree unchanged. The same count is taken on the source
and subtracted per character, clamped at zero, so an escape the author wrote is
not charged to the writer. The probe is the sweep the three engine ratchets run,
lifted out into a standalone script:

````
$ node idle-escape-probe.mjs <engine>/dist/index.js spec/tests/corpus
````

A/B at ONE corpus pin (spec `7cb4769`, 1362 documents), the same writer without
and with the narrowing:

````
--- 8f83eea^ (234fff0) ---
corpus documents swept: 1362
documents with at least one invented idle escape: 29
invented idle escapes: 76

--- 8f83eea (markup-carve/carve-js#1307, the narrowing) ---
corpus documents swept: 1362
documents with at least one invented idle escape: 25
invented idle escapes: 59
````

So the narrowing retires 4 documents and 17 escapes, and lands at 25 / 59 -
the ticket's pair, confirmed. "15 of 72" came from subtracting these two halves
at different pins.

Per-document, the four documents that retired and the ten whose counts dropped:

````
=== retired by the narrowing (in before, not after) ===
145-definition-list-as-a-first-class-block-opener-3
160-indented-colon-fence-blocks-stay-literal
160-indented-colon-fence-blocks-stay-literal-3
379-a-reference-definition-cannot-take-its-destination-from-the-next-line
=== per-doc deltas ===
157-indented-attribute-line-stays-literal 4->3
157-indented-attribute-line-stays-literal-2 5->3
159-indented-reference-and-footnote-definitions-stay-literal 3->2
159-indented-reference-and-footnote-definitions-stay-literal-2 2->1
160-indented-colon-fence-blocks-stay-literal-2 3->2
195-a-definition-inside-a-container-is-collected-at-that-container-s-content-column-3 4->3
369-a-quote-is-reached-by-its-marker-and-a-column-never-reaches-into-one 3->2
369-a-quote-is-reached-by-its-marker-and-a-column-never-reaches-into-one-2 3->2
369-a-quote-is-reached-by-its-marker-and-a-column-never-reaches-into-one-3 3->2
396-an-idle-escape-does-not-spread-from-the-block-that-needed-one 4->2
````

Corpus 396 going 4 -> 2 is the clause's worked example: the second paragraph's
`\(b\)` retires, and the escaped `##` opener run stays. That is why 396 belongs
in the `opener run` row - it is a floor, not debt.

The 25 split exactly as the clause's three causes say, which is what makes the
classification checkable rather than asserted: `opener run` 103 + 132 + 396 =
7 escapes, `minimal class` 72-escape-coverage-2 + 390 = 5, leaving `unit scope`
at 20 documents / 47 escapes.

## Why the wording changed shape rather than just the digits

A bare pair of magnitudes rots the moment the corpus grows - that is how this
clause got here. The reading now states the pin and the builds it was swept
between, and a new paragraph says plainly that a count here is a reading at a
pin, so both halves of a difference have to come from the same corpus. Without
that, the next corpus addition puts the clause straight back where it was.

The second new paragraph is there for the same honesty reason. Writing "all
three engines land at 25 / 59" in the present tense would have been stale on
the day it landed: all three have since taken the per-opener-occurrence test
(markup-carve/carve-js#1327, markup-carve/carve-php#1578, markup-carve/carve-rs#1254) and their ratchets read 5
documents / 12 escapes with the same five slugs and the same counts, which
retires the `unit scope` rows. That is reported, not ruled - the clause it
belongs to is #1533 and stays open.

## Nothing pins the magnitude in this repo

No test in this repo asserts the old numbers, so the rot mechanism here was
prose only. The magnitude IS pinned - by the three engine ratchets, which
already read 5 / 12 and are gates. `resources/normative-clauses.txt` is
unaffected: the clause heading does not move and none of the new subheadings
carries the `-- NORMATIVE` marker.

The changelog's Unreleased entry carried the same stale pair and is corrected
with it. No new entry was added.
