### PR TITLE
spec: define colon fence mismatch tooling

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -33,6 +33,9 @@ and pre-commit hooks:
 carve lint docs/**/*.crv
 ```
 
+Use `carve lint --json` when an editor, CI job, or migration tool needs stable
+rule IDs, source ranges, and rule-specific details rather than display text.
+
 By default `carve lint` reports the semantic rules below plus the
 Djot/Markdown constructs that actually mis-render in Carve (`**bold**`,
 `~~strike~~`, `^sup^`, and `+` bullets). It does **not** flag valid Carve
@@ -110,6 +113,7 @@ the command-line and editor behavior stay aligned.
 | `list-item-block-overindented` | a recognized block opener past an item's canonical content column, including the pre-#1701 full-prefix column of an attributed marker; under #1705 it is structural and `fmt` canonicalizes it. Dedent for the canonical structural spelling or escape the opener to preserve the literal meaning older readers assigned to it |
 | `carve-version-unsupported` | a document declaring a Carve spec version the processor does not implement, so constructs added after that version render as something else without any error |
 | `unclosed-container-fence` | a `:::` opener with no matching closer; the container runs to end of input, which is legal (PART 9 §12) and rarely what was meant |
+| `colon-fence-length-mismatch` | a bare colon run plausibly intended to close the innermost container has a different width; reports both widths, the opener location, and whether the line actually opens a nested container or remains text |
 | `fence-title-syntax` | text after a fence type word that is neither a quoted `"title"` nor a `[label]`, which makes the whole opener line plain text |
 | `footnote-labels-differ-only-in-whitespace` | two footnote definitions whose labels differ only in whitespace; labels are matched exactly, so they are two separate footnotes and a reader comparing them sees no reason why |
 | `table-cell-attribute-before-marker` | a table cell whose `{...}` block is written directly before a `<`, `>` or `~`, which is the order PART 9 §5 T10 retired; the block still attaches to the cell, but the marker is now literal content and the cell is not aligned. Reported and not rewritten: the retired order and the current one render different documents, so only the author can say which was meant |

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1906,6 +1906,23 @@ admonition = admonition_open, newline,
    quote a container fence, so this is the path every document that describes
    Carve in Carve takes.
 
+   TOOLING FOR NEAR MATCHES (PART 9 §12). Exact length remains a parse rule,
+   not a recoverable syntax error. A processor with diagnostics SHOULD report
+   `colon-fence-length-mismatch` when a bare colon run does not close the
+   innermost open container, would close it after resizing, and plausibly
+   expresses closing intent. The finding names the authored and expected
+   widths, the opener position, and the line's actual parse outcome (a nested
+   container or literal text). It MUST NOT fire for typed openers, escaped
+   colons, opaque code/raw/comment payloads, or a different-width child fence
+   that has its own exact closer.
+
+   A tool MAY offer separate fixes to resize the run or preserve it as literal
+   content. Neither is a canonical-formatting decision: `carve fmt` MUST NOT
+   choose an intention. Editors SHOULD pair and highlight exact opener/closer
+   ranges from parser structure. Automatic paired edits stop after either side
+   is independently changed; proximity alone never licenses resizing a nested
+   fence. (carve#1727)
+
    A CLOSER IS REQUIRED. Only a fence that closes is opaque. A ``` or ~~~
    opener with no closer ahead opens NO span: the container's own closer
    stays structural, and the lines after it are parsed normally. This is the

--- a/tests/lint-rule-table-claims.test.mjs
+++ b/tests/lint-rule-table-claims.test.mjs
@@ -140,6 +140,10 @@ const UNPRODUCIBLE_IN_BUILD = new Set(['portable-quote-marker-space'])
  */
 const NOT_IN_THE_PIN_YET = new Map([
   [
+    'colon-fence-length-mismatch',
+    'specified by markup-carve/carve#1727; the carve-js implementation is landing alongside this spec change',
+  ],
+  [
     'unattached-block-attribute',
     'specified by markup-carve/carve#1281; no engine implements it yet',
   ],


### PR DESCRIPTION
## What this changes

Defines the tooling contract for exact-width colon fences without changing parsing semantics.

- Specifies `colon-fence-length-mismatch` and its structured details
- Defines when near matches must stay quiet, including intentional nested fences and opaque payloads
- Requires separate close and literal-preservation fixes
- Keeps the formatter neutral about author intent
- Documents parser-driven pairing, highlighting, and safe linked editing
- Documents structured `carve lint --json` output

## Why this helps

Exact-width closers keep nesting deterministic and let the writer choose local fence widths, but a one-colon typo is visually subtle. This contract makes that mistake visible and fixable without weakening the language rule or silently rewriting valid nesting.

## Validation

- `node --test tests/lint-rule-table-claims.test.mjs tests/normativity.test.mjs`
- Documentation Carve samples passed in the focused documentation run

Closes #1727
