### PR TITLE
tooling: a cross-engine shape diff is named, not gated and not dropped

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -626,6 +626,17 @@ const waiverProblems = []
 const extentDriftProblems = []
 const ungatedProblems = []
 
+/*
+ * The cross-engine shape diffs, per engine, rolled up at the end of the run.
+ *
+ * They are NOT gated - `reportEngineDisagreement` states the policy for that
+ * whole family below - but they must not be silent either, which is the defect
+ * carve#1637 is about. Counted here, named on each engine's summary line, and
+ * printed once at the end so a reader knows the number exists and which panel
+ * owns it.
+ */
+const referenceShapeCounts = []
+
 /**
  * Every declaration this run reconciles, gated together at the end.
  *
@@ -1499,6 +1510,7 @@ function report(engine, label, findings) {
     outstanding,
     undeclared,
     extent,
+    reference,
     ungated,
     problems,
     extentProblems,
@@ -1509,6 +1521,7 @@ function report(engine, label, findings) {
         outstanding: 0,
         undeclared: 0,
         extent: 0,
+        reference: 0,
         ungated: 0,
         problems: [],
         extentProblems: [],
@@ -1518,6 +1531,7 @@ function report(engine, label, findings) {
   waiverProblems.push(...problems)
   extentDriftProblems.push(...extentProblems)
   ungatedProblems.push(...ungatedLines)
+  if (reference > 0) referenceShapeCounts.push({ label, count: reference })
 
   if (findings.length === 0) {
     console.log(`${label}: conformant\n`)
@@ -1534,10 +1548,11 @@ function report(engine, label, findings) {
   const ranked = groupFindings(findings)
   const split = exempt
     ? `not reconciled: ${exempt}`
-    : waived + outstanding + undeclared + extent + ungated === findings.length
+    : waived + outstanding + undeclared + extent + reference + ungated === findings.length
       ? `${waived} waived, ${outstanding} outstanding` +
         (undeclared > 0 ? `, ${undeclared} UNDECLARED` : '') +
         (extent > 0 ? `, ${extent} §4 extent (declared)` : '') +
+        (reference > 0 ? `, ${reference} reference-shape (the panel's, not gated here)` : '') +
         (ungated > 0 ? `, ${ungated} UNGATED` : '')
       : 'partition disagrees with the total - this is a bug in partitionFindings'
   console.log(`${label}: ${findings.length} findings, ${ranked.length} distinct (${split})`)
@@ -1711,6 +1726,19 @@ declarationDrift.push({
     'commit that lowers the number. UNDECLARED lines above print the line to paste.',
   ],
 })
+
+if (referenceShapeCounts.length > 0) {
+  const total = referenceShapeCounts.reduce((n, e) => n + e.count, 0)
+  console.log(
+    `REFERENCE SHAPE DIFFS: ${total} (${referenceShapeCounts
+      .map((e) => `${e.label.split(' ')[0]} ${e.count}`)
+      .join(', ')}) - reported, not gated here.`,
+  )
+  console.log('  A tree differing from carve-js is an ENGINE-AGAINST-ENGINE finding, and this')
+  console.log('  fleet ports a fix over several days, so the engine that is RIGHT is routinely')
+  console.log('  the odd one out. The THREE-WAY SHAPE COMPARISON above owns these, and a')
+  console.log('  reference off its pin makes every line here describe that checkout instead.\n')
+}
 
 // The findings no ledger covers, and none should. A wrong slice, a span outside
 // its parent, a §1a run: each is a defect to fix rather than a number to

--- a/scripts/spec/ast-waivers.mjs
+++ b/scripts/spec/ast-waivers.mjs
@@ -138,6 +138,37 @@ export function extentFinding(text) {
   return null
 }
 
+/*
+ * THE ONE CLASS THAT IS REPORTED AND DELIBERATELY NOT GATED.
+ *
+ * `checkShapeParity` diffs a satellite's tree against carve-js's. It is the
+ * only finding in this list that is an ENGINE-AGAINST-ENGINE comparison rather
+ * than a statement about the source, and `reportEngineDisagreement` in
+ * scripts/ast-conformance.mjs states the policy for that whole family in its
+ * own words: NOT A GATE, deliberately, because in this fleet a fix lands in one
+ * engine first, so the engine that is RIGHT is routinely the odd one out for a
+ * few days and failing on that would make the fix for a red run "wait".
+ *
+ * It is worse than that here. A reference checkout that is behind or locally
+ * modified turns every satellite's line into a statement about the operator's
+ * working copy - `referenceProvenance` exists because that measured 70 findings
+ * once - so this is the one class whose count is not even about the engine it
+ * names.
+ *
+ * COUNTED AND NAMED, not dropped. That distinction is the whole point of
+ * carve#1637: the bucket it replaces was silent, and a run could print thirty
+ * findings while reporting nothing about them. This one is reported on the
+ * engine's own summary line and rolled up at the end of the run, and the panel
+ * that DOES own it reconciles it against resources/ast-span-divergence.txt and
+ * the shape comparison beside it.
+ */
+const REFERENCE_SHAPE = /^tree differs from the reference at /
+
+/** True where a finding is the cross-engine shape diff, which has its own panel. */
+export function isReferenceShapeFinding(text) {
+  return REFERENCE_SHAPE.test(text)
+}
+
 const extentKeyOf = (engine, rule, type) => `${engine}\t${rule}\t${type}`
 
 /** `<engine>  <rule>  <type>  <count>  <owner/repo#N>` - the extent ledger. */
