### PR TITLE
fix: a figure's imported target is the captioned block, not a paragraph around it

### DIFF
--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -51,10 +51,11 @@ and whose source disagree is green twice over. That is how three shapes arrived
 here at once (markup-carve/carve#1601) - a table cell, an anchor and a text run,
 each of which leaves `htmlToCarve` meaning something the `htmlToAst` tree never
 said. Writing the check found two more in fixtures that had been read and
-reviewed: a `<figure>` whose target the tree wraps in a paragraph no source
-spells (markup-carve/carve#1606), and a one-item `<li><p>` list whose tree says
-loose where its own source says tight (markup-carve/carve#1607, which needs a
-call rather than a derivation).
+reviewed. One is settled: a `<figure>` whose target the tree wrapped in a
+paragraph no source spells (markup-carve/carve#1606), where the TREE was the
+wrong exit and the fixtures now record the target itself. The other is a
+one-item `<li><p>` list whose tree says loose where its own source says tight
+(markup-carve/carve#1607, which needs a call rather than a derivation).
 
 THE SOURCE IS THE ARTIFACT A MIGRATION KEEPS, which is what makes the invariant
 worth more than either exit alone. A reader who runs `carve migrate` keeps
@@ -221,6 +222,17 @@ caption line produces, so the import is a round trip rather than a rescue:
 ![a](i.png)
 ^ cap
 ```
+
+THE TARGET IS THE CAPTIONED BLOCK, NOT A PARAGRAPH AROUND IT, and on this shape
+the round trip is what says so. PART 9 §4b's hosts are "an image, a quote, a
+code block, a display-math paragraph": the image host is the image, and only
+the math host is a paragraph, which §4b spells out for that one. So the tree is
+`figure{target: image}` - the same node the source above parses to - and a
+synthesized paragraph wrapper is a different document, rendering
+`<figure><p><img></p>` where the input had no `<p>` at all. A `<figure>` whose
+body is genuinely prose is the other case and is untouched: a caption line does
+not attach to prose (§4's enumeration is closed), so that target stays a
+paragraph and the loss is on the writing side (markup-carve/carve#1606).
 
 The `cite` attribute rides the block-attribute line, which is the ordinary
 channel for an attribute on a block:

--- a/tests/html-import-contract.check.mjs
+++ b/tests/html-import-contract.check.mjs
@@ -93,6 +93,23 @@ const PIN_LAG = new Map([
       'node and spelled `[t]()`, which is literal text ' +
       '(markup-carve/carve-js#1371)',
   ],
+  // THE TREE, NOT THE SOURCE. Both fixtures' `expected.crv` is what the pin
+  // already writes; what lags is `htmlToAst`, which wraps the image in a
+  // paragraph the source does not spell and the render does not agree with
+  // (markup-carve/carve#1606). carve-rs writes the same source and returns
+  // `figure{target: image}` for the same input, so this is one engine's
+  // wrapper rather than an unruled shape.
+  [
+    'figure-caption',
+    'the tree wraps a captionable figure target in a synthesized paragraph, ' +
+      'so the same import renders <p><img></p> from the tree and <img> from ' +
+      'the source it writes (PART 9 §4b; markup-carve/carve-js#1381)',
+  ],
+  [
+    'caption-attributes',
+    'the same paragraph wrapper as figure-caption ' +
+      '(markup-carve/carve-js#1381)',
+  ],
 ])
 
 /*

--- a/tests/html-import/caption-attributes/expected.ast.json
+++ b/tests/html-import/caption-attributes/expected.ast.json
@@ -1,1 +1,1 @@
-{"type":"document","children":[{"type":"figure","target":{"type":"paragraph","children":[{"type":"image","src":"i.png","alt":"a"}]},"caption":[{"type":"text","value":"c"}]}]}
+{"type":"document","children":[{"type":"figure","target":{"type":"image","src":"i.png","alt":"a"},"caption":[{"type":"text","value":"c"}]}]}

--- a/tests/html-import/figure-caption/expected.ast.json
+++ b/tests/html-import/figure-caption/expected.ast.json
@@ -1,1 +1,1 @@
-{"type":"document","children":[{"type":"figure","target":{"type":"paragraph","children":[{"type":"image","src":"i.png","alt":"a"}]},"caption":[{"type":"text","value":"cap"}]}]}
+{"type":"document","children":[{"type":"figure","target":{"type":"image","src":"i.png","alt":"a"},"caption":[{"type":"text","value":"cap"}]}]}

--- a/tests/the-two-import-exits-agree.test.mjs
+++ b/tests/the-two-import-exits-agree.test.mjs
@@ -34,20 +34,17 @@ const root = new URL('./html-import/', import.meta.url)
  * fixture that disagrees and is not listed is red; a listed fixture that now
  * agrees is red too, so the line goes out with the commit that fixed it.
  *
- * Both entries were found by writing this check, and neither is
- * markup-carve/carve#1601's own subject.
+ * All three entries were found by writing this check, and none is
+ * markup-carve/carve#1601's own subject. Two are gone again: the `<figure>`
+ * pair was RULED rather than tolerated (markup-carve/carve#1606). The tree was
+ * the wrong exit - PART 9 §4b's hosts are "an image, a quote, a code block, a
+ * display-math paragraph", so the image host is the image and only the math
+ * host is a paragraph - and the fixtures now record `figure{target: image}`,
+ * which is what the source beside them always parsed to. The engine that wraps
+ * is declared as pin lag in the contract check, and the tree it returned is
+ * held as a literal below so retiring these entries does not retire the proof.
  */
 const UNMET = new Map([
-  [
-    'figure-caption',
-    'the tree wraps the figure target in a paragraph, which the source it ' +
-      'writes does not spell and which renders <p><img></p> rather than <img> ' +
-      '(markup-carve/carve#1606)',
-  ],
-  [
-    'caption-attributes',
-    'the same paragraph wrapper as figure-caption (markup-carve/carve#1606)',
-  ],
   [
     'derived-endnotes-section',
     'the tree says a one-item list is loose where its own source says tight, ' +
@@ -214,4 +211,39 @@ test('the invariant rejects the source both engines wrote for the three shapes',
         `tree, so this check would not have caught the shape it was written for`,
     )
   }
+})
+
+/*
+ * THE WRAPPER IS HELD AS A LITERAL TOO, and for the same reason - but on the
+ * other side of the invariant. The three shapes above were wrong in the SOURCE
+ * an importer wrote, so the literal to keep is a source string. The `<figure>`
+ * pair was wrong in the TREE (markup-carve/carve#1606): the source both engines
+ * write is `![a](i.png)` plus a caption line, which is right, and one of the
+ * two trees beside it wrapped the image in a paragraph. So the literal to keep
+ * is the tree, measured on carve-js `1568546` and declared as pin lag in
+ * tests/html-import-contract.check.mjs (markup-carve/carve-js#1381).
+ *
+ * Both directions are asserted. Rejecting the wrapper says the check can see
+ * the shape; accepting the ruled tree says it is not simply rejecting every
+ * tree put in front of it, which is the failure mode that would make the first
+ * assertion worthless.
+ */
+test('the invariant rejects the paragraph-wrapped figure tree, and accepts the ruled one', async () => {
+  const { parse } = await import('@markup-carve/carve')
+  const source = '![a](i.png)\n^ cap\n'
+  const image = { type: 'image', src: 'i.png', alt: 'a' }
+  const caption = [{ type: 'text', value: 'cap' }]
+  const figure = (target) => ({ type: 'document', children: [{ type: 'figure', target, caption }] })
+
+  assert.ok(
+    disagreement(normalize(parse(source)), normalize(figure({ type: 'paragraph', children: [image] }))),
+    'the paragraph-wrapped tree agrees with the source it was written beside, so this ' +
+      'check would not have caught the shape markup-carve/carve#1606 ruled',
+  )
+  assert.equal(
+    disagreement(normalize(parse(source)), normalize(figure(image))),
+    null,
+    'the ruled tree disagrees with its own source, so the check rejects everything ' +
+      'and the assertion above means nothing',
+  )
 })


### PR DESCRIPTION
Closes #1606.

Two shared fixtures recorded a tree whose `figure.target` was a paragraph wrapping the image, beside an `expected.crv` that parses to the image directly. The invariant added in #1609 declared both, and it fails in both directions, so the declarations go out in this commit.

### Which exit is wrong: the tree

The ticket asked to establish this before changing either side, and three readings agree.

PART 9 §4b enumerates what a caption makes of its host, and PART 12 §17 and `docs/ast-json.md` repeat the enumeration verbatim: "an image, a quote, a code block, a display-math paragraph". The image host is the image; only the math host is a paragraph, and §4b spells that one out ("a captioned standalone display-math block is a `figure` whose target is that paragraph"). The asymmetry is named, not an omission.

`resources/grammar.ebnf`, in the `caption_slot` note, closes the other reading directly:

> (Reading this note as "only a production attaches a caption" would make a captioned image a paragraph, which §4 denies and no engine does.)

And the render corpus pins it 19 times: every fixture whose HTML holds a `<figure>` and an `<img>` has the image as a direct child, with no `<p>`. The wrapped tree renders `<figure><p><img></p>`, which is not the input.

### Measured across the engines rather than assumed

The ticket expected the same shape in all three. It is not:

```
carve-js 1568546   htmlToAst -> figure{target: paragraph{image}}      the wrapper
carve-rs d948992   htmlToAst -> figure{target: image}                 already right
carve-php 5d8d9ab  no HTML-to-AST entry point at all                  not affected
```

carve-rs, verbatim:

```
AST: {"type":"document","children":[{"type":"figure","target":{"type":"image","src":"i.png","alt":"a"},"caption":[{"type":"text","value":"cap"}]}],"srcByteLength":0}
CRV: "![a](i.png)\n^ cap\n"
DIAG: HtmlImportReport { mode: Safe, adapter: Generic, diagnostics: [] }
```

Both engines write the same source; one of the two trees beside it disagrees with it. Filed with the expected bytes as markup-carve/carve-js#1381, and both fixtures are declared as `PIN_LAG` until the pin carries the fix.

### The fixture change is load-bearing in both directions

Before the two ledgers were touched, the fixture edit alone turns both of them red - the contract check because the pinned build no longer reproduces the fixture, the two-exits ledger because the fixtures now agree:

```
not ok 4 - the pinned build imports every fixture the way the fixture says
  error: |-
    tests/html-import/caption-attributes: expected.ast.json: Expected values to be strictly deep-equal:

not ok 1 - every fixture records two exits that say the same thing
  error: 'tests/html-import/caption-attributes is declared as not meeting the invariant ("the same paragraph wrapper as figure-caption (markup-carve/carve#1606)") but its two exits now agree. Delete the entry, in the commit that fixed it.'
```

### The proof does not leave with the declaration

`tests/the-two-import-exits-agree.test.mjs` already holds the three sources #1609 measured as literals, so that fixing an engine does not retire the proof. This shape was wrong in the TREE rather than in the source, so the literal kept is the tree, asserted in both directions - the wrapper is rejected, the ruled tree is accepted.

Both assertions were mutated to confirm they can fail. Pointing "rejects" at the ruled tree:

```
not ok 3 - the invariant rejects the paragraph-wrapped figure tree, and accepts the ruled one
  error: 'the paragraph-wrapped tree agrees with the source it was written beside, so this check would not have caught the shape markup-carve/carve#1606 ruled'
  code: 'ERR_ASSERTION'
```

Pointing "accepts" at the wrapper:

```
not ok 3 - the invariant rejects the paragraph-wrapped figure tree, and accepts the ruled one
  error: |-
    the ruled tree disagrees with its own source, so the check rejects everything and the assertion above means nothing
    + actual - expected

    + '.children[0].target.type: source says "image", tree says "paragraph"'
    - null
```

The file was restored from a copy taken beforehand and the restore confirmed with `diff -q`.

### Also in this change

`docs/html-import.md` now states the consequence where the figure round trip is described - the target is the captioned block, not a paragraph around it - and the paragraph-bodied `<figure>`, which a caption line cannot attach to, is named as the untouched case. The page's list of what writing the invariant found says this one is settled and the other (#1607) still needs a call.

The fixture edit is a one-line surgical replace in each file, so the byte style of the fixtures is unchanged.
