### PR TITLE
docs: document the fenced block quote

### DIFF
--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -19,7 +19,7 @@ A block owns a rectangle of the document: it starts on its own line and is separ
 
 - Paragraph
 - Heading - `# … ###### …`
-- Block quote - `> …`
+- Block quote - `> …`, or the same block fenced as `::: >`
 - List (bullet `-` / `*`, ordered `1.` / `1)`, task `- [ ]`) and its list items
 - Code block (fenced) - ` ``` `
 - Generic div / admonition / line-block / local hard-break block - `::: …`
@@ -129,6 +129,29 @@ Both tokens can end up visible, so the distinction is *role*, not visibility:
 | Standalone block | `<p class="admonition-title">` heading line | `<p class="div-label">` caption (the graceful-degradation floor - authored text never vanishes) |
 | tabs / code-group active | stays **inside** the panel | moves **out** to the tab button; the fallback caption disappears |
 | details extension | becomes the `<summary>` | ignored (details has no group to name) |
+
+### The block quote has two spellings
+
+`> …` on every line, or a colon fence whose type token is a bare `>`:
+
+```
+::: >
+Notes from the meeting:
+
+- ship the parser
+- then the renderer
+:::
+```
+
+Same block, same tree, same HTML. The fence earns its place when the quote holds structure a marker would cost a line apiece - a list, a code block, a table, a nested quote - because lazy continuation folds only plain paragraph text into a quote, never new block structure.
+
+Three things follow from the two spellings being one node:
+
+- **`carve fmt` writes back whichever you used.** The node records the authored spelling, so formatting never converts one into the other.
+- **It nests at constant width.** A typed opener is never bare and only a bare equal-length line closes, so `::: >` inside `::: >` needs no widening. Re-quoting is therefore prepend the opener, append the closer, and nothing already inside changes.
+- **It takes the `^` caption on its CLOSING fence**, and a captioned quote is a `<figure>` either way.
+
+The separator is a space: `:::>` opens nothing and stays paragraph text, exactly as `:::|` and a glued backslash do.
 
 Rules of thumb: a standalone admonition wants quotes; a panel in a group wants brackets; use both to have a named tab whose panel also carries a visible heading (`::: tab "Install on Linux" [Linux]`). A title never feeds the tab name - if a tab has no `[label]`, the name falls back to the deprecated `{label="…"}` attribute or first inner heading, then to `Tab N`.
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -86,6 +86,13 @@ Bare delimiters work only at word boundaries; force one intraword with the brace
 +                             block to the quote - no > prefixing)
 - list now lives inside the quote
 
+::: >                        (the SAME block quote, fenced: no marker on
+notes:                        every line. `fmt` writes back whichever
+                              spelling you used. Nests at constant width,
+- a                           so re-quoting is prepend-and-append. Takes
+- b                           the ^ caption on its CLOSING fence.)
+:::
+
 ```language "Header" [Label]
 code block
 ```

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -902,6 +902,12 @@ as more than restyled Djot:
 - **Tables with rowspan / colspan / multi-line cells** and captions on images,
   quotes, and tables.
 - **Native admonitions**, editorial/critic markup, `@mentions`, and `#tags`.
+- **A fenced block quote** - `::: >` is the block quote written without a marker
+  on every line. Same node, same HTML, and `carve fmt` writes back whichever
+  spelling the author used. Djot has only the marker form; the proposal for a
+  fenced one is jgm/djot#401, still open there. It nests at CONSTANT width,
+  which Carve's exact-length closer allows and Djot's greedy one does not: in
+  Djot each wrap would need a fence one colon wider than the one it wraps.
 - **Inline footnotes** - `^[content]` carries a note in place (pandoc-style),
   numbered into the same endnotes as a reference `[^label]`. Canonical djot has
   only reference footnotes; `^[…]` is a carve addition (grammar §16).


### PR DESCRIPTION
Item 3 of markup-carve/carve#1718. The spelling shipped in the spec, the oracle and all three engines without appearing in any document a reader would look in, so there was no way to discover it.

## What changed

**`cheatsheet.md`** gains an entry beside the marker form.

**`blocks-and-attributes.md`** names both spellings in the block-element list, and gets a short section on why there are two and what follows from their being one node:

- `carve fmt` writes back whichever spelling the author used
- the fence nests at constant width, so re-quoting is prepend-and-append and nothing already inside changes
- the `^` caption hangs on the CLOSING fence, and a captioned quote is a `<figure>` either way

**`divergence-from-djot.md`** lists it under what Carve adds rather than what it breaks, since Djot has no equivalent, and names the upstream proposal (jgm/djot#401, still open) so a reader can follow it.

That last entry also records why the constant-width nesting does not carry to Djot. It rests on Carve's exact-length closer; Djot's closer is greedy, closing every open div of less-or-equal length, so a wrap there needs a fence one colon wider each time. Measured against djot.js 0.3.2 rather than inferred.

## Note

A `docs:build` writes three generated schemas into `docs/public/`, and only one of them is in `.gitignore`. So the other two show up as untracked and a `git add docs` sweeps them into a commit - which happened here and was backed out. Worth a follow-up to ignore all three; not fixed here to keep this docs-only.
