### PR TITLE
fix: the round-trip corpus compares the published AST, not the internal parse tree

### DIFF
--- a/tests/corpus-roundtrip/13-definition-list-after-a-list.crv
+++ b/tests/corpus-roundtrip/13-definition-list-after-a-list.crv
@@ -1,0 +1,3 @@
+- one
+:: term
+:  def

--- a/tests/corpus-roundtrip/13-definition-list-after-a-list.expected.crv
+++ b/tests/corpus-roundtrip/13-definition-list-after-a-list.expected.crv
@@ -1,0 +1,4 @@
+- one
+
+:: term
+:  def

--- a/tests/corpus-roundtrip/14-footnote-definition-inside-a-container.crv
+++ b/tests/corpus-roundtrip/14-footnote-definition-inside-a-container.crv
@@ -1,0 +1,5 @@
+See [^a].
+
+::: note
+[^a]: note body
+:::

--- a/tests/corpus-roundtrip/14-footnote-definition-inside-a-container.expected.crv
+++ b/tests/corpus-roundtrip/14-footnote-definition-inside-a-container.expected.crv
@@ -1,0 +1,7 @@
+See [^a].
+
+::: note
+
+:::
+
+[^a]: note body

--- a/tests/corpus-roundtrip/README.md
+++ b/tests/corpus-roundtrip/README.md
@@ -122,6 +122,40 @@ that: carve-js and carve-php respelled EVERY break to `***`, carve-rs respelled
 only the leading one. Reproducing the author's `___` removes the collision
 instead of paying for it, and the three converge on the identity.
 
