### PR TITLE
ci: cut AST conformance wall time with parallel shards

### DIFF
--- a/.github/workflows/ast-conformance.yml
+++ b/.github/workflows/ast-conformance.yml
@@ -22,6 +22,12 @@ on:
     - cron: '0 4 * * 1-6'
     - cron: '0 4 * * 0'
   workflow_dispatch:
+    inputs:
+      depth:
+        description: Run the daily gates or include the weekly exploratory sweeps
+        type: choice
+        options: [daily, full]
+        default: daily
 
 permissions:
   contents: read
@@ -32,17 +38,71 @@ permissions:
   issues: write
   actions: read
 
-# Two runs at once - the 04:00 schedule and a dispatch someone wanted NOW - would
-# reach the verdict step together and each find no open ticket, filing two. The
-# group serializes them; `cancel-in-progress: false` because a run that is 30
-# minutes into building four engines is worth finishing.
+# Scheduled and manual runs use separate groups: a diagnostic dispatch must not
+# queue behind the daily run. A newer manual dispatch supersedes an older one;
+# scheduled evidence is allowed to finish.
 concurrency:
-  group: ast-conformance
-  cancel-in-progress: false
+  group: ast-conformance-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
+  formatter:
+    name: formatter (shard ${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['0/4', '1/4', '2/4', '3/4']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - uses: actions/checkout@v4
+        with:
+          repository: markup-carve/carve-js
+          path: carve-js
+          submodules: recursive
+      - name: Build carve-js
+        working-directory: carve-js
+        run: npm ci && npm run build
+      - uses: actions/checkout@v4
+        with:
+          repository: markup-carve/carve-rs
+          path: carve-rs
+          submodules: recursive
+      - name: Build carve-rs
+        working-directory: carve-rs
+        run: cargo build --release
+      - uses: actions/checkout@v4
+        with:
+          repository: markup-carve/carve-php
+          path: carve-php
+          submodules: recursive
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - name: Install carve-php
+        working-directory: carve-php
+        run: composer install --no-interaction --no-progress
+      - name: PART 11 formatter and render conformance
+        env:
+          CARVE_JS_DIR: ${{ github.workspace }}/carve-js
+          CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
+          CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
+        run: npm run compare:impls -- --roundtrip --fail-on-diff --shard=${{ matrix.shard }} --report=/tmp/compare-impls.json
+      - name: Cross-engine render comparison
+        if: always()
+        run: npm run compare:report -- /tmp/compare-impls.json
+
   conformance:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check out carve
         uses: actions/checkout@v4
@@ -154,88 +214,8 @@ jobs:
         # are the ones most likely to catch drift.
         run: npm run ast:check
 
-      # PART 11: the formatter must not change what a document says. The
-      # `--roundtrip` mode formats each corpus document and re-reads the result,
-      # which is the only automated check of that invariant across engines - and
-      # it had never run. It caught carve-rs#432, where `carve fmt` on a
-      # blockquote containing a comment emitted source in which the hidden text
-      # rendered as a visible paragraph: content the author hid, published by
-      # running the formatter. Green by not running, while that shipped.
-      #
-      # GATES, because a formatter that changes the document is wrong under every
-      # reading of PART 11 - there is no design question to settle first.
-      - name: PART 11 formatter round trip
-        # ALWAYS, because this gate is independent of the one above it. The
-        # first run of this workflow had PART 12 fail, which SKIPPED this step -
-        # so a formatter that changed what a document says would have gone
-        # unmeasured because of an unrelated AST finding, and the job would have
-        # reported one failure while silently not performing the other check.
-        if: always()
-        env:
-          CARVE_JS_DIR: ${{ github.workspace }}/carve-js
-          CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
-          CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
-        # `--report` makes this the ONLY pass over the corpus. The step below
-        # used to be a second full invocation of this same script, over the same
-        # corpus with the same three engines, purely to apply a different subset
-        # of the gate; `--roundtrip` is additive, so this run already computes
-        # the cross-engine and fixture counts it needs. It now writes them out
-        # and the step below gates them. See the note there.
-        run: npm run compare:impls -- --roundtrip --fail-on-diff --report=/tmp/compare-impls.json
-
-      # EVERY render target, gated.
-      #
-      # This was report-only because its remaining differences needed language
-      # decisions, all of which lived on `carve`, the canonical writer
-      # (carve#478, carve#481). Both are now closed and that target compares
-      # clean: 536 documents, 0 diffs, in all three engines. markdown, plain and
-      # ansi reached the same state earlier and were gated first.
-      #
-      # Leaving a target in a job that cannot fail means agreement, once
-      # reached, is observed rather than defended. That is not hypothetical:
-      # carve#516 was a Markdown divergence on a line block whose input the
-      # corpus already contained - the fixture existed, the target was compared,
-      # and nothing was allowed to go red. It stayed open until someone read the
-      # report by hand.
-      #
-      # A corpus fixture carries an HTML expectation only, so for every other
-      # target this engine-against-engine comparison IS the check.
-      #
-      # If a target starts diverging for a reason that turns out to need a
-      # language decision, move THAT target back to a reporting step
-      # (`--targets=` takes a list) rather than deleting the gate. Gating on an
-      # unresolved question teaches people to ignore the job, which is how both
-      # of these checkers came to be unwired in the first place; gating on a
-      # settled one is what keeps them settled.
-      #
-      # THIS STEP NO LONGER RE-RUNS THE COMPARISON. It used to be
-      # `compare:impls -- --fail-on-diff`, a second walk of the whole corpus
-      # with the same three engines, and at 669s it was 29% of this job. The
-      # step above already computed everything it needed: `--roundtrip` does not
-      # narrow the targets, the corpus or the comparison loop, it only adds a
-      # pass on top. What differed was the GATE - compare-impls hands each mode
-      # a different subset of the failing conditions and zeroes the other's
-      # counts - so the second invocation existed for its gate, not its work.
-      #
-      # Deleting it was therefore not an option: it carries the only gate on an
-      # engine disagreeing with a FIXTURE, the check whose comment in
-      # compare-impls records that it "could not fail the job" until it was
-      # added. So the run above writes its counts and this reads them. Both
-      # conditions still fail the job; the corpus is walked once.
-      #
-      # It stays a SEPARATE STEP rather than being folded into the one above
-      # because the verdict step at the end of this job reports failures by STEP
-      # NAME. One merged step would tell the tracking ticket that "conformance"
-      # broke without saying whether the formatter changed a document or the
-      # engines disagree about a render target, which is most of what makes that
-      # ticket worth reading.
-      #
-      # `if: always()`, for the reason the step above documents: this gate is
-      # independent of that one, and a round-trip failure must not skip it.
-      # A missing report is a failure here, not a pass - see the script.
-      - name: Cross-engine render comparison (all targets)
-        if: always()
-        run: npm run compare:report -- /tmp/compare-impls.json
+      # Formatter and render conformance run concurrently in the sharded
+      # formatter matrix above; this job retains AST and the short auxiliary gates.
 
       # The converters run the OTHER direction - foreign source to Carve - and
       # sat outside every gate: carve#1130 lists six converter fixes in one
@@ -337,7 +317,7 @@ jobs:
       # this needs all three engine mains built. A dispatch runs it too, so a
       # finding can be re-measured immediately.
       - name: Curated combinatorial seam families
-        if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 4 * * 0'
+        if: github.event.schedule == '0 4 * * 0' || inputs.depth == 'full'
         env:
           CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
           CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
@@ -349,7 +329,7 @@ jobs:
       # remains a hard failure; exit 1 stays visible without making the whole
       # weekly conformance verdict permanently red while adjudication proceeds.
       - name: Differential fuzz sweep
-        if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 4 * * 0'
+        if: github.event.schedule == '0 4 * * 0' || inputs.depth == 'full'
         env:
           CARVE_JS_DIR: ${{ github.workspace }}/carve-js
           CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
@@ -462,12 +442,24 @@ jobs:
           TITLE="AST conformance is failing on $REF_NAME"
           MARKER="<!-- ast-conformance-verdict ref=$REF_NAME -->"
 
+          # Formatter shards run beside this job. Wait for them before reading
+          # the run so one verdict covers every independent gate.
+          for attempt in $(seq 1 80); do
+            pending="$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate \
+              --jq '[.jobs[] | select(.name != "conformance" and .status != "completed")] | length')"
+            [ "$pending" -eq 0 ] && break
+            sleep 15
+          done
+
           # Which steps failed, read back from the run itself. A hand-kept list
           # of step ids would go stale the first time a step is added, and a
           # step this report forgot to name is a step whose failure is invisible
           # again.
           failed="$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate \
             --jq '.jobs[].steps[] | select(.conclusion == "failure") | "- `" + .name + "`"')"
+          bad_jobs="$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate \
+            --jq '.jobs[] | select(.conclusion == "cancelled" or .conclusion == "timed_out") | "- `" + .name + "` (" + .conclusion + ")"')"
+          failed="${failed}${failed:+$'\n'}${bad_jobs}"
 
           # Matched on the marker in the body rather than on the title, so
           # renaming the issue does not fork it into two, and listed rather than
@@ -478,7 +470,7 @@ jobs:
                 '.[] | select(.pull_request == null) | select((.body // "") | contains($m)) | .number')"
           issue="${open_issues%%$'\n'*}"
 
-          if [ "$JOB_STATUS" = "success" ]; then
+          if [ -z "$failed" ] && [ "$pending" -eq 0 ]; then
             echo "AST conformance is green on $HEAD_SHA."
             if [ -n "$issue" ]; then
               gh issue comment "$issue" --repo "$REPO" --body \

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -36,7 +36,7 @@
  *   ../carve-php   (serializes through `bin/carve --json`)
  */
 
-import { execFileSync } from 'node:child_process'
+import { execFileSync as nodeExecFileSync } from 'node:child_process'
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -151,6 +151,17 @@ const phpDir = process.env.CARVE_PHP_DIR ?? resolve(root, '../carve-php')
 const UNKNOWN_PROPERTY_SAMPLE = Number(process.env.CARVE_UNKNOWN_PROBE_SAMPLE ?? 6)
 
 const MAX_SUBPROCESS_OUTPUT = 256 * 1024 * 1024
+const SUBPROCESS_TIMEOUT_MS = 15_000
+const execFileSync = (file, args, options = {}) => nodeExecFileSync(file, args, {
+  timeout: SUBPROCESS_TIMEOUT_MS,
+  ...options,
+})
+
+function progress(engine, index, total, name) {
+  if (index === 0 || (index + 1) % 100 === 0 || index + 1 === total) {
+    console.log(`[${engine}] ${index + 1}/${total}: ${name}`)
+  }
+}
 
 const DISPLAY_LIMIT = Number(process.env.CARVE_DISPLAY_LIMIT ?? 8)
 
@@ -1098,7 +1109,8 @@ if (rsBinary) {
   const rsFindings = []
 let rsProbed = 0
 let rsRootShaped = false
-  for (const { name, source } of satelliteSamples) {
+  for (const [index, { name, source }] of satelliteSamples.entries()) {
+    progress('rust', index, satelliteSamples.length, name)
     let doc
     try {
       doc = JSON.parse(
@@ -1177,7 +1189,8 @@ let rsRootShaped = false
 const rbShapes = new Map()
 if (existsSync(resolve(rbDir, 'lib/carve'))) {
   const rbFindings = []
-  for (const { name, source } of satelliteSamples) {
+  for (const [index, { name, source }] of satelliteSamples.entries()) {
+    progress('ruby', index, satelliteSamples.length, name)
     let doc
     try {
       const out = execFileSync(
@@ -1295,7 +1308,8 @@ if (existsSync(resolve(phpDir, 'bin/carve'))) {
   const phpFindings = []
 let phpProbed = 0
 let phpRootShaped = false
-  for (const { name, source } of satelliteSamples) {
+  for (const [index, { name, source }] of satelliteSamples.entries()) {
+    progress('php', index, satelliteSamples.length, name)
     let doc
     try {
       const out = execFileSync('php', ['bin/carve', '--json'], {

--- a/scripts/check-compare-report.mjs
+++ b/scripts/check-compare-report.mjs
@@ -93,6 +93,9 @@ if (mode.corpus !== 'core') {
 if (mode.limit !== null && mode.limit !== undefined) {
   narrowed.push(`--limit=${mode.limit} compared part of the corpus`)
 }
+if (mode.shard && !/^\d+\/\d+$/.test(mode.shard)) {
+  narrowed.push(`invalid shard metadata: ${mode.shard}`)
+}
 const missingTargets = COMPARISON_TARGETS.filter((t) => !(mode.targets ?? []).includes(t))
 if (missingTargets.length > 0) {
   narrowed.push(`target(s) not compared: ${missingTargets.join(', ')}`)

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -11,6 +11,7 @@ import {
   expectedFileFor,
   targetOf,
 } from './lib/corpus-targets.mjs'
+import { parseShard, selectShard } from './lib/shard.mjs'
 import { parseConverterLedger } from './lib/drift-ledger.mjs'
 import { phpDir, rustBinary, rustDir } from './lib/engine-locations.mjs'
 import { miscount, shortfall } from './spec/participants.mjs'
@@ -73,6 +74,15 @@ let staleUnreachable = []
 const manifestFeatures = new Set()
 const limitArg = process.argv.find((a) => a.startsWith('--limit='))
 const limit = limitArg ? Number(limitArg.slice('--limit='.length)) : Infinity
+const shardArg = process.argv.find((a) => a.startsWith('--shard='))
+let shard
+try {
+  shard = parseShard(shardArg?.slice('--shard='.length))
+} catch (error) {
+  console.error(error.message)
+  process.exit(2)
+}
+const { index: shardIndex, total: shardTotal } = shard
 const corpusArg = process.argv.find((a) => a.startsWith('--corpus='))
 const corpusName = corpusArg ? corpusArg.slice('--corpus='.length) : 'core'
 
@@ -727,10 +737,10 @@ function availableCaseCount() {
 
 function loadPairs() {
   if (!isOptional) {
-    return readdirSync(corpusDir)
+    return selectShard(readdirSync(corpusDir)
       .filter((f) => f.endsWith('.crv'))
       .sort()
-      .slice(0, limit)
+      .slice(0, limit), shard)
       .map((f) => ({
         slug: basename(f, '.crv'),
         feature: 'core',
@@ -746,7 +756,7 @@ function loadPairs() {
   for (const entry of manifest.cases) {
     if (entry.feature) manifestFeatures.add(entry.feature)
   }
-  return manifest.cases.slice(0, limit).map((entry) => {
+  return selectShard(manifest.cases.slice(0, limit), shard).map((entry) => {
     const slug = basename(entry.slug)
     const target = targetOf(entry)
     // Surfaces a manifest typo here rather than as a confusing missing-file
@@ -1049,6 +1059,11 @@ async function runConvertMode() {
 }
 
 const pairs = loadPairs()
+const offeredCases = availableCaseCount()
+const selectedCases = Number.isFinite(limit) ? Math.min(limit, offeredCases) : offeredCases
+const expectedShardCases = selectedCases <= shardIndex
+  ? 0
+  : Math.floor((selectedCases - 1 - shardIndex) / shardTotal) + 1
 
 /*
  * And how many CASES it saw. Without `--limit` the run must cover the corpus it
@@ -1056,18 +1071,18 @@ const pairs = loadPairs()
  * typo rather than a sample size - it used to run the engines over nothing and
  * report `pass=0/0 mismatch=0`.
  */
-const casePopulation = Number.isFinite(limit)
+const casePopulation = expectedShardCases === 0
   ? shortfall({
       label: 'CASES',
       actual: pairs.length,
       atLeast: 1,
       of: 'case(s)',
-      hint: 'Raise --limit, or drop it to compare the whole corpus.',
+      hint: 'Choose a populated shard, raise --limit, or drop it to compare the whole corpus.',
     })
   : miscount({
       label: 'CASES',
       actual: pairs.length,
-      expected: availableCaseCount(),
+      expected: expectedShardCases,
       of: 'case(s)',
     })
 if (casePopulation !== null) {
@@ -1402,7 +1417,7 @@ if (roundtrip) {
 console.log('\nImplementation summary')
 const profile = corpusName === 'optional' ? 'optional/opt-in' : 'default/no-opt-in'
 console.log(
-  `profile=${profile} corpus=${corpusName} corpus_pairs=${pairs.length} targets=${activeTargets.join(',')}`,
+  `profile=${profile} corpus=${corpusName} corpus_pairs=${pairs.length} shard=${shardIndex}/${shardTotal} targets=${activeTargets.join(',')}`,
 )
 if (targetNote) console.log(`target_note=${targetNote}`)
 // A `--targets` subset can exclude a case's pinned target outright. Saying so
@@ -1554,7 +1569,7 @@ if (isOptional) {
     // A LIMITED run covers a slice, so "this feature reached two engines" is not
     // knowable from it and a documented entry outside the slice is not stale.
     // Skipped rather than guessed, and printed so the skip is visible.
-    staleUnreachable = limit === Infinity
+    staleUnreachable = limit === Infinity && shardTotal === 1
       ? Object.keys(UNREACHABLE_REASONS).filter((feature) => !unreachable.has(feature))
       : []
     if (limit !== Infinity) {
@@ -1623,6 +1638,7 @@ if (reportPath) {
           countsOnly,
           corpus: corpusName,
           limit: limit === Infinity ? null : limit,
+          shard: `${shardIndex}/${shardTotal}`,
           targets: activeTargets,
           engines: active.map((impl) => impl.name),
         },

--- a/scripts/lib/shard.mjs
+++ b/scripts/lib/shard.mjs
@@ -1,0 +1,15 @@
+export function parseShard(value) {
+  if (value === undefined) return { index: 0, total: 1 }
+  const match = value.match(/^(\d+)\/(\d+)$/)
+  if (!match) throw new Error(`Invalid --shard=${value}. Use --shard=INDEX/TOTAL, with INDEX starting at 0.`)
+  const index = Number(match[1])
+  const total = Number(match[2])
+  if (total < 1 || index >= total) {
+    throw new Error(`Invalid --shard=${value}. INDEX must be between 0 and TOTAL-1, and TOTAL must be positive.`)
+  }
+  return { index, total }
+}
+
+export function selectShard(values, { index, total }) {
+  return values.filter((_, position) => position % total === index)
+}

--- a/tests/a-failed-engine-run-is-named.test.mjs
+++ b/tests/a-failed-engine-run-is-named.test.mjs
@@ -31,8 +31,25 @@ import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:f
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { parseShard, selectShard } from '../scripts/lib/shard.mjs'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+test('four formatter shards partition the corpus exactly once', () => {
+  const corpus = Array.from({ length: 1384 }, (_, index) => index)
+  const shards = Array.from({ length: 4 }, (_, index) =>
+    selectShard(corpus, parseShard(`${index}/4`)),
+  )
+  assert.deepEqual(shards.map((shard) => shard.length), [346, 346, 346, 346])
+  assert.deepEqual(shards.flat().sort((a, b) => a - b), corpus)
+  assert.deepEqual(selectShard([1, 2, 3], parseShard()), [1, 2, 3])
+})
+
+test('invalid and empty formatter shards are rejected', () => {
+  assert.throws(() => parseShard('4/4'), /INDEX must be between/)
+  assert.throws(() => parseShard('0/0'), /TOTAL must be positive/)
+  assert.throws(() => parseShard('one\/four'), /Use --shard/)
+})
 
 /** A shell stub at `path`, executable. */
 const stub = (path, body) => {


### PR DESCRIPTION
## What changed

- deterministically partition the complete formatter corpus across four matrix jobs
- run formatter/render gates concurrently with PART 12 and the auxiliary conformance gates
- retain exact per-shard population checks and both formatter/render failure modes
- cancel superseded manual dispatches without cancelling scheduled evidence
- make weekly exploratory sweeps opt-in for manual dispatches (`depth: full`)
- add 15-second AST child-process timeouts, progress heartbeats, and 20-minute job ceilings
- wait for every formatter shard before the existing issue verdict is filed

## Validation

- `npm test` — 2,953 passed, 1 skipped
- targeted shard/harness tests — 5 passed
- `actionlint .github/workflows/ast-conformance.yml`
- four-shard smoke run: 8 fixtures covered exactly once, 2 by each shard
- live workflow run: https://github.com/markup-carve/carve/actions/runs/32681945788

The live run remained red on existing engine findings, as the unsharded workflow was: PART 12, converters, and shard 2 reported current divergences. The harness, population checks, aggregation, and the other three shards completed normally.

## Measured gain

| | Before | This PR | Gain |
| --- | ---: | ---: | ---: |
| Formatter hot step | 28m04s | 8m14s slowest shard | 70.7% |
| Workflow wall time | 38m40s | 11m58s | 69.1% |

The comparison uses completed run 32674741449 as the recent baseline and branch run 32681945788. Full corpus and every target/engine remain covered.