### PR TITLE
spec: record the canonical form corpus 411 writes back to

### DIFF
--- a/resources/corpus-sidecars.lock.json
+++ b/resources/corpus-sidecars.lock.json
@@ -101,6 +101,8 @@
   "407-one-consumed-boolean-spells-the-looseness-no-blank-line-can.fmt": "c273f62c1fe6470a",
   "408-the-writer-spells-looseness-only-where-a-blank-line-cannot-2.fmt": "733d9ac1374dcc42",
   "408-the-writer-spells-looseness-only-where-a-blank-line-cannot.fmt": "361a4b39bb40dcbe",
+  "411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-2.fmt": "ef896b7a6d93c4a6",
+  "411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.fmt": "6b4757286e96e92b",
   "43-abbreviations.ansi": "4332a088c2ae546d",
   "43-abbreviations.md": "4332a088c2ae546d",
   "43-abbreviations.txt": "4332a088c2ae546d",

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-2.fmt
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-2.fmt
@@ -1,0 +1,3 @@
+![Apollo][moon]
+
+[moon]: a.jpg

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.fmt
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.fmt
@@ -1,0 +1,1 @@
+![Apollo](a.jpg)


### PR DESCRIPTION
Closes #1672

Corpus category `411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so` shipped without a `.fmt` sidecar, so nothing in this repository stated what the canonical writer emits for it. Two engines blocked their spec-pin bump on that gap.

## The ruling this records

The writer is right to decline the indented spelling. PART 11 section 1c says it outright for exactly this shape: where a block's whole content is a single node whose own spelling at the block's own column reads back as a block opener of that node's kind, the writer emits that spelling and the wrapper is LOST, and `parse(fmt(x)) == parse(x)` is unattainable for such a document. Both `411` documents are that shape, so section 1 is not the rule that applies to them.

Section 1c also gives the reason the ceiling is uniform rather than positional: one level down the indented spelling does not exist at any marker width, because the marker's own content column absorbs the padding. A writer preserving the shape at top level and losing it at the next level, with nothing declaring the difference, would not be a preservation rule.

So the corpus records the writer's behavior instead of asking it to change.

## What the sidecars say

Measured against the build this repository pins (`carve-js` at `71add23f`), not predicted. Each source line carries one leading space; the written form carries none.

Document one, source:

````
 ![Apollo](a.jpg)
````

writes back as:

````
![Apollo](a.jpg)
````

Document two, the reference spelling, source:

````
 ![Apollo][moon]

[moon]: a.jpg
````

writes back as:

````
![Apollo][moon]

[moon]: a.jpg
````

This is the same normalization `158-indented-image-and-caption-stay-literal.fmt` already records for the neighboring document. That one keeps its wrapper because its formatted form is still two lines; `411` is a lone image, so the wrapper has nowhere to survive.

## Why not a drift entry

`resources/engine-fmt-drift.txt` is for a document the pin reads fine and cannot WRITE back out faithfully. The pin writes both `411` documents correctly, and the sidecars are the proof, so no entry applies.

## Proof the fixture is load-bearing

Rewriting the first sidecar to assert the indented spelling (the alternative the ruling rejected) turns `fmt(x) matches every .fmt fixture (PART 11 section 2)` red with exit 1, naming the document and both spellings:

````
expected: " ![Apollo](a.jpg)\n"
  actual: "![Apollo](a.jpg)\n"
````

Restoring it returns exit 0. The other three sweeps in `tests/corpus-fmt-roundtrip.test.mjs` stay green under the same mutation, which is the ticket's own point: `toHtml(fmt(x)) == toHtml(x)` and `fmt(fmt(x)) == fmt(x)` both pass on `411` by construction, so the bytes were the only unmeasured half.

## Scope

No engine change, no ruling reversed, no clause amended. `resources/corpus-sidecars.lock.json` gains the two lock entries `npm run corpus:build` derives; no `.crv` or `.html` moved.

The two open drafts on this repository (1026, 291) both touch `docs/examples/edge-cases.md`. `411` is authored in `resources/examples/edge-cases.md` and this branch touches neither, so there is no overlap to rebase against.

## On the carve-js correction

The ticket's own premise that `toHtml(fmt(x)) == toHtml(x)` passes on `411` "by construction" was corrected there: it holds for carve-rs and carve-php and fails for carve-js on its own `main`, which is markup-carve/carve-js#1437 rather than a spec question.

That does not weaken these fixtures, because the bytes are derived from section 1c rather than from whatever an engine happens to emit. Two independent confirmations, both run here:

- the build this repository pins (`71add23f`) emits exactly these bytes for both documents, and formatting is idempotent and HTML-preserving on both;
- the executable spec, which is not carve-js, renders the fixture and the case input identically for both documents, so each sidecar is a faithful serialization of its own case.

A useful side effect: `scripts/fmt-fixture-claims.mjs` reads these same files against all three engines in the scheduled conformance workflow, so a writer that disagrees with the canonical form now shows up as a byte mismatch naming the document. That workflow is where carve-js's divergence will surface; per-PR CI here does not build sibling engines and is unaffected.