### PR TITLE
docs: keep the core page to what works, and route the class case to edge cases

### DIFF
--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -146,7 +146,6 @@ out: examples/core.md
   41-line-blocks-3
   41-line-blocks-4
   41-line-blocks-5
-  41-line-blocks-6
   41-line-blocks-7
   42-admonitions
   42-admonitions-2
@@ -382,6 +381,7 @@ index: examples/edge-cases/index.md
   a-definition-behind-an-alternating-container-prefix-registers-at-the-innermost-content-column
   41-line-blocks-8
   12-inline-code-5
+  41-line-blocks-6
   24-generic-divs-2
   24-generic-divs-3
   24-generic-divs-4

--- a/resources/examples/core.md
+++ b/resources/examples/core.md
@@ -3989,7 +3989,7 @@ plain line.</p>
 
 ::::
 
-The behavior keys off the `|` type token, not the class name. Writing the class by hand - on an attribute line, the only place a `:::` opener takes attributes - gets the CSS hook and none of the semantics: no hard breaks, no preserved leading whitespace. (An inline `::: {.line-block}` is not a fence at all, and renders as a literal paragraph; that rule belongs to every `:::` opener, and is shown under [Generic divs](#generic-divs).)
+The layout preservation comes from the `|` type token on the opener. A plain `:::` block carrying the `line-block` class from an attribute line is an ordinary div that happens to have that class - the class is a CSS hook, and no stylesheet in the toolchain defines it.
 
 :::: compare
 

--- a/resources/examples/extensions.md
+++ b/resources/examples/extensions.md
@@ -49,7 +49,7 @@ A `::: name` opener's behavior keys off the **type word** (not a class). Only th
 | Type word | Renders as | Special behavior |
 |-----------|-----------|------------------|
 | `note` `tip` `warning` `danger` `info` `success` `example` `quote` | `<aside class="admonition {type}">` | Admonition (PART 9 §12); optional quoted title → `<p class="admonition-title">` |
-| `\|` (pipe) | `<div class="line-block">` | Line block - preserves the author's per-line layout / soft breaks (PART 9 §23). The token is the pipe, not a word; an inline `::: {.line-block}` is not a fence at all (strict djot) but an ordinary paragraph. |
+| `\|` (pipe) | `<div class="line-block">` | Line block - preserves the author's per-line layout / soft breaks (PART 9 §23). The type token is the pipe itself, not a word. |
 | *(any other word)* | `<div class="{word}">` | None in core, a generic fenced div; meaning supplied by a Tier-2 or Tier-3 extension (e.g. `tabs`, `code-group`, `mermaid`). |
 
 Because the behavior keys to the bare type word, give a purely presentational container a class on an **attribute line before the opener** (`{.mybox}` then `:::`) so you never collide with a recognized type word. The `:::` fence takes no inline attributes (strict djot), so an inline `::: {.mybox}` is a paragraph, not a div.


### PR DESCRIPTION
Follow-up to 1720. The core page should show what to type; boundary notes belong on the edge-case pages.

Two things on the core page were the negative half of a rule rather than usage:

- the `41-line-blocks-6` segment, whose point was that a hand-written `line-block` class gets the CSS hook without the semantics
- the container-type table row, which repeated that an inline `::: {.line-block}` is not a fence

## Routing, not deletion

`resources/example-pages.txt` routes fixtures to pages independently of where they sit in the source, so this costs nothing in the corpus: no renumbering, no fixture content change, conformance coverage unchanged. `npm run corpus:build` writes the same 1405 pairs before and after.

The case lands next to `24-generic-divs-2` on the containers edge page - the fixture that pins the same rule for a plain div, and already routed there.

Fully hiding it is not an option, by design: the generator hard-errors unless every corpus pair is routed exactly once, on the grounds that a pair on no page has no reader.

## Prose

A routed segment carries the paragraph above its compare block, and the old wording leaned on the core section around it, so it is rewritten to stand alone. The core page loses nothing - that the pipe is the type token is already stated where the block is introduced.

## Correction to 1720

That PR's body justified replacing the example in place, rather than deleting it, by saying a delete would renumber the following examples and invalidate the engines' category allowlists. The second half is wrong: engines allowlist by category (`NN-slug`), and a within-section suffix shift leaves those untouched. The real hazard is `resources/ast-span-divergence.txt` and `resources/engine-pin-drift.txt`, which name suffixed cases (`41-line-blocks-2 and -3`) - a shift silently repoints those waivers at different fixtures. Same conclusion, different mechanism.

## Unrelated defect found while measuring

Not addressed here, filed separately: the executable spec drops the attribute block on `::: |` and `::: \`, while honoring it on plain divs, admonitions, blockquotes and code fences. `docs/blocks-and-attributes.md` says the preceding-line attribute rule is uniform across every block and names line-blocks explicitly, and carve-js applies it. Measured with `scripts/spec/layout.mjs` plus `renderDoc` against carve-js HEAD.
