### PR TITLE
Exercise Rust's BBCode importer

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -1005,8 +1005,8 @@ Absence is declared, never silent, in two files checked in both directions on
 every run:
 
 - **A missing importer** is a capability gap: it lives in
-  `scripts/lib/converter-formats.mjs` with the reason (today: carve-rs has no
-  BBCode importer). A format an engine can
+  `scripts/lib/converter-formats.mjs` with the reason. There are no declared
+  importer gaps today: carve-rs#1275 added the last missing BBCode path. A format an engine can
   neither convert nor explain fails the run; a declared gap the engine has
   quietly closed is a stale entry and fails too - the runner probes the engine
   itself rather than trusting the table.

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -311,7 +311,7 @@ const impls = [
     // declared table in lib/converter-formats.mjs; a format missing here MUST
     // be declared there, and the runner checks both directions.
     convertCommand: (format) =>
-      ['markdown', 'djot', 'html'].includes(format)
+      ['markdown', 'djot', 'html', 'bbcode'].includes(format)
         ? [...rustBaseCommand, 'migrate', '--from', format]
         : null,
     // Exit 0 = the importer exists after all (a DECLARED gap has gone stale).

--- a/scripts/lib/converter-formats.mjs
+++ b/scripts/lib/converter-formats.mjs
@@ -45,9 +45,7 @@ export function formatOfExtension(ext) {
  * day) and re-verified against the checkouts when this file was written.
  */
 export const UNIMPLEMENTED_IMPORTERS = {
-  rust: {
-    bbcode: 'carve-rs has no BBCode importer (carve#1130 coverage table); `carve migrate --from bbcode` rejects the format',
-  },
+  rust: {},
   js: {},
   php: {},
 }


### PR DESCRIPTION
Follows markup-carve/carve-rs#1410.

Removes the now-stale carve-rs BBCode importer gap and drives Rust through both shared BBCode converter cases. The implementation comparison now records no missing importers across Rust, JS, and PHP.

Validation:
- `node --test tests/corpus-convert.test.mjs`
- `npm run docs:build`
- local three-engine converter run with carve-rs#1410: Rust 71/71, mismatch=0, error=0, skipped=0