### PR TITLE
test: pin the canonical form of a lone indented image in a container

### DIFF
--- a/resources/corpus-sidecars.lock.json
+++ b/resources/corpus-sidecars.lock.json
@@ -102,6 +102,8 @@
   "408-the-writer-spells-looseness-only-where-a-blank-line-cannot-2.fmt": "733d9ac1374dcc42",
   "408-the-writer-spells-looseness-only-where-a-blank-line-cannot.fmt": "361a4b39bb40dcbe",
   "411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-2.fmt": "ef896b7a6d93c4a6",
+  "411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-3.fmt": "d02f3075cceee229",
+  "411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-5.fmt": "ad329c336a3ada22",
   "411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so.fmt": "6b4757286e96e92b",
   "43-abbreviations.ansi": "4332a088c2ae546d",
   "43-abbreviations.md": "4332a088c2ae546d",

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-3.fmt
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-3.fmt
@@ -1,0 +1,1 @@
+> ![Apollo](a.jpg)

--- a/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-5.fmt
+++ b/tests/corpus/411-a-lone-indented-image-is-a-paragraph-and-its-html-cannot-say-so-5.fmt
@@ -1,0 +1,3 @@
+- t
+
+  ![Apollo](a.jpg)


### PR DESCRIPTION
Corpus 411 gained four container-level cases in #1682, when the oracle started asking the PART 11 §1c question in every container rather than only at the top level. Two of them change under `fmt`, and neither carried the `.fmt` canonical-form sidecar that their top-level siblings (`411` and `411-2`) already have.

## Why they need one

The extra indentation is significant. An indented lone image stays a paragraph; one at the container's content column is a block-level image. `411-3` and `411-5` are authored past their container's content column, a paragraph has nowhere to keep that leading space, and the writer respells at the content column - so the output re-parses to a different tree than the input.

`411-3` source:

```
>   ![Apollo](a.jpg)
```

`411-3.fmt`:

```
> ![Apollo](a.jpg)
```

`411-5` source:

```
- t

   ![Apollo](a.jpg)
```

`411-5.fmt`:

```
- t

  ![Apollo](a.jpg)
```

`411-4` and `411-6` sit exactly at their container's content column, write back byte-identical, and correctly need no sidecar.

## What the sidecar buys

That re-parse difference is the ceiling §1c licenses, and the `.fmt` sidecar is how the corpus records it. Without one, an engine falls through to the plain `parse(fmt(x)) == parse(x)` invariant and goes red the moment it bumps its pin past #1682. With one, it takes the canonical-form branch instead, which asserts strictly more: that the difference is a wrapper loss and nothing else, and that the writer's bytes match these exactly.

`scripts/fmt-fixture-claims.mjs` holds all three engines to the same bytes in the conformance workflow. Measured before pinning - carve-js `9b3e7c2b`, carve-php `b7c42281` and carve-rs `f3773c5b` each write exactly these bytes for both documents.

## Verification

`npm test` green (2996 pass, 0 fail, 1 skip) by exit code.

The fixtures are load-bearing, proved by mutation: changing `411-3.fmt`'s alt text to `Apollon` fails `fmt(x) matches every .fmt fixture (PART 11 §2)` with "the writer disagrees with its pinned canonical form" (exit 1); restoring it returns exit 0. The control `a .fmt fixture is read, so it can fail` passed on both sides.

The lock entries are `npm run corpus:build` output - it records the sha of the `.crv` each sidecar was derived against, so a later change to the input fails here rather than in a downstream repo. The regeneration touched nothing else; the lock diff is two added lines.

Nothing was added to any ledger, allowlist or drift file.
