### PR TITLE
chore: release tracking points at the maintained process, and the Pygments matrix rows are pinned

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -106,5 +106,11 @@ snapshot is maintained on the wiki:
 
 ## Release tracking
 
-Active release coordination happens in issue
-[carve#65](https://github.com/markup-carve/carve/issues/65).
+The maintained release process lives in [`MAINTAINING.md`](MAINTAINING.md):
+the lockstep between the spec and the engines, what a pin bump has to sweep,
+the order for a cross-cutting behavior change, and the coordination rules that
+keep parallel automation from stacking duplicate or reverting PRs.
+
+This section used to point at issue `carve#65`, "Prepare first (0.1) release".
+That issue was a one-off for the 0.1 cut and closed with it, so it is not where
+release coordination lives.

--- a/tests/bump-downstream-early-exit.test.mjs
+++ b/tests/bump-downstream-early-exit.test.mjs
@@ -452,6 +452,23 @@ test('pandoc-carve installs its required host executable before conformance', ()
   )
 })
 
+/**
+ * Slice one job out of the workflow by its top-level key.
+ *
+ * The two matrices this file asserts on live in different jobs, and a repo's
+ * stale-draft row (a `- repo:` line plus `submodule:`, nothing else) is a
+ * strict PREFIX of its bump row. So a regex run over the whole file finds the
+ * bump row twice and the stale-draft row never - the match silently lands in
+ * the wrong matrix. Cutting the job out first is what tells the two rows apart.
+ */
+function jobSection(text, name) {
+  const keys = [...text.matchAll(/^ {2}([a-z][\w-]*):$/gm)]
+  const at = keys.findIndex((m) => m[1] === name)
+  assert.notEqual(at, -1, 'the workflow no longer has a job named ' + name)
+  const end = at + 1 < keys.length ? keys[at + 1].index : text.length
+  return text.slice(keys[at].index, end)
+}
+
 test('carve-lsp is covered by the downstream bump matrix', () => {
   const text = readFileSync(workflow, 'utf8')
   const row = text.match(
@@ -460,4 +477,30 @@ test('carve-lsp is covered by the downstream bump matrix', () => {
   assert.ok(row, 'carve-lsp is absent from the bump matrix')
   assert.match(row.groups.body, /submodule: tests\/spec/)
   assert.match(row.groups.body, /test: npm ci && npm run build && npm test/)
+})
+
+test('the Pygments lexer is covered by both downstream matrices', () => {
+  const text = readFileSync(workflow, 'utf8')
+
+  const bump = jobSection(text, 'bump')
+  assert.match(bump, /- name: Bump /, 'the bump job slice is not the bump job')
+  const bumpRow = bump.match(
+    /- repo: markup-carve\/pygments-carve\n(?<body>[\s\S]*?)(?=\n\s+(?:- repo:|# NOT here:))/,
+  )
+  assert.ok(bumpRow, 'pygments-carve is absent from the bump matrix')
+  assert.match(bumpRow.groups.body, /submodule: spec/)
+  assert.match(bumpRow.groups.body, /lang: python/)
+  assert.match(bumpRow.groups.body, /test: pip install -e '\.\[test\]' && pytest -q/)
+
+  const stale = jobSection(text, 'close-superseded-drafts')
+  assert.match(
+    stale,
+    /close-superseded-bump\.sh/,
+    'the close-superseded-drafts job slice is not the stale-draft job',
+  )
+  const staleRow = stale.match(
+    /- repo: markup-carve\/pygments-carve\n(?<body>[\s\S]*?)(?=\n\s+(?:- repo:|steps:))/,
+  )
+  assert.ok(staleRow, 'pygments-carve is absent from the stale-draft matrix')
+  assert.match(staleRow.groups.body, /submodule: spec/)
 })


### PR DESCRIPTION
Two small maintenance changes.

## 1. `VERSIONING.md` pointed at a closed issue

The "Release tracking" section said active release coordination happens in
issue `carve#65`. That issue is closed (2026-08-03), titled "Prepare first
(0.1) release" - a one-off for the 0.1 cut, finished. So the document sent
anyone asking where release coordination lives to a closed issue about a
release that already shipped.

It now points at `MAINTAINING.md`, which is where the process is actually
maintained and kept current: "The lockstep", "What a pin bump has to sweep",
"Order for a cross-cutting behavior change", and "Coordination rules (avoid
duplicate / reverting PRs)". No new checklist was invented - the section just
names the four things that document already carries, and says plainly that
`carve#65` was a one-off so a reader who remembers the old pointer knows why it
moved.

## 2. Nothing kept pygments-carve in the bump matrices

markup-carve/carve#1590 added `markup-carve/pygments-carve` to both the bump
matrix and the stale-draft matrix in `.github/workflows/bump-downstream.yml`.
There was no test keeping it there, so a later edit could drop either row and
nothing would notice.

`tests/bump-downstream-early-exit.test.mjs` now asserts both rows, following
the same read-the-workflow-and-match-the-row pattern its neighboring
`pandoc-carve` and `carve-lsp` tests already use.

### The prefix trap

Reading the two rows apart takes care. A repo's stale-draft row is a
`- repo:` line plus `submodule:` and nothing else:

````yaml
          - repo: markup-carve/pygments-carve
            submodule: spec
````

which is a strict PREFIX of its five-line bump row:

````yaml
          - repo: markup-carve/pygments-carve
            submodule: spec
            lang: python
            test: pip install -e '.[test]' && pytest -q
            allowlist: ...
````

So a regex run over the whole file finds the bump row twice and the stale-draft
row never, and a naive replace or a count assertion silently addresses the
wrong matrix. The test slices each job out by its top-level key first, then
matches inside that slice - and asserts each slice really is the job it wanted
(the bump slice must contain a `Bump ` step, the stale-draft slice must contain
`close-superseded-bump.sh`) before trusting the row match.

### Both halves proven to fail independently

The workflow was copied aside, one matrix entry removed at a time, the test
run, and the workflow restored from the copy (`diff` clean).

Bump matrix entry removed:

````
not ok 9 - the Pygments lexer is covered by both downstream matrices
  ---
  duration_ms: 0.862227
  type: 'test'
  failureType: 'testCodeFailure'
  error: 'pygments-carve is absent from the bump matrix'
  code: 'ERR_ASSERTION'
  ...
# pass 8
# fail 1
````

Stale-draft matrix entry removed:

````
not ok 9 - the Pygments lexer is covered by both downstream matrices
  ---
  duration_ms: 0.896192
  type: 'test'
  failureType: 'testCodeFailure'
  error: 'pygments-carve is absent from the stale-draft matrix'
  code: 'ERR_ASSERTION'
  ...
# pass 8
# fail 1
````

Distinct messages, so a future failure says which matrix lost the row.

### Why this is worth a test rather than leaning on the coverage job

The guard that caught the original gap, the `matrix-coverage` job, runs only on
push and workflow dispatch, and every such run is currently failing with a 401
from `BUMP_TOKEN` (markup-carve/carve#1591). Until that token is rotated the
coverage check protects nothing, so this test is the only thing that would
notice a regression - and unlike `matrix-coverage`, it runs on pull requests.

## Not included

No CHANGELOG entry: this is docs and CI only, nothing under the shipped source
changed.
