### PR TITLE
docs: mark the retired category 413 title

### DIFF
--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -27405,6 +27405,13 @@ construct renders as the text the author typed.
 :::
 ## An item's attribute block moves its content column; its checkbox does not
 
+::: warning Historical category label
+The heading is retained as the append-only corpus ID. The rule it originally
+named was reversed before release: marker-attached attributes and task
+checkboxes both contribute zero to the content column. The current rule and
+fixtures below are authoritative.
+:::
+
 `90-list-item-attributes-4` is the only document that puts attributes on a task
 item, and it is a single line, so it has no continuation and cannot say where
 the item's content begins. `06-task-lists` and


### PR DESCRIPTION
## What changed

Add an explicit historical-label notice below category 413's retained heading.

The notice states the current rule directly: marker-attached attributes and task checkboxes both contribute zero to a list item's content column.

## Why

Category 413 was introduced while the specification briefly said marker attributes widened the content column. The rule was reversed before release, and the category's fixtures and explanatory text were updated, but its heading still states the retired rule.

The heading also defines an append-only corpus ID that every engine allowlists. Renaming it would invalidate those downstream lists and create a large fixture rename with no semantic value. Keeping the stable ID and marking it as historical resolves the reader-facing contradiction without destabilizing the conformance contract.

## User value

Readers no longer mistake a historical corpus identifier for current syntax. The page now makes clear that changing an item's class, ID, or other marker metadata never requires reindenting its body.

## Verification

- `npm run corpus:build`: all 1,450 corpus pairs regenerated with no fixture changes
- `npm run docs:pages`: all generated documentation pages completed
- `tests/corpus.test.mjs`: 1,452 passed
- `git diff --check`

No changelog entry is included.
