### PR TITLE
chore: three rulings the unreleased section did not reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **PART 11 §1c: a wrapper its own content spells away is a declared
+  ceiling** (carve#1658). A paragraph holding only an image or only a comment
+  writes the child's spelling, and the producer declares the loss.
 - **PART 9 §17 L7: a block-attribute `loose` boolean spells the looseness a
   blank line cannot** (carve#1623). It is consumed, not emitted.
 - **A definition list's spelled looseness is a field** (carve#1624, PART 12 §8).
@@ -62,6 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A div unwraps when it kept nothing only a container can hold**
+  (carve#1650, markup-carve/carve-rs#1315). This widens carve#1578 past a bare
+  attribute test: a grouping label keeps the fence too.
 - **The canonical writer spells `loose` only where a blank line cannot**
   (markup-carve/carve-rs#1305, carve#1639).
 - **An ingested value the schema calls absent is normalized away** (carve#1615,
@@ -133,6 +139,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A lone indented image is a paragraph holding an inline image, not a block
+  image** (carve#1660). The strict column-0 rule reaches it; the rendered HTML
+  is the same bytes, so only the tree moves.
 - **A figure's imported target is the captioned block, not a paragraph around
   it** (carve#1606, PART 9 §4b, markup-carve/carve-js#1381).
 - **The escape test reads the source the writer will emit, not the tree**


### PR DESCRIPTION
Second reconciliation pass over the `[Unreleased]` section ahead of 0.1.4. The
first pass (carve#1646) took the section back to tag `0.1.3`; carve#1653 then
condensed it. Ten merges landed after carve#1646, and every one of them was
reconciled against the section rather than assumed covered.

## What was missing

Three rulings had no entry, in any wording:

| ruling | merge | where it went |
| --- | --- | --- |
| carve#1650 | carve#1654 | Changed |
| carve#1658 | carve#1659 | Added |
| carve#1660 | carve#1662 | Fixed |

carve#1650 widens the div-unwrap boundary carve#1578 set: the old test was
`attrs` literally, and a grouping label keeps the fence too. carve#1658 adds
PART 11 §1c, which narrows the round-trip invariant the writer had been
violating silently and requires the loss to be declared. carve#1660 rules that
a lone indented image is a paragraph holding an inline image; the rendered HTML
is byte-identical either way, so only the tree moves.

## What earns nothing, and why

The user-facing surface of this repo is the normative clauses and the corpus, so
an entry requires a clause, a schema field or a corpus document to have moved.
The other seven merges move none:

- carve#1649 and carve#1661 are workflow and test-manifest scaffolding.
- carve#1655 adds import-coverage fixtures against an unchanged contract.
- carve#1653 is the condense itself.
- carve#1657 deletes five stale lines from `resources/converter-drift.txt`. A
  drift ledger records where engines stand, not what the language says.
- carve#1648 corrects prose about which engines have shipped the spelled
  looseness. The field's definition is unchanged.
- carve#1651 repairs one fixture that recorded a source-layout field an import
  cannot produce, against a rule `docs/ast-json.md` and the schema already
  stated.

## Direction

Entries went up, not down. Nothing was trimmed to make the section agree with
the draft release, and each addition sits at the head of its subsection with
every reference kept.

Entry count: 91 before, 94 after. Cut point verified at `9f951e6f`.
