### PR TITLE
spec: the oracle asks the PART 11 §1c question in every container, not only at the top level

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1390 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1394 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -133,3 +133,27 @@
 # panel reports, not this one: a node that is not in the tree publishes no
 # scalar to disagree about. So the emptiness here is about scalars across 1134
 # samples, and says nothing about that gap.
+
+# NOT EMPTY ANY MORE, and the row arrived with the document that reaches it.
+# `411-...-6` is the flush half of the list-item pair added under carve#1677:
+#
+#   - t
+#
+#     ![Apollo](a.jpg)
+#
+# carve-rs publishes `tight: true` for that list; carve-js, carve-php and the
+# executable spec publish `tight: false`. The engines agree about the SECOND
+# block - it collapses to a bare `<img>` in all three, which is the half
+# carve#1677 ruled - so what differs is the LIST's looseness, and only for an
+# image written at the item's own content column. One column further in, and
+# with a text second block, carve-rs agrees.
+#
+# DECLARED RATHER THAN LEFT RED, and declared in the same commit that adds the
+# document, which is what "update it in the commit that moves the number" asks
+# for. The alternative was to leave the flush spelling unpinned, and that is the
+# spelling the divergence lives on - a corpus that only holds the shapes the
+# engines already agree about cannot report the ones they do not.
+#
+# Measured over 1397 samples at carve-js 99b28ab, carve-rs 661d4ff and carve-php
+# 38de559, each built from a fresh clone of main.
+list.tight  1  carve-rs alone; tracked at markup-carve/carve-rs#1358

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -27196,6 +27196,110 @@ reason.
 
 :::
 
