### PR TITLE
ci: the bump matrix reaches the Pygments lexer

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -108,6 +108,15 @@ jobs:
             lang: node
             test: npm ci && npm run build && npm test
             allowlist: none - its regression tests consume the pinned engine and spec fixtures
+          # The Pygments lexer. It does not render either, so its conformance
+          # is that no corpus document drives the lexer into an Error token,
+          # over every document rather than a sampled few, plus a construct
+          # sweep against the shared inventory. Same draft signal as the rest.
+          - repo: markup-carve/pygments-carve
+            submodule: spec
+            lang: python
+            test: pip install -e '.[test]' && pytest -q
+            allowlist: the `NOT_COVERED` map in `tests/test_constructs.py` (the corpus check has none by design - every document must lex without Error tokens)
           # NOT here: markup-carve/intellij-carve, which also carries the spec
           # submodule. Its corpus snapshots run through Gradle with an IDE SDK
           # download, which does not fit this workflow's node/rust/php shape.
@@ -130,6 +139,11 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
+      - name: Set up Python
+        if: matrix.lang == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       # Some downstream suites need a host executable in addition to their
       # language runtime. Keep that setup beside the matrix entry so a missing
@@ -577,6 +591,8 @@ jobs:
             submodule: spec
           - repo: markup-carve/carve-lsp
             submodule: tests/spec
+          - repo: markup-carve/pygments-carve
+            submodule: spec
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
`pygments-carve` carries the spec submodule at path `spec` and was not in the bump matrix, so its pin sat 48 commits behind spec `main`. The `matrix-coverage` job has been reporting that correctly and failing on `main` since `131e8915`.

## Matrix, not `EXCEPT`

The repo genuinely tracks the corpus. `tests/test_corpus.py` globs `spec/tests/corpus/*.crv` and asserts that no document drives the lexer into a `Token.Error`, plus a `test_corpus_is_substantial` guard so an absent submodule cannot read as a pass. That is the same covered-or-explain shape the grammar satellites carry, so it belongs in the matrix. An `EXCEPT` entry would have to claim the surface does not track the corpus, and that claim would be false.

Python is a fourth toolchain, so a `setup-python` step joins node, rust and php, keyed off `matrix.lang` the same way. The scheduled `close-superseded-drafts` matrix gains the same entry, which `tests/close-superseded-bump.test.mjs` requires.

## The guard still fails without the entry

Removing just the new matrix lines and running the `matrix-coverage` step's script verbatim against the org:

````
GUARD_WITHOUT_ENTRY_EXIT=1
--- stdout ---
- `markup-carve/pygments-carve` carries the spec submodule and nothing bumps it
--- step summary ---
## Bump matrix is out of date

- `markup-carve/pygments-carve` carries the spec submodule and nothing bumps it
````

With the entry restored, the same script exits 0 and prints `Bump matrix covers every repo carrying the spec submodule.` The workflow file was restored from a copy and confirmed byte-identical with `diff`.

Closes #1588
