### PR TITLE
spec: the last newline of a code block is its terminator, not a line

### DIFF
--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -428,6 +428,58 @@ such an element is not a figure to rebuild or to preserve: it unwraps to its
 content with `element-unwrapped`, in every mode, which is the behavior this rule
 leaves untouched.
 
+## The last newline of a code block is its terminator, not a line
+
+A code block's content is bytes the author wrote, so gaining or losing a line
+is a CONTENT change and not a formatting one (markup-carve/carve#1708).
+
+**Strip exactly one newline immediately before `</code>`, or before `</pre>`
+where there is no `<code>`. Any further newline is content, and so is any
+trailing space or tab on the last line.**
+
+The renderer settles this rather than taste. A Carve renderer writes exactly
+one newline before the closing tag for a code block whose content is `x`, and
+two for one whose content ends in a blank line:
+
+````
+```
+x
+```
+````
+
+```html
+<pre><code>x
+</code></pre>
+```
+
+````
+```
+x
+
+```
+````
+
+```html
+<pre><code>x
+
+</code></pre>
+```
+
+An importer that strips NO newline reads the first back as content ending in a
+blank line, so the document gains a line every time it goes round. One that
+strips them ALL reads both back as `x`, so the second loses the line the author
+wrote and the two documents arrive indistinguishable. Only removing exactly one
+makes the importer the inverse of the renderer, and `roundtrip` on an engine's
+OWN output is what that mode is defined by.
+
+The asymmetry mirrors HTML's own at the other end, where a newline immediately
+after `<pre>` is stripped and one before `</pre>` is not.
+
+**Nothing is reported**, in any mode. The newline removed was the terminator,
+so no content was lost and there is nothing to declare. The correction applies
+in `safe` and `semantic` as well; only `roundtrip` can be checked by a round
+trip, but the content question is the same in all three.
+
 ## A whitespace-only block keeps its content and drops its layout
 
 An element whose text is entirely whitespace is two different documents


### PR DESCRIPTION
Rules markup-carve/carve#1708, on the ruling posted there.

## The rule

Strip exactly one newline immediately before `</code>` (or `</pre>` where there is no `<code>`). Any further newline is content, and so is any trailing space or tab on the last line. No diagnostic in any mode.

## Why the renderer settles it rather than taste

A Carve renderer writes exactly one newline before the closing tag for a code block whose content is `x`:

`````
```
x
```
`````

```html
<pre><code>x
</code></pre>
```

and two for one whose content ends in a blank line:

`````
```
x

```
`````

```html
<pre><code>x

</code></pre>
```

An importer that strips NO newline reads the first back as content ending in a blank line, so a document gains a line every time it goes round. One that strips them ALL reads both back as `x`, so the second loses the line the author wrote and the two documents arrive indistinguishable. Only removing exactly one makes the importer the inverse of the renderer, and `roundtrip` on an engine's own output is what that mode is defined by.

It mirrors HTML's existing asymmetry at the other end, where a newline immediately after `<pre>` is stripped and one before `</pre>` is not.

## Measured across the three engines while writing this

All three answers were in the field at once, which is what a page saying nothing about it buys:

| engine | `<pre><code>x\n</code></pre>` | `<pre><code>x\n\n</code></pre>` |
| --- | --- | --- |
| carve-js | content `x` | content `x` plus a blank line |
| carve-rs | content `x` plus a blank line | content `x` plus two |
| carve-php | content `x` | content `x` |

carve-js already matches the rule (it landed in markup-carve/carve-js#1282, which is why the ticket's own measurement of an older build no longer reproduces there). carve-rs strips none. carve-php uses `rtrim`, so it strips every trailing newline AND every trailing space and tab, which is why the two inputs above are indistinguishable to it.

## Blast radius here

Prose only. No fixture under `tests/html-import` has a `<pre>` whose content ends in a newline, so no expected report or expected source moves, and no engine pin is involved.

A conformance fixture is deliberately not added in this PR: the fixture runner drives the PUBLISHED `markup-carve/carve` npm build, so a fixture pinning this would need a declared pin-lag entry until a release carries it. The engine ports carry the tests instead.

## Ports

carve-rs and carve-php follow; carve-js needs no change.
