### PR TITLE
docs: an engine HAS shipped the spelled looseness, in three places that say none has

### DIFF
--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -1151,9 +1151,16 @@ false says *loose* - the opposite of the default, in the one place a consumer is
 most likely to write `if (node.tight)`.
 
 ::: info Engine support
-No engine has shipped `{loose}` yet, so none emits this field. The corpus
-documents that spell it are declared in `resources/engine-pin-drift.txt` until a
-pin catches up.
+carve-rs emits this field on its `main` as of markup-carve/carve-rs#1304 and
+markup-carve/carve-rs#1314. carve-js and carve-php render `{loose}` correctly and
+do not publish the field yet (markup-carve/carve-js#1410,
+markup-carve/carve-php#1660), so a three-way AST comparison still parts them:
+measured on [run 32678870595](https://github.com/markup-carve/carve/actions/runs/32678870595),
+`carve-js=(absent) carve-rs=true carve-php=(absent)`.
+
+The PINNED build is a separate window and is further behind: it still renders the
+key literally as `<dl loose="">`, which is what the corpus documents declared in
+`resources/engine-pin-drift.txt` are declared for.
 :::
 
 ## Composite figures

--- a/tests/a-spelled-looseness-is-a-definition-list-field.test.mjs
+++ b/tests/a-spelled-looseness-is-a-definition-list-field.test.mjs
@@ -24,9 +24,11 @@
  *
  * The oracle is the measurement here rather than an engine, for the reason the
  * corpus test gives: the spec repo proves its own fixtures without waiting for
- * an implementation to ship a rule. No engine has shipped L7 at all yet, which
- * is why `definition_list.loose` is declared in
- * `tests/schema-fields-are-produced.test.mjs` as engine-rollout-pending.
+ * an implementation to ship a rule. carve-rs has shipped L7 on its main and
+ * carve-js and carve-php have not, and the PINNED build has not either, which is
+ * why `definition_list.loose` is still declared in
+ * `tests/schema-fields-are-produced.test.mjs` as engine-rollout-pending - that
+ * exemption is measured against the pin, not against any engine's main.
  */
 
 import { test } from 'node:test'

--- a/tests/schema-fields-are-produced.test.mjs
+++ b/tests/schema-fields-are-produced.test.mjs
@@ -64,7 +64,7 @@ const OPT_IN_ONLY = {
 /** Fields permitted by the schema before the corresponding engine rollout. */
 const ENGINE_ROLLOUT_PENDING = {
   'definition_list.loose':
-    'PART 9 §17 L7 (carve#1624): the consumed `loose` boolean, which no engine has shipped yet - the pinned build still renders it literally as `<dl loose="">`. The two corpus documents that spell it are declared in resources/engine-pin-drift.txt for the same window.',
+    'PART 9 §17 L7 (carve#1624): the consumed `loose` boolean. The pinned build still renders it literally as `<dl loose="">`, which is what this exemption is measured against; carve-rs has shipped it on its main and carve-js and carve-php have not. The two corpus documents that spell it are declared in resources/engine-pin-drift.txt for the same window.',
   'figure.shortCaption': 'structural publishing field: Carve 0.1 source has no spelling; produced only by AST/Pandoc consumers',
   'table.shortCaption': 'structural publishing field: Carve 0.1 source has no spelling; produced only by AST/Pandoc consumers',
 }


### PR DESCRIPTION
`docs/ast-json.md` tells a reader **"No engine has shipped `{loose}` yet, so none
emits this field"**, and two test docblocks repeat it. carve-rs emits it on its main
as of markup-carve/carve-rs#1304 and markup-carve/carve-rs#1314, so the claim is false
in the one place a consumer decides whether to look for the field.

## Measured, not inferred

https://github.com/markup-carve/carve/actions/runs/32678870595, `PART 12 conformance`
at 2026-08-24T01:19:09Z, every engine built from a fresh checkout of its own default
branch at run time:

```
THREE-WAY VALUE COMPARISON: 2 field(s) disagree, across 2 document(s)
     1 doc(s)  definition_list.loose
        carve-js=(absent)  carve-rs=true  carve-php=(absent)
        e.g. 407-one-consumed-boolean-spells-the-looseness-no-blank-line-can-2.crv
```

The ports are filed as markup-carve/carve-js#1410 and markup-carve/carve-php#1660.
The row is undeclared on the value panel and stays red until both land, which is
carve#1605's business rather than this PR's.

## Two windows, and conflating them is what made the sentence wrong

The engines' mains are one thing; the build this repo PINS is another and is further
behind - it still renders the key literally as `<dl loose="">`. Everything the old
sentence said is true of the PIN and of nothing else.

So the two declarations that depend on the pin are **unchanged**:

- `resources/engine-pin-drift.txt` keeps both `407-...` entries;
- `ENGINE_ROLLOUT_PENDING['definition_list.loose']` in
  `tests/schema-fields-are-produced.test.mjs` keeps its exemption, because
  `orphanedPromises()` measures it against the pinned `@markup-carve/carve`
  devDependency and not against any engine's main.

Only the prose moves, and each of the three places now names which window it is
talking about.

## Nothing else moves

No behavior change, and no declaration file in `resources/` is touched. Green locally
on this tree: `npm test` (2954 tests, 1 skipped), `html-import:check`,
`escape:check`, `core:check`, and `engine:report -- --check` ("Drift matches what is
declared"). The rest of the PR gates run in CI.
