### PR TITLE
docs: ground the item-attribute content column in PART 9 section 15 A8

### DIFF
--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -27413,11 +27413,26 @@ two halves of `-{#k} [x] ` were each pinned alone and the combination was pinned
 nowhere - which is how three engines came to read it three ways with every gate
 green (carve#1692).
 
-The rule is one rule applied twice. A checkbox is CONTENT (carve#1690), so it
-does not move the column; an attribute block is part of the MARKER that
-introduces the item, so it does. `-{#k} [x] a` is therefore the marker `-{#k} `
-and then content beginning at the checkbox, and the item's content column is 6.
-A line written there is inside the item.
+The rule is stated, not inferred. PART 9 §15 A8 says what the block binds to -
+"a `-{…} text` with no space after the marker attributes the LIST ITEM" - and
+`docs/divergence-from-djot.md` §17 puts it in as many words: "the attribute
+block binds to the MARKER". Part of the marker counts toward the marker's width,
+so `-{#k} [x] a` is the marker `-{#k} ` and then the checkbox, and the item's
+content column is 6. A line written there is inside the item.
+
+DJOT SETTLES NOTHING HERE, which is the first thing a reader asks of a rule
+about attributed markers. Djot has no such construct: `-{#k} [x] item` is a
+PARAGRAPH there, the `{#k}` an inline attribute on a literal `-`, because a
+bullet needs its separator before anything else. A djot list is attributed
+through a preceding attribute line, and that line attaches to the LIST rather
+than to an item. §17 records Carve's marker-glued form as a deliberate extension
+and a source break, so the question can only be answered from Carve's own
+grammar.
+
+The other half is carve#1690: a checkbox is CONTENT, so it does not move the
+column. The two together are why the column is the bullet plus the block and
+nothing else - not the bullet alone, and not the full width of what the marker
+line carries.
 
 ::: compare
 
@@ -27437,9 +27452,10 @@ A line written there is inside the item.
 :::
 
 Column 2 is the other spelling, and it has to be pinned beside the first rather
-than instead of it: reading the column as the bare bullet width puts it there,
-which is INSIDE the attribute block, and each engine used to read exactly one of
-the two as a continuation. A document holding only one of them passes on the
+than instead of it: reading the column as the bare bullet width treats the block
+as though it were not there and puts the column INSIDE it - which A8 also rules
+out from the other side, since the marker still needs content of its own. Each
+engine used to read exactly one of the two as a continuation. A document holding only one of them passes on the
 engine that reads the other. Below the content column the line is lazy paragraph
 text, so the `#` survives literally.
 


### PR DESCRIPTION
Follow-up to the category-413 batch. The rule is unchanged and no behavior
moves; what the rule rests on is corrected.

The comments and prose derived the column from markup-carve/carve#1690 - a
checkbox is content, so an item's content starts at the checkbox. That reaches
the right answer, but by extrapolating from the ruling next door. **PART 9 §15
A8 states the premise outright:**

> ON A LIST-ITEM MARKER LINE, ALONE MEANS ATTRIBUTE LINE. A `-{…} text` with no
> space after the marker attributes the LIST ITEM (PART 2, list items; the
> marker still needs content, so a bare `-{…}` is not a list item at all).

The block binds to the MARKER. Part of the marker counts toward the marker's
width, so `-{#k} [x] a` has its content column at 6 because of what the block
binds to - not because of where the checkbox happens to begin.
`docs/divergence-from-djot.md` §17 puts it in as many words: *"the attribute
block binds to the MARKER"*.

A8 also rules out the losing reading from the other side, which is now said
explicitly: the marker still needs content of its own, so a column landing
inside the attribute block is not a column any content could begin at.

## Why djot cannot be appealed to

This is the first question a reader asks of a rule about attributed markers, so
the answer is now written down where they will be reading. **Djot has no such
construct.** `-{#k} [x] item` is a PARAGRAPH there - the `{#k}` is an inline
attribute on a literal `-`, because a bullet needs its separator before anything
else - and a djot list is attributed through a preceding attribute line that
attaches to the LIST rather than to an item. §17 records Carve's marker-glued
form as a deliberate extension and a source break, so only Carve's own grammar
can decide it.

A fix resting on an inference invites the next reader to re-derive it. This one
cites the clause.

## Scope

Prose only. The section's own text is what a reader of the examples page sees;
`npm run corpus:build` regenerates the six pairs byte-identical, and `npm test`
is green at 1400 pairs.
