### PR TITLE
chore: the guard column is verified against the file, not asserted

### DIFF
--- a/scripts/declaration-audit.mjs
+++ b/scripts/declaration-audit.mjs
@@ -112,6 +112,26 @@ const REPOS = {
  * about this script: `two-way` means the file itself asserts that a declared
  * row still reproduces, so a stale row goes red there. Anything else means it
  * cannot, and this script says so on every run.
+ *
+ * `staleness` is what stops that claim from being the very thing this script
+ * exists to find. A `guard` field alone is an ASSERTION NOBODY CHECKS - the
+ * carve#755 shape, sitting inside the gate written to catch it. Measured:
+ * after markup-carve/carve-js#1449 and markup-carve/carve-php#1689 wired three
+ * lists in both directions, this file still reported all three as unwired,
+ * because flipping the word was a separate manual step nothing tied to the
+ * code.
+ *
+ * So where `staleness` is present it names a LITERAL STRING that must appear
+ * in the file - the assertion providing the reverse direction. Deleting or
+ * renaming that assertion now fails here, which is the regression mode that
+ * actually happens. It does NOT prove the assertion FIRES; only a mutation run
+ * does that, and each of these carries one in its own PR.
+ *
+ * Where `staleness` is ABSENT the guard is reported as CLAIMED rather than
+ * verified, and the run says how many of each there are. That is deliberate:
+ * back-filling every entry at once would mean inventing anchors for two dozen
+ * files in one commit, and a wrong anchor is a false failure on the pre-tag
+ * gate. The honest intermediate state is to say which claims are checked.
  */
 const MANIFEST = [
   // -- the spec repo's own ledgers ------------------------------------------
@@ -168,10 +188,10 @@ const MANIFEST = [
   { repo: 'carve-js', path: 'test/html-import-conformance.test.ts', name: 'AHEAD_OF_PIN', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'mirrors spec PIN_LAG' },
   { repo: 'carve-js', path: 'test/the-report-answers-to-the-published-schema.test.ts', name: 'AHEAD_OF_PIN', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'test/the-report-answers-to-the-published-schema.test.ts' },
   { repo: 'carve-js', path: 'test/an-import-s-two-exits-say-the-same-thing.test.ts', name: 'UNMET', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'mirrors spec UNMET' },
-  { repo: 'carve-js', path: 'test/no-whitespace-only-line.test.ts', name: 'KNOWN_REMAINING', kind: 'js', policy: 'owed', guard: 'one-way', owner: 'orphan guard only - no staleness half' },
+  { repo: 'carve-js', path: 'test/no-whitespace-only-line.test.ts', name: 'KNOWN_REMAINING', kind: 'js', policy: 'owed', guard: 'two-way', staleness: "it('is behind only what it is still behind on'", owner: 'markup-carve/carve-js#1449' },
   // ONE-WAY, and it hid four stale rows. Nothing asserts a listed document
   // still loses, so a document that STOPS losing sits here reading as coverage.
-  { repo: 'carve-js', path: 'test/ast-round-trip-preserves-source.test.ts', name: 'KNOWN_LOSSES', kind: 'js', policy: 'owed', guard: 'one-way', owner: 'markup-carve/carve#817' },
+  { repo: 'carve-js', path: 'test/ast-round-trip-preserves-source.test.ts', name: 'KNOWN_LOSSES', kind: 'js', policy: 'owed', guard: 'two-way', staleness: "it('still loses what it says it loses'", owner: 'markup-carve/carve-js#1449' },
 
   // -- carve-php -------------------------------------------------------------
   { repo: 'carve-php', path: 'tests/CarveCorpusTest.php', name: 'KNOWN_GAPS', kind: 'php', policy: 'owed', guard: 'two-way', owner: 'tests/CarveCorpusTest.php' },
@@ -186,7 +206,7 @@ const MANIFEST = [
   // ONE-WAY, like its carve-js twin, and its single row names a corpus
   // document that upstream renumbered - so it excuses nothing and no check
   // reports it.
-  { repo: 'carve-php', path: 'tests/TestCase/Renderer/NoWhitespaceOnlyLineTest.php', name: 'KNOWN_REMAINING', kind: 'php', policy: 'owed', guard: 'none', owner: 'no orphan guard, no staleness half' },
+  { repo: 'carve-php', path: 'tests/TestCase/Renderer/NoWhitespaceOnlyLineTest.php', name: 'KNOWN_REMAINING', kind: 'php', policy: 'owed', guard: 'two-way', staleness: 'public function testKnownRemainingIsStillBehindOnWhatItClaims', owner: 'markup-carve/carve-php#1689' },
 
   // -- carve-rs --------------------------------------------------------------
   { repo: 'carve-rs', path: 'tests/corpus.rs', name: 'KNOWN_GAPS', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/corpus.rs' },
@@ -499,6 +519,8 @@ if (doFetch) {
 
 let failed = 0
 const unwired = []
+const verifiedGuards = []
+const claimedGuards = []
 const manualRows = []
 const rowsFor = new Map()
 
@@ -547,6 +569,16 @@ for (const entry of MANIFEST) {
   }
   if (entry.policy === 'manual' && rows.length > 0) manualRows.push({ entry, rows })
   if (entry.guard !== 'two-way') unwired.push({ entry, count: rows.length })
+  // THE CLAIM, CHECKED. `guard` describes the file; `staleness` is the string
+  // that proves it is still there. A named anchor that has gone is a guard that
+  // was removed, and the manifest would otherwise keep vouching for it.
+  else if (entry.staleness !== undefined) {
+    if (src.includes(entry.staleness)) verifiedGuards.push(entry)
+    else {
+      console.log(`${' '.repeat(12)}GUARD GONE: ${entry.path} no longer contains ${JSON.stringify(entry.staleness)}`)
+      failed += 1
+    }
+  } else claimedGuards.push(entry)
 }
 
 /* ------ the sweep that keeps the manifest itself from going stale --------- */
@@ -592,6 +624,12 @@ if (unwired.length > 0) {
   // audit exists to find, so it fails rather than warns.
   for (const { count } of unwired) if (count > 0) failed += 1
 }
+
+console.log(
+  `GUARDS: ${verifiedGuards.length} verified against a named assertion, ` +
+    `${claimedGuards.length} claimed but unverified, ${unwired.length} not two-directional.`,
+)
+console.log()
 
 if (undeclared.length > 0) {
   console.log('UNDECLARED - declaration-shaped constants this manifest does not name:')

--- a/tests/declaration-audit-counts-what-it-claims.test.mjs
+++ b/tests/declaration-audit-counts-what-it-claims.test.mjs
@@ -129,3 +129,29 @@ test('every manifest entry names a policy and a guard the reporter understands',
     assert.ok(entry.owner, `${entry.path} :: ${entry.name} names no owner - an entry nobody owns cannot be retired`)
   }
 })
+
+test('a staleness anchor belongs only to a guard that claims to be two-directional', () => {
+  // The field VERIFIES the `two-way` claim, so naming one beside `one-way` or
+  // `none` would read as evidence for a claim the same row denies.
+  for (const entry of MANIFEST) {
+    if (entry.staleness === undefined) continue
+    assert.equal(
+      entry.guard,
+      'two-way',
+      `${entry.path} :: ${entry.name} names a staleness anchor but declares guard ${entry.guard}`,
+    )
+    assert.ok(
+      entry.staleness.length > 12,
+      `${entry.path} :: ${entry.name} has an anchor too short to identify one assertion`,
+    )
+  }
+})
+
+test('at least one guard is verified rather than merely claimed', () => {
+  // The non-vacuity guard on the verification itself. If every entry lost its
+  // anchor the run would report "0 verified, N claimed" and still pass every
+  // other assertion here - a check that cannot fail, which is the whole
+  // subject of this file.
+  const anchored = MANIFEST.filter((entry) => entry.staleness !== undefined)
+  assert.ok(anchored.length > 0, 'no manifest entry verifies its guard claim against the file')
+})


### PR DESCRIPTION
> **Merge after `markup-carve/carve-php#1689`.** One of the three anchors names an assertion that so far exists only on that PR's branch, so until it lands a `pre-tag-check.sh` run correctly reports `GUARD GONE` for it. That is the check working, not a defect.
>
> To be precise about the blast radius: the audit is **not** wired into any workflow — it runs from `pre-tag-check.sh` and needs sibling engine checkouts CI does not have — so this PR's own CI is unaffected either way, and so is `main`'s. The only thing affected is a pre-tag run taken in the window between the two merges. `markup-carve/carve-js#1449`, the other half, is already merged.

## Why

`#1676` added a `guard` column saying whether each declaration list can detect a STALE row. It was a hand-written field, and nothing tied it to the code — an assertion nobody checks, which is the exact `carve#755` shape sitting inside the gate written to find it.

That is not theoretical. After `markup-carve/carve-js#1449` and `markup-carve/carve-php#1689` wired three lists in both directions, this script still reported all three as unwired:

```
UNWIRED GUARDS - these lists cannot report a STALE row, empty or not:
  [one-way] carve-js test/no-whitespace-only-line.test.ts :: KNOWN_REMAINING (0 row(s))
  [one-way] carve-js test/ast-round-trip-preserves-source.test.ts :: KNOWN_LOSSES (0 row(s))
  [none]    carve-php …/NoWhitespaceOnlyLineTest.php :: KNOWN_REMAINING (0 row(s))
```

Flipping the word was a separate manual step. A manifest that vouches for a guard nobody removed reads identically to one that vouches for a guard someone did.

## What

An optional `staleness` field naming a literal string that must appear in the file — the assertion that provides the reverse direction. Where present, the run verifies it:

```
GUARD GONE: tests/TestCase/Renderer/NoWhitespaceOnlyLineTest.php no longer contains
            "public function testKnownRemainingIsStillBehindOnWhatItClaims"
GUARDS: 2 verified against a named assertion, 48 claimed but unverified, 0 not two-directional.
```

Against the finished state of both engine PRs:

```
GUARDS: 3 verified against a named assertion, 47 claimed but unverified, 0 not two-directional.
```

**What it does and does not prove.** It does not prove the assertion FIRES — only a mutation does, and each of the three carries one in its own PR. It catches the regression mode that actually happens: the assertion deleted or renamed while the manifest keeps claiming it.

**Why not back-fill everything.** Anchoring all 51 entries in one commit means inventing anchors for two dozen files at once, and a wrong anchor is a false failure on the pre-tag gate. So an entry with no anchor is reported as CLAIMED rather than verified, and the run prints how many of each. Saying which claims are checked is the honest intermediate state; the count is the backlog.

## Proof

Disabling the comparison (`if (src.includes(...))` → `if (true)`) makes the missing anchor read as verified and removes the `GUARD GONE` line entirely — so the check is what produces it:

```
GUARDS: 3 verified against a named assertion, 48 claimed but unverified, 0 not two-directional.
```

Restored, it catches carve-php's not-yet-merged anchor again (quoted above).

Two assertions added to the self-test: an anchor may only sit beside a `two-way` claim (naming one beside `one-way` would be evidence for a claim the same row denies), and at least one entry must be anchored — without that, every anchor could be dropped and the run would still report "0 verified" and pass.

Self-test: 14 pass, 0 fail.