### PR TITLE
spec: an unclosed bare colon fence opens a container like a labeled one

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -21,15 +21,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>735 / 754</strong>
+    <strong>735 / 755</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>735 / 754</strong>
+    <strong>735 / 755</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>737 / 754</strong>
+    <strong>737 / 755</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -40,9 +40,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `5b03787` | `735 / 754` | `0` | `0` | `3.01` |
-| JS | `8105210` | `735 / 754` | `0` | `0` | `76.02` |
-| PHP | `a5f18fb` | `737 / 754` | `0` | `0` | `68.54` |
+| Rust | `5b03787` | `735 / 755` | `0` | `0` | `3.01` |
+| JS | `8105210` | `735 / 755` | `0` | `0` | `76.02` |
+| PHP | `a5f18fb` | `737 / 755` | `0` | `0` | `68.54` |
 
 Spec commit: `2cde4a1`, plus the three corpus cases this change adds
 
@@ -858,7 +858,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=754 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=755 targets=html,markdown,plain,carve,ansi
 rust: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=3.01
   mismatching documents: 0
 js: pass=690/690 mismatch=0 error=0 skipped=0 runs=3375 avg_ms=76.02

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1404 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1405 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -385,6 +385,7 @@ index: examples/edge-cases/index.md
   24-generic-divs-2
   24-generic-divs-3
   24-generic-divs-4
+  an-unclosed-bare-colon-fence-opens-a-div
 
 [edge-blocks] Paragraphs, breaks and captions
 > Paragraph folding, thematic breaks, caption attachment and adjacent block openers.

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -27634,3 +27634,29 @@ outer item.
 ```
 
 :::
+
+## An unclosed bare colon fence opens a div
+
+A fence with no type word is still an opener, and an opener with no closer
+ahead of it still opens: the container runs to the end of the input and closes
+there, exactly as a labeled one does (PART 9 §12, PART 2). Section 12 used to
+carve out the bare spelling and call it literal text, which no engine ever
+implemented and which PART 2 had already superseded; the shape went unpinned
+long enough for the two clauses to disagree in writing (carve#1717).
+
+:::: compare
+
+```carve
+before
+:::
+after
+```
+
+```html
+<p>before</p>
+<div>
+  <p>after</p>
+</div>
+```
+
+::::

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -5251,8 +5251,8 @@ EOF = (* end of file *) ;
       BARE fence of EXACTLY its opener's length -- the guard the formal
       `colon_fence_close` states as `len(close) = len(open)` -- so a bare
       `:::` inside a `::::` block is content rather than a closer, and a bare
-      `::::` inside a `:::` block is likewise not one. A bare opener with no
-      matching closer ahead is literal text.
+      `::::` inside a `:::` block is likewise not one. AN UNCLOSED OPENER STILL
+      OPENS, bare or labeled, and closes at end of input by PART 2's rule.
 
       EQUAL-LENGTH FENCES DO NEST, because a closer must be BARE: `::: note`
       may hold `::: tip`, the inner line being an opener rather than a closer
@@ -5264,6 +5264,18 @@ EOF = (* end of file *) ;
       `::::` leaves the block open and that `::: note` holds `::: tip`. Recorded
       rather than quietly corrected because the two sentences had been read as
       the rule (carve#770).
+
+      THIS PARAGRAPH ALSO SAID A BARE OPENER WITH NO MATCHING CLOSER AHEAD IS
+      LITERAL TEXT. That was its third wrong sentence, and the one the
+      carve#770 pass left standing three lines above its own correction note.
+      It contradicted PART 2, which states the rule with no such exception and
+      names the literal-text reading as the EARLIER one, dropped because it
+      "turned one wrong character into a corrupted document". All three
+      engines open a div for a bare `:::` with nothing closing it; none
+      produces the literal text this asked for. It survived because the corpus
+      pinned only the LABELED unclosed opener, so the one shape the two
+      clauses disagreed about was the one shape nothing gated. The bare shape
+      is pinned now (carve#1717).
 
       THE CANONICAL WIDTH IS A FUNCTION OF DEPTH, AND THAT COSTS O(depth^2)
       BYTES (carve#1553). The exact-length guard leaves the DIRECTION free --
@@ -7498,10 +7510,14 @@ EOF = (* end of file *) ;
         nests shorter fences and a too-short line is content, not a closer.
       - A `%%%` opener with NO MATCHING CLOSER AHEAD does NOT open a block.
         The line degrades to a `comment_line` (its first two `%` are the line
-        marker), so every FOLLOWING BLOCK STILL RENDERS. This mirrors the
-        `:::` rule (§12: "a bare opener with no matching closer ahead is
-        literal text") and exists for the same reason: an unterminated opener
-        must not swallow the rest of the document. An implementation that
+        marker), so every FOLLOWING BLOCK STILL RENDERS. This DIVERGES from
+        the `:::` rule (§12), where an unclosed opener opens and closes at end
+        of input, and the difference is VISIBILITY: an unclosed div still
+        renders the blocks it swallowed, so a forgotten closer costs the
+        reader a stray wrapper, while an unclosed comment would HIDE them and
+        silently delete the rest of the document. This clause used to claim it
+        MIRRORED §12, quoting a §12 sentence that has since been removed for
+        saying the opposite of what §12 means (carve#1717). An implementation that
         surfaces diagnostics SHOULD report an unterminated comment fence;
         emitting one is OPTIONAL, since not every implementation has a
         warning channel.

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,11 +1,11 @@
 {
   "engine": "@markup-carve/carve",
   "engineCommit": "7bc97ce0e651ced2fbbd5acfab5c3907c05f65e5",
-  "corpusDocuments": 1404,
+  "corpusDocuments": 1405,
   "htmlImportPopulation": {
-    "completed": 1403,
-    "canonicalFixedPoints": 1402,
-    "renderedTextPreserved": 1388,
+    "completed": 1404,
+    "canonicalFixedPoints": 1403,
+    "renderedTextPreserved": 1389,
     "expectedRejections": [
       "182-openers-past-the-nesting-cap-are-one-paragraph.crv"
     ]

--- a/tests/corpus/414-an-unclosed-bare-colon-fence-opens-a-div.crv
+++ b/tests/corpus/414-an-unclosed-bare-colon-fence-opens-a-div.crv
@@ -1,0 +1,3 @@
+before
+:::
+after

--- a/tests/corpus/414-an-unclosed-bare-colon-fence-opens-a-div.html
+++ b/tests/corpus/414-an-unclosed-bare-colon-fence-opens-a-div.html
@@ -1,0 +1,4 @@
+<p>before</p>
+<div>
+  <p>after</p>
+</div>

--- a/tests/spec/414-an-unclosed-bare-colon-fence-opens-a-div.test
+++ b/tests/spec/414-an-unclosed-bare-colon-fence-opens-a-div.test
@@ -1,0 +1,12 @@
+An unclosed bare colon fence opens a div
+
+```
+before
+:::
+after
+.
+<p>before</p>
+<div>
+  <p>after</p>
+</div>
+```


### PR DESCRIPTION
Closes #1717.

PART 9 §12 and PART 2 gave opposite answers for one shape, and the corpus could not catch it because that shape was unpinned.

## The contradiction

`resources/grammar.ebnf` §12 said:

> A bare opener with no matching closer ahead is literal text.

PART 2, on the same construct, states the rule with no such exception and names the other one as already superseded:

> The closer is OPTIONAL: an opener always opens, and a block still open at END OF INPUT closes there, innermost first ... the earlier rule (the opener and everything after it degrade to literal text) turned one wrong character into a corrupted document.

They agree on a labeled opener and disagree on a bare one. carve-js, carve-php and carve-rs all implement PART 2:

```
before
:::
after
```

```html
<p>before</p>
<div>
  <p>after</p>