+### Inside a container, where the pair above cannot reach
+
+The two examples above are both TOP-LEVEL, and that is the whole extent of what
+this category pinned. Measured across every `.crv` in the corpus: the only
+container-hosted image anywhere was `405-a-captioned-image-inside-a-container`,
+which is flush AND captioned - so a caption line keeps the lone-image promotion
+from firing at all, and no document indented an image past a container's content
+column. That is why `npm run ast:check` passed 1393 documents unanimous while
+carve-js emitted `<blockquote><p><img></p></blockquote>`: no check failed,
+because no document reached the shape (markup-carve/carve-js#1440, carve#1677).
+
+The four pairs below reach it. They also settle two places where the oracle
+answered §1c differently depending on which container the shape sat in - a
+quote framed its lone-image child on one line where a div indents it, and a list
+item kept the `<p>` this section's own prose says is not written. Both were
+oracle defects, ruled at carve#1677; all three engines already emitted what is
+recorded here.
+
+A QUOTE HOLDING NOTHING ELSE. The child is spelled as a paragraph and is not one
+by the time it is serialized, so the quote takes the same expanded frame a `<div>`
+takes for the identical child. The one-line form is for a child that stays a
+paragraph, which `> t` still is.
+
+::: compare
+
+```carve
+>   ![Apollo](a.jpg)
+```
+
+```html
+<blockquote>
+  <img src="a.jpg" alt="Apollo">
+</blockquote>
+```
+
+:::
+
+The flush spelling is the control, and it carries the weight here: the quote's
+content column is where the image is ORDINARY, so a change that framed every
+quoted paragraph the same way would show up on this pair rather than on the
+indented one. Both fold to the same bytes, for the reason the top-level pair
+already gives - the HTML cannot see which reading produced the image.
+
+::: compare
+
+```carve
+> ![Apollo](a.jpg)
+```
+
+```html
+<blockquote>
+  <img src="a.jpg" alt="Apollo">
+</blockquote>
+```
+
+:::
+
+A LIST ITEM, INDENTED PAST ITS CONTENT COLUMN. The item's second block is a
+paragraph whose whole content is one image, so it renders as a bare `<img>` -
+the rule stated at the top of this section, applied in the one container the
+oracle used to exempt. The item is loose, so its first block keeps its `<p>`.
+
+::: compare
+
+```carve
+- t
+
+   ![Apollo](a.jpg)
+```
+
+```html
+<ul>
+  <li><p>t</p>
+    <img src="a.jpg" alt="Apollo">
+  </li>
+</ul>
+```
+
+:::
+
+And the flush control for the item, at the content column. carve-rs publishes
+`tight: true` for this list where carve-js, carve-php and the oracle publish
+`tight: false`, so its first block loses the `<p>` - a looseness bug the blank
+line settles on its own, unrelated to §1c and tracked at markup-carve/carve-rs#1358. This
+pair is what makes it visible; the indented spelling above does not reach it.
+
+::: compare
+
+```carve
+- t
+
+  ![Apollo](a.jpg)
+```
+
+```html
+<ul>
+  <li><p>t</p>
+    <img src="a.jpg" alt="Apollo">
+  </li>
+</ul>
+```
+
+:::
+
 ## A lone reference image at column 0, in every spelling
 
 `411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so` pins what an

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,17 +1,17 @@
 {
   "engine": "@markup-carve/carve",
   "engineCommit": "58a2196d1fd0617c6efe0f48f2bbf9fd0cf8e159",
-  "corpusDocuments": 1390,
+  "corpusDocuments": 1394,
   "htmlImportPopulation": {
-    "completed": 1389,
-    "canonicalFixedPoints": 1388,
-    "renderedTextPreserved": 1373,
+    "completed": 1393,
+    "canonicalFixedPoints": 1392,
+    "renderedTextPreserved": 1377,
     "expectedRejections": [
       "182-openers-past-the-nesting-cap-are-one-paragraph.crv"
     ]
   },
   "renderImportRoundTrips": {
-    "html": 595,
-    "markdown": 370
+    "html": 599,
+    "markdown": 374
   }
 }

--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -269,10 +269,22 @@ function renderBlock(b, depth, ctx) {
       // - a div, a list item, a quote holding a captioned CODE block - already
       // indents it, so this was the quote contradicting the rest of the file
       // rather than a reading of the clause.
+      //
+      // AND THE COMPACT ARM ASKS ABOUT A CHILD THAT MAY NO LONGER EXIST. PART
+      // 11 §1c collapses a paragraph whose whole content is one image into a
+      // block image, so `> ![Apollo](a.jpg)` holds no paragraph by the time it
+      // is serialized - and this asked only for the node's TYPE, which is still
+      // `para`, and framed it compactly. Give a `<div>` the identical child and
+      // this renderer indents it on its own line, as all three engines do for
+      // both containers, so the quote was applying "renders on one line" to a
+      // shape the div arm does not - the oracle contradicting itself rather
+      // than reading the clause (carve#1677). `isBlockImageParagraph` asks the
+      // §1c question the same way the `para` arm above answers it.
       const compact =
         b.children.length === 1 &&
         b.children[0].t === 'para' &&
-        b.children[0].caption === undefined
+        b.children[0].caption === undefined &&
+        !isBlockImageParagraph(b.children[0], ctx)
       // Depth-first and synchronous, so a saved/restored flag is a stack. The
       // children are rendered ONCE, under `inBlockquote`, which is what keeps a
       // quoted heading out of the implicit-reference index.
@@ -549,6 +561,32 @@ function renderBlock(b, depth, ctx) {
   }
 }
 
+/**
+ * PART 11 §1c, asked as a question about a NODE rather than about a string: is
+ * this paragraph one whose whole content is a single image, and therefore not a
+ * paragraph any more by the time it reaches HTML?
+ *
+ * The `para` arm of `renderBlock` answers this by rendering; two other sites
+ * need the answer BEFORE they render - a quote deciding its frame, and a list
+ * item deciding whether to build a `<p>` by hand - and both got it wrong by
+ * asking for the node's type instead (carve#1677). §1c is phrased over what a
+ * shape SPELLS rather than over the context it sits in, so one predicate serves
+ * every container.
+ *
+ * The probe render is discarded, and that is safe for the same reason the
+ * `para` arm's own call is: `renderStandaloneImage` reads `ctx.linkDefs` and
+ * writes nothing, and `renderInline` restores the inline state it saves. A
+ * captioned paragraph is excluded here rather than at each call site, since a
+ * caption makes the host a `figure` and the figure is what gets framed.
+ */
+function isBlockImageParagraph(b, ctx) {
+  return (
+    b.t === 'para' &&
+    b.caption === undefined &&
+    renderStandaloneImage(b.lines.join('\n'), '', ctx) !== null
+  )
+}
+
 function renderStandaloneImage(line, attrs, ctx) {
   // Resolve reference images before paragraph serialization, so PART 10's
   // standalone-image shape is a block decision rather than a final HTML rewrite.
@@ -660,7 +698,17 @@ function renderItem(item, list, depth, ctx) {
     // duplicates the top-level paragraph logic instead of delegating, and
     // carve#626 was `battrs` going the same way. Delegating is the fix in both
     // cases; the inline path stays only for the plain shape it exists for.
-    if (b.t === 'para' && b.caption === undefined) {
+    //
+    // This is the THIRD field this site has dropped, and the first one that is
+    // not a field at all: a paragraph whose whole content is one image is not a
+    // paragraph by the time it is serialized (PART 11 §1c), so the hand-built
+    // `<p>` wrapped a shape the document level and the `<div>` arm both leave
+    // bare. Category 411's own prose states that rule without qualification and
+    // this site contradicted it - the oracle disagreeing with text it already
+    // ships, rather than a content model a list item has been shown to have
+    // (carve#1677). Delegating is the fix here for the same reason it was for
+    // carve#693 and carve#626.
+    if (b.t === 'para' && b.caption === undefined && !isBlockImageParagraph(b, ctx)) {
       // render the whole paragraph in one inline pass (lines joined by soft
       // breaks) so an inline construct spanning a soft break -- e.g. a
       // multi-line `` ``` ``-run folded in as lazy text -- is one span, not one

--- a/tests/ast-values.test.mjs
+++ b/tests/ast-values.test.mjs
@@ -96,8 +96,24 @@ const shippedDeclaration = () =>
  * NO FLOOR either way. An empty map against an empty ledger reconciles to
  * nothing, which is the state the panel is trying to reach, and a row that
  * appears in either place alone still fails.
+ *
+ * NOT EMPTY since 2026-08-24, and this is the commit that measures it. Corpus
+ * `411-...-6` - the flush half of the list-item pair added under carve#1677 -
+ * is the first document to put a lone image at a list item's own content
+ * column, and carve-rs publishes `tight: true` for that list where carve-js,
+ * carve-php and the executable spec publish `tight: false`. Measured over 1397
+ * samples at carve-js 99b28ab, carve-rs 661d4ff and carve-php 38de559, each
+ * built from a fresh clone of main; `npm run ast:check` reports
+ *
+ *   THREE-WAY VALUE COMPARISON: 1 field(s) disagree, across 1 document(s)
+ *        1 doc(s)  list.tight
+ *           carve-js=false  carve-rs=true  carve-php=false
+ *
+ * Tracked at markup-carve/carve-rs#1358. Both this row and the ledger's clear
+ * together, in whichever carve-rs PR ships the fix - the run reports FIXED and
+ * fails until they go, which is the reminder this pair exists for.
  */
-const LAST_MEASURED = new Map([])
+const LAST_MEASURED = new Map([['list.tight', 1]])
 
 /** A measurement of `count` distinct documents - the reconciler counts them. */
 const documents = (count) =>

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-3.crv
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-3.crv
@@ -1,0 +1,1 @@
+>   ![Apollo](a.jpg)

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-3.html
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-3.html
@@ -1,0 +1,3 @@
+<blockquote>
+  <img src="a.jpg" alt="Apollo">
+</blockquote>

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-4.crv
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-4.crv
@@ -1,0 +1,1 @@
+> ![Apollo](a.jpg)

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-4.html
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-4.html
@@ -1,0 +1,3 @@
+<blockquote>
+  <img src="a.jpg" alt="Apollo">
+</blockquote>

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-5.crv
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-5.crv
@@ -1,0 +1,3 @@
+- t
+
+   ![Apollo](a.jpg)

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-5.html
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-5.html
@@ -1,0 +1,5 @@
+<ul>
+  <li><p>t</p>
+    <img src="a.jpg" alt="Apollo">
+  </li>
+</ul>

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-6.crv
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-6.crv
@@ -1,0 +1,3 @@
+- t
+
+  ![Apollo](a.jpg)

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-6.html
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-6.html
@@ -1,0 +1,5 @@
+<ul>
+  <li><p>t</p>
+    <img src="a.jpg" alt="Apollo">
+  </li>
+</ul>

--- a/tests/spec/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.test
+++ b/tests/spec/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.test
@@ -13,3 +13,43 @@ A lone indented image is a paragraph, and its HTML cannot say so
 .
 <img src="a.jpg" alt="Apollo">
 ```
+
+```
+>   ![Apollo](a.jpg)
+.
+<blockquote>
+  <img src="a.jpg" alt="Apollo">
+</blockquote>
+```
+
+```
+> ![Apollo](a.jpg)
+.
+<blockquote>
+  <img src="a.jpg" alt="Apollo">
+</blockquote>
+```
+
+```
+- t
+
+   ![Apollo](a.jpg)
+.
+<ul>
+  <li><p>t</p>
+    <img src="a.jpg" alt="Apollo">
+  </li>
+</ul>
+```
+
+```
+- t
+
+  ![Apollo](a.jpg)
+.
+<ul>
+  <li><p>t</p>
+    <img src="a.jpg" alt="Apollo">
+  </li>
+</ul>
+```


### PR DESCRIPTION
Closes #1677.

Both questions on the ticket were ruled the same way: **the executable spec is
wrong twice, the engines are right, no engine changes.** This implements that,
and adds the four fixtures that were deliberately held back until it was
settled.

## The two oracle fixes

**A quote whose one child is a lone image framed it compactly.** PART 11 section
1c collapses a paragraph whose whole content is one image into a block image, so
the child is not a paragraph by the time it is serialized - but the compact arm
asked for the node's TYPE, which is still `para`.

Input:

```
> ![Apollo](a.jpg)
```

Before:

```html
<blockquote><img src="a.jpg" alt="Apollo"></blockquote>
```

After, which is what carve-js, carve-rs and carve-php all already emit:

```html
<blockquote>
  <img src="a.jpg" alt="Apollo">
</blockquote>
```

The deciding argument is not the 3-to-1 count. Give a `<div>` the identical
child and this renderer already indents it on its own line, so the oracle was
applying "compact for a child that renders on one line" to a blockquote and not
to a div, for the same child. The stated rule is not wrong; its antecedent is.

**A list item kept a `<p>` its own section says is not written.**

Input:

```
- t

   ![Apollo](a.jpg)
```

Before:

```html
<ul>
  <li><p>t</p>
    <p><img src="a.jpg" alt="Apollo"></p>
  </li>
</ul>
```

After, again matching all three engines:

```html
<ul>
  <li><p>t</p>
    <img src="a.jpg" alt="Apollo">
  </li>
</ul>
```

Category 411's committed prose states the rule without qualification - "a
paragraph whose whole content is one image renders as a bare `<img>` with no
`<p>` wrapper" - and the oracle applied it at document level and inside a
`<div>` and not here. The prose is unchanged: amending it would state an
exception nobody has an argument for, and section 1c is deliberately phrased
over what a shape SPELLS rather than over the context it sits in.

This is the third field the list-item path has dropped by duplicating the
top-level paragraph logic instead of delegating - #693 was the caption, #626 the
block attributes. One predicate, `isBlockImageParagraph`, now serves both call
sites.

## Mutation

Each half reverted separately, with the other left in place:

| reverted | corpus documents red |
|---|---|
| the quote's `!isBlockImageParagraph` | `411-...-3` and `411-...-4`, and only those two |
| the list item's `!isBlockImageParagraph` | `411-...-5` and `411-...-6`, and only those two |
| both | all four |

Each half is pinned by exactly its own pair, and the other pair stays green on
every revert - which is what says the fix is two independent decisions rather
than one blanket change. The 1390 documents the corpus already held pass under
both reverts and after both fixes, so nothing previously pinned moves: the
shapes simply were not reachable before.

Restored from a pre-mutation copy rather than `git checkout --`, and confirmed
by an empty `git status --porcelain` plus the predicate still being present in
the file.

## What the four new documents reach

Corpus 411 pinned only the two TOP-LEVEL spellings. The only container-hosted
image anywhere in the corpus was `405`, which is flush AND captioned - and a
caption keeps the lone-image promotion from firing at all. So no document
indented an image past a container's content column, which is why AST
conformance passed 1393 documents unanimous while carve-js emitted
`<blockquote><p><img></p></blockquote>` (markup-carve/carve-js#1440, fixed in
markup-carve/carve-js#1446). The gap was not a check that failed; no document
reached the shape. The section now says that where the next reader will find it.

- `-3` quote, indented past the content column
- `-4` quote, flush - the control, and the one that would catch a fix that
  collapsed every quoted paragraph rather than only the section 1c shape
- `-5` list item, indented past the content column
- `-6` list item, flush

## A carve-rs defect the flush control found

`-6` also reaches something unrelated to section 1c: carve-rs publishes
`tight: true` for that list where carve-js, carve-php and the oracle publish
`tight: false`, so its first block loses its `<p>`. It is specific to an image
at the item's own content column - one column further in, and with a text second
block, carve-rs agrees. Filed as markup-carve/carve-rs#1358 and declared in
`resources/ast-value-divergence.txt` with its measured count, so the run stays
honest rather than red; the declaration is deleted by whichever carve-rs PR
fixes it.

## Also in the diff

- `docs/index.md` corpus count 1390 -> 1394.
- `resources/import-roundtrip-baseline.json`: every counter moved by exactly 4,
  so all four new documents import-round-trip cleanly.
