### PR TITLE
spec: a colon fence in a list item opens without a closer too

### DIFF
--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -4094,11 +4094,12 @@ its cells hold* below - so "no body row yet" would answer that document wrongly
 ## Fence opener with a nested-list body inside a list item
 
 A `:::` opener inside a list item opens its block even when its body is a
-nested list, provided the matching closer sits at the item content column
-(PART 9 §12). A bullet (`-`) or ordered marker (`1.`) on the next line is part
-of the admonition body, not a sibling list that swallows the opener as literal
-text. The closer must align with the opener's content column; a `:::` at column
-zero (outside the item) does not close it.
+nested list (PART 9 §12). A bullet (`-`) or ordered marker (`1.`) on the next
+line is part of the admonition body, not a sibling list that swallows the
+opener as literal text. The matching closer sits at the item content column; a
+`:::` at column zero (outside the item) does not close it. The closer is
+OPTIONAL here as everywhere (PART 2): an opener with none ahead of it still
+opens, and the container closes at end of input.
 
 A nested unordered list body is wrapped by the admonition:
 
@@ -4199,8 +4200,10 @@ A blank line between the opener and the nested list still opens the block:
 
 ::::
 
-NEGATIVE: with no closer, the opener stays literal text and the bullet starts an
-ordinary nested list:
+With NO closer, the opener still opens and the container closes at end of
+input, so the nested list is wrapped exactly as it is with a closer at the item
+content column. This label used to read the other way, calling the opener
+literal text under bytes that show it opening (carve#1722):
 
 :::: compare
 

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -5467,11 +5467,26 @@ EOF = (* end of file *) ;
       a valid closer, the bullet/ordered marker lines are the admonition's
       body and the block wraps the nested `<ul>`/`<ol>`. A blank line
       between the opener and the nested list still opens the block, and an
-      empty body (opener immediately followed by its closer) opens too. With
-      NO matching closer, the opener degrades to literal text and the marker
-      lines form an ordinary nested list. The corpus pins these
+      empty body (opener immediately followed by its closer) opens too. A
+      MISSING closer changes none of this: PART 2's UNCLOSED rule governs
+      unqualified, the opener opens and the container closes at end of input.
+      The corpus pins these
       (resources/examples/edge-cases.md "Fence opener with a nested-list body inside a list
       item").
+
+      THIS PARAGRAPH ALSO SAID THAT WITH NO MATCHING CLOSER THE OPENER
+      DEGRADES TO LITERAL TEXT AND THE MARKER LINES FORM AN ORDINARY NESTED
+      LIST. That is the retired literal-text reading carve#1719 removed from
+      this section three screens up, wearing a list item. PART 2 grants it no
+      such carve-out: it names ONE exception and it is LAZY FOLDING, a
+      different shape (`- ::: d` over a flush-left `tail`, which opens
+      nothing), not a missing closer. carve-js, carve-php and carve-rs all
+      wrap the nested list in the container, byte for byte what the same
+      document produces WITH a closer at the item content column. It survived
+      the carve#770 pass, and it survived carve#1719 because the corpus pinned
+      the right bytes under a NEGATIVE label that described the removed rule --
+      a gate cannot fail on prose. The label is corrected with this sentence
+      (carve#1722).
 
       The two tiers for a typed block:
 


### PR DESCRIPTION
Fixes #1722.

Section 12's `FENCE OPENER WITH A NESTED-LIST BODY` paragraph said:

> With NO matching closer, the opener degrades to literal text and the marker lines form an ordinary nested list.

That is the retired literal-text reading wearing a list item. PART 2 states the
unclosed rule with no such carve-out - the closer is optional, an opener always
opens, and a block still open at end of input closes there - and it names the
literal-text reading as "the earlier rule", dropped because it turned one wrong
character into a corrupted document. carve#1719 removed the sibling spelling
from the same section on that reasoning; this is the second one.

## No engine implements it

Input:

````
- ::: d
  - a
  - b
````

Output from carve-rs and carve-js built from source:

````html
<ul>
  <li>
    <div class="d">
      <ul>
        <li>a</li>
        <li>b</li>
      </ul>
    </div>
  </li>
</ul>
````

Byte-identical to the same document WITH a closer at the item content column.
The missing closer changes nothing.

The lazy-fold exception PART 2 does name is a different shape (`- ::: d` over a
flush-left `tail`) and is implemented.

## What changed

`resources/grammar.ebnf` - the false sentence is gone. The paragraph now points
at PART 2's UNCLOSED rule instead of restating it, so the rule lives in one
place, and a correction note records what the sentence said and why it went, in
the style the carve#770 and carve#1719 passes over this same section used.

`resources/examples/edge-cases.md` - the `NEGATIVE:` label above the no-closer
fixture said the opener stays literal text while the `:::: compare` block
directly beneath it pinned the admonition wrapping the nested list. The bytes
were right and the label said the opposite of them, which is why nothing gated
it: a prose label cannot fail a test. The label now says what its own fixture
shows. **No fixture bytes moved** - `corpus:build` left the tree clean apart
from the two prose files.

The section's opening sentence carried a softer spelling of the same rule
("opens its block ... provided the matching closer sits at the item content
column"), making the block's opening conditional on a closer. It now states
where the closer sits and that the closer is optional, separately.

## The paragraph's remaining claims are pinned

Checked each against the corpus section the paragraph points at
(`Fence opener with a nested-list body inside a list item`):

- closer located at the item content column - pinned
- a `:::` at column zero does not close the item and opens a div of its own - pinned by the column-zero NEGATIVE fixture
- the block wraps the nested `<ul>` / `<ol>` - pinned by three fixtures
- a blank line between opener and nested list still opens - pinned
- an empty body opens - pinned by the GUARD fixture
- the no-closer shape - pinned by the fixture whose label this PR corrects

## Sweep result

carve#1717's third item asked whether section 12 says anything else no engine
implements. Swept `resources/grammar.ebnf` and `resources/examples/` for every
further spelling of the retired rule - a missing closer producing literal text -
including a multi-line scan, since this one wrapped across two lines and a
single-line grep missed it.

**Nothing else turned up.** Every other hit is a different rule and each is
correct:

- `%%%` comment fence with no closer ahead opens nothing (section 28, grammar lines ~2093, ~4362, ~7604) - a deliberate divergence, already documented as one
- an unterminated braced comment `{%` stays literal (grammar ~2118, edge-cases "An UNTERMINATED opener stays literal text")
- the over-cap nesting degrade (grammar ~7313 onward)
- indented colon-fence blocks stay literal - the strict column-0 rule, not the closer
- below-content-column div body in a list item - lazy folding, the one exception PART 2 does name
- an unterminated code fence does not interrupt a paragraph (section 10 I4), stated beside the note that a `:::` opener is explicitly NOT guarded

The class is closed.
