### PR TITLE
chore: retire five converter declarations the engines caught up with

### DIFF
--- a/resources/converter-drift.txt
+++ b/resources/converter-drift.txt
@@ -98,11 +98,26 @@
 # Full HTML-import fixture sweep added by carve#1600, measured 2026-08-24 on
 # clean current mains: carve-rs 9cf16d05, carve-js 05e1cc27, carve-php 06c27aaa.
 # Each entry is removed when that engine reproduces the normative fixture.
+#
+# FIVE OF THE EIGHT LANDED, and the ledger's stale half is what said so. Measured
+# 2026-08-24 in AST conformance run 32683876950, at carve 4f911379, which builds
+# every engine from a fresh checkout of its own default branch:
+#
+#     rust: convert_pass=60/61 declared_drift=1 mismatch=0 error=0 skipped=2
+#     js:   convert_pass=61/63 declared_drift=1 mismatch=1 error=0 skipped=0
+#     php:  convert_pass=61/63 declared_drift=1 mismatch=1 error=0 skipped=0
+#
+# and it named exactly these five as STALE, one failure line each:
+#
+#     rust/html-import--empty-definition-description           carve-rs#1319
+#     rust/html-import--empty-definition-description-not-last  carve-rs#1319
+#     php/html-import--empty-definition-description-not-last   carve-php#1646
+#     rust/html-import--endnotes-section-not-last              carve-rs#1318
+#     rust/html-import--note-reference-in-a-span               carve-rs#1317
+#
+# The three derived-endnotes-section lines are NOT stale: each engine's
+# declared_drift=1 above is that line being used, so all three still describe a
+# live divergence and stay.
 rust/html-import--derived-endnotes-section  the importer does not preserve the derived endnotes list looseness (carve#1612)
 js/html-import--derived-endnotes-section  the importer does not preserve the derived endnotes list looseness (carve#1612)
 php/html-import--derived-endnotes-section  the importer does not preserve the derived endnotes list looseness (carve#1612)
-rust/html-import--empty-definition-description  an empty description is not reproduced as the fixture's definition-list row (carve#1636)
-rust/html-import--empty-definition-description-not-last  dropping the empty description changes the following definition-list structure (carve#1636)
-php/html-import--empty-definition-description-not-last  dropping the empty description changes the following definition-list structure (carve#1636)
-rust/html-import--endnotes-section-not-last  the importer relocates a non-final endnotes section (carve#1600)
-rust/html-import--note-reference-in-a-span  the note reference consumes the surrounding span boundary (carve#1600)


### PR DESCRIPTION
`AST conformance` on `main` is red on two independent causes. This clears one of
them: five lines in `resources/converter-drift.txt` still declared a divergence
the engine had already fixed.

A declaration nothing diverges on is the same defect as an undeclared
divergence, and only one of the two announces itself - which is why this ledger
fails in both directions.

## What was measured

Run [32683876950](https://github.com/markup-carve/carve/actions/runs/32683876950),
dispatched for this change at `4f911379`. The workflow builds every engine from a
fresh checkout of its own default branch, so it measures engine `main` at run
time rather than a pin.

```
rust: convert_pass=60/61 declared_drift=1 mismatch=0 error=0 skipped=2
js:   convert_pass=61/63 declared_drift=1 mismatch=1 error=0 skipped=0
php:  convert_pass=61/63 declared_drift=1 mismatch=1 error=0 skipped=0
cross_convert_diffs=1
```

It named exactly five STALE lines, and those five are what this deletes:

| line | fixed by |
| --- | --- |
| `rust/html-import--empty-definition-description` | markup-carve/carve-rs#1319 |
| `rust/html-import--empty-definition-description-not-last` | markup-carve/carve-rs#1319 |
| `php/html-import--empty-definition-description-not-last` | markup-carve/carve-php#1646 |
| `rust/html-import--endnotes-section-not-last` | markup-carve/carve-rs#1318 |
| `rust/html-import--note-reference-in-a-span` | markup-carve/carve-rs#1317 |

The three `derived-endnotes-section` lines are **not** stale and stay. Each
engine's `declared_drift=1` in the summary above IS that line being used, so all
three still describe a live divergence.

## Proven in both directions

Against the three engines built from their merged mains - carve-rs `0e12c39`,
carve-js `ba42673`, carve-php `a09d4c4`.

With the five lines gone, `npm run compare:convert` reports **no STALE line at
all**:

```
1 converter gate failure(s):
  - php diverges on html-import--container-label-keeps-the-fence and resources/converter-drift.txt does not declare it.
```

Re-adding one of the deleted lines puts it straight back:

```
2 converter gate failure(s):
  - php diverges on html-import--container-label-keeps-the-fence and resources/converter-drift.txt does not declare it.
  - converter-drift.txt declares rust/html-import--note-reference-in-a-span and the engine now matches (or the case is gone) - delete the STALE line in the commit that fixed it.
```

The mutation was reverted from a pre-mutation copy and the file re-checked by
grep, not by exit status.

## What is deliberately left red

`html-import--container-label-keeps-the-fence` is a **live** divergence, opened
by carve#1654 minutes before this measurement and not yet landed in carve-php.
It is not declared here on purpose: declaring a divergence that is hours from
being fixed silences a defect, and the reason this ledger fails in both
directions is so that cannot happen quietly. Between the CI run and the local
proof, carve-js landed its half - CI saw `js` mismatch on it, the local run does
not - which is the same shape and the reason a declaration was never the answer.

`resources/ast-value-divergence.txt` is untouched. The other `AST conformance`
failure, `NEW definition_list.loose diverges in 1 document(s) and is not
declared`, is likewise a real live divergence being fixed in the engines
(markup-carve/carve-js#1410, markup-carve/carve-php#1660) and stays red.

## Gates

`npm test` (2957 pass, 0 fail, 1 skip) and `npm run core:check` (1384/1384
conformant, 0 defects) green by exit code on the pushed commit, under Node 24.
