### PR TITLE
docs: document quote-fence-ends-the-quote-above, and move the carve-js pin

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -133,6 +133,7 @@ the command-line and editor behavior stay aligned.
 | `figure-group-empty` | a `::: figure` group with no captionable panel; the group figure holds only the preserved content (PART 9 §4c) |
 | `figure-group-single-panel` | a `::: figure` group holding a single panel; a plain captioned figure renders the same content without the group wrapper (PART 9 §4c) |
 | `unattached-block-attribute` | a floating `{...}` block attribute that never reaches a block, because the document or the container holding it ended first (PART 9 §15 A4). Nothing is emitted for it, so `> {.k}` on a quote's last line renders neither on the quote nor on anything after it |
+| `quote-fence-ends-the-quote-above` | a `::: >` opener at the column of the quote directly above it. It is a block opener, so it ends that quote and starts a sibling one, and the two render as adjacent blockquotes rather than the nesting the indentation suggests. Nothing is malformed and lint otherwise exits 0, which is why this container kind needs a rule of its own: write `> ::: >` to nest it, or leave a blank line to make two quotes deliberate |
 
 ### Declaring a target version
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#79d005f0521e2d985f1c3ea4e3005e0a23a77f93",
+        "@markup-carve/carve": "github:markup-carve/carve-js#10a1698e41b5da2100aab553bb6cbedc87449da9",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#79d005f0521e2d985f1c3ea4e3005e0a23a77f93",
-      "integrity": "sha512-qg0MYHDvh9xJDlx8Ld/JCk4gVoB1Wlxyl4ELjBzUCAGpCNX8m9L/2eO3zhF9pK7o5EY8qqxRVGVlCJ5QuT6Lhg==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#10a1698e41b5da2100aab553bb6cbedc87449da9",
+      "integrity": "sha512-zpJwd1JLAxTbn/0i192e2OjD8Z9zHlNwHrwhqw5yk09oaEJDE+hpMPzkYjl0pfE3CP7Ziabd6Mt6OOJu4HiI5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#79d005f0521e2d985f1c3ea4e3005e0a23a77f93",
+    "@markup-carve/carve": "github:markup-carve/carve-js#10a1698e41b5da2100aab553bb6cbedc87449da9",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-fmt-drift.txt
+++ b/resources/engine-fmt-drift.txt
@@ -14,4 +14,3 @@
 # engine-pin-drift.txt says the same thing for the same reason.
 #
 # Format: <slug><space><space><reason>
-419-a-definition-list-inside-a-footnote-body-carries-its-authored-base-2  the pin READS this correctly and writes it back with a different meaning (carve#1761): canonicalizing the definition opener from column 3 to the body minimum carries the quote from 6 to 5, and the quote then leaves the `dd`. carve#1752 requires the canonical form to preserve what the document says.

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -27,4 +27,3 @@
 422-a-recognized-opener-in-a-body-needs-no-blank-line-above-it-7  the pin does not read a payload written directly under a description line as the description's content (carve-js#1518): it makes the line paragraph text or a sibling of the `dl`, depending on its column. The oracle reads it as description content at any indent above zero.
 422-a-recognized-opener-in-a-body-needs-no-blank-line-above-it-8  same band as -7, inside a list item (carve-js#1518).
 422-a-recognized-opener-in-a-body-needs-no-blank-line-above-it-9  same band as -7, inside a footnote body (carve-js#1518).
-423-the-definition-and-footnote-base-rule-does-not-reach-a-list-item  the pin gives a definition list past a LIST ITEM's content column the authored base carve#1729 states for definition and footnote bodies alone (carve-js#1514), so the quote lands in the `dd` instead of the item. Fixed by carve-js#1520, which is merged and past this pin: delete this line in the commit that moves the pin.

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,6 +1,6 @@
 {
   "engine": "@markup-carve/carve",
-  "engineCommit": "7ada8844c84c0d501379d2bd0e34405873b9a7fc",
+  "engineCommit": "10a1698e41b5da2100aab553bb6cbedc87449da9",
   "corpusDocuments": 1443,
   "htmlImportPopulation": {
     "completed": 1442,
@@ -11,7 +11,7 @@
     ]
   },
   "renderImportRoundTrips": {
-    "html": 612,
+    "html": 613,
     "markdown": 376
   }
 }

--- a/tests/lint-rule-table-claims.test.mjs
+++ b/tests/lint-rule-table-claims.test.mjs
@@ -104,6 +104,7 @@ const TRIGGERS = {
   'semantic-attribute-value-ignored': '[x]{kbd="https://example.org/dune"}\n',
   'semantic-attribute-outside-span': '`c`{kbd}\n',
   'braced-comment-in-a-template-source': '{% if user %}\n',
+  'quote-fence-ends-the-quote-above': '> a\n::: >\nb\n:::\n',
 }
 
 /*


### PR DESCRIPTION
Closes #1765, and does the first half of #1771.

`quote-fence-ends-the-quote-above` ships in carve-js (markup-carve/carve-js#1510)
and carve-php (markup-carve/carve-php#1761), and the page did not list it. The
page itself says a rule id is spec surface; an id nobody can look up is the same
broken contract one step earlier.

Trigger, which is also the trigger-map entry:

```
> a
::: >
b
:::
```

## Why the pin moves in the same commit

`tests/lint-rule-table-claims.test.mjs` measures the page against the pinned
build in both directions, so the row could not land on its own: the pin was five
commits short of the rule and the row would have failed as a promise with no
producer. #1765 says as much, so the pin moves here, `79d005f0` to `10a1698e`.

That is also the first half of #1771. The gates render through this pin, so
"did the engine render the corpus correctly" was being answered about a build
that predated last night's carve-js regression. The staleness gate that ticket
asks for is deliberately not here - it needs the decision the ticket describes.

The bump is green: full suite, `core:check`, `escape:check` and the import
contract all pass against `10a1698e`, with no corpus golden touched.

## The id was checked, not assumed

Read out of each engine rather than copied from the ticket:

| engine | id | where |
| --- | --- | --- |
| carve-js | `quote-fence-ends-the-quote-above` | `src/lint.ts`, merged |
| carve-php | `quote-fence-ends-the-quote-above` | `src/Lint/QuoteFenceLinter.php`, merged |
| carve-rs | `quote-fence-ends-the-quote-above` | `src/lint.rs` on markup-carve/carve-rs#1416, still open |

Byte-identical in all three, and so is the message text. carve-rs has not merged
its side, so that engine is inside the usual window rather than spelling anything
differently. Nothing to file.

## What the bump retires

Two declarations, each in the direction its own file asks for:

- `resources/engine-fmt-drift.txt` loses its `419-...-2` line: the build now
  writes that document back with the meaning it read
  (markup-carve/carve-js#1520).
- `resources/engine-pin-drift.txt` loses its `423-...` line, which was added in
  #1769 with the instruction to delete it in the commit that moves the pin.

`423` is also the whole of the one import count that moves. Render/import HTML
round trips go 612 to 613, and a set diff of that population over both builds
names `423` as the entire difference; every other count is unchanged. The
baseline's `engineCommit` now names the build its numbers were measured against,
which it did not before.

Both directions of the rule-table check were mutated to confirm they fire:
dropping the row fails "every rule the engine emits is on the page", and putting a
blank line into the trigger document fails "every trigger provokes the rule it
names".
