### PR TITLE
chore: reconcile authored body engine pins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#5279560618692b5466b200c07153447d8c05ef72",
+        "@markup-carve/carve": "github:markup-carve/carve-js#7ada8844c84c0d501379d2bd0e34405873b9a7fc",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#5279560618692b5466b200c07153447d8c05ef72",
-      "integrity": "sha512-l+YaxmpiD22qErP4M3GV5Q29odfVCpyXR1MhSSpbq8YvOzWioukWsZfZe1DpSb2fP/CkjcEty4zyNCmuDIK26g==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#7ada8844c84c0d501379d2bd0e34405873b9a7fc",
+      "integrity": "sha512-CtpbHBFU+0If9pQjdJJpCSTpX9yg9fdcQBkBKRKsHiUbegK0EIxXhs9nLn1AZ1OD9IMl6Fca3Cx/PdDvcSLywQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#5279560618692b5466b200c07153447d8c05ef72",
+    "@markup-carve/carve": "github:markup-carve/carve-js#7ada8844c84c0d501379d2bd0e34405873b9a7fc",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,6 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-218-a-footnote-body-s-own-column-is-two-and-a-third-column-is-its-text  pinned writer still preserves the pre-1729 literal over-indent
-220-a-definition-past-a-footnote-body-s-column-is-the-body-s-own-text  pinned writer still preserves the pre-1729 literal over-indent
-269-a-definition-body-continuation-indented-past-its-column-is-lazy-text  pinned writer still preserves the pre-1729 literal over-indent

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,6 +1,6 @@
 {
   "engine": "@markup-carve/carve",
-  "engineCommit": "5279560618692b5466b200c07153447d8c05ef72",
+  "engineCommit": "7ada8844c84c0d501379d2bd0e34405873b9a7fc",
   "corpusDocuments": 1412,
   "htmlImportPopulation": {
     "completed": 1411,
@@ -11,7 +11,7 @@
     ]
   },
   "renderImportRoundTrips": {
-    "html": 607,
+    "html": 608,
     "markdown": 374
   }
 }

--- a/tests/lint-rule-table-claims.test.mjs
+++ b/tests/lint-rule-table-claims.test.mjs
@@ -73,6 +73,7 @@ const TRIGGERS = {
   'list-item-block-overindented': '-{.x1} item\n\n       # heading\n',
   'carve-version-unsupported': '---\ncarve-version: 99.0\n---\n\nx\n',
   'unclosed-container-fence': '::: note\nbody\n',
+  'colon-fence-length-mismatch': ':::: note\nbody\n:::\n',
   'figure-group-nested': ':::: figure\n::: figure\n![a](a.png)\n^ (a) A\n:::\n::::\n^ Figure #: G\n',
   'figure-group-opener-metadata': '::: figure "Title"\n![a](a.png)\n^ (a) A\n:::\n',
   'figure-group-panel-number': '::: figure\n![a](a.png)\n^ Figure #: panel\n:::\n^ Figure #: G\n',
@@ -139,10 +140,6 @@ const UNPRODUCIBLE_IN_BUILD = new Set(['portable-quote-marker-space'])
  *   - listed here and absent from the page -> a declaration about nothing.
  */
 const NOT_IN_THE_PIN_YET = new Map([
-  [
-    'colon-fence-length-mismatch',
-    'specified by markup-carve/carve#1727; the carve-js implementation is landing alongside this spec change',
-  ],
   [
     'unattached-block-attribute',
     'specified by markup-carve/carve#1281; no engine implements it yet',


### PR DESCRIPTION
## Summary

- move the pinned JavaScript reference build past the authored definition and footnote body implementation
- remove the three temporary `authoredBodyBases` corpus drift declarations
- record that `colon-fence-length-mismatch` is now present in the same pinned build and give its documentation contract a real trigger
- update the measured HTML round-trip baseline from 607 to 608

## Why

The spec, JavaScript, Rust, and PHP implementations now agree on markup-carve/carve#1729. Keeping the old drift rows would hide regressions in a capability that has shipped across every reconciled engine.

The newer JavaScript pin also includes the colon-fence diagnostic from markup-carve/carve#1727. Updating its executable documentation assertion in the same commit prevents the pin bump from leaving a stale “not implemented” exception behind.

The HTML round-trip gain was inspected document by document across the three changed corpus cases. Document 269 now round-trips exactly because its over-indented quote remains structural through HTML; documents 218 and 220 remain outside the exact round-trip set. No import-population, canonicalization, visible-text, or Markdown count changed.

## Verification

- reference engine report: 1,412/1,412 corpus pairs reproduced, zero mismatches, zero declared drift
- full spec suite: 3,070 passed, one unrelated skipped; the sole stale-pin assertion found by the run was updated and its focused suite passes 8/8
- formal core: 1,412/1,412 conformant, zero defects, zero sentinel leaks
- HTML import contract: 7/7 checks passed, including the inspected 608-round-trip baseline

Completes markup-carve/carve#1729.
