### PR TITLE
docs: move definition continuations to the canonical content column

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -640,7 +640,7 @@ Output:
 ```
 :: Term
 : This definition continues \
-   on the next line.
+  on the next line.
 : Second definition.
 ```
 
@@ -648,8 +648,8 @@ Or with indentation:
 ```
 :: Term
 : This definition has
-   multiple lines through
-   indentation continuation.
+  multiple lines through
+  indentation continuation.
 ```
 
 **Rules:**

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -950,7 +950,7 @@ Most Djot source needs only mechanical changes:
    of prose now starts a block. Where you relied on Djot keeping it in the
    paragraph, add a blank line or escape the marker.
 7. Definition lists: rewrite `: term` (+ indented body) as `:: term` then
-   `:  definition`. A multi-paragraph Djot `<dd>` carries over - a Carve
+   `: definition`. A multi-paragraph Djot `<dd>` carries over - a Carve
    definition continues like a list item (indent a block after a blank line, or
    use a lone `+`; see section 9).
 8. **Attribute blocks that Djot accepted and Carve does not.** A class or id

--- a/docs/native-features-analysis.md
+++ b/docs/native-features-analysis.md
@@ -34,7 +34,7 @@ A feature should remain an **extension** if:
 | Admonitions | `::: note`, `::: warning` | ✅ In spec (4.12) |
 | Frontmatter | `---` YAML block | ✅ In spec (4.23) |
 | Footnotes | `[^ref]` | ✅ In spec (4.11) |
-| Definition lists | `:: term` / `:  definition` | ✅ In spec (4.5) |
+| Definition lists | `:: term` / `: definition` | ✅ In spec (4.5) |
 | Task lists | `- [ ]`, `- [x]` | ✅ In spec (4.5) |
 | Profiles | Feature restriction | ✅ In spec (4.21) |
 | Attributes | `{#id .class key=value}` | ✅ In spec (4.10) |


### PR DESCRIPTION
#1776 converted the separator and the merge from main took main's copy of two files back, so three spots landed on `main` still carrying the old form.

**The case study's two continuation runs.** The content column follows the separator, so a one-space `: ` puts the body at column 2:

```
:: Term
: This definition has
  multiple lines through
  indentation continuation.
```

carve-js `40327a90` normalizes 3 spaces to 2 for both the indentation and the backslash continuation, and corpus `279-a-boundary-line-inside-an-open-fence-does-not-end-the-container-3.fmt` pins the same column for a block in the body. The column is load-bearing rather than cosmetic - under `:  ` (column 3) a block at 2 spaces falls out of the definition entirely.

The **term** example above them stays at three spaces: `:: ` is a three-character marker, so column 3 is its content column, and the writer keeps it there.

**Two prose spots naming the marker**, each with no sample beside it to stay consistent with: the feature table in `docs/native-features-analysis.md` (a page #1776 did not touch), and the Djot migration step in `docs/divergence-from-djot.md` telling a reader what to rewrite a definition list as.

Not swept, deliberately: the prose in `resources/examples/` and the marker spellings in `resources/grammar.ebnf`. Each of those sits beside a two-space sample it describes, contrasts the two widths on purpose (`: x` is column 2, `:  x` is column 3), or records the exact input of a past ruling.

`npm test` 3110 pass / 0 fail; `npm run html-import:check` 7/0.
