### PR TITLE
fix: a caption spills onto its continuation lines in the oracle too

### DIFF
--- a/resources/oracle-divergence.txt
+++ b/resources/oracle-divergence.txt
@@ -13,8 +13,12 @@
 #   - markup-carve/carve#1517: three engines folded a later list marker into an
 #     open paragraph, the oracle read the clause correctly, and nothing in this
 #     repository went red for months.
-#   - the two entries below: three engines agree with each other AND with the
-#     normative text, and the oracle is the one that is wrong.
+#   - markup-carve/carve#1561 and markup-carve/carve#1562: three engines agree
+#     with each other AND with the normative text, and the oracle is the one
+#     that is wrong. Named here rather than counted, because an EMPTY list is
+#     the goal - a count would turn retiring the last entry into a
+#     documentation change, which is how a ledger acquires a header nobody
+#     believes.
 #
 # So the reason field says which way the finding points, and names the clause it
 # was decided against. That is what makes the entry retirable: the gate fails on
@@ -30,5 +34,4 @@
 #
 # Format: <document id><space><space><reason>
 
-docs/cheatsheet.md#7  The oracle ends a caption at its own line; PART 2 MULTI-LINE CAPTIONS says a caption is multi-line inline content whose text spills onto following lines exactly like a paragraph, which is what all three engines do. Oracle defect, markup-carve/carve#1561.
 docs/migrate-from-markdown.md#7  The oracle numbers an inline `^[...]` note ahead of an earlier `[^label]` use; PART 10 R2 numbers by FIRST-REFERENCE order from one shared footnoteSeq, which is what all three engines do. Oracle defect, markup-carve/carve#1562.

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -1471,7 +1471,7 @@ export function parse(src) {
       if (b === null || typeof b !== 'object') continue
       if (b.t === 'para' && b.pendingRef !== undefined) {
         if (!state.linkDefs.has(b.pendingRef)) {
-          b.lines = [...b.lines, b.captionSrc]
+          b.lines = [...b.lines, ...b.captionSrc]
           delete b.caption
         }
         delete b.pendingRef
@@ -1593,6 +1593,78 @@ function parseBlocksImpl(lines, state, top, inItem = false, seeded = undefined, 
     return node
   }
   const push = (node) => blocks.push(flushAttrs(node))
+
+  /*
+   * A CAPTION SLOT, WITH THE CONTINUATION LINES IT SPILLS ONTO -- PART 2,
+   * MULTI-LINE CAPTIONS.
+   *
+   * `from` is the index just past the captionable host. The return value is
+   * `null` when no caption line follows, or `{ text, next, src }`: the folded
+   * caption text, the index to resume the block loop at, and the caption's
+   * SOURCE lines for the one caller that may have to put them back
+   * (`pendingRef`, an unresolved reference image, unwraps the figure and the
+   * caption returns to the paragraph as literal text).
+   *
+   * ONE HELPER RATHER THAN FIVE COPIES, for the reason the `CAPTION` pattern
+   * gives above it: five sites read this slot -- code block, figure group,
+   * table, block quote and image/display-math paragraph -- and each carried
+   * its own three-line spelling that read exactly one line. So the caption
+   * ENDED at its own line in all five, and no corpus document holds a caption
+   * with a continuation line, which is how the oracle held a reading no engine
+   * and no clause shares (markup-carve/carve#1561).
+   *
+   * WHERE IT ENDS is the clause's own list, and the clause says outright that
+   * the list is a paragraph's: "It ends the same way an open paragraph does".
+   * So the ends are read from `peekInterrupts`, the §10 I1/I4/I5 predicate the
+   * paragraph collector already uses, plus the two the clause names on its
+   * own account:
+   *
+   *   - a further `^ ` line does NOT continue the caption (item 4). There is
+   *     no repeated marker, so the second caret line ends this caption and,
+   *     with nothing captionable above it, becomes paragraph text.
+   *   - a LIST MARKER does NOT end it (item 3), which is why no marker test
+   *     appears here. A caption folds `- x` in as literal text exactly as a
+   *     paragraph does.
+   *
+   * WHAT IT DOES NOT NORMALIZE. A continuation line keeps its leading run and
+   * drops only its trailing whitespace, the same treatment the caption's own
+   * line gets from `CAPTION`. The clause's paragraph comparison is about the
+   * EXTENT -- which lines belong to the caption -- and it enumerates the ends
+   * to say so; nothing in it, and nothing in `caption_continuation_line =
+   * inline_content, newline`, dedents the line. So the indented spelling is
+   * left as written rather than given a normalization the text does not state.
+   */
+  const captionSlot = (from) => {
+    let j = from
+    if (j < n && isBlank(lines[j] ?? '') && CAPTION.test(lines[j + 1] ?? '')) j++
+    const cap = j < n && lines[j] !== undefined ? CAPTION.exec(lines[j]) : null
+    if (!cap) return null
+    const text = [cap[1]]
+    const src = [stripIndent(lines[j]).replace(/[ \t]+$/, '')]
+    let k = j + 1
+    while (k < n && !isBlank(lines[k])) {
+      // A LAZY line is a paragraph continuation by construction (PART 1 S4),
+      // so it folds without asking the interruption predicate anything - the
+      // same short-circuit the paragraph collector takes, and for the same
+      // reason: the marker it is missing is what made it lazy.
+      if (lines[k].startsWith(LAZY)) {
+        text.push(lines[k].slice(LAZY.length).replace(/[ \t]+$/, ''))
+        src.push(lines[k].slice(LAZY.length).replace(/[ \t]+$/, ''))
+        k++
+        continue
+      }
+      for (const [re, what] of REFUSERS) {
+        if (re.test(lines[k])) throw new Refuse(`${what} interrupting a caption`)
+      }
+      if (CAPTION.test(lines[k])) break // item 4: no repeated marker
+      if (ind(k).rest.startsWith('%%')) break // §10 I5
+      if (peekInterrupts(k)) break // §10 I1/I4/I5
+      text.push(lines[k].replace(/[ \t]+$/, ''))
+      src.push(stripIndent(lines[k]).replace(/[ \t]+$/, ''))
+      k++
+    }
+    return { text: text.join('\n'), next: k, src }
+  }
 
   while (i < n) {
     // SS17 L3 asks this parser where the FIRST block ends (see firstBlockEnd).
@@ -1794,12 +1866,10 @@ function parseBlocksImpl(lines, state, top, inItem = false, seeded = undefined, 
           text: lines.slice(i + 1, close).map(stripLazy).join('\n') + (close > i + 1 ? '\n' : ''),
         }
         i = close + 1
-        let j = i
-        if (j < n && isBlank(lines[j] ?? '') && CAPTION.test(lines[j + 1] ?? '')) j++
-        const cap = j < n && lines[j] !== undefined ? CAPTION.exec(lines[j]) : null
+        const cap = captionSlot(i)
         if (cap) {
-          node.caption = cap[1] // a captioned code block is a LISTING (SS4)
-          i = j + 1
+          node.caption = cap.text // a captioned code block is a LISTING (SS4)
+          i = cap.next
         }
         push(node)
         continue
@@ -2049,12 +2119,10 @@ function parseBlocksImpl(lines, state, top, inItem = false, seeded = undefined, 
                 // caption at the CLOSER (SS4's sixth host; one blank allowed).
                 // A group closed by end of input has no closer line to host
                 // the slot.
-                let j = i
-                if (j < n && isBlank(lines[j] ?? '') && CAPTION.test(lines[j + 1] ?? '')) j++
-                const cap = j < n && lines[j] !== undefined ? CAPTION.exec(lines[j]) : null
+                const cap = captionSlot(i)
                 if (cap) {
-                  node.caption = cap[1]
-                  i = j + 1
+                  node.caption = cap.text
+                  i = cap.next
                 }
               }
               push(node)
@@ -2177,12 +2245,10 @@ function parseBlocksImpl(lines, state, top, inItem = false, seeded = undefined, 
         }
       }
       // caption (SS4; one blank line allowed)
-      let j = i
-      if (j < n && isBlank(lines[j] ?? '') && CAPTION.test(lines[j + 1] ?? '')) j++
-      const cap = j < n && lines[j] !== undefined ? CAPTION.exec(lines[j]) : null
+      const cap = captionSlot(i)
       if (cap) {
-        node.caption = cap[1]
-        i = j + 1
+        node.caption = cap.text
+        i = cap.next
       }
       push(node)
       continue
@@ -2416,12 +2482,10 @@ function parseBlocksImpl(lines, state, top, inItem = false, seeded = undefined, 
       const children = parseBlocks(inner, state, false)
       const node = { t: 'quote', children }
       // caption -> <figure><blockquote/><figcaption> (PART 9 SS4)
-      let j = i
-      if (j < n && isBlank(lines[j]) && CAPTION.test(lines[j + 1] ?? '')) j++
-      const cap = j < n ? CAPTION.exec(lines[j]) : null
+      const cap = captionSlot(i)
       if (cap) {
-        node.caption = cap[1]
-        i = j + 1
+        node.caption = cap.text
+        i = cap.next
       }
       push(node)
       continue
@@ -2495,9 +2559,7 @@ function parseBlocksImpl(lines, state, top, inItem = false, seeded = undefined, 
     }
     const pnode = { t: 'para', lines: para }
     // image paragraph caption -> figure (PART 9 SS4; one blank line allowed)
-    let j = i
-    if (j < n && isBlank(lines[j] ?? '') && CAPTION.test(lines[j + 1] ?? '')) j++
-    const cap = j < n && lines[j] !== undefined ? CAPTION.exec(lines[j]) : null
+    const cap = captionSlot(i)
     if (cap) {
       // A REFERENCE image is an image: the bracket form takes a caption
       // exactly as the parenthesis form does. Only the inline form was
@@ -2506,7 +2568,7 @@ function parseBlocksImpl(lines, state, top, inItem = false, seeded = undefined, 
       // figure - and nothing caught it, because every captioned-image case
       // in the corpus uses the inline form.
       if (isCaptionableParagraph(para)) {
-        pnode.caption = cap[1]
+        pnode.caption = cap.text
         // A reference image is captionable ONLY IF IT RESOLVES, and the
         // definition may sit below it - so the decision cannot be made
         // here, in a single forward pass. Record what an unwrap would need
@@ -2534,9 +2596,13 @@ function parseBlocksImpl(lines, state, top, inItem = false, seeded = undefined, 
           // put a figure around literal text in one case and dropped a caption
           // from a resolving image in the other.
           pnode.pendingRef = refImage[1] === '' ? para[0].slice(2, altEnd - 1) : refImage[1]
-          pnode.captionSrc = stripIndent(lines[j]).replace(/[ \t]+$/, '')
+          // EVERY line of the caption, not the marker line alone. The unwrap
+          // appends these to the paragraph, so a caption that spilled onto a
+          // continuation line has to give all of them back or the document
+          // loses a line (PART 2, MULTI-LINE CAPTIONS).
+          pnode.captionSrc = cap.src
         }
-        i = j + 1
+        i = cap.next
       }
       // a caption after a non-captionable block stays literal paragraph
       // text (handled by the paragraph collector on the next pass)

--- a/tests/caption-inside-a-container.test.mjs
+++ b/tests/caption-inside-a-container.test.mjs
@@ -92,3 +92,98 @@ test('an orphan caption line with nothing captionable above it stays text', () =
   assert.ok(!out.includes('<figcaption>'), out)
   assert.match(out, /\^ not a caption/, out)
 })
+
+/*
+ * WHERE THE CAPTION ENDS -- PART 2, MULTI-LINE CAPTIONS
+ * (markup-carve/carve#1561).
+ *
+ * The clause has been explicit since it was written: "A caption is multi-line
+ * inline CONTENT, so its text spills onto following lines exactly like a
+ * PARAGRAPH (section 10), NOT like a heading", and "Continuation lines join
+ * with a newline, so `^ cap` + `more` yields the caption text `cap\nmore`".
+ *
+ * The oracle read exactly one line at all FIVE of its caption sites, so the
+ * continuation line became a second block. No corpus document holds a caption
+ * with a continuation line, and the authored docs sample that does
+ * (`docs/cheatsheet.md`) had no reader until
+ * markup-carve/carve#1552 gave it one - so four readers held two answers with
+ * nothing red.
+ *
+ * PINNED PER HOST, not once. The five sites each had their own copy of the
+ * slot read, which is what let one rule be wrong in five places; a single
+ * assertion would leave four of them free to drift back. The pinned engine is
+ * asserted beside the oracle on the same source for the same reason the
+ * comparison exists at all: agreement is the claim, not the oracle's output
+ * in isolation.
+ */
+
+const CONTINUED = {
+  image: '![alt](/i.png)\n^ cap\nmore\n',
+  table: '| a | b |\n^ cap\nmore\n',
+  quote: '> q\n^ cap\nmore\n',
+  code: '```\nx\n```\n^ cap\nmore\n',
+  math: '$$`x`\n^ cap\nmore\n',
+}
+
+for (const [host, source] of Object.entries(CONTINUED)) {
+  test(`a caption on a ${host} folds its continuation line in`, () => {
+    const out = html(source)
+    assert.match(out, /cap\nmore</, out)
+    assert.ok(!out.includes('<p>more</p>'), out)
+  })
+}
+
+test('the pinned engine folds it the same way, on every host', async () => {
+  const { carveToHtml } = await import('@markup-carve/carve')
+  for (const [host, source] of Object.entries(CONTINUED)) {
+    assert.match(carveToHtml(source), /cap\nmore</, host)
+  }
+})
+
+test('a caption folds three continuation lines, joined with newlines', () => {
+  assert.match(html('![alt](/i.png)\n^ cap\ntwo\nthree\n'), /<figcaption>cap\ntwo\nthree<\/figcaption>/)
+})
+
+test('a blank line ends the caption (item 1)', () => {
+  const out = html('![alt](/i.png)\n^ cap\n\nafter\n')
+  assert.match(out, /<figcaption>cap<\/figcaption>/, out)
+  assert.match(out, /<p>after<\/p>/, out)
+})
+
+test('a paragraph interrupter ends the caption (item 2)', () => {
+  // Section 10's relation, one member per kind it names.
+  for (const [what, line] of Object.entries({
+    heading: '# H',
+    quote: '> q',
+    table: '| a | b |',
+    fence: '```\nc\n```',
+    div: '::: note\nx\n:::',
+    thematic: '---',
+    comment: '%% c',
+  })) {
+    const out = html(`![alt](/i.png)\n^ cap\n${line}\n`)
+    assert.match(out, /<figcaption>cap<\/figcaption>/, `${what}: ${out}`)
+  }
+})
+
+test('a list marker does NOT end the caption (item 3)', () => {
+  // The one paragraph end condition the clause overrides: a list needs a blank
+  // line to interrupt, so the marker line folds in as literal caption text.
+  assert.match(html('![alt](/i.png)\n^ cap\n- x\n'), /<figcaption>cap\n- x<\/figcaption>/)
+})
+
+test('a second caret line does NOT continue the caption (item 4)', () => {
+  // No repeated marker. The second line ends this caption and, with nothing
+  // captionable above it, is ordinary paragraph text.
+  const out = html('![alt](/i.png)\n^ cap\n^ two\n')
+  assert.match(out, /<figcaption>cap<\/figcaption>/, out)
+  assert.match(out, /<p>\^ two<\/p>/, out)
+})
+
+test('an unresolved reference image gives every caption line back', () => {
+  // The unwrap appends the caption's SOURCE to the paragraph. Reading one line
+  // where the caption held three would silently drop two of them.
+  const out = html('![alt][r]\n^ cap\nmore\nyet\n')
+  assert.ok(!out.includes('<figure>'), out)
+  assert.match(out, /\^ cap\nmore\nyet/, out)
+})


### PR DESCRIPTION
Closes #1561.

PART 2 MULTI-LINE CAPTIONS has said this since it was written:

> A caption is multi-line inline CONTENT, so its text spills onto following
> lines exactly like a PARAGRAPH (§10), NOT like a heading. It ends the same way
> an open paragraph does: [...] Continuation lines join with a newline.

The oracle ended the caption at its own line, so a continuation line became a
second block:

Input:

````
![Photo](img.jpg)
^ A long caption that
continues on the next line.
````

`scripts/spec` rendered:

````html
<figure>
  <img src="img.jpg" alt="Photo">
  <figcaption>A long caption that</figcaption>
</figure>
<p>continues on the next line.</p>
````

## Why it was wrong in five places at once

Each of the five caption sites carried its own three-line copy of the slot
read - code block, figure group, table, block quote, and the
image/display-math paragraph - and every copy read exactly one line. That is
the same failure mode the `CAPTION` pattern above them was written to avoid
("Done in the PATTERN rather than at each use: five places read this capture,
and the rule was missing from all five"). So the five become one `captionSlot`
helper that reads the slot and then folds.

Where the caption ends is the clause's own list, and the clause says outright
that the list is a paragraph's, so the ends come from `peekInterrupts` - the
§10 I1/I4/I5 predicate the paragraph collector already uses - plus the two the
clause names on its own account: a further `^ ` line ends the caption (item 4,
there is no repeated marker), and a list marker does not (item 3, a list needs
a blank line to interrupt).

One caller had to move with it. An unresolved reference image unwraps its
figure and hands the caption back to the paragraph as literal text, and it
recorded a single source line - a caption that spilled would have silently
dropped every line but the first.

## What is deliberately NOT normalized

A continuation line keeps its leading run and drops only its trailing
whitespace, which is the treatment the caption's own line already gets from
`CAPTION`. The clause's paragraph comparison is about the EXTENT, and it
enumerates the ends to say so; neither it nor `caption_continuation_line =
inline_content, newline` dedents the line. A paragraph does dedent its
continuation lines, so "exactly like a paragraph" could be stretched that far -
but the pinned engine keeps the indent, and inventing a normalization the text
does not state would plant a divergence on a shape no document holds. Left as
written, and said out loud in the helper's comment.

## Blast radius, measured

| population | documents | change output |
| --- | --- | --- |
| core corpus with an html fixture | 1363 | **0** |
| optional corpus with an html fixture | 41 | 0 (39 non-participations before and after, unchanged) |
| authored documents | 85 | **1** (`docs/cheatsheet.md#7`) |

No committed golden pinned the oracle's old caption extent: the core corpus
reproduces all 1363 fixtures byte for byte both before and after, so there are
no MODIFIED goldens and no NEW ones. Nothing was re-snapshotted.

The declaration for this finding comes out of `resources/oracle-divergence.txt`
in this commit, which is what the ledger's stale-direction check demands. The
header's "the two entries below" becomes a naming rather than a count, so
retiring the last entry does not turn into a documentation change.

## No CHANGELOG entry

Nothing a consumer installs moves: no clause changed, no engine changed, and
zero corpus fixtures changed. This is the same shape as #1565, the change that
built the comparison, which added no entry either.
