### PR TITLE
docs: pin what a hand-written line-block class does, not what it does not

### DIFF
--- a/resources/examples/core.md
+++ b/resources/examples/core.md
@@ -3989,27 +3989,28 @@ plain line.</p>
 
 ::::
 
-The behavior keys off the `|` type token on the opener, not the class. The inline `::: {.line-block}` class form is not a fence at all (strict djot: no inline attributes on the opener), so it renders as an ordinary paragraph (no div, no hard breaks).
+The behavior keys off the `|` type token, not the class name. Writing the class by hand - on an attribute line, the only place a `:::` opener takes attributes - gets the CSS hook and none of the semantics: no hard breaks, no preserved leading whitespace. (An inline `::: {.line-block}` is not a fence at all, and renders as a literal paragraph; that rule belongs to every `:::` opener, and is shown under [Generic divs](#generic-divs).)
 
 :::: compare
 
 ```carve
-::: {.line-block}
+{.line-block}
+:::
 one
 two
 :::
 ```
 
 ```html
-<p>::: {.line-block}
-one
-two
-:::</p>
+<div class="line-block">
+  <p>one
+two</p>
+</div>
 ```
 
 ::::
 
-For a smaller local opt-in to visible line breaks, use `::: \`. It turns soft breaks in direct paragraph children into hard breaks, but it does not preserve leading whitespace and does not affect nested blocks.
+`::: \` is the other line-break block. It turns soft breaks in direct paragraph children into hard breaks and does nothing else - it does not preserve leading whitespace and does not affect nested blocks. That makes it the one to reach for when the goal is only to show the breaks you typed; `::: |` is for the narrower case where the leading whitespace is itself content - verse, addresses, ASCII alignment.
 
 :::: compare
 

--- a/tests/corpus/41-line-blocks-6.crv
+++ b/tests/corpus/41-line-blocks-6.crv
@@ -1,4 +1,5 @@
-::: {.line-block}
+{.line-block}
+:::
 one
 two
 :::

--- a/tests/corpus/41-line-blocks-6.html
+++ b/tests/corpus/41-line-blocks-6.html
@@ -1,4 +1,4 @@
-<p>::: {.line-block}
-one
-two
-:::</p>
+<div class="line-block">
+  <p>one
+two</p>
+</div>

--- a/tests/spec/41-line-blocks.test
+++ b/tests/spec/41-line-blocks.test
@@ -64,15 +64,16 @@ plain line.</p>
 ```
 
 ```
-::: {.line-block}
+{.line-block}
+:::
 one
 two
 :::
 .
-<p>::: {.line-block}
-one
-two
-:::</p>
+<div class="line-block">
+  <p>one
+two</p>
+</div>
 ```
 
 ```


### PR DESCRIPTION
The Line blocks section carried a counter-example that pinned a rule already pinned one section earlier, and framed the two line-break blocks the wrong way round.

## The duplicate

`41-line-blocks-6` was:

````
::: {.line-block}
one
two
:::
````

```html
<p>::: {.line-block}
one
two
:::</p>
```

`24-generic-divs-2` already pins exactly that, with a different class name:

````
::: {.sidebar}
not a div
:::
````

```html
<p>::: {.sidebar}
not a div
:::</p>
```

The rule belongs to every `:::` opener, not to line blocks, so stating it twice covered nothing extra.

## Replaced in place, not removed

`scripts/generate-corpus.mjs` numbers examples by position within a section, and its own comment (line 173) notes that every engine allowlists categories by `NN-slug`. Deleting the sixth example would have renumbered the seventh and eighth and invalidated those allowlists across the engines. Swapping the input leaves the numbering untouched: only `41-line-blocks-6` moves.

## What the replacement pins

The prose above the example claims the behavior keys off the `|` token rather than the class, but the old example could not show that - it never produced the class at all. The attribute-line form does:

````
{.line-block}
:::
one
two
:::
````

```html
<div class="line-block">
  <p>one
two</p>
</div>
```

Class lands, hard breaks do not, leading whitespace is not preserved. Nothing in the corpus covered this - no `.crv` had `line-block` on an attribute line. It is the case a reader hits after seeing `<div class="line-block">` in Carve's output and trying to reproduce it by hand.

## Framing of the backslash form

`::: \` was introduced as "a smaller local opt-in to visible line breaks", which reads as a footnote to `::: |`. The pipe form is the narrower of the two: it exists for content where leading whitespace is part of the text - verse, addresses, ASCII alignment. Both are now described by what each is for, with no claim about which is more used.
