### PR TITLE
docs: correct colon fence lookahead guidance

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -33,8 +33,8 @@ turning your content into a JavaScript program.
 | Feature completeness/consistency | ❌ | ❌ | ❌ | ✅ |
 
 \* Inline parsing is single-pass with a delimiter stack; at the block level a
-fence / `:::` opener uses a bounded forward scan for a matching closer
-(closer lookahead, not backtracking) - see
+code or raw fence uses a bounded forward scan for a matching closer. A `:::`
+container opens without that lookahead and may close at end of input. See
 [Technical Rationale](/technical-rationale).
 \*\* Like Markdown for quotes, headings, tables and closed fences; list markers
 (both bullet and ordered) deliberately never interrupt a paragraph - a list

--- a/docs/parsing-ambiguities.md
+++ b/docs/parsing-ambiguities.md
@@ -516,9 +516,11 @@ of this matches Djot; the heading half deliberately does not.
 
 **Other carve-outs:**
 
-1. **Closer lookahead** — a fence (`` ``` ``/`~~~`) or `:::` interrupts only
+1. **Closer lookahead** — a code or raw fence (`` ``` ``/`~~~`) interrupts only
    when a matching closer exists ahead. An unterminated opener stays paragraph
-   text, so a stray marker never swallows the rest of the block.
+   text, so a stray marker never swallows the rest of the block. A `:::` opener
+   is different: it opens without a closer and closes at its container boundary
+   or end of input (§12).
 2. **Image excluded** — a bare image `![alt](url)` is inline content, not a
    block, so it renders inside the paragraph.
 

--- a/docs/technical-rationale.md
+++ b/docs/technical-rationale.md
@@ -134,15 +134,21 @@ This matters because block structure is decided before inline parsing starts.
 You do not need an inline parser guessing whether a later line will turn the
 current line into some different block type.
 
-### One bounded exception: fence/`:::` closer lookahead
+### One bounded exception: code/raw fence closer lookahead
 
 There is a single, deliberate departure from "decided from the line beginning
 alone". Under the paragraph-interruption rule (`resources/grammar.ebnf` PART 9
-§10), a fenced-code or `:::` opener interrupts an open paragraph **only when a
-matching closer exists ahead** in the same context; an unterminated opener stays
-paragraph text instead of swallowing the rest of the block. Deciding that needs
-a forward scan over later lines — so for fences and divs, a *later* line does
-co-determine whether the current line is a block opener or prose.
+§10), a code or raw fence interrupts an open paragraph **only when a matching
+closer exists ahead** in the same context; an unterminated opener stays paragraph
+text instead of swallowing the rest of the block. Deciding that needs a forward
+scan over later lines, so for verbatim fences a *later* line co-determines whether
+the current line is a block opener or prose.
+
+A colon-fence opener is not guarded by closer lookahead. It interrupts whether
+or not a closer follows, and an unclosed container closes at its container
+boundary or end of input (PART 9 §12). The separate lazy-folding rule can still
+make a below-content-column marker line paragraph text inside a list item; that
+is a column-ownership decision, not a missing-closer rule.
 
 This is a conscious trade, not an oversight:
 
@@ -150,14 +156,14 @@ This is a conscious trade, not an oversight:
   parses the paragraph and then rewinds to reparse it under a new interpretation.
 - It stays **linear-time** because the block pre-pass already walks every line
   once; "does a matching closer follow?" is memoized during that single walk
-  rather than rescanned per opener. Without that memo a naive implementation is
-  O(n²), so the pre-scan is the load-bearing detail.
+  rather than rescanned per verbatim opener. Without that memo a naive
+  implementation is O(n²), so the pre-scan is the load-bearing detail.
 - It is **not** the "bounded local lookahead" the inline layer uses; it is a
   bounded *block-level* forward scan, bounded by the enclosing container.
 
 The payoff is a usability guarantee neither CommonMark nor Djot give: a stray
-` ``` ` or `:::` inside prose can never eat the remainder of the document. Carve
-accepts the narrower parser contract to buy that. Everything else in block
+` ``` ` inside prose cannot turn the remainder into a code block. Carve accepts
+the narrower parser contract to buy that. Everything else in block
 structure — headings, quotes, bullet lists, thematic breaks, table rows — is
 still decided from the line beginning alone, with no lookahead.
 

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -1599,9 +1599,11 @@ paragraph with no blank line before it, at the top level and inside nested
 content. Three carve-outs keep common prose safe: **list markers never
 interrupt** — neither a bullet (`- `/`* `) nor an ordered marker, in any dialect
 or value, so a list always needs a blank line before it (symmetric, Djot-like);
-a fence or `:::` interrupts only when it has a matching closer ahead; and a bare
-image is never a block. Invisible constructs (reference definitions, comments,
-block-attribute lines) interrupt as they always have.
+a code or raw fence interrupts only when it has a matching closer ahead; and a
+bare image is never a block. A `:::` opener interrupts with or without a closer
+and closes at its container boundary or end of input. Invisible constructs
+(reference definitions, comments, block-attribute lines) interrupt as they
+always have.
 
 A heading marker after a prose line interrupts.
 
@@ -1812,9 +1814,10 @@ text
 
 :::
 
-**Carve-out — closer lookahead.** A `:::` block (or a fence) with no matching
-closer ahead does not interrupt; it stays paragraph text, so a stray marker
-never swallows the rest of the block.
+**Invalid glued colon fence.** A type word requires a separating space.
+`:::note` is therefore paragraph text, independently of whether a closer
+follows. A valid `::: note` or bare `:::` opens immediately and may close at
+the container boundary or end of input.
 
 :::: compare
 


### PR DESCRIPTION
## What changed

- limit closer-lookahead guidance to code and raw fences
- state consistently that a valid `:::` opener opens without a closer and closes at its container boundary or end of input
- distinguish the list-item lazy-folding exception from missing-closer behavior
- relabel the existing `:::note` example as an invalid glued type token instead of evidence for closer lookahead

## Why

PART 9 sections 10 and 12, the formal matching-fence clause, and corpus 414 agree that colon containers do not require a closer. Four documentation locations still described the retired rule that grouped `:::` with code and raw fences.

That stale explanation also obscured an important separate rule: a marker below an active list item's content column can fold as paragraph text. This is decided by column ownership and open-paragraph state, not by whether a colon closer exists.

## User value

Authors can now predict whether an unclosed colon container opens, and implementers are no longer directed to add the wrong forward scan. The corrected explanation also makes the narrow list-item exception explicit instead of making the general container rule appear inconsistent.

## Verification

- regenerated the corpus with `npm run corpus:build`; fixture output did not change
- built the documentation with `npm run docs:build`
- ran `tests/portable-whitespace.test.mjs`, `tests/corpus.test.mjs`, `tests/examples.test.mjs`, and `tests/doc-carve-samples.test.mjs`: 1,551 passed
- `git diff --check`

No changelog entry is included.