@@ -265,6 +296,10 @@ export function parseWaivers(text) {
  *   `permitted` category because §4 exempts a reassembled node.
  *   §4 EXTENT       -> `resources/ast-extent-findings.txt`, issue-only, no
  *   permitted category at all.
+ *   REFERENCE SHAPE -> `reference`, counted and named on the summary line and
+ *   rolled up at the end of the run, and gated by NEITHER ledger. It is the one
+ *   ENGINE-AGAINST-ENGINE finding in this list and the run's own policy for that
+ *   family is not to gate it - see the note above `REFERENCE_SHAPE`.
  *   ANYTHING ELSE   -> `ungated`, which fails on sight. There is no ledger for
  *   a wrong slice, a span outside its parent or a §1a run, and there should not
  *   be: those are defects to fix, not numbers to record.
@@ -277,6 +312,7 @@ export function partitionFindings(engine, findings, declared, extentDeclared = n
   const measured = new Map()
   const extentMeasured = new Map()
   const ungated = []
+  let reference = 0
   for (const finding of findings) {
     const { document, text } = splitFinding(finding)
     const type = document === null ? null : waivableType(text)
@@ -289,6 +325,10 @@ export function partitionFindings(engine, findings, declared, extentDeclared = n
     if (found !== null) {
       const key = extentKeyOf(engine, found.rule, found.type)
       extentMeasured.set(key, (extentMeasured.get(key) ?? 0) + 1)
+      continue
+    }
+    if (isReferenceShapeFinding(text)) {
+      reference += 1
       continue
     }
     ungated.push(finding)
@@ -371,6 +411,7 @@ export function partitionFindings(engine, findings, declared, extentDeclared = n
     outstanding,
     undeclared,
     extent,
+    reference,
     ungated: ungated.length,
     problems,
     extentProblems,

--- a/tests/ast-waivers.test.mjs
+++ b/tests/ast-waivers.test.mjs
@@ -24,6 +24,7 @@ import {
   describeDocuments,
   extentFinding,
   groupFindings,
+  isReferenceShapeFinding,
   notReconciledBecause,
   parseExtentDeclarations,
   parseWaivers,
@@ -133,7 +134,12 @@ test('UNWAIVED: a finding no line covers', () => {
   // the report's own summary line understates what the run measured.
   assert.equal(result.undeclared, 1)
   assert.equal(
-    result.waived + result.outstanding + result.undeclared + result.extent + result.ungated,
+    result.waived +
+      result.outstanding +
+      result.undeclared +
+      result.extent +
+      result.reference +
+      result.ungated,
     2,
   )
 })
@@ -200,6 +206,41 @@ test('a finding that is not a position can never be waived, and now it GATES', (
   // alive by an unrelated finding in the same document.
   assert.equal(result.problems.length, 1)
   assert.match(result.problems[0], /^FIXED/)
+})
+
+test('a cross-engine shape diff is counted and named, and gated by neither ledger', () => {
+  // THE ONE CLASS THAT MUST NOT GATE HERE, and the reason it is named rather
+  // than dropped. `checkShapeParity` diffs a satellite against carve-js, and
+  // this fleet ports a fix over several days - so the engine that is RIGHT is
+  // routinely the odd one out, and the run's own policy for that family is to
+  // attribute it loudly and let the panel carry it. A reference checkout off
+  // its pin makes the line describe the operator's working copy besides.
+  //
+  // Silently dropping it would be the carve#1637 defect wearing a new hat, so
+  // it lands in its own counted bucket and on the engine's summary line.
+  assert.equal(
+    isReferenceShapeFinding(
+      'tree differs from the reference at $.children[1]:footnote - reference has 12 nodes, this has 12',
+    ),
+    true,
+  )
+  assert.equal(isReferenceShapeFinding('missing pos on "text" at $.c[0]'), false)
+  assert.equal(isReferenceShapeFinding('span reaches past its last child on "footnote" at $.c[0]: x'), false)
+
+  const result = partitionFindings(
+    'carve-php',
+    [
+      '410-a-footnote-continuation-survives-a-blank-run.crv: tree differs from the reference ' +
+        'at $.children[1]:footnote - reference has 10 nodes, this has 10 (got $.children[1]:paragraph)',
+    ],
+    declare(''),
+    declareExtents(''),
+  )
+  assert.equal(result.reference, 1)
+  assert.equal(result.ungated, 0)
+  assert.deepEqual(result.problems, [])
+  assert.deepEqual(result.extentProblems, [])
+  assert.deepEqual(result.ungatedProblems, [])
 })
 
 test('every §4 extent rule is recognized, and nothing else is', () => {
@@ -370,7 +411,15 @@ test('every finding leaves through exactly one door, and the doors add up', () =
     declare('carve-rs  a.crv  text  1  permitted'),
     declareExtents('carve-rs  ends-past-last-child  footnote  1  markup-carve/carve-rs#1303'),
   )
-  assert.equal(result.waived + result.outstanding + result.undeclared + result.extent + result.ungated, 3)
+  assert.equal(
+    result.waived +
+      result.outstanding +
+      result.undeclared +
+      result.extent +
+      result.reference +
+      result.ungated,
+    3,
+  )
   assert.equal(result.waived, 1)
   assert.equal(result.extent, 1)
   assert.equal(result.ungated, 1)


### PR DESCRIPTION
Follow-up to #1640, which gated the PART 12 §4 source-reading findings for #1637.

The first full run with that gate turned up four findings the three-door split
did not account for, all in carve-php:

```
UNGATED carve-php  410-a-footnote-continuation-survives-a-blank-run-2.crv: tree
differs from the reference at $.children[1]:footnote - reference has 12 nodes,
this has 12 (got $.children[1]:list)
```

Those come from `checkShapeParity`, which diffs a satellite's tree against
carve-js's. It is the only finding in that list that is an
ENGINE-AGAINST-ENGINE comparison rather than a statement about the source, and
`reportEngineDisagreement` in the same file states the policy for that whole
family in its own words:

> NOT A GATE, deliberately. In this fleet a fix lands in one engine first and is
> ported over the following days, so the engine that is RIGHT is routinely the
> odd one out for a while. Failing on that would put this repo red after every
> correct carve-js change, and the fix for a red build would be to wait.

It is worse than that for this particular class: `referenceProvenance` exists
because a reference checkout that is behind or locally modified turns every
satellite's line into a statement about the operator's working copy - measured
once at 70 findings. So this is the one class whose count is not even about the
engine it names.

Gating it would have swapped a check that cannot fail for a check that cannot
pass, which is the failure mode #1637's own brief warns about.

Dropping it silently would have been #1637's defect wearing a new hat, so it
gets a door of its own instead: counted, named on the engine's summary line,
and rolled up once at the end beside the panel that owns it.

```
carve-php: 95 findings, 30 distinct (57 waived, 0 outstanding, 34 §4 extent (declared), 4 reference-shape (the panel's, not gated here))

REFERENCE SHAPE DIFFS: 4 (carve-php 4) - reported, not gated here.
  A tree differing from carve-js is an ENGINE-AGAINST-ENGINE finding, and this
  fleet ports a fix over several days, so the engine that is RIGHT is routinely
  the odd one out. The THREE-WAY SHAPE COMPARISON above owns these, and a
  reference off its pin makes every line here describe that checkout instead.
```

The arithmetic term the report prints is now
`waived + outstanding + undeclared + extent + reference + ungated`, and
`UNGATED` keeps its meaning: a finding class with no ledger and no panel, which
fails on sight.
