### PR TITLE
chore: retire the two span rows the engines' PART 12 §4 fixes closed

### DIFF
--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -615,5 +615,75 @@
 # resources/ast-position-waivers.txt owes nothing. Shape is unanimous over all
 # 1359 documents and the value panel declares nothing that still diverges.
 
-paragraph (extent) 1
-code (extent) 1
+
+# AND THE POST-FIX MEASUREMENT, 2026-08-24, from FRESH CLONES of every main
+# taken at run time rather than from a pin: carve-js 5101a7c, carve-rs 236b5d3
+# and carve-php 10e3854, against carve aac95ba1, over 1384 corpus documents plus
+# 3 synthetic samples. Of 28,578 comparable spans, NOTHING disagrees. The panel
+# reads "the engines place every node identically", so BOTH remaining rows came
+# back AGREED and both lines are deleted, leaving no declaration at all.
+#
+#   paragraph (extent)   1 -> 0   AGREED, and the line is deleted.
+#   code (extent)        1 -> 0   AGREED, and the line is deleted.
+#
+# https://github.com/markup-carve/carve/actions/runs/32674741449, PART 12
+# conformance at 2026-08-24T00:29:18Z. The run was dispatched for this edit
+# rather than rerun from an older one, because a rerun overwrites the evidence.
+#
+# BOTH ROWS WERE ONE DOCUMENT AND ONE ENGINE, and one fix closed them. The two
+# lines named `380-a-terminal-comment-line-still-leaves-an-empty-verse-line`,
+# where carve-php named an end line 2 column 3 for an offset all three agreed
+# was 8, on a line that has no column 3. markup-carve/carve-php#1639 is that
+# issue and markup-carve/carve-php#1647 is the fix: a position is spelled on the
+# line its own offset is on. The block above attributed the same document to
+# carve-php#1457 and expected that issue to close it; the defect outlived that
+# attribution and was refiled, so the closing step belongs to #1639.
+#
+# THE ROWS THAT NEVER REACHED THIS FILE ARE THE LARGER HALF OF THE STORY, and a
+# reader looking for deleted lines will not find them. Run 32668375087 at
+# 2026-08-23T21:53Z read EIGHT rows across 35 documents, six of them NEW and
+# undeclared rather than declared here:
+#
+#   footnote (extent)          27 doc(s)   NEW, never declared
+#   paragraph (extent)          5 doc(s)   COUNT against the 1 declared
+#   text (extent)               4 doc(s)   NEW, never declared
+#   definition_term (extent)    2 doc(s)   NEW, never declared
+#   heading (extent)            1 doc(s)   NEW, never declared
+#   code (extent)               1 doc(s)   declared, and matched
+#   list (extent)               1 doc(s)   NEW, never declared
+#   list_item (extent)          1 doc(s)   NEW, never declared
+#
+# `footnote`, `definition_term` and `heading` are the thirty PART 12 §4 extent
+# violations markup-carve/carve#1637 found a run printing in full while exiting
+# green: a container with no closer ending one codepoint past its last child.
+# markup-carve/carve-rs#1303 (fixed by carve-rs#1308) and
+# markup-carve/carve-php#1638 (fixed by carve-php#1645) closed them within an
+# hour of each other, both after that run measured and both before this one did,
+# so they were never written down here. Deleting a line was never the work; the
+# work was the two engine fixes, and this file records that they landed.
+#
+# `text`, `list`, `list_item` and FOUR of that paragraph count were a different
+# defect on new corpus ground: the `410-a-footnote-continuation-survives-a-blank-run`
+# category that markup-carve/carve#1633 added at 21:32, where carve-php ended the
+# note at the blank run and the continuation escaped it. markup-carve/carve-php#1643
+# (fixed by carve-php#1651) closed all four documents, which is why `paragraph`
+# fell from 5 to 0 rather than from 5 to 4.
+#
+# A ROW COUNT STILL DOES NOT SEPARATE DEFECTS, which is the same reading the
+# block above kept. `paragraph (extent)` carried the `380` line-and-column fault
+# and four `410` shape faults under one key, owned by two different issues in two
+# different engines, and no number here said so.
+#
+# EVERY ENGINE'S OWN §4 REPORT IS IDENTICAL AND CLEAN: 57 findings, 3 distinct,
+# 57 waived, 0 outstanding on each of the three, so
+# resources/ast-position-waivers.txt owes nothing and
+# resources/ast-extent-findings.txt stays empty. Shape is unanimous over all
+# 1387 documents. The value panel still declares three fields, which this file
+# does not speak for.
+#
+# carve-rb remains outside this panel, as the block above says. Its own §4
+# report still shows `span reaches past its last child` on `footnote` and
+# `definition_term` because it serializes an embedded carve-rs that predates
+# carve-rs#1308, and the same run reports BINDING PARITY differing from carve-rs
+# on the four `410` documents. That is a stale `ext/carve/Cargo.toml` pin in
+# carve-rb, not a span this file could declare.

