### PR TITLE
spec: a list item is a container the innermost-base rule reaches too

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1474 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1475 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -28621,6 +28621,43 @@ block's base, so the quote at the definition's content column remains in the
 
 :::
 
+Nor is the innermost owner a definition body in particular. A LIST ITEM opened at
+a footnote body's own column owns the lines below it the same way, so a quote
+written at that item's content column stays in the item rather than being rebased
+to the body's column and lifted out of it.
+
+::: compare
+
+```carve
+[^n]: intro
+
+  - item
+
+    > quote
+
+see[^n]
+```
+
+```html
+<p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a></p>
+<section role="doc-endnotes" aria-label="Footnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>intro</p>
+      <ul>
+        <li>item
+          <blockquote><p>quote</p></blockquote>
+        </li>
+      </ul>
+      <p><a href="#fnref1" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+:::
+
 ## A definition body's separator width sets its content column
 
 The separator after `:` is a run of one or more spaces, and the body's content

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,11 +1,11 @@
 {
   "engine": "@markup-carve/carve",
   "engineCommit": "40327a90276d999dd5fc3702f79546c59540b59c",
-  "corpusDocuments": 1474,
+  "corpusDocuments": 1475,
   "htmlImportPopulation": {
-    "completed": 1473,
-    "canonicalFixedPoints": 1472,
-    "renderedTextPreserved": 1458,
+    "completed": 1474,
+    "canonicalFixedPoints": 1473,
+    "renderedTextPreserved": 1459,
     "expectedRejections": [
       "182-openers-past-the-nesting-cap-are-one-paragraph.crv"
     ]

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -1486,7 +1486,17 @@ export function normalizeAuthoredBodyBases(lines, state = {}) {
     const line = lines[index]
     const measured = indentCols(line)
     const establishesBase = measured.col > 0 && opensAuthoredBase(measured.rest)
-    const protectsInnermostContainer = measured.col === 0 && opensSubBlock(measured.rest)
+    // A LIST ITEM IS A CONTAINER TOO (carve#1781). `opensSubBlock` answers a
+    // different question - whether a blank-separated sub-block leaves a list
+    // TIGHT - and a list marker is deliberately absent from it there, because a
+    // marker at a body's own column opens a SUBLIST rather than a sub-block.
+    // Here the question is whose content the lines below belong to, and the
+    // answer for a marker is the item it opens. Without this a quote written at
+    // a nested item's content column was rebased to the outer body's column and
+    // lifted out of the item it was written into, which is the same defect this
+    // clause fixed one container kind over.
+    const protectsInnermostContainer = measured.col === 0 &&
+      (opensSubBlock(measured.rest) || matchMarkerAt(measured) !== null)
     if (!establishesBase && !protectsInnermostContainer) {
       out.push(line)
       continue

--- a/tests/corpus/423-one-authored-base-rule-reaches-a-definition-nested-in-a-list-item-2.crv
+++ b/tests/corpus/423-one-authored-base-rule-reaches-a-definition-nested-in-a-list-item-2.crv
@@ -1,0 +1,7 @@
+[^n]: intro
+
+  - item
+
+    > quote
+
+see[^n]

--- a/tests/corpus/423-one-authored-base-rule-reaches-a-definition-nested-in-a-list-item-2.html
+++ b/tests/corpus/423-one-authored-base-rule-reaches-a-definition-nested-in-a-list-item-2.html
@@ -1,35 +1,3 @@
-One authored base rule reaches a definition nested in a list item
-
-```
-- intro
-
-   :: term
-   :  definition
-
-      > quote
-.
-<ul>
-  <li>intro
-    <dl>
-      <dt>term</dt>
-      <dd>
-        <p>definition</p>
-        <blockquote><p>quote</p></blockquote>
-      </dd>
-    </dl>
-  </li>
-</ul>
-```
-
-```
-[^n]: intro
-
-  - item
-
-    > quote
-
-see[^n]
-.
 <p>see<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a></p>
 <section role="doc-endnotes" aria-label="Footnotes">
   <hr>
@@ -45,4 +13,3 @@ see[^n]
     </li>
   </ol>
 </section>
-```


### PR DESCRIPTION
Follow-up to #1788 (markup-carve/carve#1781).

## Do the spellings differ behaviorally?

**Yes, and one container kind was still left out after the unification.**

`THE BASE BELONGS TO THE INNERMOST OPEN CONTAINER` is applied in
`normalizeAuthoredBodyBases` through `protectsInnermostContainer`, which asks
`opensSubBlock`. A list marker is not in `opensSubBlock`, so a body still took a
fresh base at a quote written at a nested LIST ITEM's content column and lifted
it out of the item:

```
[^n]: intro

  - item

    > quote

see[^n]
```

on `main` (`70e794b0`):

```html
      <p>intro</p>
      <ul>
        <li>item</li>
      </ul>
      <blockquote><p>quote</p></blockquote>
```

with this change:

```html
      <p>intro</p>
      <ul>
        <li>item
          <blockquote><p>quote</p></blockquote>
        </li>
      </ul>
```

## Why the term was missing

`opensSubBlock` answers a different question - whether a blank-separated
sub-block leaves a list TIGHT - and a list marker is deliberately absent from it
*there*, because a marker at a body's own column opens a SUBLIST rather than a
sub-block. The question in this pass is whose content the lines below belong to,
and for a marker the answer is the item it opens.

## Goldens

None moved. The corpus had no document at this shape, which is why the gap
survived the unification: the pass was measured against definition descriptions,
and a nested list item is the same clause with a different opener.
`423-...-nested-in-a-list-item-2` pins it, and it discriminates - reverting
`scripts/spec/layout.mjs` fails that one document and nothing else.

## Ledger

**No row added or retired.** carve-js, carve-php and carve-rs all keep the quote
inside the item on this document already - measured on each engine's `main`
(`4664e64`, `4e8193e`, `c755d97`). The oracle was the sole outlier, so
`engine:report --check` still reports the same five declared rows.
