### PR TITLE
chore: advance the carve-js pin, and retire the drift it closes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#704c557700145f7dfccfa6fcfc33ea445b5a5ee2",
+        "@markup-carve/carve": "github:markup-carve/carve-js#7bc97ce0e651ced2fbbd5acfab5c3907c05f65e5",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#704c557700145f7dfccfa6fcfc33ea445b5a5ee2",
-      "integrity": "sha512-adC8KnyMmVTApny0KVP3HqZ5VSt2f8erB78yhaDUn2M+PUH+Rk66CDFx5RRP9JHMjgj5uuI3YKj+mRJGV2f6Ag==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#7bc97ce0e651ced2fbbd5acfab5c3907c05f65e5",
+      "integrity": "sha512-bLXriMVRY8dPNAyXtPhEZvDlBZOtXjXKhAUEWomRllArbSSYZUkpOmsm9+4DPkB7a8DJcP2y4omluZR7J/rwcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#704c557700145f7dfccfa6fcfc33ea445b5a5ee2",
+    "@markup-carve/carve": "github:markup-carve/carve-js#7bc97ce0e651ced2fbbd5acfab5c3907c05f65e5",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,11 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-413-an-item-s-attribute-block-moves-its-content-column-its-checkbox-does-not  carve#1701: the released reference build still counts marker attributes
-413-an-item-s-attribute-block-moves-its-content-column-its-checkbox-does-not-10  carve#1701: attributed-parent sublist uses the new bare-marker column
-413-an-item-s-attribute-block-moves-its-content-column-its-checkbox-does-not-2  carve#1701: the old full-prefix task body now demotes
-413-an-item-s-attribute-block-moves-its-content-column-its-checkbox-does-not-4  carve#1701: plain attributed item uses the bare-marker column
-413-an-item-s-attribute-block-moves-its-content-column-its-checkbox-does-not-5  carve#1701: ordered attributed item uses the bare-marker column
-413-an-item-s-attribute-block-moves-its-content-column-its-checkbox-does-not-7  carve#1701: different-length attributes share a body column
-413-an-item-s-attribute-block-moves-its-content-column-its-checkbox-does-not-8  carve#1701: legacy full-prefix indentation demotes under the new rule
-413-an-item-s-attribute-block-moves-its-content-column-its-checkbox-does-not-9  carve#1701/#1698: Unicode attribute spelling contributes zero

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,6 +1,6 @@
 {
   "engine": "@markup-carve/carve",
-  "engineCommit": "704c557700145f7dfccfa6fcfc33ea445b5a5ee2",
+  "engineCommit": "7bc97ce0e651ced2fbbd5acfab5c3907c05f65e5",
   "corpusDocuments": 1404,
   "htmlImportPopulation": {
     "completed": 1403,
@@ -11,7 +11,7 @@
     ]
   },
   "renderImportRoundTrips": {
-    "html": 600,
+    "html": 601,
     "markdown": 374
   }
 }


### PR DESCRIPTION
## What this clears

`resources/engine-pin-drift.txt` had eight rows and now has none. They were one
window, not eight problems: the pinned reference build predated the bare-marker
content column, so category 413 was the corpus running ahead of the engine.
carve-js has landed it (carve-js#1467), so the window closes.

The pin moves from `704c5577` to `7bc97ce0`, carve-js `main`, and the lockfile
with it. Against that build:

```text
pinned reference build:  github:markup-carve/carve-js#7bc97ce0e651ced2fbbd5acfab5c3907c05f65e5
corpus pairs:            1404
reproduced:              1404
mismatched:              0
threw:                   0

declared drift:          0 (resources/engine-pin-drift.txt)

Drift matches what is declared.
```

All eight rows reported `STALE` against the new build, so all eight go here, in
the commit that moves the pin. The other six ledgers were at zero before and
stay at zero.

## What the bump surfaced beyond the eight rows

The bump carries seven carve-js commits besides the bare-marker one, so it was
read for movement rather than assumed to be the one change. Nothing was
re-snapshotted to make anything pass.

- No corpus HTML moved and no `.fmt` fixture moved. `corpus:build` leaves the
  working tree clean, and the full suite is green at 3011 tests without a single
  golden being rewritten.
- No new drift of any kind appeared. `mismatched` is 0, not "0 after declaring
  something".
- One measurement moved, and it is retaken rather than re-snapshotted. See below.

## The import round-trip baseline, decomposed

`resources/import-roundtrip-baseline.json` records the engine commit it was
measured at, so a pin move stales it by construction. It moves by exactly two
fields, and each is accounted for separately rather than summed:

**`engineCommit`**: `704c5577` to `7bc97ce0`. Bookkeeping that follows the pin.

**`renderImportRoundTrips.html`**: 600 to 601. Corpus growth contributes zero to
this. The baseline was last taken over these exact 1404 documents and the corpus
is byte-identical since, so the whole delta is the pin. It was then measured at
both pins, and the set difference is one document:

```text
documents that round-trip at the new pin but not the old:
  413-an-item-s-attribute-block-moves-its-content-column-its-checkbox-does-not-10.crv

documents that stopped round-tripping:
  (none)
```

That document is the attributed-parent sublist, one of the eight rows being
retired. So the gain is the same bare-marker fix the bump is for, and not a
side effect of an unrelated commit. Every other count is unchanged and stays
written as it was: `completed` 1403, `canonicalFixedPoints` 1402,
`renderedTextPreserved` 1388, `markdown` 374, and the single expected
rejection.

## What this does NOT clear, deliberately

`npm run declarations:check` still reports one finding, and this PR does not
make it green:

```text
carve-php tests/TestCase/Converter/HtmlImportReportTest.php  AST_DIVERGENCES  6  owed  two-way  <== OWED
```

Those six rows live in carve-php and describe that engine's two HTML import
exits disagreeing on six shared fixtures. Nothing in this repo can retire them,
and no row was added anywhere to make a gate read green. It is pre-existing:
the audit reported it identically before this change, alongside the eight pin
rows, and the bump neither caused nor touched it.

No CI job runs the audit, so this does not turn any check red here. It does
mean the repo is not clear to tag on that rule until carve-php closes the six.

## Not included

No CHANGELOG entry, deliberately: that happens at the release cut. No tag, no
release.
