### PR TITLE
spec: pin the lone indented image, the shape three engines could not see

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -179,6 +179,7 @@ under the same semantic-span rule,
 `408-the-writer-spells-looseness-only-where-a-blank-line-cannot`,
 `409-a-blank-line-loosens-an-item-only-when-a-paragraph-follows-it`,
 `410-a-footnote-continuation-survives-a-blank-run`,
+`411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so`,
 `05-lists-25`,
 `05-lists-26`,
 `05-lists-27`,
@@ -253,6 +254,31 @@ own choosing, not the three this page quotes, and the five-target transcript
 above was not retaken. Editing the denominators on that evidence would publish
 a run nobody made, which is the objection stated two paragraphs up. So the
 category is declared and the numbers stand as measured.
+
+`411` IS DECLARED FOR A WINDOW THE HTML COLUMN CANNOT SHOW, which is a first on
+this page and worth stating plainly. carve#1660 ruled that an indented lone
+image is a paragraph holding an inline image and not a block image, against the
+engine split two to one: `docs/divergence-from-djot.md` section 15 says a
+top-level block opener must start at column 0, so an indented one cannot be a
+block image whatever two engines do. carve-js is right, and carve-rs and
+carve-php promote it (markup-carve/carve-rs#1341,
+markup-carve/carve-php#1681).
+
+The two documents in this category nevertheless PASS on all three engines and
+on the oracle. A paragraph whose whole content is one image renders as a bare
+`<img>` with no `<p>` wrapper, so the indented reading and the promoted one emit
+the same bytes; what differs is the tree, `paragraph > image` against a
+top-level `image`. So the mismatch counts above would not move even if the run
+were retaken today, and the reader that fails is `npm run ast:check`'s SHAPE
+comparison, which is where this window is visible.
+
+The declaration is kept for the ordinary reason - the quoted run predates the
+category - and it names the two engines rather than the corpus, so it fails from
+both sides: it goes red here if either category stops contributing fixtures, and
+whoever retakes the run has to delete the line. The engine half closes when
+those two tickets land, and `ast:check` is what says so; a line still naming an
+engine somebody has fixed reads as verified while being false, which is the
+failure this device exists to prevent.
 
 A CATEGORY THAT ALREADY EXISTED CAN GO STALE TOO, and the declaration above
 cannot say so - it names categories ADDED since the run, and its count is

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1384 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1386 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -484,6 +484,7 @@ index: examples/edge-cases/index.md
   link-reference-definition-separator-must-be-a-space
   a-reference-definition-cannot-take-its-destination-from-the-next-line
   indented-image-and-caption-stay-literal
+  a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so
   indented-reference-and-footnote-definitions-stay-literal
   a-repeated-definition-which-one-wins
   a-collapsed-reference-is-matched-by-the-label-the-author-wrote

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -27139,3 +27139,59 @@ See[^1].
 ```
 
 :::
+
+## A lone indented image is a paragraph, and its HTML cannot say so
+
+PART 9 §15's strict column-0 rule says a top-level block opener must start at
+column 0, and `docs/divergence-from-djot.md` gives the worked example: ` # H`
+renders `<p># H</p>`. A block image is a top-level block construct, so an
+indented one is not one - the leading space cannot be inert for an image and
+decisive for a heading.
+
+`158-indented-image-and-caption-stay-literal` pins the indented image WITH its
+caption, `-2` the same pair under a block-attribute line, and `-3` the flush-left
+figure. All three carry a SECOND line, and that is the whole reason this section
+exists. The lone-image promotion only fires on a paragraph whose entire content
+is one image, so a caption line under the image keeps it from firing at all -
+which left the one shape it does fire on pinned nowhere. carve-rs and carve-php
+promoted an indented lone image to a block image, carve-js did not, and every
+corpus document passed on all three while they disagreed (carve#1660).
+
+THE HTML CANNOT SEE THE DIFFERENCE, and that is stated here rather than left for
+a reader to rediscover. A paragraph whose whole content is one image renders as a
+bare `<img>` with no `<p>` wrapper - the same rule `-3` leans on - so the
+indented reading and the promoted one emit the same bytes. What differs is the
+tree: `paragraph > image` against a top-level `image`. The pair below is
+therefore an HTML control that every engine already satisfies, and the shape
+comparison in `npm run ast:check` is the reader that fails on it.
+
+::: compare
+
+```carve
+ ![Apollo](a.jpg)
+```
+
+```html
+<img src="a.jpg" alt="Apollo">
+```
+
+:::
+
+The reference spelling reaches the same promotion path by a different route: it
+is never a syntactic block image, so it arrives as a paragraph and is promoted
+afterwards or not at all. Indenting it must fold the same way, for the same
+reason.
+
+::: compare
+
+```carve
+ ![Apollo][moon]
+
+[moon]: a.jpg
+```
+
+```html
+<img src="a.jpg" alt="Apollo">
+```
+
+:::

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,17 +1,17 @@
 {
   "engine": "@markup-carve/carve",
   "engineCommit": "71add23f80f1884684cea2c8bf46de08d0b64e5c",
-  "corpusDocuments": 1384,
+  "corpusDocuments": 1386,
   "htmlImportPopulation": {
-    "completed": 1383,
-    "canonicalFixedPoints": 1329,
-    "renderedTextPreserved": 1351,
+    "completed": 1385,
+    "canonicalFixedPoints": 1331,
+    "renderedTextPreserved": 1353,
     "expectedRejections": [
       "182-openers-past-the-nesting-cap-are-one-paragraph.crv"
     ]
   },
   "renderImportRoundTrips": {
-    "html": 605,
-    "markdown": 374
+    "html": 606,
+    "markdown": 375
   }
 }

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-2.crv
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-2.crv
@@ -1,0 +1,3 @@
+ ![Apollo][moon]
+
+[moon]: a.jpg

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-2.html
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-2.html
@@ -1,0 +1,1 @@
+<img src="a.jpg" alt="Apollo">

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.crv
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.crv
@@ -1,0 +1,1 @@
+ ![Apollo](a.jpg)

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.html
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.html
@@ -1,0 +1,1 @@
+<img src="a.jpg" alt="Apollo">

--- a/tests/import-roundtrip-ratchets.check-helper.mjs
+++ b/tests/import-roundtrip-ratchets.check-helper.mjs
@@ -60,6 +60,20 @@ test('HTML import and render/import round trips cannot drift silently', async ()
       htmlImportPopulation: baseline.htmlImportPopulation,
       renderImportRoundTrips: baseline.renderImportRoundTrips,
     },
-    'the import population changed; inspect every changed count and update the pinned baseline only with the engine pin',
+    // TWO CAUSES MOVE THESE NUMBERS, and only one of them is drift.
+    //
+    //  - THE ENGINE changed what it imports or writes. Then the counts moved for
+    //    a document set that did not, and the baseline is bumped WITH the engine
+    //    pin, after inspecting every changed count.
+    //  - THE CORPUS GREW. Then every count moves by construction and the pin has
+    //    not moved at all. Bump the baseline in the same commit that adds the
+    //    documents, and say in it which of them did NOT contribute to each
+    //    round-trip count and why - an insertion that lands on `completed` but
+    //    not on `renderImportRoundTrips.html` is telling you something about the
+    //    new document.
+    //
+    // The message named only the first, so the first corpus insertion after this
+    // ratchet landed (carve#1662) was told to do nothing (carve#1660).
+    'the import population changed; if the engine pin moved, inspect every changed count and bump this with the pin - if the CORPUS grew instead, bump it in the commit that adds the documents and account for each count that did not move with it',
   )
 })

