### PR TITLE
spec: pin a lone reference image at column 0, in every spelling

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -180,6 +180,7 @@ under the same semantic-span rule,
 `409-a-blank-line-loosens-an-item-only-when-a-paragraph-follows-it`,
 `410-a-footnote-continuation-survives-a-blank-run`,
 `411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so`,
+`412-a-lone-reference-image-at-column-0-in-every-spelling`,
 `05-lists-25`,
 `05-lists-26`,
 `05-lists-27`,
@@ -279,6 +280,21 @@ whoever retakes the run has to delete the line. The engine half closes when
 those two tickets land, and `ast:check` is what says so; a line still naming an
 engine somebody has fixed reads as verified while being false, which is the
 failure this device exists to prevent.
+
+`412` IS DECLARED FOR THE ORDINARY REASON - the quoted run predates the category -
+and it is worth saying what it does NOT mean. All four of its documents pass on
+all three engines and on the oracle, so the mismatch counts above would not move
+if the run were retaken; the declaration is about which corpus the numbers
+describe, not about an engine owing anything.
+
+The category exists because nothing in the corpus held a lone reference image at
+column 0, so what the reference spellings do there was unpinned while the direct
+spelling was pinned many times over (carve#1663). The three engines agree, and
+`412` is the record of that agreement. Three of its four pairs are invisible to
+this page by construction - a paragraph whose whole content is one image renders
+as a bare `<img>` with no `<p>` wrapper, so they pass whatever the tree holds -
+and the reader that can tell those trees apart is `npm run ast:check`'s SHAPE
+comparison.
 
 A CATEGORY THAT ALREADY EXISTED CAN GO STALE TOO, and the declaration above
 cannot say so - it names categories ADDED since the run, and its count is

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1386 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1390 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/js-pub-trees-1663-59630461.mjs
+++ b/js-pub-trees-1663-59630461.mjs
@@ -1,0 +1,15 @@
+import { carveToAstJson } from '@markup-carve/carve'
+import { writeFileSync } from 'node:fs'
+const cases = {
+  'i1-indented-direct': ' ![Apollo](a.jpg)\n',
+  'c1-resolved':        '![Apollo][moon]\n\n[moon]: a.jpg\n',
+  'c2-collapsed':       '![Apollo][]\n\n[Apollo]: a.jpg\n',
+  'c3-direct':          '![Apollo](a.jpg)\n',
+  'c4-unresolved':      '![Apollo][nope]\n',
+}
+for (const [k,v] of Object.entries(cases)) {
+  const d = carveToAstJson(v)
+  writeFileSync(`/tmp/shapes-${process.env.S}/${k}.carve-js.json`, typeof d==='string'?d:JSON.stringify(d))
+  writeFileSync(`/tmp/shapes-${process.env.S}/${k}.crv`, v)
+}
+console.log('js published trees written')

--- a/probe-nm-1663-59630461.mjs
+++ b/probe-nm-1663-59630461.mjs
@@ -1,0 +1,7 @@
+import { parse } from '@markup-carve/carve'
+const cases = {
+  '411-1 indented direct': ' ![Apollo](a.jpg)\n',
+  '412-1 resolved ref':    '![Apollo][moon]\n\n[moon]: a.jpg\n',
+  '412-3 direct':          '![Apollo](a.jpg)\n',
+}
+for (const [k,v] of Object.entries(cases)) console.log(k.padEnd(24), (parse(v).children||[]).map(c=>c.type))

--- a/probe-pub-1663-59630461.mjs
+++ b/probe-pub-1663-59630461.mjs
@@ -1,0 +1,16 @@
+import * as lib from '@markup-carve/carve'
+const cases = {
+  '411-1 indented direct': ' ![Apollo](a.jpg)\n',
+  '411-2 indented ref':    ' ![Apollo][moon]\n\n[moon]: a.jpg\n',
+  '412-1 resolved ref':    '![Apollo][moon]\n\n[moon]: a.jpg\n',
+  '412-2 collapsed':       '![Apollo][]\n\n[Apollo]: a.jpg\n',
+  '412-3 direct':          '![Apollo](a.jpg)\n',
+  '412-4 unresolved':      '![Apollo][nope]\n',
+}
+for (const [k,v] of Object.entries(cases)) {
+  const parsed = lib.parse(v)
+  const resolved = typeof lib.resolve === 'function' ? lib.resolve(parsed) : parsed
+  const doc = lib.toAstJson(resolved)
+  console.log(k.padEnd(24), 'parse=', (parsed.children||[]).map(c=>c.type).join(','),
+              '  PUBLISHED=', (doc.children||[]).map(c=>c.type).join(','))
+}

--- a/probe-public-1663-59630461.mjs
+++ b/probe-public-1663-59630461.mjs
@@ -1,0 +1,13 @@
+import { carveToAstJson } from '@markup-carve/carve'
+const cases = {
+  '411-1 indented direct': ' ![Apollo](a.jpg)\n',
+  '412-1 resolved ref':    '![Apollo][moon]\n\n[moon]: a.jpg\n',
+  '412-2 collapsed':       '![Apollo][]\n\n[Apollo]: a.jpg\n',
+  '412-3 direct':          '![Apollo](a.jpg)\n',
+  '412-4 unresolved':      '![Apollo][nope]\n',
+}
+for (const [k,v] of Object.entries(cases)) {
+  const d = carveToAstJson(v)
+  const doc = typeof d === 'string' ? JSON.parse(d) : d
+  console.log(k.padEnd(24), (doc.children||[]).map(c=>c.type).join(','))
+}

--- a/probe-stage-1663-59630461.mjs
+++ b/probe-stage-1663-59630461.mjs
@@ -1,0 +1,14 @@
+import * as lib from '@markup-carve/carve'
+const cases = {
+  '411-1 indented direct': ' ![Apollo](a.jpg)\n',
+  '412-1 resolved ref':    '![Apollo][moon]\n\n[moon]: a.jpg\n',
+  '412-2 collapsed':       '![Apollo][]\n\n[Apollo]: a.jpg\n',
+  '412-3 direct':          '![Apollo](a.jpg)\n',
+  '412-4 unresolved':      '![Apollo][nope]\n',
+}
+const kinds = d => (d.children||[]).map(c=>c.type).join(',')
+for (const [k,v] of Object.entries(cases)) {
+  const parseOnly = kinds(lib.parse(v))                       // fresh
+  const published = kinds(lib.toAstJson(lib.resolve(lib.parse(v))))  // fresh
+  console.log(k.padEnd(24), 'parse-only=', parseOnly.padEnd(34), 'PUBLISHED=', published)
+}

--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -1424,7 +1424,7 @@
     "image": {
       "type": "object",
       "title": "image (block or inline)",
-      "description": "Also valid in BLOCK position: a lone image paragraph is a block-level image.",
+      "description": "Also valid in BLOCK position: a lone image paragraph is a block-level image. This covers the DIRECT spelling `![alt](src)` and both reference spellings, `![alt][ref]` and the collapsed `![alt][]`, once they resolve - a reference that resolves to nothing has no destination and stays inside its paragraph. Read the PUBLISHED tree when checking this: an engine may promote during reference resolution rather than in its block pass, so a parse-only tree can still show the paragraph (carve#1663).",
       "required": [
         "type",
         "src",

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -485,6 +485,7 @@ index: examples/edge-cases/index.md
   a-reference-definition-cannot-take-its-destination-from-the-next-line
   indented-image-and-caption-stay-literal
   a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so
+  a-lone-reference-image-at-column-0-in-every-spelling
   indented-reference-and-footnote-definitions-stay-literal
   a-repeated-definition-which-one-wins
   a-collapsed-reference-is-matched-by-the-label-the-author-wrote

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -27195,3 +27195,106 @@ reason.
 ```
 
 :::
+
+## A lone reference image at column 0, in every spelling
+
+`411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so` pins what an
+INDENTED lone image is (carve#1660). This section pins the SPELLING axis at column
+0, where nothing was pinned at all: no document in the corpus held a lone
+reference image at column 0, so the question of whether the reference spellings
+reach block position had no answer on the record and two readings could stand
+(carve#1663).
+
+All three engines AGREE here, and these pairs record that rather than argue for
+it. On the published tree - the one a consumer receives - the direct spelling and
+both reference spellings are a top-level `image`, and an unresolved reference is a
+`paragraph`:
+
+| source | published shape |
+| --- | --- |
+| `![Apollo](a.jpg)` | `image` |
+| `![Apollo][moon]`, with `[moon]: a.jpg` | `image` |
+| `![Apollo][]`, with `[Apollo]: a.jpg` | `image` |
+| `![Apollo][nope]`, undefined | `paragraph` holding an `image` |
+
+READ THE PUBLISHED EXIT, NOT THE PARSE TREE, when checking any of this. carve-js
+promotes inside `resolve()` rather than in its syntactic block-image pass, and
+`resolve()` mutates the tree in place - so `parse()` reports a `paragraph` for the
+middle two rows and the tree a consumer receives holds an `image`. Comparing that
+intermediate stage against engines that resolve inside their own parse compares a
+stage no other engine exposes; `scripts/ast-conformance.mjs` names the trap in its
+own source, from carve#486, and takes its reference tree through
+`toAstJson(resolve(parse(x)))` for exactly this reason. carve#1663 was filed and
+ruled on the parse-only reading and withdrawn once the published tree was
+measured.
+
+THE HTML CANNOT SEE THE FIRST THREE PAIRS. A paragraph whose whole content is one
+image renders as a bare `<img>` with no `<p>` wrapper, so a promoted image and a
+paragraph holding one emit the same bytes, and every engine passes these three
+whatever it does with the tree. The reader that can tell them apart is the SHAPE
+comparison in `npm run ast:check`. The fourth pair is the one the HTML does
+report, because a reference that resolves to nothing degrades to the literal
+source it was written as.
+
+::: compare
+
+```carve
+![Apollo][moon]
+
+[moon]: a.jpg
+```
+
+```html
+<img src="a.jpg" alt="Apollo">
+```
+
+:::
+
+The collapsed spelling resolves by its own derived label and reaches the same
+promotion, so it lands the same way.
+
+::: compare
+
+```carve
+![Apollo][]
+
+[Apollo]: a.jpg
+```
+
+```html
+<img src="a.jpg" alt="Apollo">
+```
+
+:::
+
+The direct spelling is the one the syntactic block-image pass matches, and it is
+here so the three spellings are pinned together rather than one of them being
+inferred from the other two.
+
+::: compare
+
+```carve
+![Apollo](a.jpg)
+```
+
+```html
+<img src="a.jpg" alt="Apollo">
+```
+
+:::
+
+An unresolved reference stays a paragraph on all three, and this is where the
+HTML does move: nothing defines `nope`, so there is no destination and the
+construct renders as the text the author typed.
+
+::: compare
+
+```carve
+![Apollo][nope]
+```
+
+```html
+<p>![Apollo][nope]</p>
+```
+
+:::

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,17 +1,17 @@
 {
   "engine": "@markup-carve/carve",
   "engineCommit": "71add23f80f1884684cea2c8bf46de08d0b64e5c",
-  "corpusDocuments": 1386,
+  "corpusDocuments": 1390,
   "htmlImportPopulation": {
-    "completed": 1385,
-    "canonicalFixedPoints": 1331,
-    "renderedTextPreserved": 1353,
+    "completed": 1389,
+    "canonicalFixedPoints": 1335,
+    "renderedTextPreserved": 1357,
     "expectedRejections": [
       "182-openers-past-the-nesting-cap-are-one-paragraph.crv"
     ]
   },
   "renderImportRoundTrips": {
-    "html": 606,
-    "markdown": 375
+    "html": 607,
+    "markdown": 376
   }
 }

--- a/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-2.crv
+++ b/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-2.crv
@@ -1,0 +1,3 @@
+![Apollo][]
+
+[Apollo]: a.jpg

--- a/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-2.html
+++ b/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-2.html
@@ -1,0 +1,1 @@
+<img src="a.jpg" alt="Apollo">

--- a/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-3.crv
+++ b/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-3.crv
@@ -1,0 +1,1 @@
+![Apollo](a.jpg)

--- a/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-3.html
+++ b/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-3.html
@@ -1,0 +1,1 @@
+<img src="a.jpg" alt="Apollo">

--- a/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-4.crv
+++ b/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-4.crv
@@ -1,0 +1,1 @@
+![Apollo][nope]

--- a/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-4.html
+++ b/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling-4.html
@@ -1,0 +1,1 @@
+<p>![Apollo][nope]</p>

--- a/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling.crv
+++ b/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling.crv
@@ -1,0 +1,3 @@
+![Apollo][moon]
+
+[moon]: a.jpg

--- a/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling.html
+++ b/tests/corpus/412-a-lone-reference-image-at-column-0-in-every-spelling.html
@@ -1,0 +1,1 @@
+<img src="a.jpg" alt="Apollo">

--- a/tests/spec/412-a-lone-reference-image-at-column-0-in-every-spelling.test
+++ b/tests/spec/412-a-lone-reference-image-at-column-0-in-every-spelling.test
@@ -1,0 +1,29 @@
+A lone reference image at column 0, in every spelling
+
+```
+![Apollo][moon]
+
+[moon]: a.jpg
+.
+<img src="a.jpg" alt="Apollo">
+```
+
+```
+![Apollo][]
+
+[Apollo]: a.jpg
+.
+<img src="a.jpg" alt="Apollo">
+```
+
+```
+![Apollo](a.jpg)
+.
+<img src="a.jpg" alt="Apollo">
+```
+
+```
+![Apollo][nope]
+.
+<p>![Apollo][nope]</p>
+```


### PR DESCRIPTION
Nothing in the corpus held a lone reference image at column 0. The direct spelling
was pinned many times over, so what `![a][r]` and `![a][]` do there was unpinned,
and two readings of it could stand at once. That is what markup-carve/carve#1663
was about; the ticket is closed as moot, and this is the corpus hole it exposed.

Category 412 pins all four spellings. **All three engines agree on every one**, so
the category records agreement rather than arguing for it:

| source | published shape, all three engines |
| --- | --- |
| `![Apollo](a.jpg)` | `image` |
| `![Apollo][moon]`, with `[moon]: a.jpg` | `image` |
| `![Apollo][]`, with `[Apollo]: a.jpg` | `image` |
| `![Apollo][nope]`, undefined | `paragraph` holding an `image` |

Measured on `carve-js` 8ca9c804, `carve-rs` 5e58310a, `carve-php` 0d4c73b3, each
built fresh, read through the published exit and classified with this repo's own
`classifyShapeDisagreement` over `shapePaths(shapeOf(...))`.

## Three of the four pairs are invisible to HTML

A paragraph whose whole content is one image renders as a bare `<img>` with no
`<p>` wrapper, so a promoted image and a paragraph holding one emit the same bytes
and pass on every engine whatever the tree holds. The reader that can tell those
trees apart is the SHAPE comparison in `npm run ast:check`. The fourth pair is the
one the HTML does report, because a reference that resolves to nothing degrades to
its literal source.

## The section says which exit to read

carve-js promotes inside `resolve()` rather than in its syntactic block-image
pass, and `resolve()` mutates in place, so `parse()` reports a `paragraph` for the
two reference rows while the tree a consumer receives holds an `image`. Comparing
that intermediate stage against engines that resolve inside their own parse
compares a stage no other engine exposes - `scripts/ast-conformance.mjs` names
that trap in its own source, from markup-carve/carve#486, and takes its reference
tree through `toAstJson(resolve(parse(x)))` for exactly that reason. The section
now states it where someone writing such a table will actually read it.

## Schema sentence

The `image` description said only "a lone image paragraph is a block-level image".
Its silence about which spellings it covered is what let two readings stand. It now
names all three promoting spellings, says an unresolved reference stays in its
paragraph, and points at the published tree.

## Declared lag

The ordinary reason - the quoted run predates the category. All four documents pass
on all three engines, so the mismatch counts do not move and no engine owes
anything here. `resources/import-roundtrip-baseline.json` moves by construction:
+4 documents, completions, canonical fixed points and rendered-text-preserved, and
+1 on each of `html` and `markdown` because only the direct spelling round-trips -
the reference spellings import as an inline image and the definition the source
carried is gone.

Gates run locally by exit code: `npm test`, `npm run html-import:check`,
`npm run escape:check`, `npm run core:check`, `npm run corpus:build`,
`npm run docs:pages`, `npm run compare:counts` (1510/1510 on all three engines).
`npm run ast:check` was run locally against all three engine checkouts.
