### PR TITLE
test: an import records no attribute slot, and the engine is held to it too

### DIFF
--- a/tests/html-import-contract.check.mjs
+++ b/tests/html-import-contract.check.mjs
@@ -79,11 +79,23 @@ test('every expected.crv is a fixed point of the canonical writer', async () => 
  * red too, so the line goes out with the pin bump that fixed it.
  */
 const PIN_LAG = new Map([
+  // THE SOURCE EXIT ONLY, and the tree beside it is NOT lagging - it is right,
+  // and the engine that fixes the source exit breaks it. The id here EQUALS its
+  // generated slug rather than differing from it, which is the whole reason the
+  // pinned build drops it; markup-carve/carve-js#1416 keeps it, and keeps it by
+  // recording an `#id` SLOT in the imported tree. A slot is a source-layout
+  // field, and markup-carve/carve#1647 ruled that an import records none of
+  // them, so the bump past #1416 turns `expected.ast.json` red for a defect in
+  // the engine rather than in the fixture. tests/the-two-import-exits-agree.test.mjs
+  // holds that line on both sides; do not re-record the tree to clear it
+  // (markup-carve/carve#1671).
   [
     'auto-text-link',
-    'the source exit omits an authored heading ID that differs from its generated slug; ' +
-      'fixed upstream by markup-carve/carve-js#1416, but the spec pin cannot advance ' +
-      'until the unrelated round-trip regressions in that newer engine are resolved',
+    'the source exit drops an authored heading ID whose value EQUALS its ' +
+      'generated slug; kept upstream by markup-carve/carve-js#1416, but the ' +
+      'spec pin cannot advance until the unrelated round-trip regressions in ' +
+      'that newer engine are resolved - and that engine keeps the id by ' +
+      'recording an `#id` slot the imported tree may not carry',
   ],
   [
     'marker-shaped-cell',

--- a/tests/the-two-import-exits-agree.test.mjs
+++ b/tests/the-two-import-exits-agree.test.mjs
@@ -181,6 +181,48 @@ test('the source-layout scan finds the field the fixture recorded', () => {
   assert.deepEqual(sourceLayoutKeys({ type: 'document', children: [{ type: 'list', items: [] }] }), [])
 })
 
+/*
+ * AND THE ENGINE IS HELD TO IT TOO, not only the fixtures
+ * (markup-carve/carve#1671).
+ *
+ * The check above reads FIXTURE BYTES, which is all it could read when the rule
+ * was written. That leaves the rule stated on the recordings and unstated on
+ * the thing that produces them - so an importer may start recording a
+ * source-layout field, and the only way to notice is a fixture someone
+ * re-records to match it. That is the wrong direction to fix it in, and it is
+ * the direction markup-carve/carve#1671 proposed: the fixture was reported as
+ * stale because its tree carries no `#id` slot while a newer engine's import
+ * does. The fixture is right; the slot is the thing that may not be there.
+ *
+ * The pinned build is in this repository, so the rule can be read off the
+ * IMPORT rather than off a recording of one. It is green at `71add23f`, which
+ * records no source-layout field for any of the fixtures, and it goes red the
+ * moment the pin passes markup-carve/carve-js#1416 - which keeps an authored
+ * heading id by pushing an `#id` slot into the tree it publishes, and is the
+ * only arm of either importer that does. Measured on carve-js `dd75592`: one
+ * hit, `auto-text-link -> .children[0].attrs.order`, and none anywhere else.
+ *
+ * So a bump that trips this is naming an ENGINE defect. Fix it there; do not
+ * re-record a fixture to accept a spelling the import never read.
+ */
+test('the pinned build records no source-layout field on any import either', async () => {
+  const { htmlToAst, toAstJson } = await import('@markup-carve/carve')
+  const fixtures = (await readdir(root, { withFileTypes: true })).filter((entry) => entry.isDirectory())
+  assert.ok(fixtures.length > 0)
+  for (const { name } of fixtures) {
+    const html = await readFile(new URL(`${name}/input.html`, root), 'utf8')
+    assert.deepEqual(
+      sourceLayoutKeys(toAstJson(htmlToAst(html).value)),
+      [],
+      `the pinned build's htmlToAst records a source-layout field for ` +
+        `tests/html-import/${name}. An import reads HTML and has no source to read one ` +
+        `off (markup-carve/carve#1647), so the field states a spelling it never saw. ` +
+        `Fix the importer - re-recording the fixture to match would retire the rule ` +
+        `rather than the defect (markup-carve/carve#1671).`,
+    )
+  }
+})
+
 const disagreement = (parsed, recorded, path = '') => {
   if (Array.isArray(parsed) || Array.isArray(recorded)) {
     if (!Array.isArray(parsed) || !Array.isArray(recorded)) return `${path}: array against non-array`


### PR DESCRIPTION
Closes #1671

## The ticket asked for the wrong file to move

`tests/html-import/auto-text-link/expected.crv` spells `{#Target}`, which parses
to `attrs: {"id":"Target","order":["#id"]}`. The `expected.ast.json` beside it
records `attrs: {"id":"Target"}` with no `order`. The ticket read that as a stale
recording and asked for the tree to be re-recorded with the slot.

**Neither file is wrong.** `order` is a SOURCE-LAYOUT field, and #1647 already
ruled that an import records none of them - it reads HTML and has no source to
read a spelling off. `tests/the-two-import-exits-agree.test.mjs` both states that
rule and compares the two exits modulo exactly those fields, so the fixture's two
halves already agree under the contract this repository holds.

Re-recording turns that test red, which is how the premise was caught:

```
✖ no fixture records a source-layout field, because an import read no source
  tests/html-import/auto-text-link/expected.ast.json records a source-layout field.
  An import reads HTML and has no source to read one off, which is the ground
  SOURCE_LAYOUT_FIELDS is skipped on above (markup-carve/carve#1647).
```

The premise the ticket reasons from - that a recorded tree must equal a parse of
the recorded source in *every* field - is the one thing the contract does not
say. `resources/ast-schema.json` says the same in its own words: `order` is
"absent on a programmatically built tree".

## What is actually defective is an engine

carve-js `main` keeps an authored heading id by pushing an `#id` slot into the
tree it publishes - the field it may not record. Scanned every fixture's import
through both builds:

| build | fixtures recording a source-layout field |
| --- | --- |
| pinned `71add23f` | none |
| carve-js `dd75592` | `auto-text-link -> .children[0].attrs.order`, and nothing else |

One arm of one importer. Every other arm of both engines omits it, which is why
14 other fixtures record attrs with no `order` and are correct in doing so. The
same is true of carve-rs: its own fixture runner reads `expected.crv` and the
report codes and never the tree, so nothing there sees it either.

## What this changes

**The rule is read off the IMPORT, not only off the recordings.** The check
`#1647` added reads fixture BYTES, which is all it could read when it was
written - so the rule was stated on the recordings and unstated on the thing that
produces them. An importer can start recording a source-layout field and the only
way to notice is a fixture someone re-records to match it. That is the wrong
direction to fix it in, and it is the direction this ticket proposed.

The pinned build is in this repository, so the same emptiness is now required of
the import itself. It is green at `71add23f` and goes red on the bump past
markup-carve/carve-js#1416, naming the engine rather than inviting a re-recording.

**The pin-lag reason was wrong in two ways** and is corrected: it described the id
as one that "differs from its generated slug" when its value equals it - which is
the whole reason the pinned build drops it - and it named the fixture as lagging
without saying which half. Only the source exit lags. The tree beside it is right,
and the engine that fixes the source exit is the one that breaks it.

## Why the new check can fail

Pointed at carve-js `main`, which is past markup-carve/carve-js#1416:

```
✖ the pinned build records no source-layout field on any import either
  AssertionError: the pinned build's htmlToAst records a source-layout field for
  tests/html-import/auto-text-link. An import reads HTML and has no source to read
  one off (markup-carve/carve#1647), so the field states a spelling it never saw.
  actual:   [ '.children[0].attrs.order' ]
  expected: []
```

It fails on that fixture and on no other, which is also the measurement above.
Restored and re-run green afterwards.

## Follow-up, not in this PR

carve-js's importer records `order` on its heading arm and nowhere else. That is
an engine defect against #1647 and it belongs in that repository; filed separately
so the pin bump has something to point at.

## Gates

`npm test` (all suites), `npm run html-import:check` and `npm run core:check` ran
locally and are green by exit code.
