### PR TITLE
spec: a colon fence whose type token is a bare marker opens a block quote

### DIFF
--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -643,6 +643,10 @@
             "$ref": "#/$defs/blockNode"
           }
         },
+        "fenced": {
+          "description": "True when the quote was authored as a ::: > container rather than with > line markers. The two spellings are one node; this records which one, so the canonical writer can write back what it read. Absent on a >-prefixed quote.",
+          "const": true
+        },
         "attrs": {
           "$ref": "#/$defs/attrs"
         },

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -2030,6 +2030,28 @@ local_hard_break_block = local_hard_break_block_open, newline,
                          [admonition_close, newline] ;
 local_hard_break_block_open = colon_fence:open, space, backslash ;
 
+(* --- Fenced block quote (PART 9 section 12: the container rules govern it) --- *)
+(* A SECOND SPELLING of the block quote, not a second block: a colon fence
+   whose type token is a bare `>` opens a quote whose body is ordinary block
+   content, and the node is the one `blockquote_line` produces. The two forms
+   are the same tree, so every rule that speaks of a block quote reaches both.
+   Third member of the sigil-fence family beside `line_block_open` and
+   `local_hard_break_block_open`, and it takes the same REQUIRED space before
+   its token; `:::>` is not an opener.
+   WHY A SIGIL AND NOT A KEYWORD: `::: quote` is already an admonition kind
+   rendering `<aside class="admonition quote">`, so the keyword is taken and
+   means something else. The `>` is unambiguous because it is already the
+   block-quote marker (markup-carve/carve#1718; jgm/djot#401).
+   WHICH SPELLING AN AUTHOR USED is carried on the node as `fenced` (PART 12),
+   because `carve fmt` must be able to write back what it read: normalizing
+   one spelling to the other would rewrite documents no one asked to change.
+   The flag is ABSENT on a `>`-prefixed quote, so a document that predates
+   this clause serializes exactly as it did. *)
+quote_block = quote_block_open, newline,
+              {block - admonition_close},
+              [admonition_close, newline] ;
+quote_block_open = colon_fence:open, space, ">" ;
+
 (* --- Comments --- *)
 (* A line comment may be indented: optional leading whitespace before `%%` does
    not matter, so an indented line whose first non-whitespace content is `%%` is

--- a/tests/schema-fields-are-produced.test.mjs
+++ b/tests/schema-fields-are-produced.test.mjs
@@ -65,6 +65,7 @@ const OPT_IN_ONLY = {
 const ENGINE_ROLLOUT_PENDING = {
   'figure.shortCaption': 'structural publishing field: Carve 0.1 source has no spelling; produced only by AST/Pandoc consumers',
   'table.shortCaption': 'structural publishing field: Carve 0.1 source has no spelling; produced only by AST/Pandoc consumers',
+  'block_quote.fenced': 'fenced block quote (PART 9 section 12): the ::: > spelling is specified and the pinned engine does not parse it yet, so no corpus document can carry the flag',
 }
 
 /**


### PR DESCRIPTION
First slice of #1718. Specifies the fenced block quote and the wire field that carries the author's choice of spelling; no corpus documents yet, because the pinned engine cannot parse the syntax and every fixture would fail the gate.

## The production

A colon fence whose type token is a bare marker character opens a block quote whose body is ordinary block content. It is a second SPELLING of the block quote, not a second block: the node is the one the line-marker form produces, so every rule that already speaks of a block quote reaches both. Third member of the sigil-fence family beside the line block and the hard-break block, taking the same required space before its token.

The keyword form was unavailable rather than unattractive. A quote kind already exists among the admonition types and renders an aside, so the word is taken and means something else.

## The wire field

`block_quote.fenced`, absent on a marker-prefixed quote.

It exists because the canonical writer has to write back what it read. Without it `carve fmt` must pick one spelling structurally, and measuring that showed the cost: a rule of "fenced when the quote holds a non-paragraph block" re-canonicalizes **50 of the 1404 corpus documents** and every user document with a multi-block quote. A flag keeps the change purely additive - a document that predates this clause serializes byte for byte as it did.

`additionalProperties: false` on the type means the schema has to admit the field before an engine may emit it, which inverts the usual engine-first order. `ENGINE_ROLLOUT_PENDING` is the sanctioned way to hold that gap, and its companion test forces the entry back out once the pinned engine produces the field.

## Sequencing

1. this PR - production, schema field, rollout entry
2. carve-js - produce the field, writer, ingest, then bump its spec pin
3. here - bump the engine pin, add the corpus, drop the rollout entry
4. carve-rs, carve-php
5. the caption-slot host, then the lint rule for the trap described on the issue

## Note on CI

`origin/main` is red independently of this branch. `the oracle reads the engine's formatted output as the same document` (05-lists-11) and `every trigger provokes the rule it names` (list-item-body-detached, list-item-block-overindented) both fail on a clean checkout with this branch's changes stashed, and both look adjacent to #1707. This branch is 3011/3014 with exactly those two failing and nothing else.
