### PR TITLE
docs: record the image spellings that reach block position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The AST schema names which image spellings reach block position**
+  (carve#1663). At column 0 the direct spelling and both reference spellings
+  promote to a block image once resolved; an unresolved reference stays in its
+  paragraph. Read the published tree, not the parse tree.
 - **PART 11 §1c: a wrapper its own content spells away is a declared
   ceiling** (carve#1658). A paragraph holding only an image or only a comment
   writes the child's spelling, and the producer declares the loss.


### PR DESCRIPTION
One entry, for `cc06bb5c` (carve#1666, ruling carve#1663).

That commit added corpus category 412 - a lone reference image at column 0 in
all four spellings - taking the pinned example count from 1386 to 1390, and
widened the AST schema's `image` description from "a lone image paragraph is a
block-level image" to name the direct spelling, both reference spellings, and
what an unresolved reference does instead. A new corpus document and a changed
schema description both meet the cut principle for this repo.

It goes in **Added**, not folded into the carve#1660 line under Fixed. That line
records a tree that moved; this one records agreement that had never been on the
record, and no engine behavior changes.

The other two commits since the last reconciliation merge earn nothing:
`597302ca` drops five scratch probe files from the repository root, and
`165b6ce5` adds `scripts/shape-table.mjs` plus its guard test and a docs
paragraph. Neither moves a normative clause, a schema field or a corpus
document.

Unreleased bullets: 94 before, 95 after. Nothing trimmed.
