### PR TITLE
chore: retire the list.tight divergence, which no longer reproduces

### DIFF
--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -156,4 +156,3 @@
 #
 # Measured over 1397 samples at carve-js 99b28ab, carve-rs 661d4ff and carve-php
 # 38de559, each built from a fresh clone of main.
-list.tight  1  carve-rs alone; tracked at markup-carve/carve-rs#1358


### PR DESCRIPTION
chore: retire the list.tight divergence, which no longer reproduces

markup-carve/carve-rs#1359 made a list item whose second block is a lone or
captioned image at the item's content column loose, matching carve-js,
carve-php and the executable spec.

AST conformance run 32751456715 reports the value panel clean and names this
row:

    THREE-WAY VALUE COMPARISON: the engines publish the same values everywhere.
    THREE-WAY VALUE COMPARISON does not match resources/ast-value-divergence.txt:
      FIXED      list.tight no longer diverges - delete its line

The file fails until the line is deleted, which is the two-directional half
working: a declaration that stops reproducing is a defect, not bookkeeping.

Closes #1685