### PR TITLE
spec: an HTML comment imports as a Carve comment

### DIFF
--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -428,6 +428,48 @@ such an element is not a figure to rebuild or to preserve: it unwraps to its
 content with `element-unwrapped`, in every mode, which is the behavior this rule
 leaves untouched.
 
+## An HTML comment imports as a Carve comment
+
+An HTML comment was dropped in every mode with nothing reported, and the usual
+reason for dropping - the language has no spelling for the shape - does not
+apply: **Carve has comments** (markup-carve/carve#1709). Dropping one was
+therefore a choice to lose bytes the format can represent, in a mode whose whole
+job is fidelity, and it was a choice nobody had made.
+
+**An HTML comment imports as a `comment` node, in every mode.** A comment
+renders nothing in either language, so this is invisible in the output and
+lossless in the source.
+
+The POSITION decides the spelling, and it is not relocated:
+
+| where the comment sits | the node | the source a writer spells it as |
+| --- | --- | --- |
+| among blocks | a block comment | the `%%%` fence, widened past any fence line inside it |
+| inside an inline run | a delimited inline comment | `{% … %}` |
+
+The block form always has a spelling: the fence widens the way a code fence
+does, so no payload can close it early. The inline form does not, and where it
+does not the comment is DROPPED with one `element-dropped` row saying so.
+
+**Two payloads have no inline spelling**, and both close the comment early
+rather than being escapable:
+
+- text containing `%}`, which is the closer;
+- text containing a BLANK line, which ends the paragraph the run is in.
+
+**Do not truncate or escape a comment to force it into the inline form.** A
+comment that came back shorter, or with characters the author did not write, is
+a silent content change; the drop plus its row is the honest answer, and the row
+is the point.
+
+**The comment is not relocated to make it spellable.** Moving an inline comment
+out to a block comment would put text somewhere the author did not write it, and
+`roundtrip` reading its own output would then find the document had moved. Where
+only one position can be represented, the other is reported.
+
+**A comment inside an element preserved as raw HTML needs no row.** It is inside
+the preserved bytes and reaches the output with them.
+
 ## The last newline of a code block is its terminator, not a line
 
 A code block's content is bytes the author wrote, so gaining or losing a line


### PR DESCRIPTION
Rules markup-carve/carve#1709, on the ruling posted there.

## The rule

An HTML comment imports as a `comment` node, in every mode. The position decides the spelling and the comment is not relocated: among blocks it is a block comment, inside an inline run it is the delimited inline form. Where the inline form has no spelling, the comment is dropped with one `element-dropped` row.

## Why a rule rather than a diagnostic

The usual reason an importer drops something is that the language cannot express the shape. That reason does not apply here: Carve has comments. Dropping one was a choice to lose bytes the format can represent, in the mode whose whole job is fidelity, and it was a choice nobody had made - the behavior had no clause behind it in any of the three engines.

## The two payloads with no inline spelling

Measured against the canonical writer and its own parser rather than reasoned about:

| inline payload | read back as |
| --- | --- |
| `note` | the comment, intact |
| two lines joined by a newline | the comment, intact |
| text containing the closer | the comment ends early, the rest becomes prose |
| text containing a blank line | the paragraph ends, both halves become prose |

The block form has no such case: its fence widens the way a code fence does, so no payload can close it early. Checked against a payload that is itself a longer fence line, an empty payload, a payload holding a blank line, and one ending in a newline - all four round trip.

That is why the drop is inline-only, and why the rule says do not truncate or escape: a comment that came back shorter, or carrying characters the author did not write, is a silent content change. The drop plus its row is the honest answer.

## Not relocated

Moving an inline comment out to a block comment would put text somewhere the author did not write it, and `roundtrip` reading its own output would find the document had moved. Where only one position can be represented, the other is reported.

## Blast radius here

Prose only. No fixture under `tests/html-import` contains an HTML comment, so no expected report or expected source moves.

## Ports

All three engines drop comments silently today, in all three modes, with zero diagnostics. They follow.
