### PR TITLE
spec: the endnotes fixture spells its looseness, and the carve-out becomes pin lag

### DIFF
--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -630,6 +630,13 @@ The importer writes the key **only where the blank-line spelling cannot express
 the looseness** - a multi-item loose list keeps the blank lines and takes no
 attribute line - which is the same rule the canonical writer follows.
 
+The `derived-endnotes-section` fixture is where this is recorded, and it is the
+shape that raised the question: a document with a single footnote imports as a
+one-item `<li><p>...</p></li>` list, which is exactly the case a blank line
+cannot reach (markup-carve/carve#1607). Its source carries the key, its tree
+carries no attribute for it - the key is consumed - and the two exits therefore
+say the same thing with no carve-out left to justify.
+
 ## A derived attribute does not come back
 
 An importer **drops an attribute whose value equals what the renderer derives
@@ -995,7 +1002,7 @@ The shared set is deliberately small and each directory has one subject:
 | `figure-caption` | a `<figure>` with a `<figcaption>`, which imports as the image and a caption line |
 | `blockquote-cite` | a `<blockquote cite>`, whose attribute is kept on a block-attribute line |
 | `derived-accessible-name` | a diagram fence's derived `role` and name, dropped, beside an authored name that is kept |
-| `derived-endnotes-section` | a reference-less endnotes `<section>`, whose wrapper and both attributes are derived, so nothing is reported |
+| `derived-endnotes-section` | a reference-less endnotes `<section>`, whose wrapper and both attributes are derived, so nothing is reported - and whose one-item list spells its looseness with `{loose}` |
 | `synthesized-wrapper-path` | a bare inline run wrapped in a paragraph the importer added, whose diagnostic is numbered among the body children rather than inside the wrapper |
 | `container-round-trip` | a rendered callout and a named container, which come back as the containers they were written from rather than as a body and a `div` |
 | `caption-attributes` | an attribute on a `<figcaption>`, dropped because a caption line has no slot for it, and reported rather than dropped in silence |

--- a/tests/a-derived-endnotes-section-is-not-a-reported-loss.test.mjs
+++ b/tests/a-derived-endnotes-section-is-not-a-reported-loss.test.mjs
@@ -4,9 +4,8 @@
  *
  * WHY THIS EXISTS BESIDE THE FIXTURE. The same reason its sibling for
  * `derived-accessible-name` does: tests/html-import-contract.check.mjs runs
- * this fixture through the PINNED engine, and while that engine still reports
- * the endnotes wrapper as a loss the fixture sits under a declared PIN_LAG
- * entry. A lagging fixture is compared only for INEQUALITY, so its
+ * this fixture through the PINNED engine, and while that engine does not write
+ * the `{loose}` key the fixture sits under a declared PIN_LAG entry. A lagging fixture is compared only for INEQUALITY, so its
  * expectations could be rewritten to say anything at all - including a blanket
  * "report nothing for a `<section>`", which the clause does not adopt - and the
  * contract check would stay green, because the engine disagrees with that too.
@@ -41,10 +40,13 @@ test('the fixture states an empty report, and its source keeps every visible byt
   const report = JSON.parse(await read('expected.report.json'))
   assert.deepEqual(report.diagnostics, [])
   const crv = await read('expected.crv')
-  // The degraded form: the `<hr>` and the `<ol>` the section is built from.
+  // The degraded form: the `<hr>` and the `<ol>` the section is built from,
+  // with the looseness spelled by the consumed `{loose}` boolean - a one-item
+  // list has no BETWEEN for a blank line to stand in (PART 9 section 17 L7;
+  // markup-carve/carve#1607, markup-carve/carve#1612).
   // Reported nothing AND lost nothing - the two claims have to hold together,
   // because silence over a document that lost its text is the worse defect.
-  assert.equal(crv, '---\n\n1. Note text.\n')
+  assert.equal(crv, '---\n\n{loose}\n1. Note text.\n')
 })
 
 test('the source and the AST carry neither derived attribute', async () => {

--- a/tests/html-import-contract.check.mjs
+++ b/tests/html-import-contract.check.mjs
@@ -126,6 +126,13 @@ const PIN_LAG = new Map([
       'markup-carve/carve-js#1380, markup-carve/carve-php#1615)',
   ],
   [
+    'derived-endnotes-section',
+    'the importer writes no `{loose}` key, so a one-item list whose HTML said ' +
+      'loose comes back tight - and the pinned build does not consume the key ' +
+      'either, rendering it as `<ol loose="">` ' +
+      '(PART 9 section 17 L7; markup-carve/carve#1612)',
+  ],
+  [
     'empty-definition-description',
     'the importer writes a bare `:` line for an empty <dd>, which the parser ' +
       'reads as more of the term above it - so the loss exceeds the row that ' +

--- a/tests/html-import/derived-endnotes-section/expected.crv
+++ b/tests/html-import/derived-endnotes-section/expected.crv
@@ -1,3 +1,4 @@
 ---
 
+{loose}
 1. Note text.

--- a/tests/the-two-import-exits-agree.test.mjs
+++ b/tests/the-two-import-exits-agree.test.mjs
@@ -47,9 +47,13 @@ const root = new URL('./html-import/', import.meta.url)
 const UNMET = new Map([
   [
     'derived-endnotes-section',
-    'the tree says a one-item list is loose where its own source says tight, ' +
-      'and Carve has no spelling for a loose one-item list ' +
-      '(markup-carve/carve#1607)',
+    'the source now spells the looseness with the consumed `{loose}` boolean, ' +
+      'and the PINNED build does not consume it - it reads the list tight and ' +
+      'carries the key as an attribute, where the fixture records the loose ' +
+      'list with no attribute. A pin-lag entry, not an open question: the ' +
+      'shape was ruled in markup-carve/carve#1607 and the spelling landed as ' +
+      'PART 9 section 17 L7. Delete this with the bump that ships it in the ' +
+      'engines (markup-carve/carve#1612)',
   ],
 ])
 


### PR DESCRIPTION
Closes #1607.

The import half of the one-item loose list. The decision was taken on the ticket
- give Carve a spelling rather than reporting `structure-unspellable` - and the
spelling landed as PART 9 section 17 L7 in #1623. This is the fixture catching up.

## What changes

`tests/html-import/derived-endnotes-section` recorded a tree saying `tight:
false` beside a source that parses tight, which the invariant added for #1601
forbids. The source had no way to say otherwise: Carve spells tightness with a
blank line BETWEEN items, and a document with a single footnote imports as a
one-item list, which has no between.

Now it says it:

```
---

{loose}
1. Note text.
```

The key is CONSUMED, so the tree carries no attribute for it and the recorded
`expected.ast.json` is unchanged. The two exits agree on the bytes.

## What is left is a pin, not a question

The build this repo pins neither writes the key on import nor consumes it on
parse - it renders `<ol loose="">` and reads the list tight. So both readings
declare that, and both fail in both directions:

- a `PIN_LAG` entry in `tests/html-import-contract.check.mjs`;
- the invariant's `UNMET` carve-out rewritten from an open decision into a pin
  reason, pointing at #1612 for the three engines.

That is the difference this PR makes to the ticket. Before it, the carve-out
existed because nobody had decided; after it, the recorded answer IS the ruled
one and the only thing outstanding is shipping the key, which #1612 tracks.

`tests/a-derived-endnotes-section-is-not-a-reported-loss.test.mjs` reads the
fixture's bytes directly, so it moves with them - and it is the reason the
lagging fixture cannot be rewritten to say anything convenient, since a lagging
fixture is otherwise compared only for inequality. Its stale note about why the
PIN_LAG entry exists is corrected too: the pin stopped reporting the endnotes
wrapper as a loss when it moved in #1596, and the entry is now there for the
key.

## Proof both new declarations can fail

Undeclare the PIN_LAG entry, and the pinned importer's actual output is what
comes back:

```
✖ the pinned build imports every fixture the way the fixture says (68.840588ms)
  AssertionError [ERR_ASSERTION]: tests/html-import/derived-endnotes-section: expected.crv: got "---\n\n1. Note text.\n"
```

Revert the fixture bytes while the byte assertion stands:

```
✖ the fixture states an empty report, and its source keeps every visible byte (8.907174ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  + actual - expected

  + '---\n\n1. Note text.\n'
  - '---\n\n{loose}\n1. Note text.\n'
```

The `expected.crv` is also a fixed point of the canonical writer, which the
contract check asserts separately - the pinned writer already leaves the
attribute line alone.

No `CHANGELOG.md` entry, per the standing instruction that the release cut
writes the section.
