### PR TITLE
chore: declare the canonical-form writer's ahead-of-pin constant

### DIFF
--- a/scripts/declaration-audit.mjs
+++ b/scripts/declaration-audit.mjs
@@ -211,6 +211,7 @@ const MANIFEST = [
   // -- carve-rs --------------------------------------------------------------
   { repo: 'carve-rs', path: 'tests/corpus.rs', name: 'KNOWN_GAPS', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/corpus.rs' },
   { repo: 'carve-rs', path: 'tests/corpus.rs', name: 'AHEAD_OF_PIN', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/corpus.rs' },
+  { repo: 'carve-rs', path: 'tests/corpus_canonical_form.rs', name: 'AHEAD_OF_PIN', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/corpus_canonical_form.rs' },
   { repo: 'carve-rs', path: 'tests/optional_corpus.rs', name: 'DECLARED_UNIMPLEMENTED', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/optional_corpus.rs' },
   { repo: 'carve-rs', path: 'tests/optional_corpus.rs', name: 'AHEAD_OF_PIN', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/optional_corpus.rs' },
   { repo: 'carve-rs', path: 'tests/html_import.rs', name: 'BEHIND_THE_RULING', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'mirrors spec PIN_LAG' },


### PR DESCRIPTION
`tests/corpus_canonical_form.rs` grew an `AHEAD_OF_PIN` constant in markup-carve/carve-rs#1427, and the manifest never named it. The audit reported it under UNDECLARED, which is the one state where an obligation is invisible: nothing checks the rows, and nothing retires them when the pin catches up.

It takes the same policy and guard as `tests/corpus.rs::AHEAD_OF_PIN`, which it mirrors deliberately - the render side has recorded the value since it was written, and this is that shape on the writer side. It is already two-directional: it fails when the declared-ahead form does not match, and again when the actual output equals the expected form, which is the pin having caught up.

## This does not reduce the finding count

Measured before and after on `6dac47e2`, both `DECLARATION AUDIT FAILED - 4 finding(s)`:

| | before | after |
| --- | --- | --- |
| UNDECLARED | 1 | 0 |
| owed ledgers | 3 | 4 |

It moves four rows out of UNDECLARED and into a declared owed ledger, so the audit reports the same total with an honest composition. Those rows retire when the carve-rs spec pin moves past the one-space definition separator, alongside the other ahead-of-pin declarations.