+## 13-definition-list-after-a-list and 14-footnote-definition-inside-a-container
+
+Neither is an escaping case. Both exist because the comparison this corpus is
+read through used to be the wrong object, and no document here could see it
+(carve#1616).
+
+`../roundtrip.test.mjs` compared carve-js's INTERNAL `parse()` return rather
+than the published PART 12 tree. An internal tree carries fields the schema
+never declares - `footnoteDefPos` on the root, and `termSpans`,
+`definitionSpans` and `definitionLines` on a definition-list item - and every
+one of them records where a node was WRITTEN. Moving blocks is most of what the
+writer does, so the reading reported a difference for 74 of the 1371 corpus
+documents that say nothing different afterwards. This corpus stayed green on it
+by luck: none of `01` through `12` holds a definition list, and the one that
+holds footnote definitions (`11`) has them at document level already, so no
+recorded span moved.
+
+`13` is the smallest document whose spans move. `:: term` is a first-class block
+opener, so it interrupts the list above it, and the writer separates the two
+blocks with a blank line - which shifts every term and definition span down one
+line. `14` is the same failure through the other field: the definition is
+authored inside a container, §7 collects it to document level, and its recorded
+position moves with it. The container is left empty, which is what faithfully
+writing a tree whose only child was hoisted out looks like.
+
+Both expected files were derived the way this README requires, from PART 11 and
+§7 rather than from the writer: definitions are collected to document level and
+written in source order, sibling blocks are separated by one blank line. The
+pinned build then reproduces both byte for byte.
+
+The pair also fails LOUDLY under the old reading - two assertions each, the §1
+invariant and the fixture's own self-check - so the object being compared cannot
+quietly revert.
+
 ## Regenerating
 
 Do **not** regenerate expected files from an implementation's current output -

--- a/tests/roundtrip.test.mjs
+++ b/tests/roundtrip.test.mjs
@@ -11,6 +11,20 @@
  *     the class of bug that shipped in carve-rs as a nested list being
  *     reformatted from tight to loose (carve-rs#286).
  *
+ *     The tree those invariants are compared over is the PUBLISHED one -
+ *     `toAstJson(parse(x))`, the PART 12 shape - never the engine's internal
+ *     `parse()` return. An internal tree carries fields PART 12 never declares
+ *     and `resources/ast-schema.json` never lists, and those fields record
+ *     where a node was WRITTEN: `footnoteDefPos` on the root,
+ *     `termSpans` / `definitionSpans` / `definitionLines` on a definition-list
+ *     item. Moving nodes is most of what the writer does, so comparing them
+ *     reports a difference for every document whose definitions the writer
+ *     hoists or whose blocks it re-separates - 74 of the 1371 corpus documents,
+ *     none of which says anything different afterwards (carve#1616). This file
+ *     was green on that reading only because none of its 12 documents had a
+ *     definition list and only one had a footnote definition; `13` and `14`
+ *     below close that hole.
+ *
  *   - The BYTES (PART 11 §2, §4) pin the escaping decision itself. They were
  *     skipped while no engine implemented minimal escaping; the pinned carve-js
  *     build does now (carve-js#397), and it reproduces them exactly apart from
@@ -24,7 +38,7 @@ import assert from 'node:assert/strict'
 import { readFileSync, readdirSync } from 'node:fs'
 import { basename, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { carveToCarve, parse } from '@markup-carve/carve'
+import { carveToCarve, parse, toAstJson } from '@markup-carve/carve'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const dir = resolve(here, 'corpus-roundtrip')
@@ -74,8 +88,13 @@ function mergeTextRuns(node) {
   return node
 }
 
-// `pos` records source offsets, which legitimately move when the writer
-// renormalizes indentation, so it is not part of "same document".
+/*
+ * Drop the recorded source positions.
+ *
+ * `pos` and `srcByteLength` record WHERE a node was written, which legitimately
+ * moves when the writer renormalizes indentation, so neither is part of "same
+ * document".
+ */
 function withoutPositions(node) {
   if (Array.isArray(node)) return node.map(withoutPositions)
   if (node && typeof node === 'object') {
@@ -90,7 +109,7 @@ function withoutPositions(node) {
 }
 
 for (const { slug, source, expected } of cases) {
-  const comparable = (src) => mergeTextRuns(withoutPositions(parse(src)))
+  const comparable = (src) => mergeTextRuns(withoutPositions(toAstJson(parse(src))))
 
   test(`${slug}: parse(fmt(x)) == parse(x)`, () => {
     assert.deepEqual(


### PR DESCRIPTION
Closes #1616.

`tests/roundtrip.test.mjs` is the only place in this repo that compares
carve-js's return from `parse()`. It compared the INTERNAL tree, not the
published PART 12 one, and the internal tree carries fields the spec never
declares:

| field | where | what it records |
| --- | --- | --- |
| `footnoteDefPos` | root | the source span of each footnote definition |
| `termSpans`, `definitionSpans`, `definitionLines` | definition-list item | the source spans of the terms and descriptions |

None of the four appears in `resources/ast-schema.json`, in
`resources/ast-source-layout-schema.json`, or anywhere in `docs/`. Every one of
them records where a node was WRITTEN - the same thing `pos` and
`srcByteLength` record, which the comparison already strips for exactly this
reason. Moving nodes is most of what the canonical writer does, so the reading
reports a difference for 74 of the 1371 corpus documents that say nothing
different afterwards (measured on #1616).

This compares `toAstJson(parse(x))` instead. That is the shape PART 11 §1 is a
statement about, and it is what carve-php's `CarveFmtCorpusTest` and carve-js's
`test/render-carve.test.ts` already compare - carve-php's docblock says outright
that walking the internal object reports 18 differences the published AST does
not have.

## The hole that let it stay green

The file was green on the old reading by luck, not by correctness. Of its twelve
documents none holds a definition list, and the one that holds footnote
definitions (`11-two-footnotes-in-source-order`) has them at document level
already, so no recorded span ever moved.

Two documents close it, one per field:

`13-definition-list-after-a-list`

```
- one
:: term
:  def
```

`:: term` is a first-class block opener, so it interrupts the list; the writer
separates the two blocks with a blank line, which shifts every term and
definition span down one line.

`14-footnote-definition-inside-a-container`

```
See [^a].

::: note
[^a]: note body
:::
```

The definition is authored inside the container, PART 9 §7 collects it to
document level, and its recorded position moves out with it.

Both expected files were derived from PART 11 and §7 rather than from the
writer, as `tests/corpus-roundtrip/README.md` requires - definitions collected
to document level and written in source order, sibling blocks separated by one
blank line - and the pinned build then reproduces both byte for byte.

## Proof the pair can fail

With the fix reverted and the two documents in place, four assertions go red -
the §1 invariant and the fixture self-check, on each document - while the
original twelve stay green:

```
✖ 13-definition-list-after-a-list: parse(fmt(x)) == parse(x) (3.267347ms)
✔ 13-definition-list-after-a-list: fmt is idempotent (0.665737ms)
✖ 13-definition-list-after-a-list: the expected output re-parses to the same document (1.129091ms)
✔ 13-definition-list-after-a-list: fmt(x) == expected bytes (PART 11 §2) (0.388453ms)
✖ 14-footnote-definition-inside-a-container: parse(fmt(x)) == parse(x) (1.18149ms)
✔ 14-footnote-definition-inside-a-container: fmt is idempotent (1.22931ms)
✖ 14-footnote-definition-inside-a-container: the expected output re-parses to the same document (0.79489ms)
✔ 14-footnote-definition-inside-a-container: fmt(x) == expected bytes (PART 11 §2) (0.33951ms)
ℹ tests 57
ℹ pass 53
ℹ fail 4
```

and the difference reported is the phantom field itself:

```
✖ 13-definition-list-after-a-list: parse(fmt(x)) == parse(x)
  AssertionError [ERR_ASSERTION]: the formatter changed what the document says
  + actual - expected
              definitionLines: [
  +             4
  -             3
              ],
              definitionSpans: [
                {
                  endColumn: 7,
  +               endLine: 4,
  +               endOffset: 21,
  -               endLine: 3,
  -               endOffset: 20,
```

That both fixtures fail TWICE is deliberate: the object being compared cannot
quietly revert to the internal tree.

No `CHANGELOG.md` entry, per the standing instruction that the release cut
writes the section.