</div>
```

None produces the literal text §12 asked for.

## Why it survived

`resources/examples/edge-cases.md` pinned the labeled case only - `::: note` with no closer. No corpus document carried a bare unclosed `:::`, so the one shape the two clauses disagreed about was the one shape nothing gated, and a conformance run could not fail on it. Same class as carve#770, which corrected two other wrong sentences in that very paragraph and left this one standing three lines above its own correction note.

## What changed

- The §12 sentence is gone, and the correction is **recorded in place** rather than applied silently, the way the earlier pass recorded its siblings.
- §28's rationale is rewritten. It justified the comment fence by claiming it mirrors §12 and quoting the removed sentence, but the behavior is the opposite rather than a mirror - a comment fence degrades to a `comment_line` and the document continues, while a colon fence opens and closes at end of input. The reason for the divergence is visibility: an unclosed div still renders the blocks it swallowed, while an unclosed comment would hide them and silently delete the rest of the document.
- `414-an-unclosed-bare-colon-fence-opens-a-div` pins the bare shape, routed onto the containers page.

No engine change: all three already do the right thing, and the pinned carve engine dependency (0.1.4) passes the new fixture.

## On the corpus-count numbers

The new pair is not in a declared-lag category, so the effective core count moves and three docs assertions follow it: `754 -> 755` in `docs/implementation-comparison.md` and `1404 -> 1405` on the landing page.

Denominators only, matching the precedent set by #1516, which moved `753 -> 754` the same way. Numerators, engine SHAs and timings are left as the last full sweep recorded them - refreshing those would re-snapshot the whole comparison page and effectively declare the 140 lag categories closed, which is a separate change.

I did run `npm run compare:counts` against all three engines built from their current mains. It reports `corpus_pairs=1405` with `pass=1529/1529` and zero errors on every engine, which is why the fixture is pinned rather than declared as drift.
