### PR TITLE
chore: move the carve-js pin to main and empty the pin-drift ledger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#9cd86939089358a449d2fab09a5650579346fc7e",
+        "@markup-carve/carve": "github:markup-carve/carve-js#5279560618692b5466b200c07153447d8c05ef72",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#9cd86939089358a449d2fab09a5650579346fc7e",
-      "integrity": "sha512-5oKMbCsuTjP9ltCd0C8h4UlGrhUlIuDP+yjuYh7wkMm4IVNNuDbswpIrLhp6AearMjlVCFzoaHp5kv+PPTdgsQ==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#5279560618692b5466b200c07153447d8c05ef72",
+      "integrity": "sha512-l+YaxmpiD22qErP4M3GV5Q29odfVCpyXR1MhSSpbq8YvOzWioukWsZfZe1DpSb2fP/CkjcEty4zyNCmuDIK26g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#9cd86939089358a449d2fab09a5650579346fc7e",
+    "@markup-carve/carve": "github:markup-carve/carve-js#5279560618692b5466b200c07153447d8c05ef72",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,6 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-24-generic-divs-4  carve#1725 permits an ASCII digit to start an explicit class
-71-attribute-edge-cases-15  carve#1725 permits ASCII digits to start explicit IDs and classes
-71-attribute-edge-cases-17  carve#1725 permits an ASCII digit to start an explicit class

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,6 +1,6 @@
 {
   "engine": "@markup-carve/carve",
-  "engineCommit": "9cd86939089358a449d2fab09a5650579346fc7e",
+  "engineCommit": "5279560618692b5466b200c07153447d8c05ef72",
   "corpusDocuments": 1412,
   "htmlImportPopulation": {
     "completed": 1411,
@@ -11,7 +11,7 @@
     ]
   },
   "renderImportRoundTrips": {
-    "html": 608,
+    "html": 607,
     "markdown": 374
   }
 }


### PR DESCRIPTION
Moves the pinned reference build to carve-js `main` and clears every drift row the move makes stale. This is pre-tag ledger work: it clears the way for a tag, it does not create one.

Pin: `9cd86939089358a449d2fab09a5650579346fc7e` to `5279560618692b5466b200c07153447d8c05ef72`, lockfile with it. The lockfile diff is the pin and its integrity hash and nothing else.

## `resources/engine-pin-drift.txt`: 3 rows removed, now empty

All three named the same rule, markup-carve/carve#1725, which the new build ships (markup-carve/carve-js#1486). The report calls each one stale by name:

```
24-generic-divs-4
71-attribute-edge-cases-15
71-attribute-edge-cases-17
```

`engine:report` goes from 3 mismatched to 0 over 1412 corpus pairs, with 0 declared.

## `resources/engine-fmt-drift.txt`: 1 row KEPT, and it is not empty

The row still reproduces on the new build. It was measured against both builds and the writer emits the same bytes either way, so nothing about it went stale.

Input:

```
-{#k} [x] {#h}
 # h
```

What both the old pin and the new pin write:

````
-{#k} [x] +

\# h
````

Of the five signals the ratchet consults, only one fires: the oracle reads a task marker labelled `+` out of the written form where the source had an empty one.

```
changesMeaning : false
unsettled      : false
oracleChanges  : true
fmtBytesDiffer : n/a (no .fmt fixture for this slug)
reparseDiffers : n/a
```

The oracle on the source:

```html
<li id="k"><input type="checkbox" checked disabled> </li>
```

The oracle on the written form:

```html
<li id="k"><input type="checkbox" checked disabled aria-label="+"> +</li>
```

The reason line is as true as it was, so it stands unedited. Deleting this row would have been deleting a live declaration.

## `resources/import-roundtrip-baseline.json`: `renderImportRoundTrips.html` 608 to 607

The document set did not move (1412 either way), so this is pin movement and not corpus growth. Five documents changed how they import, and the two causes are separable.

Gained, both the digit-leading rule above:

```
24-generic-divs-4
71-attribute-edge-cases-15
```

Lost, all three one shape, a figure whose target is a display-math paragraph:

```
281-a-caption-attaches-across-one-blank-line-7
281-a-caption-attaches-across-one-blank-line-8
282-two-blank-lines-detach-a-caption-9
```

608 - 3 + 2 = 607.

The three losses are markup-carve/carve-js#1480, "a figure unwraps when its target cannot carry a caption", whose own commit names this exact case: a display-math paragraph takes the unwrap exit. Safe and semantic used to write a caption line back out of that figure, which the parser then read as more prose in the same paragraph. They now unwrap and declare it instead.

Old pin, default (safe) mode:

````
$$`E = mc^2`
^ Equation: mass-energy
````

with no diagnostics. New pin, same mode:

````
$$`E = mc^2`

Equation: mass-energy
````

with one `element-unwrapped` info row. Roundtrip mode is unchanged on both builds and still preserves the figure as raw HTML with a `raw-preserved` warning. The change trades a silent corruption for a declared loss, so 607 is the honest count and not a ratcheted regression.

Only the HTML round-trip count moved. Each of the others held for a reason this change predicts:

| count | before | after | why it did not move |
| --- | --- | --- | --- |
| `corpusDocuments` | 1412 | 1412 | no document was added or removed |
| `htmlImportPopulation.completed` | 1411 | 1411 | none of the five started or stopped throwing; what changed is what the import produces |
| `htmlImportPopulation.canonicalFixedPoints` | 1410 | 1410 | the old spelling and the new one are both already fixed points of the writer |
| `htmlImportPopulation.renderedTextPreserved` | 1396 | 1396 | the caption survives as a paragraph, so the visible text is the same string either way |
| `htmlImportPopulation.expectedRejections` | 1 | 1 | unchanged allowlist |
| `renderImportRoundTrips.markdown` | 374 | 374 | a figure rule on the HTML importer does not reach the markdown path |

`engineCommit` moves with the pin. Nothing reads that field, but a stale one would misdescribe which build produced the counts.

## Nothing else moved

No fixture and no golden was re-snapshotted. `corpus:build` leaves the working tree clean, and the suite is 3023 passing with 1 skipped, the same numbers as before the bump. The `NOT_IN_THE_PIN_YET` map in `tests/lint-rule-table-claims.test.mjs` needed no edit: neither `unattached-block-attribute` nor `table-marker-run-padding` arrived in the new build, and its two-way guard is green.

## Declarations gate

`npm run declarations:check` goes from 5 findings to 4. The one it clears is this repo's `engine-pin-drift.txt`. What remains is one row here that is genuinely owed (`engine-fmt-drift.txt`, above) and three `AHEAD_OF_PIN` ledgers in the engine repos, which clear when each engine moves its own spec pin and are out of scope for a change in this repo:

```
carve-js  test/corpus.test.ts        AHEAD_OF_PIN  3
carve-php tests/CarveCorpusTest.php  AHEAD_OF_PIN  3
carve-rs  tests/corpus.rs            AHEAD_OF_PIN  3
```

All three name markup-carve/carve#1725, the same rule this bump caught up on here.
