### PR TITLE
docs: point the README at the ecosystem page and Awesome Carve

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ tested against, and the design rationale behind each decision.
 | **Tooling** | Language server, tree-sitter grammar, formatter and linter (`carve fmt` / `carve lint`), converters from Markdown, HTML, Djot, and BBCode. |
 | **Editors** | VS Code, JetBrains, Sublime Text, Vim/Neovim, Emacs, Zed, Helix. |
 | **Integrations** | Laravel, Symfony, WordPress, Shopware, Hugo, Astro, Eleventy, Jekyll, Docusaurus, webpack/Next.js, Obsidian, and a Pandoc bridge to LaTeX, Typst, DOCX, and PDF. |
+| **Ecosystem** | The [Ecosystem page](https://markup-carve.github.io/carve/ecosystem) groups every project by role with conformance status; [Awesome Carve](https://github.com/markup-carve/awesome-carve) is the curated list. |
 
 Pre-1.0, a minor release may still change the grammar; the stability tiers and
 the release lockstep between the spec and the engines are defined in
-[VERSIONING.md](VERSIONING.md) and [MAINTAINING.md](MAINTAINING.md). The full
-project list is at <https://github.com/markup-carve#projects>.
+[VERSIONING.md](VERSIONING.md) and [MAINTAINING.md](MAINTAINING.md). Every
+project maintained here is listed at <https://github.com/markup-carve#projects>;
+[Awesome Carve](https://github.com/markup-carve/awesome-carve) curates the same
+ground for readers and is where third-party tools built outside the organization
+are submitted.
 
 **File extension:** `.crv`
 


### PR DESCRIPTION
The README named the org project list and nothing else, so a reader arriving at
this repo had no way to tell the three ecosystem surfaces apart:

| Surface | Scope |
|---|---|
| `github.com/markup-carve#projects` | every repository maintained here, exhaustive |
| [Ecosystem page](https://markup-carve.github.io/carve/ecosystem) | grouped by role, with conformance status |
| [Awesome Carve](https://github.com/markup-carve/awesome-carve) | curated, and the only one that takes third-party entries |

The docs site has carried the Awesome Carve link since `docs/ecosystem.md` was
written, but that page is a click away from the site and zero links away from
this repo.

Two changes:

- an **Ecosystem** row in the Status table, for discovery where readers already
  scan;
- the paragraph under the table now says what each surface is for, including
  that third-party tools built outside the organization are submitted to Awesome
  Carve. That fact was previously written down nowhere.

Docs-only, no normative text and no corpus touched.
