### PR TITLE
chore: retire the list.tight divergence, carve-rs shipped the fix

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -156,4 +156,15 @@
 #
 # Measured over 1397 samples at carve-js 99b28ab, carve-rs 661d4ff and carve-php
 # 38de559, each built from a fresh clone of main.
-list.tight  1  carve-rs alone; tracked at markup-carve/carve-rs#1358
+#
+# AND EMPTY AGAIN, within the day. markup-carve/carve-rs#1358 landed, so
+# carve-rs publishes `tight: false` for the flush spelling like the other two
+# engines and the executable spec. Measured in AST conformance run 32751456715,
+# at carve b971f2d6, which builds every engine from a fresh checkout of its own
+# default branch, over 1394 corpus documents plus 3 synthetic samples:
+#
+#   THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:
+#     FIXED      list.tight no longer diverges - delete its line
+#
+# which is the FIXED direction the pair exists to report. The row and
+# `LAST_MEASURED` in tests/ast-values.test.mjs go together, as their notes say.

--- a/tests/ast-values.test.mjs
+++ b/tests/ast-values.test.mjs
@@ -97,23 +97,23 @@ const shippedDeclaration = () =>
  * nothing, which is the state the panel is trying to reach, and a row that
  * appears in either place alone still fails.
  *
- * NOT EMPTY since 2026-08-24, and this is the commit that measures it. Corpus
- * `411-...-6` - the flush half of the list-item pair added under carve#1677 -
- * is the first document to put a lone image at a list item's own content
- * column, and carve-rs publishes `tight: true` for that list where carve-js,
- * carve-php and the executable spec publish `tight: false`. Measured over 1397
- * samples at carve-js 99b28ab, carve-rs 661d4ff and carve-php 38de559, each
- * built from a fresh clone of main; `npm run ast:check` reports
+ * EMPTY AGAIN since 2026-08-24, and this is the commit that measures it.
+ * Corpus `411-...-6` - the flush half of the list-item pair added under
+ * carve#1677 - was the first document to put a lone image at a list item's own
+ * content column, and carve-rs published `tight: true` for that list where
+ * carve-js, carve-php and the executable spec published `tight: false`. It was
+ * declared here and in the ledger for the few hours that window was open;
+ * markup-carve/carve-rs#1358 closed it. Measured in AST conformance run
+ * 32751456715, at carve b971f2d6, over 1394 corpus documents plus 3 synthetic
+ * samples, each engine built from a fresh checkout of its own default branch:
  *
- *   THREE-WAY VALUE COMPARISON: 1 field(s) disagree, across 1 document(s)
- *        1 doc(s)  list.tight
- *           carve-js=false  carve-rs=true  carve-php=false
+ *   THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:
+ *     FIXED      list.tight no longer diverges - delete its line
  *
- * Tracked at markup-carve/carve-rs#1358. Both this row and the ledger's clear
- * together, in whichever carve-rs PR ships the fix - the run reports FIXED and
- * fails until they go, which is the reminder this pair exists for.
+ * Both this map and the ledger's row clear together, which is what those notes
+ * asked for - the run reports FIXED and fails until they go.
  */
-const LAST_MEASURED = new Map([['list.tight', 1]])
+const LAST_MEASURED = new Map()
 
 /** A measurement of `count` distinct documents - the reconciler counts them. */
 const documents = (count) =>


### PR DESCRIPTION
`resources/ast-value-divergence.txt` carried one row, `list.tight`, declared
this morning with the document that reaches it - corpus `411-...-6`, the flush
half of the list-item pair added under markup-carve/carve#1677. carve-rs
published `tight: true` for that list where carve-js, carve-php and the
executable spec published `tight: false`.

markup-carve/carve-rs#1358 closed it, so the window lasted hours rather than
weeks. Measured in AST conformance run 32751456715, at carve `b971f2d6`, over
1394 corpus documents plus 3 synthetic samples, each engine built from a fresh
checkout of its own default branch:

```
THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:
  FIXED      list.tight no longer diverges - delete its line
```

The ledger row and `LAST_MEASURED` in `tests/ast-values.test.mjs` clear
together, which is what both of their notes ask for.

Proved load-bearing in both directions on a host with no engines, since the
reconciler compares the shipped file against the recorded measurement:

- put the ledger row back, leave the map empty: `FIXED list.tight no longer
  diverges - delete its line`, 3 tests fail.
- keep the map entry, leave the ledger empty: `NEW list.tight diverges in 1
  document(s) and is not declared`, 3 tests fail.

With this, `npm run declarations:check` goes from 11 findings at `384a9316`
this morning to 1. The one that remains is `carve-php`'s own
`AST_DIVERGENCES` list of 6 rows, which lives in that repository.

One thing this does NOT clear, so it is not mistaken for silence: the scheduled
conformance run is still red on a separate finding the same sweep reported, a
cross-engine ANSI divergence on corpus `411-...-3`. Filed separately with the
measurement.