--- a/tests/spec/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.test
+++ b/tests/spec/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.test
@@ -1,0 +1,15 @@
+A lone indented image is a paragraph, and its HTML cannot say so
+
+```
+ ![Apollo](a.jpg)
+.
+<img src="a.jpg" alt="Apollo">
+```
+
+```
+ ![Apollo][moon]
+
+[moon]: a.jpg
+.
+<img src="a.jpg" alt="Apollo">
+```


### PR DESCRIPTION
Closes #1660

An indented lone image is a paragraph holding an inline image, not a block image.
Section 15's strict column-0 rule reaches it: a block image is a top-level block
construct, so the leading space cannot be inert for an image and decisive for a
heading. carve-js is right and the other two engines move
(markup-carve/carve-rs#1341, markup-carve/carve-php#1681).

## The hole this closes

All three `158-indented-image-and-caption-stay-literal` documents carry a SECOND
line. The lone-image promotion only fires on a paragraph whose whole content is
one image, so a caption line keeps it from firing - which means all three passed
on all three engines while the engines disagreed about the one-line case. No
document anywhere had a lone indented image.

Category `411` is that document, in both spellings. The reference form is never a
syntactic block image, so it arrives as a paragraph and reaches the same
promotion by a different route; indenting it must fold the same way.

## What the pairs can and cannot see

A paragraph whose whole content is one image renders as a bare `<img>` with no
`<p>` wrapper. So the indented reading and the promoted one emit the same bytes,
and both documents pass on all three engines and on the oracle today. What
differs is the tree:

| source | tree | HTML |
| --- | --- | --- |
| `![Apollo](a.jpg)` | `image` | `<img src="a.jpg" alt="Apollo">` |
| ` ![Apollo](a.jpg)` | `paragraph > image` | the same bytes |

The reader that fails on it is the SHAPE comparison in `npm run ast:check`, which
is why the section says so in prose rather than leaving a reader to rediscover
that an HTML fixture pins nothing here.

## The declared lag

`411` is added to the declared-lag line in `docs/implementation-comparison.md`,
with a note naming the two engines and the tickets that close the window. It
fails from both sides, which is the point of the device:
`tests/implementation-comparison-counts.test.mjs` goes red if the category stops
contributing fixtures, and red again for whoever retakes the run without deleting
the line.

## Gates

`npm test` locally: 2967 pass, 0 fail. `npm run ast:check` needs the three
sibling engine checkouts and is provisioned only by the scheduled
`ast-conformance` workflow, so it was not run here - it is the gate that will
report the engine window, and it is expected to name `411` until
markup-carve/carve-rs#1341 and markup-carve/carve-php#1681 land.