--- a/tests/ast-spans.test.mjs
+++ b/tests/ast-spans.test.mjs
@@ -249,31 +249,26 @@ test('a malformed declaration line is an error, never a silent skip', () => {
  * one taken because the previous one had stopped being true, and a seventh the
  * next day that replaced the surviving row with a different one.
  */
-// The POST-FIX run, 2026-08-23, from fresh clones of every main after
-// markup-carve/carve-js#1318 merged: carve-js cc5726c, carve-rs 6f36d9d and
-// carve-php d21336c, 27,915 spans, TWO rows across ONE document. `list`,
-// `list_item`, `soft_break` and `text` all AGREED and are gone, and
-// `paragraph` fell from 2 to 1 - one document leaving the panel, and it
-// carried five of the six rows.
+// The POST-FIX run, 2026-08-24, from fresh clones of every main taken at run
+// time: carve-js 5101a7c, carve-rs 236b5d3 and carve-php 10e3854, over 1384
+// corpus documents plus 3 synthetic samples, 28,578 spans, and NO row at all.
+// The panel reads "the engines place every node identically", so both surviving
+// rows came back AGREED and the ledger is now empty
+// (https://github.com/markup-carve/carve/actions/runs/32674741449).
 //
-// THE SPAN COUNT DID NOT MOVE, which is the tell for what kind of fix this
-// was: 27,915 before and after. The engine published the same nodes with the
-// same offsets throughout and named the wrong LINE for them, so nothing was
-// added or dropped, only relocated. A run whose total moves is a fix that
-// changed what gets a position; this one is not that.
+// BOTH ROWS WERE ONE DOCUMENT AND ONE ENGINE. `380-a-terminal-comment-line-
+// still-leaves-an-empty-verse-line` is closed by markup-carve/carve-php#1639,
+// not by the #1457 the block above expected: a position is now spelled on the
+// line its own offset is on, so carve-php stops naming line 2 column 3 for an
+// end offset all three agree is 8.
 //
-// WHAT SURVIVES IS carve-php ALONE ON `380-a-terminal-comment-line-still-
-// leaves-an-empty-verse-line`, naming line 2 column 3 for an end offset all
-// three agree is 8 - a column that line does not have
-// (markup-carve/carve-php#1457). Before this run the same two keys ALSO
-// covered a carve-js offset defect on the same document, so one key stood for
-// two faults in two engines and its count moved by neither when the first was
-// fixed. A key says which type moved; it does not say how many faults are
-// standing behind it - see resources/ast-span-divergence.txt.
-const LAST_MEASURED = new Map([
-  ['paragraph (extent)', 1],
-  ['code (extent)', 1],
-])
+// AN EMPTY MAP HERE IS NOT A WEAKER TEST. The AGREED direction is exercised by
+// its own unit test above, against a literal one-row declaration, and the NEW
+// direction is exercised below by adding a row this file does not declare. What
+// this map pins is only that the shipped ledger matches the last run, and the
+// last run measured nothing - see resources/ast-span-divergence.txt for the six
+// undeclared rows that were closed in the engines before they ever reached it.
+const LAST_MEASURED = new Map()
 
 const asMeasured = (counts) =>
   new Map(


### PR DESCRIPTION
Both remaining rows in `resources/ast-span-divergence.txt` came back **AGREED** on a
fresh measurement, so both lines are deleted and the ledger is now empty.

## The measurement

Dispatched for this edit rather than rerun from an older run, because a rerun
overwrites the evidence:

| | |
| --- | --- |
| run | https://github.com/markup-carve/carve/actions/runs/32674741449 |
| step | `PART 12 conformance`, 2026-08-24T00:29:18Z |
| ref | `main` at `aac95ba1` |
| corpus | 1384 documents plus 3 synthetic samples |
| engines | carve-js `5101a7c`, carve-rs `236b5d3`, carve-php `10e3854`, each from a fresh checkout of its own default branch at run time |

```
THREE-WAY SPAN COMPARISON: the engines place every node identically (28578 span(s) compared).

THREE-WAY SPAN COMPARISON does not match resources/ast-span-divergence.txt:
  AGREED     paragraph (extent) no longer disagrees - delete its line
  AGREED     code (extent) no longer disagrees - delete its line
```

Both rows named one document and one engine: `380-a-terminal-comment-line-still-leaves-an-empty-verse-line`,
where carve-php spelled an end position as line 2 column 3 for an offset all three
agreed was 8, on a line that has no column 3. The ledger attributed that to
markup-carve/carve-php#1457 and expected that issue to close it; the defect outlived
the attribution and was refiled as markup-carve/carve-php#1639, fixed by
markup-carve/carve-php#1647.

## The larger half is rows that never reached the file

The diff deletes two lines, not eight. Run 32668375087 at 2026-08-23T21:53Z read
eight rows across 35 documents, six of them NEW and undeclared:

| row | documents | state then |
| --- | --- | --- |
| `footnote (extent)` | 27 | NEW, never declared |
| `paragraph (extent)` | 5 | COUNT against the 1 declared |
| `text (extent)` | 4 | NEW, never declared |
| `definition_term (extent)` | 2 | NEW, never declared |
| `heading (extent)` | 1 | NEW, never declared |
| `code (extent)` | 1 | declared, and matched |
| `list (extent)` | 1 | NEW, never declared |
| `list_item (extent)` | 1 | NEW, never declared |

`footnote`, `definition_term` and `heading` are the thirty PART 12 §4 extent
violations #1637 found a run printing in full while exiting green - a container
with no closer ending one codepoint past its last child.
markup-carve/carve-rs#1303 (fixed by markup-carve/carve-rs#1308) and
markup-carve/carve-php#1638 (fixed by markup-carve/carve-php#1645) closed them,
both after that run measured and both before this one did, so no line was ever
written for them.

`text`, `list`, `list_item` and four of that paragraph count belonged to the
`410-a-footnote-continuation-survives-a-blank-run` category #1633 added at 21:32.
markup-carve/carve-php#1643 (fixed by markup-carve/carve-php#1651) closed all
four, which is why `paragraph` fell from 5 to 0 rather than from 5 to 4.

## `LAST_MEASURED` moves with the file

`tests/ast-spans.test.mjs` runs on a host with no engine checkouts and only pins
that the shipped ledger matches the last run, so its map is now empty. That does
not weaken the suite - the AGREED direction has its own unit test against a
literal one-row declaration, and the NEW direction is exercised by a row the
shipped file does not declare. Both were driven by mutation: re-adding
`paragraph (extent) 1` to the ledger fails with `AGREED`, and adding the same key
to `LAST_MEASURED` alone fails with `NEW`. Restored and re-run clean afterwards.

## Same run, still red and deliberately untouched here

Reported for markup-carve/carve#1605 rather than fixed:

- three undeclared value rows: `definition_list.attrs.keyValues` and
  `definition_list.attrs.order` (carve-rs alone on
  `407-one-consumed-boolean-spells-the-looseness-no-blank-line-can-2`), and
  `list.tight` (carve-php alone on
  `409-a-blank-line-loosens-an-item-only-when-a-paragraph-follows-it-2`);
- three render cases, `rust=2 php=1`, and 4 cross-implementation differences,
  down from 13 cases and 24 differences on run 32668375087;
- carve-rb serializing an embedded carve-rs that predates carve-rs#1308: its own
  §4 report still shows `span reaches past its last child` on `footnote` and
  `definition_term`, and BINDING PARITY differs from carve-rs on the four `410`
  documents. That is a stale `ext/carve/Cargo.toml` pin, not a span this file
  could declare.

Nothing was added to any declaration file to make a gate pass. The three position
reports are identical and clean (57 findings, 3 distinct, 57 waived, 0
outstanding), so `resources/ast-position-waivers.txt` owes nothing and
`resources/ast-extent-findings.txt` stays empty. Shape is unanimous over all 1387
documents.
