### PR TITLE
spec: an attribute the preserved bytes keep is not a dropped one

### DIFF
--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -1041,6 +1041,20 @@ lossy decision should be observable. The common diagnostic codes are:
 - `element-dropped`: an element and its contents were removed.
 - `element-unwrapped`: an unsupported element was replaced by its children.
 - `attribute-dropped`: an attribute was not represented.
+- `attribute-preserved`: an attribute the importer would not represent as a
+  Carve attribute reached the output anyway, inside the bytes of an element
+  kept whole under `raw-preserved`. Nothing was lost, so it is NOT
+  `attribute-dropped`: a consumer that filters on the code rather than reading
+  the prose would be told a drop happened that did not. An importer that
+  preserves an element as raw HTML MUST report the element's own refused
+  attributes under this code instead. Its severity MUST be `error` where the
+  attribute is one a renderer refuses for safety - an event handler, an
+  injection sink, a value carrying a denied URL scheme - and `info` otherwise.
+  The `error` is not a failed import; it is the strongest thing the report can
+  say, and this row earns it because `roundtrip` is the mode that is not safe
+  for untrusted input and this is the row saying such an attribute is LIVE in
+  the output. A dropped handler already spends `warning`, so spending `warning`
+  here too would tell a filter nothing about which of the two it is looking at.
 - `style-unmapped`: CSS had no explicit semantic mapping.
 - `table-degraded`: a table could not be represented structurally.
 - `raw-preserved`: unsupported trusted markup was retained as raw HTML.

--- a/resources/html-import-schema.json
+++ b/resources/html-import-schema.json
@@ -15,7 +15,7 @@
         "required": ["code", "message", "severity"],
         "additionalProperties": false,
         "properties": {
-          "code": { "enum": ["element-dropped", "element-unwrapped", "attribute-dropped", "style-unmapped", "table-degraded", "raw-preserved", "structure-unspellable", "structure-split", "encoding-assumed", "diagnostics-truncated"] },
+          "code": { "enum": ["element-dropped", "element-unwrapped", "attribute-dropped", "attribute-preserved", "style-unmapped", "table-degraded", "raw-preserved", "structure-unspellable", "structure-split", "encoding-assumed", "diagnostics-truncated"] },
           "message": { "type": "string" },
           "severity": { "enum": ["info", "warning", "error"] },
           "path": {


### PR DESCRIPTION
Adds `attribute-preserved` to the HTML import report vocabulary and rules its severity.

## The defect it exists for

`roundtrip` hands some elements back verbatim as raw HTML. An importer reads an element's attributes on the way past, long before any arm decides that, so every attribute the policy refuses was reported `attribute-dropped` while the preserved bytes carried it into the output.

Measured on carve-js `main` and carve-rs `main`, both:

```
<form onclick="x()" id="q"><p>a</p></form>
```

imports to

````
```=html
<form onclick="x()" id="q"><p>a</p></form>
```
````

and reports:

```
attribute-dropped  warning  Dropped event-handler attribute onclick on <form>
raw-preserved      warning  Preserved unsupported <form> element as raw HTML
```

Nothing was dropped. The handler is in the output.

## Why the row is not simply removed

Removing it would delete the only row telling a consumer that an event handler SURVIVED into the output, and this page documents `roundtrip` as not safe for untrusted input, so that is the row somebody might act on. Trading a false statement for a missing security-relevant fact is the same defect pointed the other way, and it is silent, which is worse.

So the row stays and stops claiming a drop.

## What is added

- `attribute-preserved` in the `code` enum of `resources/html-import-schema.json`.
- The paragraph in `docs/html-import.md` that says when an importer writes it, and at which severity.

It is a code of its own rather than `attribute-dropped` carrying different prose: a consumer that filters on the code rather than reading the message would still be told a drop happened.

Severity is ruled rather than copied. `error` where the attribute is one a renderer refuses for safety (an event handler, an injection sink, a value carrying a denied URL scheme), `info` otherwise. A dropped handler already spends `warning`, so a preserved one spending `warning` too would tell a filter nothing about which of the two it is looking at. The `error` is not a failed import; it is the strongest thing the report can say, and this row earns it.

## Blast radius here

No fixture under `tests/html-import` produces `raw-preserved`, so no expected report changes and no fixture gains or loses a row. The enum gains a name and the page gains a paragraph.

## What follows

markup-carve/carve-js#1468 and markup-carve/carve-rs (the same shape, measured) implement it behind a pin bump to this commit. carve-php emits no `raw-preserved` at all today, so it has no false rows to fix and owes this code only once it grows a raw-preserve arm; that is filed separately.
