### PR TITLE
test: declare the list-column clauses as running ahead of the pinned engine

### DIFF
--- a/resources/engine-fmt-drift.txt
+++ b/resources/engine-fmt-drift.txt
@@ -15,3 +15,16 @@
 #
 # Format: <slug><space><space><reason>
 415-a-floating-attribute-does-not-widen-a-list-item-s-content-column-7  pinned writer moves an empty task marker across its detached paragraph
+05-lists-11  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+143-post-blank-list-continuation-content-column-model-3  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+148-colon-fence-as-a-block-opener-in-a-list-item-3  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+149-fence-folds-as-lazy-inline-code-above-the-content-column  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+162-outer-item-with-an-internal-blank-before-an-attached-block-is-loose  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+243-a-tab-indent-is-the-column-it-reaches-whatever-the-line-holds  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+244-the-same-column-written-with-four-spaces  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+322-an-attribute-block-reaches-the-nested-list-it-precedes-9  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+369-a-quote-is-reached-by-its-marker-and-a-column-never-reaches-into-one-2  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+413-an-item-s-attribute-block-moves-its-content-column-its-checkbox-does-not-2  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+413-an-item-s-attribute-block-moves-its-content-column-its-checkbox-does-not-8  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+75-list-nesting-and-looseness-9  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation
+87-compact-list-blocks-10  oracle reads the lenient list content column of carve#1705 / carve#1707 / carve#1732; the pinned writer still emits the pre-clause indentation

--- a/tests/lint-rule-table-claims.test.mjs
+++ b/tests/lint-rule-table-claims.test.mjs
@@ -69,8 +69,6 @@ const TRIGGERS = {
   'blockquote-marker-without-space': '>quoted\n',
   'block-marker-as-text': '  ::: note\n',
   'fence-delimiter-indentation': '  ```\n  x\n  ```\n',
-  'list-item-body-detached': '1. item\n\n  # heading\n',
-  'list-item-block-overindented': '-{.x1} item\n\n       # heading\n',
   'carve-version-unsupported': '---\ncarve-version: 99.0\n---\n\nx\n',
   'unclosed-container-fence': '::: note\nbody\n',
   'figure-group-nested': ':::: figure\n::: figure\n![a](a.png)\n^ (a) A\n:::\n::::\n^ Figure #: G\n',
@@ -147,6 +145,15 @@ const NOT_IN_THE_PIN_YET = new Map([
     'table-marker-run-padding',
     'specified by markup-carve/carve#1464; no engine emits it yet, and it ' +
       'supersedes table-alignment-run-padding once they do',
+  ],
+  [
+    'list-item-body-detached',
+    'specified by markup-carve/carve#1707; no engine implements it yet',
+  ],
+  [
+    'list-item-block-overindented',
+    'specified by markup-carve/carve#1705 and markup-carve/carve#1707; no ' +
+      'engine implements it yet',
   ],
 ])
 


### PR DESCRIPTION
`main` is red on two checks. Both have the same cause and neither is a defect in the clauses themselves: the lenient list content-column rules landed in the spec and in the oracle while the pinned build still predates them, and the resulting gaps were not declared.

Reproduced on a clean checkout of `d81bd4e0` before touching anything, so this is not fallout from another branch.

## `every trigger provokes the rule it names`

carve#1707 added `list-item-body-detached` and `list-item-block-overindented` to `docs/validation.md` AND to the `TRIGGERS` map in the same commit. Neither rule exists in the pinned build - grepping the installed engine finds no such rule id - so the triggers provoke nothing.

`TRIGGERS` is an assertion that a rule fires. A rule specified ahead of the engines belongs in `NOT_IN_THE_PIN_YET`, which is what that map's own guidance says:

> If the rule is specified ahead of the engines, declare it in NOT_IN_THE_PIN_YET with the ticket that specifies it.

Both moved there. The declaration is guarded from both directions - a companion test fails if the rule stops being documented, and fails again once the pinned build starts carrying it - so this cannot quietly outlive the engine work.

## `the oracle reads the engine's formatted output as the same document`

Thirteen corpus documents, every one a list content-column shape. The oracle now reads the lenient column; the pinned writer still emits the older indentation; so the oracle reads a different document out of the formatted source than out of the original.

That is the second of the two kinds `resources/engine-fmt-drift.txt` exists to hold, named in its own header:

> the ORACLE can fail to read the pin's output back while the pin reads it fine - which is what a spec rule the pin has not shipped looks like from the writer side. Both belong here

All thirteen are declared with the clauses that moved. The first render still matches the corpus for each, which is why only the cross-read check sees them.

## After this

3022 tests, zero failures. Every line added here is deleted when the engine pin advances past the clauses - both files say so in their headers, and both have a check that forces it.
