### PR TITLE
tooling: a PART 12 §4 rule that reads the source can now fail the run

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -839,6 +839,20 @@ A row may name an issue only where one of those still declares the debt.
 | carve-php | §3a conformant on both forms: an unresolved reference is a `link` node, and the collapsed form carries the resolution key in `ref` beside `rawRef`, the same label the other two publish on every corpus document | recorded behind a parse option, enabled whenever it serializes; every block and inline placed, except the categories §4 exempts - a coalesced `text` run, a reassembled table cell, and a verbatim run continued on a `+` line |
 | carve-rb / carve-py / carve-go / carve-wasm | publish carve-rs's bytes | whatever carve-rs records |
 
+A third ledger, `resources/ast-extent-findings.txt`, records the other half of
+§4: a span that is PRESENT and points at the wrong codepoint. Those findings are
+produced by `checkStopsAtChildren` and its neighbours, which read the SOURCE
+rather than another engine - the only way a rule every engine breaks the same
+way can be seen at all, since the three-way panel compares the engines against
+each other and reads a unanimous defect as agreement. Until
+[carve#1637](https://github.com/markup-carve/carve/issues/1637) that reading was
+theoretical: the findings reached a counter that could not fail, so a run printed
+thirty of them per engine and exited green. There is no `permitted` status in
+that file - a reassembled node has no honest span, which is why the position
+waivers have one, and a span that exists and is wrong has no such reading - so
+every line names the engine issue that will delete it, and the count fails when
+it moves in either direction.
+
 The gaps are listed rather than smoothed over on purpose: "six implementations"
 is only a claim worth making if the disagreements are visible.
 

--- a/resources/ast-extent-findings.txt
+++ b/resources/ast-extent-findings.txt
@@ -1,0 +1,56 @@
+# The PART 12 §4 EXTENT findings `npm run ast:check` reports: a span that IS
+# present and points at the wrong codepoint.
+#
+# `scripts/spec/ast-positions.mjs` reads the SOURCE rather than another engine,
+# which is the only way a rule every engine breaks the same way can be seen at
+# all - the three-way panel compares the engines against each other and calls a
+# unanimous defect agreement. `checkStopsAtChildren` says so in its own
+# docblock. Its findings then landed in a counter called `unwaivable` that
+# `partitionFindings` incremented and dropped, so a run printed thirty of them
+# per engine in full and exited green (carve#1637). This file is where they are
+# reconciled instead.
+#
+# THE FORMAT is `<engine>  <rule>  <type>  <count>  <owner/repo#N>`, whitespace
+# separated, `#` comments and blank lines ignored. `rule` is one of the ids in
+# EXTENT_RULES in scripts/spec/ast-waivers.mjs:
+#
+#   ends-past-last-child         a container ends after its last child, over
+#                                source that belongs to no child of it
+#   ends-before-placed-child     it stops at its last PLACED child, leaving the
+#                                source an unplaced child owns in nothing
+#   starts-past-opening-markup   it begins inside the construct rather than at
+#                                the markup that opens it
+#   empty-span-covers-more       an empty container spans past the markup that
+#                                opened it
+#
+# THERE IS NO `permitted` STATUS, deliberately. The sibling file
+# resources/ast-position-waivers.txt has one because §4 exempts a REASSEMBLED
+# node - its value is not a slice of the source at any offset, so no honest span
+# exists. A span that exists and is wrong has no such reading, so every line
+# here names the issue that will delete it, and a status this cannot parse is an
+# error rather than a default.
+#
+# EXACT IN THREE DIRECTIONS, like every other declaration in this directory:
+#
+#   a finding no line covers          -> UNDECLARED, fails
+#   a declared line whose count moved -> COUNT, fails
+#   a declared line nothing produces  -> FIXED, fails until the line is deleted
+#
+# The third is what makes this a ratchet rather than a silencer: an engine that
+# conforms turns the run red until its line goes, so the numbers below can only
+# come down.
+#
+# DECLARED PER (engine, rule, node type), NOT PER DOCUMENT. An extent defect is
+# one construct behaving one way everywhere it appears - the argument
+# `compareSpans` gives for keying its own rows by type - so a per-document
+# ledger would be sixty lines describing two facts and every engine fix would
+# rewrite all sixty. Per type still fails on a new violation of a type nothing
+# declares, which a bare per-engine total would not.
+#
+# WHY DECLARED AT ALL, rather than gated at zero. In this fleet a fix lands in
+# one engine and is ported over the following days. Gating at zero would put the
+# scheduled AST conformance job red until every port finished, and a permanently
+# red scheduled job gets muted - which is the failure that workflow exists to
+# undo. A check that cannot pass is the same defect as a check that cannot fail.
+#
+# <engine>  <rule>  <type>  <count>  <owner/repo#N>

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -48,6 +48,7 @@ import {
   describeDocuments,
   groupFindings,
   notReconciledBecause,
+  parseExtentDeclarations,
   parseWaivers,
   partitionFindings,
 } from './spec/ast-waivers.mjs'
@@ -460,13 +461,21 @@ function reportValueDisagreements(present) {
  * the fix for a red run "wait". A declared count still fails the moment an
  * engine changes its mind about a span, which nothing else here can see.
  *
- * IT NOW NAMES A SIDE. Whether a span covers the markup that opens a node was
- * markup-carve/carve#913, and most of these rows are that question; §4 answers
- * it markup-inclusive, so an extent row is an engine owing a fix rather than an
+ * IT NOW NAMES A SIDE, AND THERE ARE TWO OF THEM. Whether a span covers the
+ * markup that opens a node was markup-carve/carve#913, and §4 answers it
+ * markup-inclusive - so an extent row is an engine owing a fix rather than an
  * open convention. What the panel still does not do is say WHICH engine owes
- * it - that needs the source, and the source-side rule is `checkOpeningMarkup`
- * in scripts/spec/ast-positions.mjs, which each engine's `report` runs against
- * its own tree.
+ * it: that needs the source, and WHICH source-side rule applies depends on
+ * which END of the span moved. `checkOpeningMarkup` tests where a span BEGINS;
+ * `checkStopsAtChildren`, over the types in `ENDS_AT_LAST_CHILD`, tests where
+ * it ENDS. Both live in scripts/spec/ast-positions.mjs and each engine's
+ * `report` runs both against its own tree.
+ *
+ * The advice below used to name only the first, so a row with a unanimous
+ * `startOffset` differing at the END read as "the narrow engine moves" when the
+ * rule for that end says the WIDE one does - carve#1637, where six of eight
+ * rows were end-only and the text pointed at the one engine with no end-side
+ * finding at all.
  */
 function reportSpanDisagreements(present) {
   const byKey = new Map()
@@ -529,8 +538,13 @@ function reportSpanDisagreements(present) {
       console.log(`  ${String(docs.size).padStart(4)} doc(s)  ${key}`)
       console.log(`        e.g. ${[...docs][0]}: ${who}`)
     }
-    console.log('  EXTENT rows are PART 12 §4: a span begins at the markup that opens the node,')
-    console.log('  so an engine spanning the content alone is the one that moves (carve#913).')
+    console.log('  EXTENT rows are PART 12 §4, and WHICH END moved decides which engine owes it:')
+    console.log('    startOffset differs - a span "begins at the markup that opens the construct",')
+    console.log('      so the engine spanning the content alone moves (carve#913, checkOpeningMarkup).')
+    console.log('    endOffset differs, startOffset unanimous - a span "ends immediately after the')
+    console.log('      last source codepoint the construct owns", and a container with no closer ends')
+    console.log('      at its last child, so the WIDE engine moves (checkStopsAtChildren, over the')
+    console.log('      types in ENDS_AT_LAST_CHILD). Read the "e.g." line to see which end moved.')
   }
 
   const problems = reconcileSpans(
@@ -544,11 +558,21 @@ function reportSpanDisagreements(present) {
     advice: [
       'Each line there is a node type the engines span differently, with the number of',
       'documents it shows up in. Update it in the commit that moves the number.',
-      'A row moving does not say WHICH engine is wrong - this panel has the trees and',
-      'not the source - but the extent rule itself is settled: PART 12 §4 is',
-      'markup-inclusive (markup-carve/carve#913; docs/ast-json.md: a span "begins at the',
-      'markup that opens the construct"), and',
-      'checkOpeningMarkup in scripts/spec/ast-positions.mjs is what names a side.',
+      'A row moving does not say WHICH engine is wrong - this panel has the trees and not',
+      'the source - and WHICH RULE names a side depends on WHICH END of the span moved.',
+      'PART 12 §4 has two sentences and they point at different checkers:',
+      '  START. A span "begins at the markup that opens the construct"',
+      '  (markup-carve/carve#913), so an engine spanning the content alone is the one that',
+      '  moves. checkOpeningMarkup in scripts/spec/ast-positions.mjs is the source-side rule.',
+      '  END. A span "ends immediately after the last source codepoint the construct owns",',
+      '  and a container with no closer "ends at its last child", so on those rows the WIDE',
+      '  engine is the one that moves. checkStopsAtChildren, over the types in',
+      '  ENDS_AT_LAST_CHILD, is the source-side rule, and what it finds is declared in',
+      '  resources/ast-extent-findings.txt.',
+      'A row whose engines agree on startOffset and differ on endOffset is the SECOND case.',
+      'Reading it as the first blames the narrow engine, which is the exact inverse',
+      '(carve#1637): six of eight rows were end-only, and the advice pointed at carve-js -',
+      'the one engine with no span-reaches-past-its-last-child finding at all.',
     ],
   })
   if (byKey.size > 0) {
@@ -559,6 +583,7 @@ function reportSpanDisagreements(present) {
 const VALUE_DIVERGENCE_FILE = resolve(here, '..', 'resources', 'ast-value-divergence.txt')
 const SPAN_DIVERGENCE_FILE = resolve(here, '..', 'resources', 'ast-span-divergence.txt')
 const POSITION_WAIVER_FILE = resolve(here, '..', 'resources', 'ast-position-waivers.txt')
+const EXTENT_FINDING_FILE = resolve(here, '..', 'resources', 'ast-extent-findings.txt')
 
 /*
  * The position declaration, read ONCE and up front.
@@ -578,8 +603,28 @@ if (waiverFileErrors.length > 0) {
   process.exit(2)
 }
 
+/*
+ * The §4 EXTENT declaration, read the same way and for the same reason.
+ *
+ * A malformed line here is a hard stop too, and the status field is stricter
+ * than the waiver file's: there is no `permitted`, so a typo cannot quietly
+ * turn a violation into a permitted one. It can only fail.
+ */
+const { declared: declaredExtents, errors: extentFileErrors } = parseExtentDeclarations(
+  readFileSync(EXTENT_FINDING_FILE, 'utf8'),
+)
+if (extentFileErrors.length > 0) {
+  console.error('resources/ast-extent-findings.txt is malformed:')
+  for (const e of extentFileErrors) console.error(`  ${e}`)
+  process.exit(2)
+}
+
 /** Accumulated across every engine's `report`, gated at the end of the run. */
 const waiverProblems = []
+
+/** The same, for the extent ledger and for the findings no ledger covers. */
+const extentDriftProblems = []
+const ungatedProblems = []
 
 /**
  * Every declaration this run reconciles, gated together at the end.
@@ -1449,10 +1494,30 @@ function report(engine, label, findings) {
   // carve-rs issue would then leave the run red until the duplicate lines went
   // too. It is the same reason the shape panel does not give that engine a vote.
   const exempt = notReconciledBecause(engine)
-  const { waived, outstanding, undeclared, unwaivable, problems } = exempt
-    ? { waived: 0, outstanding: 0, undeclared: 0, unwaivable: 0, problems: [] }
-    : partitionFindings(engine, findings, declaredWaivers)
+  const {
+    waived,
+    outstanding,
+    undeclared,
+    extent,
+    ungated,
+    problems,
+    extentProblems,
+    ungatedProblems: ungatedLines,
+  } = exempt
+    ? {
+        waived: 0,
+        outstanding: 0,
+        undeclared: 0,
+        extent: 0,
+        ungated: 0,
+        problems: [],
+        extentProblems: [],
+        ungatedProblems: [],
+      }
+    : partitionFindings(engine, findings, declaredWaivers, declaredExtents)
   waiverProblems.push(...problems)
+  extentDriftProblems.push(...extentProblems)
+  ungatedProblems.push(...ungatedLines)
 
   if (findings.length === 0) {
     console.log(`${label}: conformant\n`)
@@ -1469,10 +1534,11 @@ function report(engine, label, findings) {
   const ranked = groupFindings(findings)
   const split = exempt
     ? `not reconciled: ${exempt}`
-    : waived + outstanding + undeclared + unwaivable === findings.length
+    : waived + outstanding + undeclared + extent + ungated === findings.length
       ? `${waived} waived, ${outstanding} outstanding` +
         (undeclared > 0 ? `, ${undeclared} UNDECLARED` : '') +
-        (unwaivable > 0 ? `, ${unwaivable} not a position` : '')
+        (extent > 0 ? `, ${extent} §4 extent (declared)` : '') +
+        (ungated > 0 ? `, ${ungated} UNGATED` : '')
       : 'partition disagrees with the total - this is a bug in partitionFindings'
   console.log(`${label}: ${findings.length} findings, ${ranked.length} distinct (${split})`)
   for (const entry of ranked.slice(0, DISPLAY_LIMIT)) {
@@ -1617,6 +1683,46 @@ declarationDrift.push({
   ],
 })
 
+/*
+ * THE §4 EXTENT DECLARATION, gated beside the position one.
+ *
+ * Its findings were printed in full by every run and gated by none of them
+ * (carve#1637). The counter that held them was named `unwaivable`, which was
+ * true of a LINE in the waiver file and false of the run: nothing absorbed
+ * them and nothing failed on them either.
+ *
+ * DECLARED rather than gated at zero, and the difference matters. Thirty
+ * violations stand in carve-rs and thirty-eight in carve-php as this lands;
+ * gating at zero would put a scheduled job red until nine ports finish across
+ * three engines, and a permanently red scheduled job gets muted - which is the
+ * failure the whole workflow exists to undo. The ledger ratchets: a count that
+ * moves in EITHER direction fails, so a fix must delete its line and a new
+ * violation is red the day it lands.
+ */
+declarationDrift.push({
+  file: 'resources/ast-extent-findings.txt',
+  what: 'PART 12 §4 EXTENT FINDINGS',
+  problems: extentDriftProblems,
+  advice: [
+    'Each line there is one engine, one §4 extent rule and one node type, with a count',
+    'and the issue that will delete it. There is no "permitted" status: a span that is',
+    'PRESENT and points at the wrong codepoint has no exempt reading the way a',
+    'REASSEMBLED node has. Fix the engine and delete the line, or lower the count in the',
+    'commit that lowers the number. UNDECLARED lines above print the line to paste.',
+  ],
+})
+
+// The findings no ledger covers, and none should. A wrong slice, a span outside
+// its parent, a §1a run: each is a defect to fix rather than a number to
+// record, so this gate has no declaration file and no way to be silenced.
+if (ungatedProblems.length > 0) {
+  console.error('')
+  console.error('PART 12 findings with no permitted category at all:')
+  for (const p of ungatedProblems) console.error(`  ${p}`)
+  console.error('')
+  console.error('These have no ledger by design. Fix the engine.')
+}
+
 const drifted = declarationDrift.filter((d) => d.problems.length > 0)
 if (drifted.length > 0) {
   for (const d of drifted) {
@@ -1628,6 +1734,8 @@ if (drifted.length > 0) {
   }
   process.exit(1)
 }
+
+if (ungatedProblems.length > 0) process.exit(1)
 
 if (adjacentTextRunCounts.length > 0) {
   const total = adjacentTextRunCounts.reduce((n, e) => n + e.count, 0)

--- a/scripts/spec/ast-spans.mjs
+++ b/scripts/spec/ast-spans.mjs
@@ -44,10 +44,13 @@
  *
  * What this module still does not do is say WHICH engine owes it, because that
  * needs the source and this module only has the trees. It reports a
- * DISAGREEMENT; `checkOpeningMarkup` in ./ast-positions.mjs is the rule that
- * names a side, and each engine runs it against its own tree. A declared count
- * that moves means an engine changed its mind about a span, and nothing else in
- * this repo can see that happen.
+ * DISAGREEMENT; the rules that name a side live in ./ast-positions.mjs and each
+ * engine runs them against its own tree - `checkOpeningMarkup` for where a span
+ * BEGINS, `checkStopsAtChildren` for where it ENDS. Which one applies depends
+ * on which end of the row moved, and reading an end-only row under the start
+ * rule blames the narrow engine when the wide one owes it (carve#1637). A
+ * declared count that moves means an engine changed its mind about a span, and
+ * nothing else in this repo can see that happen.
  */
 
 import { POS_KEYS } from './ast-shape.mjs'

--- a/scripts/spec/ast-waivers.mjs
+++ b/scripts/spec/ast-waivers.mjs
@@ -69,6 +69,121 @@ export function waivableType(text) {
   return m ? m[1] : null
 }
 
+/*
+ * THE OTHER HALF OF §4, and the half that could not fail.
+ *
+ * `waivableType` above recognizes an ABSENT position. Everything else this
+ * checker produces used to fall into a counter called `unwaivable`, whose
+ * comment said "never absorbable by a line" - true, and read as "cannot be
+ * waived" when its effect was "is never gated". `partitionFindings` incremented
+ * it and `continue`d, so no `problems` entry was ever produced and a grep of a
+ * whole run for UNWAIVED returned nothing (carve#1637).
+ *
+ * What sat in it was thirty §4 EXTENT violations per engine: a span that IS
+ * present and is WRONG. `checkStopsAtChildren` in ./ast-positions.mjs was
+ * written precisely because a rule every engine breaks the same way is
+ * invisible to the three-way panel - it reads the SOURCE, the only party that
+ * cannot agree with an engine by accident - and its findings landed in the one
+ * bucket that could not fail. Had all three engines still carried the defect
+ * the panel would have been unanimous and the run GREEN.
+ *
+ * These are declared, not gated at zero, for the reason the sibling ledgers
+ * give: in this fleet a fix lands in one engine and is ported over the
+ * following days, and a gate that goes red until nine ports land across three
+ * engines is a check that cannot PASS - the mirror of the one it replaces. The
+ * declaration ratchets instead: exact in three directions, so the counts have
+ * to come down as the engines conform and a new violation is red the day it
+ * lands.
+ *
+ * DECLARED PER (engine, rule, node type) rather than per document. Per document
+ * is the finer ledger and it is the wrong one here: an extent defect is one
+ * construct behaving one way everywhere it appears - the same argument
+ * `compareSpans` gives for keying by type - so a per-document list is sixty
+ * lines describing two facts, and every engine fix would rewrite all sixty. Per
+ * type still fails on a NEW violation of a type nothing declares, which a bare
+ * per-engine total would not.
+ *
+ * THERE IS NO `permitted` STATUS HERE. A missing position has a permitted
+ * category because §4 exempts a REASSEMBLED node - no honest span exists. A
+ * span that exists and points at the wrong codepoint has no such reading, so
+ * every line names the issue that will delete it. A ledger that could say
+ * "permitted" would be the off switch this file's other half refuses to be.
+ */
+const EXTENT_RULES = [
+  ['ends-past-last-child', /^span reaches past its last child on "([A-Za-z_][A-Za-z0-9_]*)" at /],
+  [
+    'ends-before-placed-child',
+    /^span stops at its last PLACED child on "([A-Za-z_][A-Za-z0-9_]*)" at /,
+  ],
+  [
+    'starts-past-opening-markup',
+    /^pos does not begin at the markup that opens "([A-Za-z_][A-Za-z0-9_]*)" at /,
+  ],
+  [
+    'empty-span-covers-more',
+    /^span covers more than its own markup on an empty "([A-Za-z_][A-Za-z0-9_]*)" at /,
+  ],
+]
+
+/** The rule ids a declaration line may name, in the order they are checked. */
+export const EXTENT_RULE_IDS = EXTENT_RULES.map(([id]) => id)
+
+/** The §4 extent rule a finding names and the node type it names, or null. */
+export function extentFinding(text) {
+  for (const [rule, pattern] of EXTENT_RULES) {
+    const m = pattern.exec(text)
+    if (m) return { rule, type: m[1] }
+  }
+
+  return null
+}
+
+const extentKeyOf = (engine, rule, type) => `${engine}\t${rule}\t${type}`
+
+/** `<engine>  <rule>  <type>  <count>  <owner/repo#N>` - the extent ledger. */
+export function parseExtentDeclarations(text) {
+  const declared = new Map()
+  const errors = []
+  let lineNo = 0
+  for (const raw of text.split('\n')) {
+    lineNo += 1
+    const line = raw.trim()
+    if (line === '' || line.startsWith('#')) continue
+    const parts = line.split(/\s+/)
+    if (parts.length !== 5) {
+      errors.push(`line ${lineNo}: expected 5 fields (engine rule type count issue), got ${parts.length}`)
+      continue
+    }
+    const [engine, rule, type, countText, status] = parts
+    if (!EXTENT_RULE_IDS.includes(rule)) {
+      errors.push(`line ${lineNo}: unknown rule "${rule}"; known rules are ${EXTENT_RULE_IDS.join(', ')}`)
+      continue
+    }
+    const count = Number(countText)
+    if (!Number.isInteger(count) || count < 1) {
+      errors.push(`line ${lineNo}: count must be a positive integer, got "${countText}"`)
+      continue
+    }
+    // No `permitted` here, deliberately - see the note above. A §4 extent
+    // violation is always owed, so the status field is an issue or an error.
+    if (!/^[\w.-]+\/[\w.-]+#\d+$/.test(status)) {
+      errors.push(
+        `line ${lineNo}: status must be a fully qualified owner/repo#N - a §4 extent ` +
+          `violation is never "permitted", got "${status}"`,
+      )
+      continue
+    }
+    const key = extentKeyOf(engine, rule, type)
+    if (declared.has(key)) {
+      errors.push(`line ${lineNo}: ${engine} ${rule} ${type} is declared twice`)
+      continue
+    }
+    declared.set(key, { engine, rule, type, count, status, lineNo })
+  }
+
+  return { declared, errors }
+}
+
 const keyOf = (engine, document, type) => `${engine}\t${document}\t${type}`
 
 /**
@@ -139,24 +254,44 @@ export function parseWaivers(text) {
 }
 
 /**
- * One engine's findings against the declaration.
+ * One engine's findings against BOTH declarations.
  *
- * Returns the two totals the report prints and the problems that fail the run.
- * `unwaivable` is every finding that is not a missing position: counted so the
- * three numbers still add up to the total, and never absorbable by a line.
+ * Every finding now leaves through one of three doors, and each of them can
+ * fail the run. The old third door could not: `unwaivable` counted a finding
+ * and dropped it, which is how thirty §4 extent violations per engine were
+ * printed in full by a run that exited green (carve#1637).
+ *
+ *   MISSING POSITION -> `resources/ast-position-waivers.txt`, which has a
+ *   `permitted` category because §4 exempts a reassembled node.
+ *   §4 EXTENT       -> `resources/ast-extent-findings.txt`, issue-only, no
+ *   permitted category at all.
+ *   ANYTHING ELSE   -> `ungated`, which fails on sight. There is no ledger for
+ *   a wrong slice, a span outside its parent or a §1a run, and there should not
+ *   be: those are defects to fix, not numbers to record.
+ *
+ * Returns the totals the report prints and three separate problem lists, so
+ * each ledger's drift is reported against the file that owns it rather than
+ * under whichever heading happened to be printing.
  */
-export function partitionFindings(engine, findings, declared) {
+export function partitionFindings(engine, findings, declared, extentDeclared = new Map()) {
   const measured = new Map()
-  let unwaivable = 0
+  const extentMeasured = new Map()
+  const ungated = []
   for (const finding of findings) {
     const { document, text } = splitFinding(finding)
     const type = document === null ? null : waivableType(text)
-    if (type === null) {
-      unwaivable += 1
+    if (type !== null) {
+      const key = keyOf(engine, document, type)
+      measured.set(key, (measured.get(key) ?? 0) + 1)
       continue
     }
-    const key = keyOf(engine, document, type)
-    measured.set(key, (measured.get(key) ?? 0) + 1)
+    const found = extentFinding(text)
+    if (found !== null) {
+      const key = extentKeyOf(engine, found.rule, found.type)
+      extentMeasured.set(key, (extentMeasured.get(key) ?? 0) + 1)
+      continue
+    }
+    ungated.push(finding)
   }
 
   let waived = 0
@@ -196,7 +331,55 @@ export function partitionFindings(engine, findings, declared) {
     }
   }
 
-  return { waived, outstanding, undeclared, unwaivable, problems }
+  // THE EXTENT LEDGER, the same three directions. UNDECLARED prints the line to
+  // paste, because the alternative is a reader deriving five whitespace-separated
+  // fields from a sentence, and a ledger that is tedious to update is a ledger
+  // that gets widened instead.
+  let extent = 0
+  const extentProblems = []
+  for (const [key, count] of extentMeasured) {
+    extent += count
+    const [, rule, type] = key.split('\t')
+    const line = extentDeclared.get(key)
+    if (!line) {
+      extentProblems.push(
+        `UNDECLARED ${engine}  ${rule}  ${type}  ${count}  - a PART 12 §4 extent violation no ` +
+          'line covers. Fix the engine, or record it as:  ' +
+          `${engine}  ${rule}  ${type}  ${count}  <owner/repo#N>`,
+      )
+      continue
+    }
+    if (line.count !== count) {
+      extentProblems.push(
+        `COUNT      ${engine}  ${rule}  ${type}  declares ${line.count}, measured ${count}` +
+          ` (${line.status})`,
+      )
+    }
+  }
+  for (const [key, line] of extentDeclared) {
+    if (line.engine !== engine) continue
+    if (!extentMeasured.has(key)) {
+      extentProblems.push(
+        `FIXED      ${engine}  ${line.rule}  ${line.type}  is declared (${line.status}) but ` +
+          'no longer occurs - delete the line',
+      )
+    }
+  }
+
+  return {
+    waived,
+    outstanding,
+    undeclared,
+    extent,
+    ungated: ungated.length,
+    problems,
+    extentProblems,
+    ungatedProblems: ungated.map(
+      (finding) =>
+        `UNGATED    ${engine}  ${finding}  - no ledger covers this finding class, and none ` +
+        'should: fix it rather than declaring it',
+    ),
+  }
 }
 
 /**

--- a/tests/ast-waivers.test.mjs
+++ b/tests/ast-waivers.test.mjs
@@ -20,9 +20,12 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import {
+  EXTENT_RULE_IDS,
   describeDocuments,
+  extentFinding,
   groupFindings,
   notReconciledBecause,
+  parseExtentDeclarations,
   parseWaivers,
   partitionFindings,
   splitFinding,
@@ -37,6 +40,18 @@ const declare = (text) => {
 
   return declared
 }
+
+const declareExtents = (text) => {
+  const { declared, errors } = parseExtentDeclarations(text)
+  assert.deepEqual(errors, [], `fixture extent declaration did not parse: ${errors.join('; ')}`)
+
+  return declared
+}
+
+/** The finding text `checkStopsAtChildren` produces, verbatim in its shape. */
+const pastLastChild = (document, type, at = '$.children[0]') =>
+  `${document}: span reaches past its last child on "${type}" at ${at}: ` +
+  'it ends at 27, its last child ends at 26, and "\n" belongs to no child of it'
 
 test('a finding splits into its document and its text', () => {
   assert.deepEqual(splitFinding('03-links-12.crv: missing pos on "text" at $.children[0]'), {
@@ -117,7 +132,10 @@ test('UNWAIVED: a finding no line covers', () => {
   // Counted, not merely reported: the four buckets must add up to the total, or
   // the report's own summary line understates what the run measured.
   assert.equal(result.undeclared, 1)
-  assert.equal(result.waived + result.outstanding + result.undeclared + result.unwaivable, 2)
+  assert.equal(
+    result.waived + result.outstanding + result.undeclared + result.extent + result.ungated,
+    2,
+  )
 })
 
 test('COUNT: a declared line whose count moved', () => {
@@ -161,19 +179,227 @@ test('a declaration for one engine never covers another', () => {
   assert.match(result.problems[0], /^UNWAIVED\s+carve-rs/)
 })
 
-test('a finding that is not a position can never be waived', () => {
+test('a finding that is not a position can never be waived, and now it GATES', () => {
+  // THE DEFECT carve#1637 IS ABOUT. This used to land in a counter called
+  // `unwaivable`, which incremented and `continue`d - so the finding was
+  // printed in full, absorbed by no line, and produced no problem entry either.
+  // A grep of a whole run for UNWAIVED returned nothing while thirty §4
+  // violations per engine sat in that counter.
   const declared = declare('carve-js  a.crv  text  1  permitted')
   const result = partitionFindings(
     'carve-js',
     ['a.crv: §1a two adjacent text runs at $.children'],
     declared,
   )
-  assert.equal(result.unwaivable, 1)
+  assert.equal(result.ungated, 1)
   assert.equal(result.waived, 0)
+  assert.equal(result.ungatedProblems.length, 1)
+  assert.match(result.ungatedProblems[0], /^UNGATED\s+carve-js/)
+  assert.match(result.ungatedProblems[0], /no ledger covers this finding class/)
   // And the now-unproduced line still reports, so a waiver file cannot be kept
   // alive by an unrelated finding in the same document.
   assert.equal(result.problems.length, 1)
   assert.match(result.problems[0], /^FIXED/)
+})
+
+test('every §4 extent rule is recognized, and nothing else is', () => {
+  assert.deepEqual(extentFinding('span reaches past its last child on "footnote" at $.c[0]: it ends at 27'), {
+    rule: 'ends-past-last-child',
+    type: 'footnote',
+  })
+  assert.deepEqual(
+    extentFinding('span stops at its last PLACED child on "list" at $.c[0]: it ends at 4'),
+    { rule: 'ends-before-placed-child', type: 'list' },
+  )
+  assert.deepEqual(
+    extentFinding('pos does not begin at the markup that opens "block_quote" at $.c[0]: offset 2'),
+    { rule: 'starts-past-opening-markup', type: 'block_quote' },
+  )
+  assert.deepEqual(
+    extentFinding('span covers more than its own markup on an empty "div" at $.c[0]: [0, 9]'),
+    { rule: 'empty-span-covers-more', type: 'div' },
+  )
+  // A missing position is the OTHER ledger's, and a slice mismatch is neither.
+  assert.equal(extentFinding('missing pos on "text" at $.c[0]'), null)
+  assert.equal(
+    extentFinding('pos does not cover the text it belongs to on "text" at $.c[0]: offsets give "a"'),
+    null,
+  )
+  assert.equal(extentFinding('§1a two adjacent text runs at $.children'), null)
+  // The ids the declaration file may name are exactly the rules above.
+  assert.deepEqual(EXTENT_RULE_IDS, [
+    'ends-past-last-child',
+    'ends-before-placed-child',
+    'starts-past-opening-markup',
+    'empty-span-covers-more',
+  ])
+})
+
+test('the extent ledger refuses a "permitted" status', () => {
+  // THE OFF-SWITCH TEST. The sibling file has a permitted category because §4
+  // exempts a REASSEMBLED node - no honest span exists. A span that exists and
+  // points at the wrong codepoint has no such reading, so the one status that
+  // would silence a finding here must not be reachable, by typo or otherwise.
+  const { errors } = parseExtentDeclarations('carve-rs  ends-past-last-child  footnote  3  permitted')
+  assert.equal(errors.length, 1)
+  assert.match(errors[0], /never "permitted"/)
+})
+
+test('the extent ledger refuses a rule it does not know', () => {
+  const { errors } = parseExtentDeclarations('carve-rs  ends-somewhere  footnote  3  markup-carve/carve-rs#1')
+  assert.equal(errors.length, 1)
+  assert.match(errors[0], /unknown rule "ends-somewhere"/)
+})
+
+test('the extent ledger refuses a bare issue reference', () => {
+  // A bare `#1303` in this repo resolves to carve#1303, not to the engine issue
+  // it means - the same trap the position ledger's own test guards.
+  const { errors } = parseExtentDeclarations('carve-rs  ends-past-last-child  footnote  3  #1303')
+  assert.equal(errors.length, 1)
+  assert.match(errors[0], /owner\/repo#N/)
+})
+
+test('UNDECLARED: a §4 extent finding no line covers fails, and prints the line to paste', () => {
+  const result = partitionFindings(
+    'carve-rs',
+    [pastLastChild('204-a-heading-in-a-footnote-body.crv', 'footnote'), pastLastChild('312-a-note-body.crv', 'footnote')],
+    declare(''),
+    declareExtents(''),
+  )
+  assert.equal(result.extent, 2)
+  assert.equal(result.ungated, 0)
+  assert.equal(result.extentProblems.length, 1)
+  assert.match(result.extentProblems[0], /^UNDECLARED\s+carve-rs\s+ends-past-last-child\s+footnote\s+2/)
+  assert.match(
+    result.extentProblems[0],
+    /record it as: {2}carve-rs {2}ends-past-last-child {2}footnote {2}2 {2}<owner\/repo#N>/,
+  )
+  // The position ledger is untouched by an extent finding.
+  assert.deepEqual(result.problems, [])
+})
+
+test('a declared §4 extent finding at its declared count passes', () => {
+  const result = partitionFindings(
+    'carve-rs',
+    [pastLastChild('a.crv', 'footnote'), pastLastChild('b.crv', 'footnote')],
+    declare(''),
+    declareExtents('carve-rs  ends-past-last-child  footnote  2  markup-carve/carve-rs#1303'),
+  )
+  assert.deepEqual(result.extentProblems, [])
+  assert.equal(result.extent, 2)
+})
+
+test('COUNT: an extent declaration fails when the number moves DOWN', () => {
+  // The ratchet direction that matters. An engine fixing one of three must
+  // lower the line, or the ledger keeps claiming a violation that is gone.
+  const result = partitionFindings(
+    'carve-rs',
+    [pastLastChild('a.crv', 'footnote')],
+    declare(''),
+    declareExtents('carve-rs  ends-past-last-child  footnote  3  markup-carve/carve-rs#1303'),
+  )
+  assert.equal(result.extentProblems.length, 1)
+  assert.match(
+    result.extentProblems[0],
+    /^COUNT\s+carve-rs\s+ends-past-last-child\s+footnote\s+declares 3, measured 1/,
+  )
+})
+
+test('COUNT: an extent declaration fails when the number moves UP', () => {
+  const result = partitionFindings(
+    'carve-rs',
+    [pastLastChild('a.crv', 'footnote'), pastLastChild('b.crv', 'footnote')],
+    declare(''),
+    declareExtents('carve-rs  ends-past-last-child  footnote  1  markup-carve/carve-rs#1303'),
+  )
+  assert.equal(result.extentProblems.length, 1)
+  assert.match(result.extentProblems[0], /declares 1, measured 2/)
+})
+
+test('a NEW extent violation of an undeclared TYPE fails even at an unchanged total', () => {
+  // Why the ledger keys on the node type rather than counting per engine: one
+  // footnote fixed and one definition_term broken is a net-zero move, and a
+  // bare per-engine total would call that conformant.
+  const result = partitionFindings(
+    'carve-rs',
+    [pastLastChild('a.crv', 'definition_term')],
+    declare(''),
+    declareExtents('carve-rs  ends-past-last-child  footnote  1  markup-carve/carve-rs#1303'),
+  )
+  assert.equal(result.extentProblems.length, 2)
+  assert.match(result.extentProblems[0], /^UNDECLARED\s+carve-rs\s+ends-past-last-child\s+definition_term/)
+  assert.match(result.extentProblems[1], /^FIXED\s+carve-rs\s+ends-past-last-child\s+footnote/)
+})
+
+test('FIXED: an extent declaration for an engine with NO findings at all fails', () => {
+  // THE TWO-DIRECTIONAL HALF, and the one a one-way silencer would not have.
+  // An engine that has conformed is exactly when a line has to go, and a
+  // reconciliation reachable only while something is still wrong can never
+  // say so - the defect resources/ast-value-divergence.txt carried for eight
+  // months (carve#534).
+  const result = partitionFindings(
+    'carve-rs',
+    [],
+    declare(''),
+    declareExtents('carve-rs  ends-past-last-child  footnote  3  markup-carve/carve-rs#1303'),
+  )
+  assert.equal(result.extentProblems.length, 1)
+  assert.match(result.extentProblems[0], /^FIXED\s+carve-rs\s+ends-past-last-child\s+footnote/)
+  assert.match(result.extentProblems[0], /delete the line/)
+})
+
+test('an extent declaration for one engine never covers another', () => {
+  const declaredExtents = declareExtents(
+    'carve-rs  ends-past-last-child  footnote  1  markup-carve/carve-rs#1303',
+  )
+  const result = partitionFindings('carve-php', [pastLastChild('a.crv', 'footnote')], declare(''), declaredExtents)
+  assert.equal(result.extentProblems.length, 1)
+  assert.match(result.extentProblems[0], /^UNDECLARED\s+carve-php/)
+})
+
+test('every finding leaves through exactly one door, and the doors add up', () => {
+  // The arithmetic the report prints. Its old form summed a bucket that could
+  // not fail, so the line read "30 not a position" and the run exited 0.
+  const result = partitionFindings(
+    'carve-rs',
+    [
+      'a.crv: missing pos on "text" at $.c[0]',
+      pastLastChild('a.crv', 'footnote'),
+      'a.crv: §1a two adjacent text runs at $.children',
+    ],
+    declare('carve-rs  a.crv  text  1  permitted'),
+    declareExtents('carve-rs  ends-past-last-child  footnote  1  markup-carve/carve-rs#1303'),
+  )
+  assert.equal(result.waived + result.outstanding + result.undeclared + result.extent + result.ungated, 3)
+  assert.equal(result.waived, 1)
+  assert.equal(result.extent, 1)
+  assert.equal(result.ungated, 1)
+  // Only the ungated one fails: the other two are declared.
+  assert.deepEqual(result.problems, [])
+  assert.deepEqual(result.extentProblems, [])
+  assert.equal(result.ungatedProblems.length, 1)
+})
+
+test('the shipped extent declaration parses, and every line names an ENGINE issue', () => {
+  const text = readFileSync(resolve(root, 'resources/ast-extent-findings.txt'), 'utf8')
+  const { declared, errors } = parseExtentDeclarations(text)
+  assert.deepEqual(errors, [], errors.join('; '))
+  for (const line of declared.values()) {
+    // FULLY QUALIFIED, for the reason the position ledger's own test gives: a
+    // bare number resolves against THIS repo and links the wrong ticket.
+    assert.match(
+      line.status,
+      /^markup-carve\/carve-(js|rs|php)#\d+$/,
+      `${line.engine} ${line.rule} ${line.type} names "${line.status}"`,
+    )
+    // And never a DERIVED engine, whose findings are another engine's arriving
+    // a second time and are never reconciled - a FIXED that can never clear.
+    assert.equal(
+      notReconciledBecause(line.engine),
+      null,
+      `${line.engine} is declared but never reconciled, so this line can never be checked`,
+    )
+  }
 })
 
 test('the grouped report keeps every document, not one example', () => {


### PR DESCRIPTION
Closes #1637

`checkStopsAtChildren` reads the SOURCE rather than another engine. Its own
docblock says why: the three-way span panel compares the engines against each
other, so a rule every engine breaks the same way reads as agreement, and a
source-reading rule is the only party to the question that cannot agree with an
engine by accident.

Its findings then reached `partitionFindings`, which routed every
non-"missing position" finding into a counter named `unwaivable` and
`continue`d. No `problems` entry was ever produced, so a grep of a whole run for
`UNWAIVED` returned zero lines while thirty §4 violations per engine were
printed in full. "Never absorbable by a line" was true of the waiver file and
false of the run.

## What `unwaivable` was for, and what happened to it

It was the arithmetic term, not a staging mechanism. Its whole job was to make
`waived + outstanding + undeclared + unwaivable === findings.length` hold so the
report's summary line did not understate what the run measured. It had no
declaration file because it was never meant to be reconciled against one - the
comment beside it reasoned only about whether a waiver LINE could absorb it, and
never about whether anything failed.

So it is not removed, it is split into two terms that can both fail. Every
finding now leaves through one of three doors:

| door | ledger | can it fail |
|---|---|---|
| missing position | `resources/ast-position-waivers.txt`, unchanged | yes, already did |
| §4 extent | `resources/ast-extent-findings.txt`, new | yes, in three directions |
| anything else | none, by design | yes, `UNGATED`, on sight |

The arithmetic term survives as `waived + outstanding + undeclared + extent +
ungated === findings.length`.

## Why a declaration and not a flat zero

carve-rs carries thirty of these and carve-php thirty-eight, and both are being
ported now. Gating at zero would put a scheduled job red until every port landed
across three engines, and a permanently red scheduled job gets muted - which is
the failure `.github/workflows/ast-conformance.yml` exists to undo. A check that
cannot pass is the same defect as a check that cannot fail, one sign flipped.

So it ratchets, exactly like `resources/ast-span-divergence.txt` and
`resources/ast-value-divergence.txt` already do, and it is exact in three
directions rather than one:

- a finding no line covers -> `UNDECLARED`, fails
- a declared count that moved, in EITHER direction -> `COUNT`, fails
- a declared line nothing produces any more -> `FIXED`, fails until deleted

The third is what makes it a ratchet rather than a silencer: an engine that
conforms turns the run red until its line goes, so the numbers can only come
down.

There is no `permitted` status in the new file, and `parseExtentDeclarations`
refuses one as a parse error. The sibling ledger has that status because §4
exempts a REASSEMBLED node - its value is not a slice of the source at any
offset, so no honest span exists. A span that IS present and points at the wrong
codepoint has no such reading, so every line names the engine issue that will
delete it.

Keyed per (engine, rule, node type) rather than per document. An extent defect is
one construct behaving one way everywhere it appears - the argument `compareSpans`
already gives for keying its own rows by type - so a per-document ledger would be
sixty lines describing two facts and every engine fix would rewrite all sixty.
Per type still fails on a new violation of a type nothing declares, which a bare
per-engine total would not; there is a test for exactly that net-zero case.

## The advice text named the wrong rule

Second defect on the same surface, from the ticket's follow-up comment. The
advice `reportSpanDisagreements` attaches to every span drift row named
`checkOpeningMarkup` as "what names a side". That function tests where a span
BEGINS. Six of eight rows on the run that prompted the ticket have a unanimous
`startOffset` and differ only at the END, where `checkStopsAtChildren` and its
`ENDS_AT_LAST_CHILD` set govern and the WIDE engine is the one that moves. Read
literally the advice blamed carve-js - the one engine of the three with zero
`span reaches past its last child` findings.

The advice, the panel's printed EXTENT line, and the two docblocks that carried
the same sentence now split §4's two sentences and say which end each governs.

## Proof

Run against the pinned carve-js build, which carries one real §4 extent
violation in `202-a-definition-on-a-footnote-body-s-continuation-line-is-collected.crv`.

**Before, same input, same corpus** (`origin/main` in a second worktree):

```
carve-js (reference): 58 findings, 4 distinct (57 waived, 0 outstanding, 1 not a position)
OLD CODE EXIT=0
```

Zero `UNWAIVED` lines anywhere in the run.

**After** - the finding gates:

```
PART 12 §4 EXTENT FINDINGS does not match resources/ast-extent-findings.txt:
  UNDECLARED carve-js  ends-past-last-child  footnote  1  - a PART 12 §4 extent violation no line covers. Fix the engine, or record it as:  carve-js  ends-past-last-child  footnote  1  <owner/repo#N>
```

exit 1.

**Declared, the run goes green on that gate:**

```
carve-js (reference): 58 findings, 4 distinct (57 waived, 0 outstanding, 1 §4 extent (declared))
PROOF2 EXIT=0
```

**Two-directional** - a declaration left in place for a violation that does not
occur:

```
PART 12 §4 EXTENT FINDINGS does not match resources/ast-extent-findings.txt:
  FIXED      carve-js  ends-past-last-child  definition_term  is declared (markup-carve/carve-js#9999) but no longer occurs - delete the line
```

exit 1.
