### PR TITLE
fix: a break is exempt from the overlap rule against another break, not against everything

### DIFF
--- a/scripts/spec/ast-positions.mjs
+++ b/scripts/spec/ast-positions.mjs
@@ -75,7 +75,17 @@ export function checkContainment(doc, findings) {
       return
     }
     if (!node || typeof node !== 'object') return
-    const placed = typeof node.type === 'string' && node.pos
+    // AN INTEGER PAIR, not merely a `pos` object. The count below is what makes
+    // a vacuous pass distinguishable from a clean one, so counting a pair whose
+    // offsets cannot be compared inflates the one number that exists to say the
+    // rule did some work: `undefined < 3` and `undefined > 7` are both false, so
+    // such a pair is silently clean AND silently counted. A node whose offsets
+    // are not integers is reported by `checkPositions` under its own rule.
+    const placed =
+      typeof node.type === 'string' &&
+      node.pos &&
+      Number.isInteger(node.pos.startOffset) &&
+      Number.isInteger(node.pos.endOffset)
     if (placed && parent) {
       compared += 1
       const outside =
@@ -442,8 +452,24 @@ export function checkOpeningMarkup(doc, codepoints, findings) {
     const pos = node.pos
     if (!pos || !Number.isInteger(pos.startOffset) || !Number.isInteger(pos.endOffset)) continue
     if (pos.startOffset > codepoints.length) continue
+    // LEADING INDENTATION, and the line's own - not any whitespace the span
+    // happens to open on. The clause puts the indent inside the span because the
+    // indent is what places a nested item's marker, and a nested list's span
+    // legitimately starts PART WAY into that run, at its parent's content
+    // column (corpus 245 and two others). What the run may not do is skip
+    // whitespace that follows text on the line: a span opening on a space in
+    // mid-line has not begun at the construct's markup, and walking past it
+    // turned that into a pass.
     let at = pos.startOffset
-    while (at < pos.endOffset && (codepoints[at] === ' ' || codepoints[at] === '\t')) at += 1
+    let indented = true
+    for (let k = at - 1; k >= 0; k--) {
+      const c = codepoints[k]
+      if (c === '\n' || c === '\r') break
+      if (c !== ' ' && c !== '\t') { indented = false; break }
+    }
+    if (indented) {
+      while (at < pos.endOffset && (codepoints[at] === ' ' || codepoints[at] === '\t')) at += 1
+    }
     examined += 1
     // WIDE ENOUGH FOR THE LONGEST MARKER. An ordered marker is digits then a
     // delimiter, so a window that truncates before the delimiter turns a
@@ -494,7 +520,48 @@ export const HOISTED_DEFINITION_TYPES = new Set([
   'link_reference_definition',
 ])
 
-const EXEMPT_FROM_OVERLAP = new Set([...HOISTED_DEFINITION_TYPES, 'hard_break', 'soft_break'])
+/**
+ * WHICH PAIR OF SIBLINGS MAY SHARE SOURCE - a question about the PAIR, never
+ * about one node (carve#1566).
+ *
+ * The break half of this used to be a set of TYPES, consulted against each node
+ * on its own, and its stated reason was already the pair: "two BREAKS meeting at
+ * one newline share that boundary". A per-node set cannot say that. It exempted
+ * a break from the rule against every sibling of any kind, so a break
+ * overlapping a NON-break sibling - the shape the rule exists to catch - was
+ * invisible, in both directions, because an exempt node was dropped from the
+ * comparison entirely rather than merely excused from one pair.
+ *
+ * markup-carve/carve-rs#1246 is the witness. On
+ *
+ *     ::: |
+ *     *a
+ *     %% secret
+ *     c*
+ *     :::
+ *
+ * carve-rs published the break ending the emptied comment line at 9..19 beside
+ * the `comment` at 9..18: two siblings holding the same nine codepoints, which
+ * is what PART 12 §4's span tree exists to rule out. Both that reading and the
+ * fixed one passed every checker in this file. `checkContainment` was never
+ * going to see it either - the break sits inside the `strong` that contains it,
+ * so the parent bound holds - which left this rule as the only one for the
+ * shape, with the exemption turning it off.
+ *
+ * HOISTED DEFINITIONS ARE STILL EXEMPT AGAINST ANY SIBLING, and that breadth is
+ * deliberate rather than the same defect left in place - it was measured, not
+ * assumed. A definition's span points at the container it was AUTHORED in (§7),
+ * and carve#1522 ends a container emptied by that same hoisting at its own
+ * markup. Once it does, the definition is no longer INSIDE its host: on 13
+ * corpus documents carve-php and carve-rs both span the emptied quote as `> `
+ * while the definition hoisted out of it spans the whole line, and the two
+ * genuinely overlap without either engine being wrong under the rulings as they
+ * stand. Narrowing this half needs that collision ruled on first, which is
+ * carve#1571 - a checker is not where three rulings get reconciled.
+ */
+function overlapExemptPair(a, b) {
+  return BREAK_TYPES.has(a.type) && BREAK_TYPES.has(b.type)
+}
 
 /**
  * SIBLING SPANS MUST NOT OVERLAP.
@@ -518,16 +585,41 @@ function checkSiblingOverlap(node, path, findings) {
       .map((child, i) => [child, i])
       .filter(([c]) => c && typeof c === 'object' && c.pos &&
         Number.isInteger(c.pos.startOffset) && Number.isInteger(c.pos.endOffset) &&
-        !EXEMPT_FROM_OVERLAP.has(c.type))
-    for (let i = 1; i < placed.length; i++) {
-      const [prev] = placed[i - 1]
-      const [cur, idx] = placed[i]
-      // Zero-width spans touching at a boundary are fine; a real overlap is not.
-      if (cur.pos.startOffset < prev.pos.endOffset) {
-        findings.push(
-          `sibling spans overlap at ${path}.${key}[${idx}]: "${cur.type}" starts at ` +
-            `${cur.pos.startOffset}, inside "${prev.type}" which ends at ${prev.pos.endOffset}`,
-        )
+        // Hoisted definitions leave the comparison entirely, rather than being
+        // excused pair by pair: see `overlapExemptPair` for why that half is
+        // still the broad form.
+        !HOISTED_DEFINITION_TYPES.has(c.type))
+    // EVERY PAIR, not each node against the one before it. Once an exemption is
+    // a property of the PAIR, an exempt node has to stay in the comparison - and
+    // a chain that only compares neighbours then loses the pair on either side
+    // of it. A break between two siblings that overlap each other is the shape:
+    // each of them is compared against the break, the break is exempt against
+    // neither, and the two of them are never compared at all.
+    for (let j = 1; j < placed.length; j++) {
+      for (let i = 0; i < j; i++) {
+        const a = placed[i]
+        const b = placed[j]
+        if (overlapExemptPair(a[0], b[0])) continue
+        // ORDERED BY OFFSET, not by array index. Comparing every pair reaches
+        // siblings the tree lists out of source order, and `starts inside` is
+        // only meaningful about the one that starts LATER. The array index
+        // breaks a tie, so two nodes claiming the same offset are reported
+        // against the one written first.
+        const [first, second] =
+          a[0].pos.startOffset <= b[0].pos.startOffset ? [a, b] : [b, a]
+        // Zero-width spans touching at a boundary are fine; a real overlap is
+        // not. Both ends are tested: `second` starting before `first` ends is
+        // not an overlap on its own once the pair can be out of source order.
+        if (
+          first[0].pos.startOffset < second[0].pos.endOffset &&
+          second[0].pos.startOffset < first[0].pos.endOffset
+        ) {
+          findings.push(
+            `sibling spans overlap at ${path}.${key}[${second[1]}]: "${second[0].type}" starts at ` +
+              `${second[0].pos.startOffset}, inside "${first[0].type}" which ends at ${first[0].pos.endOffset}`,
+          )
+          break
+        }
       }
     }
   }
@@ -593,11 +685,23 @@ export function checkPositions(doc, source, findings) {
       // hard-break fence turning every newline into one - has no backslash
       // before it and is left alone, which is why the rule tests the source
       // rather than the node type.
+      //
+      // A CRLF TERMINATOR IS THE SAME CONSTRUCT (carve#1566). The rule used to
+      // test for a bare `\n` with the backslash directly before it, which on a
+      // CRLF document is true of neither anchoring: a break starting at the CR
+      // is not looking at a `\n` at all, and one starting at the LF finds the CR
+      // where the backslash would be. So on a CRLF document a break that
+      // dropped its backslash was invisible to the rule written for it - the
+      // terminator rule one screen up has known about `\r` from the start.
+      const at = pos.startOffset
+      const onTerminator = codepoints[at] === '\n' || codepoints[at] === '\r'
+      const beforeTerminator =
+        codepoints[at] === '\n' && codepoints[at - 1] === '\r' ? at - 2 : at - 1
       if (
         node.type === 'hard_break' &&
-        codepoints[pos.startOffset] === '\n' &&
-        pos.startOffset > 0 &&
-        codepoints[pos.startOffset - 1] === '\\'
+        onTerminator &&
+        beforeTerminator >= 0 &&
+        codepoints[beforeTerminator] === '\\'
       ) {
         findings.push(
           `hard break span starts after its backslash on "${node.type}" at ${path}: ` +
@@ -620,14 +724,23 @@ export function checkPositions(doc, source, findings) {
       // positions while spanning the same codepoints. The span is not wrong -
       // it covers precisely the source the node came from - and the engine's
       // internal spelling of an indent is not something this check can compare.
+      // AND ONLY WHERE AN ESCAPE COULD ACTUALLY EXPLAIN THE DIFFERENCE
+      // (carve#1566). The reason above is that resolving an escape leaves the
+      // slice LONGER than the value it produced, so any backslash used to
+      // disable the comparison outright. A backslash the parser left literal -
+      // one before a character Carve does not escape - resolves to nothing and
+      // keeps the two the same length, and skipping those discarded a
+      // comparison that had every reason to run.
       if (
         node.type === 'text' &&
         typeof node.value === 'string' &&
-        !node.value.includes('\ue000') &&
-        !codepoints.slice(pos.startOffset, pos.endOffset).includes('\\')
+        !node.value.includes('\ue000')
       ) {
-        const slice = codepoints.slice(pos.startOffset, pos.endOffset).join('')
-        if (slice !== node.value) {
+        const sliceChars = codepoints.slice(pos.startOffset, pos.endOffset)
+        const slice = sliceChars.join('')
+        const anEscapeCouldExplainIt =
+          sliceChars.includes('\\') && sliceChars.length > [...node.value].length
+        if (!anEscapeCouldExplainIt && slice !== node.value) {
           findings.push(
             `pos does not cover the text it belongs to on "${node.type}" at ${path}: ` +
               `offsets give ${JSON.stringify(slice)}, node says ${JSON.stringify(node.value)}`,

--- a/tests/ast-positions.test.mjs
+++ b/tests/ast-positions.test.mjs
@@ -97,6 +97,31 @@ test('a hard break that starts after its backslash is reported', () => {
   assert.match(findings[0], /hard break span starts after its backslash/)
 })
 
+test('a CRLF hard break that dropped its backslash is reported', () => {
+  // THE SAME DEFECT, ON A CRLF DOCUMENT (carve#1566). The rule tested for a
+  // bare newline with the backslash directly before it, and on CRLF that is
+  // true of neither anchoring: a break at the CR is not looking at a newline,
+  // and one at the LF finds the CR where the backslash would be. So the rule
+  // written for markup-carve/carve-rs#492 could not see it here at all.
+  const source = 'a\\\r\nb\r\n'
+  const doc = {
+    type: 'document',
+    children: [{ type: 'hard_break', pos: pos(2, 4) }],
+  }
+  const findings = findingsFor(doc, source)
+  assert.equal(findings.length, 1, findings.join('\n'))
+  assert.match(findings[0], /hard break span starts after its backslash/)
+})
+
+test('a CRLF hard break covering its backslash is accepted', () => {
+  const source = 'a\\\r\nb\r\n'
+  const doc = {
+    type: 'document',
+    children: [{ type: 'hard_break', pos: pos(1, 4) }],
+  }
+  assert.deepEqual(findingsFor(doc, source), [])
+})
+
 test('a hard break covering the backslash and the newline is accepted', () => {
   const source = 'a\\\nb\n'
   const doc = {
@@ -113,6 +138,34 @@ test('a synthesized break over a bare newline is accepted', () => {
   const doc = {
     type: 'document',
     children: [{ type: 'hard_break', pos: pos(1, 2) }],
+  }
+  assert.deepEqual(findingsFor(doc, source), [])
+})
+
+test('a text node holding a LITERAL backslash is still compared', () => {
+  // The skip's stated reason is that resolving an escape leaves the slice
+  // LONGER than the value it produced. A backslash the parser left literal -
+  // one before a character Carve does not escape - resolves to nothing and
+  // keeps the two the same length, so the reason does not reach it and the
+  // comparison runs (carve#1566). Two corpus text nodes are in this shape.
+  const source = 'a\\q b\n'
+  const doc = {
+    type: 'document',
+    children: [{ type: 'text', value: 'WRONG', pos: pos(0, 5) }],
+  }
+  const findings = findingsFor(doc, source)
+  assert.equal(findings.length, 1, findings.join('\n'))
+  assert.match(findings[0], /does not cover the text it belongs to/)
+})
+
+test('a text node whose backslash IS an escape is left alone', () => {
+  // The reason the skip exists, and it survives the narrowing: the escape is
+  // resolved into the value, so the source is longer than the text it produced
+  // and the two can never be equal.
+  const source = 'say\\ hello\n'
+  const doc = {
+    type: 'document',
+    children: [{ type: 'text', value: 'say hello', pos: pos(0, 10) }],
   }
   assert.deepEqual(findingsFor(doc, source), [])
 })
@@ -370,6 +423,167 @@ test('every definition kind the schema hoists is exempt from the overlap rule', 
 })
 
 /*
+ * A BREAK IS EXEMPT FROM THE OVERLAP RULE AGAINST ANOTHER BREAK, AND NOTHING
+ * ELSE (carve#1566).
+ *
+ * The exemption was a set of TYPES consulted against one node at a time, while
+ * its stated reason was already about the PAIR - "two breaks meeting at one
+ * newline". So a break overlapping a non-break sibling, the shape the rule
+ * exists to catch, was invisible; and because an exempt node was dropped from
+ * the comparison entirely, it was invisible in both directions.
+ */
+
+test('a break overlapping a comment is reported', () => {
+  // markup-carve/carve-rs#1246, the shape it published for
+  //
+  //     ::: |
+  //     *a
+  //     %% secret
+  //     c*
+  //     :::
+  //
+  // The `%% secret` line is 9..18 and the break that ends it is 18..19.
+  // carve-rs gave the break 9..19, so the two siblings held the same nine
+  // codepoints - and every checker in the file passed both readings.
+  const source = '::: |\n*a\n%% secret\nc*\n:::\n'
+  const doc = {
+    type: 'document',
+    children: [
+      {
+        type: 'strong',
+        pos: span(6, 21),
+        children: [
+          { type: 'text', value: 'a', pos: span(7, 8) },
+          { type: 'hard_break', pos: span(8, 9) },
+          { type: 'comment', pos: span(9, 18) },
+          { type: 'hard_break', pos: span(9, 19) },
+          { type: 'text', value: 'c', pos: span(19, 20) },
+        ],
+      },
+    ],
+  }
+  const findings = []
+  checkPositions(doc, source, findings)
+  const overlap = findings.filter((f) => f.includes('sibling spans overlap'))
+  assert.equal(overlap.length, 1, `expected one overlap finding, got: ${JSON.stringify(findings)}`)
+  assert.match(overlap[0], /"hard_break" starts at 9, inside "comment" which ends at 18/)
+})
+
+test('the same document with the break where it belongs is clean', () => {
+  // markup-carve/carve-rs#1265 fixed it to 18..19. The rule has to clear on the
+  // fix as well as fire on the defect, or it is a rule against the construct
+  // rather than against the span.
+  const source = '::: |\n*a\n%% secret\nc*\n:::\n'
+  const doc = {
+    type: 'document',
+    children: [
+      {
+        type: 'strong',
+        pos: span(6, 21),
+        children: [
+          { type: 'text', value: 'a', pos: span(7, 8) },
+          { type: 'hard_break', pos: span(8, 9) },
+          { type: 'comment', pos: span(9, 18) },
+          { type: 'hard_break', pos: span(18, 19) },
+          { type: 'text', value: 'c', pos: span(19, 20) },
+        ],
+      },
+    ],
+  }
+  const findings = []
+  checkPositions(doc, source, findings)
+  assert.deepEqual(findings.filter((f) => f.includes('sibling spans overlap')), [])
+})
+
+for (const [a, b] of [
+  ['soft_break', 'soft_break'],
+  ['hard_break', 'hard_break'],
+  ['soft_break', 'hard_break'],
+]) {
+  test(`a ${a} and a ${b} may meet at one newline`, () => {
+    // The reason the exemption exists, and it survives the narrowing: a break
+    // is anchored at a line terminator, so two of them sharing that boundary
+    // are both right.
+    const doc = {
+      type: 'document',
+      children: [{ type: a, pos: span(1, 2) }, { type: b, pos: span(1, 2) }],
+    }
+    const findings = []
+    checkPositions(doc, 'a\nb\n', findings)
+    assert.deepEqual(findings.filter((f) => f.includes('sibling spans overlap')), [])
+  })
+}
+
+test('a break between two overlapping siblings does not hide them', () => {
+  // WHY EVERY PAIR IS COMPARED. Once the exemption is a property of the pair,
+  // an exempt node stays in the comparison - and a chain that only compares
+  // neighbours then never compares the two siblings on either side of it. Each
+  // of these is compared against the break, the break is exempt against
+  // neither, and the overlap between them is the finding.
+  const doc = {
+    type: 'document',
+    children: [
+      { type: 'text', value: 'x', pos: span(0, 10) },
+      { type: 'hard_break', pos: span(10, 11) },
+      { type: 'comment', pos: span(5, 8) },
+    ],
+  }
+  const findings = []
+  checkPositions(doc, 'x'.repeat(20), findings)
+  const overlap = findings.filter((f) => f.includes('sibling spans overlap'))
+  assert.equal(overlap.length, 1, `expected one overlap finding, got: ${JSON.stringify(findings)}`)
+  assert.match(overlap[0], /"comment" starts at 5, inside "text" which ends at 10/)
+})
+
+test('siblings the tree lists out of source order are not an overlap', () => {
+  // Comparing every pair reaches siblings whose array order is not their source
+  // order, which hoisting routinely produces. `second starts before first ends`
+  // is not an overlap on its own once that is possible, so both ends are
+  // tested: these two are disjoint and the rule has to say so.
+  const doc = {
+    type: 'document',
+    children: [
+      { type: 'paragraph', pos: span(15, 29), children: [] },
+      { type: 'block_quote', pos: span(0, 13), children: [] },
+    ],
+  }
+  const findings = []
+  checkPositions(doc, 'x'.repeat(30), findings)
+  assert.deepEqual(findings.filter((f) => f.includes('sibling spans overlap')), [])
+})
+
+test('no corpus document has a sibling overlap, in either engine shape', () => {
+  // The synthetic cases above prove the narrowed rule fires; this proves it
+  // does not fire on a real document. Measured over 1363 documents when the
+  // narrowing landed: nought, which is what makes this a ratchet rather than a
+  // number to update.
+  const dir = resolve(repo, 'tests/corpus')
+  const cases = readdirSync(dir).filter((name) => name.endsWith('.crv'))
+  let compared = 0
+  for (const name of cases) {
+    const raw = readFileSync(resolve(dir, name), 'utf8')
+    const findings = []
+    // The PART 12 wire shape, for the reason the STOPS AT ITS CHILDREN pass
+    // below reads it: §4 is normative about the interchange document, and a
+    // parse tree spells some children without a `type` at all - which would
+    // drop them out of the sibling comparison entirely.
+    const doc = toAstJson(parse(raw))
+    checkPositions(doc, replaceNulls(raw), findings)
+    for (const [node] of walkNodes(doc)) {
+      for (const [key, value] of Object.entries(node)) {
+        if (key !== 'pos' && Array.isArray(value)) compared += value.length
+      }
+    }
+    assert.deepEqual(
+      findings.filter((f) => f.includes('sibling spans overlap')),
+      [],
+      `${name}: a sibling overlap is a defect in the engine, not a number to declare`,
+    )
+  }
+  assert.ok(compared > 2000, `only ${compared} sibling(s) reached the overlap rule`)
+})
+
+/*
  * A SPAN BEGINS AT THE CONSTRUCT'S OPENING MARKUP (PART 12 section 4,
  * carve#913).
  *
@@ -494,6 +708,58 @@ test('THE OPT-IN TRAP: a tree with no positions examines nothing, and says so', 
   assert.deepEqual(findings, [])
 })
 
+test('a span opening on a space in MID-LINE has not begun at its markup', () => {
+  // THE INDENT SKIP IS THE LINE'S OWN INDENTATION (carve#1566). It walked past
+  // any space or tab the span happened to open on, wherever that was, so a span
+  // starting one character early on a mid-line space matched the markup after
+  // it and read as a pass - in a rule whose whole subject is whether a span
+  // begins at the markup.
+  const source = 'see `x` here\n'
+  const doc = {
+    type: 'document',
+    children: [{ type: 'code', pos: pos(3, 7) }],
+  }
+  const findings = findingsFor(doc, source)
+  assert.equal(findings.length, 1, findings.join('\n'))
+  assert.match(findings[0], /does not begin at the markup that opens "code"/)
+})
+
+test('a nested list starting part way into the indent run is accepted', () => {
+  // The reason the skip exists, and it survives the narrowing. Corpus 245:
+  //
+  //     - a
+  //         - b
+  //
+  // the inner list's span starts at offset 6, inside the four-space indent, at
+  // its parent item's content column rather than at the line start. Everything
+  // between the line start and there is whitespace, so it is indentation and
+  // the marker is what follows it.
+  const source = '- a\n    - b\n'
+  const doc = {
+    type: 'document',
+    children: [
+      {
+        type: 'list',
+        pos: pos(6, 11),
+        children: [
+          {
+            type: 'list_item',
+            pos: pos(6, 11),
+            children: [
+              {
+                type: 'paragraph',
+                pos: pos(10, 11),
+                children: [{ type: 'text', value: 'b', pos: pos(10, 11) }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+  assert.deepEqual(findingsFor(doc, source), [])
+})
+
 test('no corpus document begins a span away from its opening markup', () => {
   // The synthetic documents above prove the rule fires; this proves it does not
   // fire on a real one, over every type the table names. The EXAMINED count is
@@ -517,6 +783,30 @@ test('no corpus document begins a span away from its opening markup', () => {
     assert.deepEqual(findings, [], `${name}\n${findings.join('\n')}`)
   }
   assert.ok(examined > 1000, `only ${examined} span(s) reached the opening-markup rule`)
+})
+
+test('CONTAINMENT does not count a pair it could not compare', () => {
+  // The count is what makes a vacuous pass distinguishable from a clean one, so
+  // a pair whose offsets are not integers must not inflate it: `undefined < 3`
+  // and `undefined > 7` are both false, which made such a pair silently clean
+  // AND silently counted (carve#1566). Latent on today's corpus - no engine
+  // publishes a non-integer offset - and the count is the only thing standing
+  // between this rule and the carve#755 shape, so it is checked here rather
+  // than left to the day one does.
+  const doc = {
+    type: 'document',
+    pos: pos(0, 10),
+    children: [
+      { type: 'paragraph', pos: { startLine: 1, endLine: 1, startColumn: 1, endColumn: 1 }, children: [] },
+    ],
+  }
+  assert.equal(checkContainment(doc, []), 0)
+  const placed = {
+    type: 'document',
+    pos: pos(0, 10),
+    children: [{ type: 'paragraph', pos: pos(0, 5), children: [] }],
+  }
+  assert.equal(checkContainment(placed, []), 1)
 })
 
 test('CONTAINMENT, in a pass of its own, over every corpus document', () => {


### PR DESCRIPTION
Closes #1566.

`checkSiblingOverlap` consulted a set of TYPES against one node at a time:

````js
const EXEMPT_FROM_OVERLAP = new Set([...HOISTED_DEFINITION_TYPES, 'hard_break', 'soft_break'])
````

The break half of that had a stated reason that was already about the PAIR:

> BREAKS. A break is anchored at a line terminator, so two breaks meeting at one
> newline share that boundary without either being wrong.

A per-node set cannot say that. It exempted a break against every sibling of any
kind, so a break overlapping a NON-break sibling was invisible - and invisible in
both directions, because an exempt node was dropped from the comparison entirely
rather than merely excused from one pair.

## The proof

markup-carve/carve-rs#1246 is the witness, fixed by markup-carve/carve-rs#1265.

Input:

````
::: |
*a
%% secret
c*
:::
````

The `%% secret` line is 9..18 and the break ending it is 18..19. carve-rs gave
the break 9..19, so two siblings held the same nine codepoints. Both readings
were built from carve-php's tree for this document and run through the checker,
verbatim:

Before, the rule as it stands on `main`:

````
broken  clean
fixed   clean
````

After, with the exemption narrowed to a pair test:

````
broken
        sibling spans overlap at $.children[0].children[0].children[0].children[3]: "hard_break" starts at 9, inside "comment" which ends at 18
fixed   clean
````

`checkContainment` was never going to see it: the break sits inside the `strong`
that contains it, so the parent bound holds.

## Why every pair is now compared

Once an exemption is a property of the pair, an exempt node has to STAY in the
comparison - and a chain that only compares neighbours then loses the pair on
either side of it. Measured on the shape directly:

````
consecutive  clean (the overlap is NOT reported)
all pairs    sibling spans overlap at $.children[2]: "comment" starts at 5, inside "text" which ends at 10
````

That in turn needs a two-ended overlap test. Comparing every pair reaches
siblings the tree lists out of source order, which hoisting routinely produces,
and the one-ended test called those a false overlap.

## The rest of the file, per assertion

Swept every other skip list and early return the same way. Four were broader than
their stated reason and are narrowed, each with a test:

- **the hard-break backslash rule** tested for a bare `\n` with the backslash
  directly before it. On a CRLF document that is true of neither anchoring, so a
  break that dropped its backslash was invisible to the rule written for exactly
  that defect. The terminator rule one screen up has known about `\r` all along.
- **the opening-markup indent skip** walked past any space or tab the span opened
  on, wherever it was, so a span starting one character early on a mid-line space
  matched the markup after it and read as a pass. It is now the line's own
  leading indentation, which keeps the 3 corpus documents where a nested list
  legitimately starts part way into the indent run.
- **the text slice comparison** was disabled by any backslash in the slice,
  though its stated reason is that resolving an escape leaves the slice LONGER.
  A backslash the parser left literal keeps the two the same length, so the
  reason does not reach it. 2 corpus text nodes are in that shape.
- **containment** counted a pair whose offsets are not integers. `undefined < 3`
  and `undefined > 7` are both false, so such a pair was silently clean AND
  silently counted, inflating the one number that exists to prove the pass was
  not vacuous. Latent today (no engine publishes one), pinned by a test.

Measured as correct and left alone: `walkNodes`' `pos` skip (a `pos` holds no
typed node, so the skip is an optimisation and not an exemption); containment's
nearest-PLACED-ancestor rule; `checkStopsAtChildren`'s position guard, child
collection, unplaced-last-child branch and last-child bound; the `OPENING_MARKUP`
and `EMPTY_CONTAINER_MARKUP` allowlists, whose absences each carry a stated
reason (no corpus document has an empty container of a type the second one does
not name, so its silence is latent rather than wrong); `checkOpeningMarkup`'s
out-of-range guard, whose every skipped span is reported by another rule; the
missing-pos rule and its document exemption; and `BREAK_TYPES` on the
line-terminator rule, which is genuinely a property of the node rather than of a
pair.

One allowlist did NOT hold up. `ENDS_AT_LAST_CHILD` says "each is absent for a
stated reason rather than an oversight", and `footnote` (81 of 219 nodes reach
past their last child), `definition_term` (6 of 129) and `heading` (3 of 408) are
absent with no reason stated. Adding a type there is a ruling about that
construct's extent, which this repo has made one construct at a time, so it is
filed as #1574 rather than swept in here.

**Hoisted definitions stay exempt against any sibling**, and that breadth was
measured rather than assumed. Narrowing it to containment reports 13 corpus
documents on carve-php and the same 13 on carve-rs: carve#1522 ends a container
emptied by hoisting at its own markup, so the definition hoisted out of it
reaches past its host and the two genuinely overlap with neither engine wrong.
Three rulings collide there. Filed as #1571 rather than settled by tightening a
checker.

## Blast radius

1363 corpus documents, each parsed by all three engines (carve-js pinned,
carve-php `eb5b52b`, carve-rs `2fb8767`), every finding class counted:

| engine | before | after |
| --- | --- | --- |
| carve-js | 85 over-reach, 59 missing pos, 20 empty-container, 0 overlap | unchanged |
| carve-php | 57 missing pos, 0 overlap | unchanged |
| carve-rs | 57 missing pos, 0 overlap | unchanged |

`checkContainment` compared 7363 / 7368 / 7368 pairs before and after. Nothing
new is reported, so no ledger declaration and no waiver was added.

Six of the added tests fail against the rule as it stood and pass against it now,
which is what says the narrowings changed behavior rather than reading as
coverage.