### PR TITLE
chore: reconcile the unreleased changelog against every merge since 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **PART 9 §17 L7: a consumed `loose` boolean spells the looseness a blank line
+  cannot** (carve#1623). The preceding block-attribute line may carry `loose`, so
+  `<li><p>x</p></li>` and `<dd><p>x</p></dd>` become writable Carve; the key is
+  consumed, not emitted. Corpus 407.
+- **A definition list's spelled looseness is a field** (carve#1624, PART 12 §8).
+  `definition_list` gains an optional `loose: true`, because the `<dd>` wrapper is
+  derived from the description's block count and cannot see the key.
 - **HTML import coverage is measured as a population and across engines**
   (carve#1600). Every grammar construct has one coverage classification, the
   complete render corpus is re-imported through the pinned JavaScript engine,
@@ -20,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bindings owe the complete output surface plus the AST** (carve#1599).
   Importers remain optional but must be explicitly implemented or declared out
   of scope; a machine-readable binding contract checks the inventory.
-
 - **An explicit closer is a spelling change, so it cannot move a list's
   tightness** (carve#1602). Corpus
   `362-an-unterminated-container-does-not-extend-the-item-past-a-blank-line-4`
@@ -101,6 +107,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The canonical writer spells `loose` only where a blank line cannot**
+  (markup-carve/carve-rs#1305, carve#1639). The criterion is decided by a re-parse
+  of the blank-line spelling, not by an item count: a one-item list already
+  loosened by a blank line inside the item keeps its source. Corpus 408.
+- **An ingested value the schema calls absent is normalized away** (carve#1615,
+  PART 12 §22). The encoder drops an ingested `start: 1`; `start: 0` and
+  `start: 2` are carried through unchanged.
+- **The same line decides what an import keeps** (carve#1628, PART 11 §7). A block
+  whose text is entirely whitespace keeps exactly the characters §7 calls content:
+  `<p>&nbsp;</p>` imports as a paragraph holding U+00A0, an ASCII-space or
+  tab-only block builds no node and reports `element-dropped`. The divider is
+  PART 2's whitespace terminal, not the entity.
+- **PART 11 §10j: an unspellable block does not cancel the list adjacency it
+  cannot spell** (carve#1621). Where every block between two sibling lists leaves
+  no character on the page, §10i decides the run as if nothing stood there.
+- **A declared loss is a ceiling, not a license, and an endnotes section keeps its
+  position** (carve#1608). An empty `<dd>` is dropped with `structure-unspellable`
+  rather than writing a bare colon line that damages the term above it; an
+  endnotes section that is not last is imported where it sits.
+- **A dropped empty description breaks the definition list rather than lending
+  it** (carve#1636). With an entry after it, writing both terms into one list
+  would give the surviving term a description it never had, so the import writes
+  two lists.
+- **An attached container's closer is a spelling change the HTML can see**
+  (carve#1613). Corpus 362-5 and 362-6 put the container below a lead block, where
+  a tight item's paragraph suppression does reach it; both spellings read tight.
+- **A blank line above an attached block loosens the item only when a paragraph
+  follows it** (carve#1622). A container has an opener to absorb the separation
+  and a paragraph has none. Corpus 409.
 - **U+0000 is replaced before the document is read** (carve#1523, PART 0 INPUT,
   PART 9 §29). Every NUL becomes U+FFFD at the parse boundary; every other C0
   control stays content. Corpus 397.
@@ -186,6 +221,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A figure's imported target is the captioned block, not a paragraph around
+  it** (carve#1606, PART 9 §4b). Two shared fixtures recorded a wrapped tree
+  beside source that parses to the image directly; only a display-math host is a
+  paragraph. Filed as markup-carve/carve-js#1381.
+- **The escape test reads the source the writer will emit, not the tree**
+  (carve#1601, PART 11 §2). A detached caption line and a span whose text opens a
+  note reference are escaped; both engines wrote source that re-parsed to
+  something else.
+- **A footnote definition's body survives a run of blank lines** (carve#1620). The
+  continuation test looked one line past the blank, so a blank run ended the body
+  and relocated its content into the endnotes section. Corpus 410.
 - **A diagnostic list is ordered by the losing element's document position**
   (carve#1586). The basis is now stated, and the `diagnostic-order` fixture pins
   two losses under one parent. carve-php already answered this way;
@@ -284,9 +330,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   task checkbox, an admonition, the endnotes section and a math span; the
   `labels` map grows from one key to ten.
 - **A tab control is `type="button"`, and two marked items select one tab**
-  (carve#1537, extensions §13.3, §13.5). A control with no `type` submitted its
-  enclosing form; the first `{selected}` mark now wins. Optional corpus 47, 48,
-  49.
+  (markup-carve/carve-php#1537, extensions §13.3, §13.5). A control with no
+  `type` submitted its enclosing form; the first `{selected}` mark now wins.
+  Optional corpus 47, 48, 49.
 - **The position checker's closerless-container set no longer claims to be
   complete while three types are missing from it** (carve#1574, PART 12 §4).
   `footnote`, `definition_term` and `heading` are in the set now, declaring 30


### PR DESCRIPTION
Release prep for 0.1.4. No tag, no version field moved: this reconciles the
`[Unreleased]` section so the cut is a one-step decision when you want it.

## What was reconciled

All 163 commits on `main` since the `0.1.3` tag, classified one by one. The
section was last reconciled at PR 1597; PRs 1609, 1610 and 1641 added their own
entries afterwards, which left sixteen merges undescribed.

Thirteen of those sixteen are user-facing for a spec repo (a normative clause or
a corpus document moved) and now have entries:

**Added** - the consumed `loose` boolean of PART 9 §17 L7 (carve#1623, corpus
407), and `definition_list.loose` in PART 12 §8 (carve#1624).

**Changed** - the writer's re-parse criterion for `loose` (carve#1639, corpus
408); an ingested `start: 1` normalized away in PART 12 §22 (carve#1615); what
an import keeps of a whitespace-only block in PART 11 §7 (carve#1628); PART 11
§10j on unspellable blocks and list adjacency (carve#1621); the empty-`<dd>` and
endnotes-section rulings (carve#1608) and the second side of that ceiling
(carve#1636); corpus 362-5 / 362-6 (carve#1613); corpus 409 (carve#1622).

**Fixed** - a figure's imported target (carve#1606); the escape test reading
emitted source (carve#1601); a footnote body surviving a blank run (carve#1620,
corpus 410).

## What was cut, and why

A change nobody who only consumes the spec and its corpus can notice gets no
entry. That cut the corpus formatter sweep (PR 1617), the escaper corpus README
(PR 1614), the round-trip corpus harness (PR 1625), the manifest-read dependency
map (PR 1635), the PART 12 §4 source rule that can now fail the run (PR 1640),
the named cross-engine shape diff (PR 1643) and the span-ledger retirement
(PR 1645) - plus, in the earlier range, every engine-pin bump, drift-ledger
entry, gate, fixture-only sweep, CI change and docs-only page.

## Two corrections

- The tab-control entry cited `carve#1537`, which resolves to an unrelated pull
  request in this repo. The ruling was taken on markup-carve/carve-php#1537 and
  the reference is now fully qualified.
- A stray blank line split the Added list into two blocks.

Gates run locally on Node 24: `tests/normativity.test.mjs` (which is what scans
`CHANGELOG.md` for PART citations) and `tests/repo-links.test.mjs`, both green.
The rest of the suite needs `npm ci` against the pinned engine and runs in CI on
this PR.
