### PR TITLE
chore: the corpus formatter sweep compares HTML byte for byte

### DIFF
--- a/tests/corpus-fmt-roundtrip.test.mjs
+++ b/tests/corpus-fmt-roundtrip.test.mjs
@@ -82,11 +82,28 @@ test('the corpus is non-empty, so a broken glob cannot pass as a clean run', () 
   assert.ok(documents.length > 100, `found ${documents.length} corpus documents`)
 })
 
+// BYTE FOR BYTE, which is what the three engines running this same property
+// do: carve-js `test/render-carve.test.ts`, carve-php
+// `tests/TestCase/CarveFmtCorpusTest.php` and carve-rs `tests/render_carve.rs`
+// all compare the two renders untrimmed. This sweep used to trim both sides,
+// which made the reference gate the loosest of the four - the wrong way round
+// for the one a spec PR runs before the engines see the change.
+//
+// What a trim cannot see is a writer that adds or drops whitespace at a
+// DOCUMENT boundary, and the corpus already holds the document that exposes
+// it: `372-an-all-blank-raw-payload-still-emits-its-line` renders HTML that
+// STARTS with two newlines, so a writer that ate the blank payload line - the
+// exact rule that document exists to pin - changed what the document says and
+// this sweep passed.
+//
+// The predicate is spelled a second time in the staleness ratchet below, and
+// the two have to stay identical: strict here and trimmed there means a
+// document excused here is reported there as an excuse that no longer applies.
 test('formatting never changes what a corpus document says', () => {
   const changed = []
   for (const { slug, source } of documents) {
     const formatted = carveToCarve(source)
-    if (carveToHtml(formatted).trim() !== carveToHtml(source).trim()) changed.push(slug)
+    if (carveToHtml(formatted) !== carveToHtml(source)) changed.push(slug)
   }
   const undeclared = changed.filter((slug) => !declaredDrift.has(slug))
   assert.deepEqual(
@@ -136,7 +153,8 @@ test('every writer-drift line still names a document the pin writes wrongly', ()
       continue
     }
     const once = carveToCarve(source)
-    const changesMeaning = carveToHtml(once).trim() !== carveToHtml(source).trim()
+    // Untrimmed, and the same predicate as the sweep above by construction.
+    const changesMeaning = carveToHtml(once) !== carveToHtml(source)
     const unsettled = carveToCarve(once) !== once
     // "CANNOT READ IT BACK THE SAME WAY" HAS TWO READERS, and the pin is only
     // one of them. corpus-fmt-cross-read.test.mjs consults this same file to
@@ -229,7 +247,9 @@ test('every drifting .fmt fixture still says what its case input says', () => {
   const wrong = []
   for (const { slug, source, expected } of pinned) {
     if (!declaredDrift.has(slug)) continue
-    if (renderDoc(parseSpec(expected)).trim() !== renderDoc(parseSpec(source)).trim()) wrong.push(slug)
+    // Untrimmed too: a fixture that drops a boundary blank line is exactly the
+    // unfaithful serialization this check exists to catch.
+    if (renderDoc(parseSpec(expected)) !== renderDoc(parseSpec(source))) wrong.push(slug)
   }
   assert.deepEqual(
     wrong,


### PR DESCRIPTION
Closes #1603.

Three call sites in `tests/corpus-fmt-roundtrip.test.mjs` trimmed both sides of an HTML comparison. All three engines running the same PART 11 §1 property compare untrimmed (`test/render-carve.test.ts`, `tests/TestCase/CarveFmtCorpusTest.php`, `tests/render_carve.rs`), so the sweep a spec PR runs before any engine sees the change was the loosest of the four.

### The trim was latent, so here is what it could not see

The corpus already holds the document that exposes it, and it is the only one:

```
$ node _probe.mjs   # carveToHtml(source) !== carveToHtml(source).trim(), over tests/corpus
documents whose HTML is not already trimmed: 1
  372-an-all-blank-raw-payload-still-emits-its-line  head="\n\n<p>after</p>" tail="\n\n<p>after</p>"
```

So the mutation is a writer that eats the blank line inside an all-blank raw payload - the exact rule that document exists to pin. Applied to the pinned `carveToCarve` at the package seam:

```js
return __carveToCarveOriginal(source, opts).replace('```=html\n\n```', '```=html\n```');
```

**With the trims, as on main.** The writer now changes what a corpus document says, and the sweep does not notice:

```
$ node --test tests/corpus-fmt-roundtrip.test.mjs
# tests 7
# pass 7
# fail 0
```

**With the trims removed.** Same mutated writer, same corpus:

```
not ok 2 - formatting never changes what a corpus document says
  ---
  error: |-
    these documents render differently after formatting, and resources/engine-pin-drift.txt does not excuse it - the writer changed the document, not just its spelling:
      372-an-all-blank-raw-payload-still-emits-its-line
    + actual - expected

    + [
    +   '372-an-all-blank-raw-payload-still-emits-its-line'
    + ]
    - []
  code: 'ERR_ASSERTION'
```

The writer mutation was then reverted and the restore confirmed with `diff -q` against the copy taken beforehand.

### Why the ratchet's copy of the predicate had to move with it

The staleness check spells the same comparison a second time, and there it decides the opposite way: untrimmed makes `changesMeaning` true, which is what KEEPS a drift declaration legitimate. Measured on the same document under the same mutation:

```
changesMeaning TRIMMED  : false
changesMeaning UNTRIMMED: true
unsettled               : false
oracleChanges           : false
fmtBytesDiffer          : false
```

`oracleChanges` is false because the oracle renders both spellings the same, so with the sweep strict and the ratchet still trimmed the two contradict each other. Declaring the slug in `resources/engine-fmt-drift.txt` and running that mixed state:

```
not ok 4 - every writer-drift line still names a document the pin writes wrongly
  ---
  error: |-
    resources/engine-fmt-drift.txt declares drift that no longer happens - delete the line in the commit that moves the pin past it:
      372-an-all-blank-raw-payload-still-emits-its-line (round-trips clean)
```

With both untrimmed and the same declaration in place: 7 tests, 7 pass. That is why this is three call sites and not one.

### The third site

`every drifting .fmt fixture still says what its case input says` compares oracle renders, and a fixture that drops a boundary blank line is exactly the unfaithful serialization it exists to catch. Declaring the same slug and giving it a `.fmt` holding only `after` - a fixture that dropped the raw block:

```
# trimmed, as on main
# tests 7
# pass 7
# fail 0

# untrimmed
not ok 7 - every drifting .fmt fixture still says what its case input says
  ---
  error: |-
    these .fmt fixtures are not faithful serializations of their case input:
      372-an-all-blank-raw-payload-still-emits-its-line
```

The temporary fixture was moved out of the repo afterwards and the drift file restored from the copy taken beforehand; `git status` is clean apart from the three lines and their comments.

One note on the ticket's motivation: `resources/engine-fmt-drift.txt` currently carries zero data lines, not three, so the ratchet has nothing to evaluate today. It does not change the argument - the sweep is the part that runs over 1370 documents.

No `CHANGELOG.md` entry: a test-side comparison, nothing a consumer observes.
