### PR TITLE
Add importer and binding coverage ratchets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **HTML import coverage is measured as a population and across engines**
+  (carve#1600). Every grammar construct has one coverage classification, the
+  complete render corpus is re-imported through the pinned JavaScript engine,
+  and all normative HTML fixtures run through Rust, JavaScript, and PHP with a
+  bidirectional drift ledger.
+- **Built-in render/import routes have a corpus round-trip ratchet**
+  (carve#1604). Exact current HTML and Markdown counts are pinned and must be
+  reviewed when either improves or regresses.
+- **Bindings owe the complete output surface plus the AST** (carve#1599).
+  Importers remain optional but must be explicitly implemented or declared out
+  of scope; a machine-readable binding contract checks the inventory.
+
 - **An explicit closer is a spelling change, so it cannot move a list's
   tightness** (carve#1602). Corpus
   `362-an-unterminated-container-does-not-extend-the-item-past-a-blank-line-4`

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -27,6 +27,13 @@ the bar for "a Carve implementation" is **Tier-1 core** (native syntax) - see
 
 Higher-level bindings and satellite packages that wrap one of the engine implementations.
 
+A binding over carve-rs exposes the complete core output surface: HTML,
+Markdown, plain text, ANSI, canonical Carve, and the published AST. Importers
+are optional, but each binding declares every HTML, Markdown, and Djot importer
+as either implemented or out of scope. The machine-readable declaration in
+`resources/binding-contract.json` checks that the required output set is exact
+and that every importer has exactly one declaration.
+
 | Project | Language | Notes |
 |---|---|---|
 | [carve-go](https://github.com/markup-carve/carve-go) | Go | Pure-Go module via wazero + WASI over carve-rs. |

--- a/docs/format-bridges.md
+++ b/docs/format-bridges.md
@@ -85,6 +85,13 @@ Carve's - a node, never in silence.
 
 ## A round trip is an expressiveness test for the AST
 
+The corpus now records this measurement directly for built-in import routes.
+At the current JavaScript engine pin, 605 of 1,384 documents return to their
+canonical Carve source through HTML, and 374 through Markdown. The exact counts
+are a bidirectional ratchet in `resources/import-roundtrip-baseline.json`: a
+regression and an improvement both require inspection rather than silently
+changing the published baseline.
+
 Bridges are usually justified by reach: one conversion unlocks a whole family of
 outputs. That is true, and it is not the most interesting property.
 

--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -1131,6 +1131,19 @@ portable adapter names are `generic`, `tiptap`, `prosemirror`, `ckeditor`,
 
 ## Conformance fixtures
 
+HTML import is gated at three scales. The normative fixture directories below
+pin source, published AST, and diagnostics. `resources/html-import-construct-coverage.json`
+classifies every construct derived from the normative grammar, including
+importable constructs that still have no shared fixture. The converter runner
+also hands every fixture to Rust, JavaScript, and PHP and reconciles known drift
+in `resources/converter-drift.txt` in both directions.
+
+The wider population gate renders all 1,384 corpus documents and imports that
+HTML through the pinned JavaScript engine. At the current pin, 1,383 complete,
+1,329 imports are canonical-writer fixed points, and 1,351 preserve visible
+rendered text. These are pinned measurements, not claims that HTML is lossless;
+any movement forces inspection and an explicit baseline update.
+
 Each directory under `tests/html-import` contains `input.html`,
 `expected.crv`, `expected.ast.json`, and `expected.report.json`. Implementations
 may add platform-specific fixtures, but shared fixtures define the portable

--- a/resources/binding-contract.json
+++ b/resources/binding-contract.json
@@ -1,0 +1,48 @@
+{
+  "requiredOutputs": ["html", "markdown", "plain", "ansi", "carve", "ast"],
+  "optionalImporters": ["html", "markdown", "djot"],
+  "bindings": {
+    "carve-go": {
+      "commit": "cb26ca6",
+      "outputs": ["html", "markdown", "plain", "ansi", "carve", "ast"],
+      "importers": {},
+      "outOfScopeImporters": {
+        "html": "the WASI binding does not currently expose migration commands",
+        "markdown": "the WASI binding does not currently expose migration commands",
+        "djot": "the WASI binding does not currently expose migration commands"
+      }
+    },
+    "carve-py": {
+      "commit": "e352220",
+      "implementation": "markup-carve/carve-py#59",
+      "outputs": ["html", "markdown", "plain", "ansi", "carve", "ast"],
+      "importers": {},
+      "outOfScopeImporters": {
+        "html": "importers are not part of the current Python API",
+        "markdown": "importers are not part of the current Python API",
+        "djot": "importers are not part of the current Python API"
+      }
+    },
+    "carve-rb": {
+      "commit": "6bfe761",
+      "implementation": "markup-carve/carve-rb#88",
+      "outputs": ["html", "markdown", "plain", "ansi", "carve", "ast"],
+      "importers": {},
+      "outOfScopeImporters": {
+        "html": "importers are not part of the current Ruby API",
+        "markdown": "importers are not part of the current Ruby API",
+        "djot": "importers are not part of the current Ruby API"
+      }
+    },
+    "carve-wasm": {
+      "commit": "01588bc",
+      "implementation": "markup-carve/carve-wasm#54",
+      "outputs": ["html", "markdown", "plain", "ansi", "carve", "ast"],
+      "importers": {"html": "htmlToCarve"},
+      "outOfScopeImporters": {
+        "markdown": "only HTML import is currently part of the WASM API",
+        "djot": "only HTML import is currently part of the WASM API"
+      }
+    }
+  }
+}

--- a/resources/converter-drift.txt
+++ b/resources/converter-drift.txt
@@ -94,3 +94,15 @@
 # the same defect, and only one of them announces itself.
 #
 # THIS FILE IS EMPTY OF DECLARATIONS AGAIN, which is the intended end state.
+
+# Full HTML-import fixture sweep added by carve#1600, measured 2026-08-24 on
+# clean current mains: carve-rs 9cf16d05, carve-js 05e1cc27, carve-php 06c27aaa.
+# Each entry is removed when that engine reproduces the normative fixture.
+rust/html-import--derived-endnotes-section  the importer does not preserve the derived endnotes list looseness (carve#1612)
+js/html-import--derived-endnotes-section  the importer does not preserve the derived endnotes list looseness (carve#1612)
+php/html-import--derived-endnotes-section  the importer does not preserve the derived endnotes list looseness (carve#1612)
+rust/html-import--empty-definition-description  an empty description is not reproduced as the fixture's definition-list row (carve#1636)
+rust/html-import--empty-definition-description-not-last  dropping the empty description changes the following definition-list structure (carve#1636)
+php/html-import--empty-definition-description-not-last  dropping the empty description changes the following definition-list structure (carve#1636)
+rust/html-import--endnotes-section-not-last  the importer relocates a non-final endnotes section (carve#1600)
+rust/html-import--note-reference-in-a-span  the note reference consumes the surrounding span boundary (carve#1600)

--- a/resources/html-import-construct-coverage.json
+++ b/resources/html-import-construct-coverage.json
@@ -1,0 +1,28 @@
+{
+  "sharedFixtures": [
+    "heading", "thematic_break", "code_block", "blockquote", "unordered_list",
+    "ordered_list", "definition_list", "table", "admonition", "div", "paragraph",
+    "block_attributes", "code_span", "inline_link", "inline_span", "inline_image",
+    "math_inline", "math_display", "emphasis", "highlight", "forced_emphasis",
+    "forced_highlight"
+  ],
+  "engineTestsOnly": [
+    "strong", "bold_italic", "underline", "strikethrough", "hard_break",
+    "forced_super", "forced_sub", "addition", "deletion", "figure_group",
+    "footnote_definition", "reference_footnote", "escaped_char", "line_block",
+    "abbreviation_definition", "autolink", "mention", "tag", "raw_block",
+    "raw_inline", "smart_quote", "reference_definition", "reference_link",
+    "collapsed_reference_link", "reference_image", "collapsed_reference_image"
+  ],
+  "uncoveredImportable": [
+    "forced_strong", "forced_underline", "forced_strike", "local_hard_break_block",
+    "auto_text_link", "extension_inline", "substitution", "editorial_comment"
+  ],
+  "notImportable": [
+    "comment_block", "comment_line", "inline_comment", "braced_comment",
+    "literal_inline", "soft_break", "symbol", "inline_footnote", "em_dash",
+    "en_dash", "braced_en_dash", "ellipsis", "arrow", "comparison",
+    "typographic_symbol"
+  ],
+  "structural": ["blank_line"]
+}

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,0 +1,17 @@
+{
+  "engine": "@markup-carve/carve",
+  "engineCommit": "71add23f80f1884684cea2c8bf46de08d0b64e5c",
+  "corpusDocuments": 1384,
+  "htmlImportPopulation": {
+    "completed": 1383,
+    "canonicalFixedPoints": 1329,
+    "renderedTextPreserved": 1351,
+    "expectedRejections": [
+      "182-openers-past-the-nesting-cap-are-one-paragraph.crv"
+    ]
+  },
+  "renderImportRoundTrips": {
+    "html": 605,
+    "markdown": 374
+  }
+}

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -377,6 +377,7 @@ const impls = [
         markdown: 'process.stdout.write(markdownToCarve(source));',
         html: 'process.stdout.write(htmlToCarve(source).value);',
         bbcode: 'process.stdout.write(bbcodeToCarve(source));',
+        djot: 'process.stdout.write(djotToCarve(source));',
       }
       if (!entries[format]) return null
       return [
@@ -385,7 +386,7 @@ const impls = [
         '-e',
         `
           import { readFileSync } from 'node:fs';
-          import { markdownToCarve, htmlToCarve, bbcodeToCarve } from './dist/index.js';
+          import { markdownToCarve, htmlToCarve, bbcodeToCarve, djotToCarve } from './dist/index.js';
           const source = readFileSync(process.argv[1], 'utf8');
           ${entries[format]}
         `,
@@ -830,6 +831,25 @@ async function runConvertMode() {
         expected: readFileSync(expectedPath, 'utf8').trim(),
       }
     })
+
+  // The HTML-import contract is a second, larger HTML population. Run every
+  // source through all available importers here as well, using its normative
+  // expected Carve source rendered by the pinned JS engine as the meaning
+  // assertion. Keeping this in the existing converter runner gives it the same
+  // per-engine drift ledger and stale-entry checks instead of inventing a
+  // weaker one-engine fixture sweep (carve#1600).
+  const { carveToHtml } = await import('@markup-carve/carve')
+  const htmlImportDir = join(root, 'tests/html-import')
+  for (const slug of readdirSync(htmlImportDir).sort()) {
+    const dir = join(htmlImportDir, slug)
+    if (!statSync(dir).isDirectory()) continue
+    cases.push({
+      slug: `html-import--${slug}`,
+      format: 'html',
+      file: join(dir, 'input.html'),
+      expected: carveToHtml(readFileSync(join(dir, 'expected.crv'), 'utf8')).trim(),
+    })
+  }
 
   const population = shortfall({
     label: 'CASES',

--- a/scripts/lib/converter-formats.mjs
+++ b/scripts/lib/converter-formats.mjs
@@ -48,8 +48,6 @@ export const UNIMPLEMENTED_IMPORTERS = {
   rust: {
     bbcode: 'carve-rs has no BBCode importer (carve#1130 coverage table); `carve migrate --from bbcode` rejects the format',
   },
-  js: {
-    djot: 'carve-js has no Djot importer - only the applyMigrationFixes linter (carve#1130 coverage table)',
-  },
+  js: {},
   php: {},
 }

--- a/tests/binding-contract.check-helper.mjs
+++ b/tests/binding-contract.check-helper.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+const contract = JSON.parse(
+  await readFile(new URL('../resources/binding-contract.json', import.meta.url), 'utf8'),
+)
+
+test('every carve-rs binding exposes every required output and declares every importer', () => {
+  assert.deepEqual(Object.keys(contract.bindings).sort(), [
+    'carve-go',
+    'carve-py',
+    'carve-rb',
+    'carve-wasm',
+  ])
+  for (const [name, binding] of Object.entries(contract.bindings)) {
+    assert.deepEqual(
+      [...binding.outputs].sort(),
+      [...contract.requiredOutputs].sort(),
+      `${name} must expose the complete render-target set plus the AST`,
+    )
+    for (const importer of contract.optionalImporters) {
+      const implemented = Object.hasOwn(binding.importers, importer)
+      const declared = Object.hasOwn(binding.outOfScopeImporters, importer)
+      assert.notEqual(
+        implemented,
+        declared,
+        `${name} ${importer} import must be implemented or explicitly out of scope, never both`,
+      )
+      if (declared) assert.ok(binding.outOfScopeImporters[importer].trim())
+    }
+  }
+})

--- a/tests/html-import-construct-coverage.check-helper.mjs
+++ b/tests/html-import-construct-coverage.check-helper.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+const grammar = await readFile(new URL('../resources/grammar.ebnf', import.meta.url), 'utf8')
+const coverage = JSON.parse(
+  await readFile(new URL('../resources/html-import-construct-coverage.json', import.meta.url), 'utf8'),
+)
+
+const production = (name) =>
+  grammar.match(new RegExp(`^${name}[ \\t]*=([\\s\\S]*?);`, 'm'))?.[1] ?? null
+const alternatives = (name) =>
+  production(name)
+    ?.replace(/\(\*[\s\S]*?\*\)/g, ' ')
+    .split('|')
+    .map((part) => part.trim())
+    .filter(Boolean) ?? null
+const isFamily = (values) =>
+  values?.length >= 2 && values.every((value) => /^[a-z_][a-zA-Z0-9_]*$/.test(value))
+
+const constructs = []
+for (const root of ['block', 'inline_element']) {
+  for (const name of alternatives(root) ?? []) {
+    const members = alternatives(name)
+    constructs.push(...(isFamily(members) ? members : [name]))
+  }
+}
+
+test('every grammar construct has exactly one HTML-import coverage declaration', () => {
+  const declared = Object.values(coverage).flat()
+  assert.equal(new Set(declared).size, declared.length, 'a construct appears in multiple buckets')
+  assert.deepEqual(
+    [...declared].sort(),
+    [...constructs].sort(),
+    'classify every new or removed grammar construct before HTML-import coverage can pass',
+  )
+})

--- a/tests/html-import-contract.check.mjs
+++ b/tests/html-import-contract.check.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
 import { readdir, readFile } from 'node:fs/promises'
 import { test } from 'node:test'
+import './binding-contract.check-helper.mjs'
+import './html-import-construct-coverage.check-helper.mjs'
+import './import-roundtrip-ratchets.check-helper.mjs'
 
 const root = new URL('./html-import/', import.meta.url)
 

--- a/tests/import-roundtrip-ratchets.check-helper.mjs
+++ b/tests/import-roundtrip-ratchets.check-helper.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import { readdir, readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+import { JSDOM } from 'jsdom'
+import {
+  carveToCarve,
+  carveToHtml,
+  carveToMarkdown,
+  htmlToCarve,
+  markdownToCarve,
+} from '@markup-carve/carve'
+
+const root = new URL('./corpus/', import.meta.url)
+const baseline = JSON.parse(
+  await readFile(new URL('../resources/import-roundtrip-baseline.json', import.meta.url), 'utf8'),
+)
+
+const visibleText = (html) =>
+  new JSDOM(html).window.document.body.textContent.replace(/\s+/g, ' ').trim()
+
+test('HTML import and render/import round trips cannot drift silently', async () => {
+  const names = (await readdir(root)).filter((name) => name.endsWith('.crv')).sort()
+  const measured = {
+    corpusDocuments: names.length,
+    htmlImportPopulation: {
+      completed: 0,
+      canonicalFixedPoints: 0,
+      renderedTextPreserved: 0,
+      expectedRejections: [],
+    },
+    renderImportRoundTrips: { html: 0, markdown: 0 },
+  }
+
+  for (const name of names) {
+    const canonical = carveToCarve(await readFile(new URL(name, root), 'utf8'))
+    const html = carveToHtml(canonical)
+    try {
+      const imported = htmlToCarve(html).value
+      measured.htmlImportPopulation.completed++
+      if (carveToCarve(imported) === imported) {
+        measured.htmlImportPopulation.canonicalFixedPoints++
+      }
+      if (visibleText(carveToHtml(imported)) === visibleText(html)) {
+        measured.htmlImportPopulation.renderedTextPreserved++
+      }
+      if (carveToCarve(imported) === canonical) measured.renderImportRoundTrips.html++
+    } catch {
+      measured.htmlImportPopulation.expectedRejections.push(name)
+    }
+    const markdownImported = markdownToCarve(carveToMarkdown(canonical))
+    if (carveToCarve(markdownImported) === canonical) {
+      measured.renderImportRoundTrips.markdown++
+    }
+  }
+
+  assert.deepEqual(
+    measured,
+    {
+      corpusDocuments: baseline.corpusDocuments,
+      htmlImportPopulation: baseline.htmlImportPopulation,
+      renderImportRoundTrips: baseline.renderImportRoundTrips,
+    },
+    'the import population changed; inspect every changed count and update the pinned baseline only with the engine pin',
+  )
+})


### PR DESCRIPTION
Closes #1600. Closes #1604. Closes #1599. Adds current corpus measurements, full cross-engine HTML fixture coverage, grammar-derived construct coverage, and the option A binding contract. Binding implementations are in markup-carve/carve-py#59, markup-carve/carve-rb#88, and markup-carve/carve-wasm#54.