### PR TITLE
docs: the unreleased section covers the container half of PART 11 section 1c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PART 11 §1c is asked in every container, not only at the top level**
+  (carve#1677). A quote or a list item holding one lone image writes the bare
+  `<img>` too, and four category 411 documents reach a container shape no
+  corpus document reached before (markup-carve/carve-js#1440).
 - **A lone indented image is a paragraph holding an inline image, not a block
   image** (carve#1660). The strict column-0 rule reaches it; the rendered HTML
   is the same bytes, so only the tree moves.


### PR DESCRIPTION
Reconciles the `Unreleased` section against every merge since `0.1.3`, immediately before the 0.1.4 cut.

One gap, and it is a normative one: PART 11 section 1c was being asked only at document level and inside a `div`, so the reference oracle answered it two different ways in a block quote and in a list item, both wrong. Four new category 411 corpus documents reach container shapes no corpus document had reached before, which is why the cross-engine check passed 1393 documents as unanimous while carve-js was emitting a wrapper for one of them (markup-carve/carve-js#1440).

Added under Fixed, beside the existing oracle entries (carve#1561, carve#1562).

Derived by walking `0.1.3..main` and resolving each PR to its closing issue before matching by content, since the section cites issue numbers while the commits cite PR numbers, and several entries cite a sibling issue in the same family rather than the PR's own. 99 of the 178 commits in the range touch a normative surface and 98 of those were already covered; the other 79 are engine pins, drift-ledger retirements, corpus guards, CI sharding and docs prose.

Two near-misses were read as diffs rather than trusted from their prefix and stay out: #1397 touches only the repo's own normativity gate, and #1462 only regenerates one convert fixture behind an already-listed entry. #1563 is borderline and stays out too. It adds a shared caption-attributes fixture that holds two engines to a behavior nothing could previously see, but it states no new rule, and the caption family is already represented by carve#1560 and carve#1575.
