### PR TITLE
chore: move the carve-js pin past both authored-base rulings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#40327a90276d999dd5fc3702f79546c59540b59c",
+        "@markup-carve/carve": "github:markup-carve/carve-js#77792ef351613cb108cf85e481a81019f822fff5",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#40327a90276d999dd5fc3702f79546c59540b59c",
-      "integrity": "sha512-A+Pb+O84oRo41rGKl+GGTlM/bb9hiwIIzc+CQTr2XT20Xr0uyUdLhvoHs2To3blyDwK4uO5HGbyF5m62xjGD+Q==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#77792ef351613cb108cf85e481a81019f822fff5",
+      "integrity": "sha512-ECYZjD3lw2T3Cq/vzbjUx7cy7H4i5eRBg1Gw8RPaxP+x3P8U36R3cfgSdRxst59Pw6Qt9DaU060rZp1DOSggBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#40327a90276d999dd5fc3702f79546c59540b59c",
+    "@markup-carve/carve": "github:markup-carve/carve-js#77792ef351613cb108cf85e481a81019f822fff5",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
     "@mermaid-lint/cli": "^0.53.1",

--- a/resources/engine-pin-drift.txt
+++ b/resources/engine-pin-drift.txt
@@ -24,8 +24,3 @@
 # Emptying this file is the normal end state after `npm run bump-carve-pin`.
 #
 # Format: <slug><space><space><reason>
-427-the-continuation-marker-attaches-one-block-in-every-container-4  the pin still lets a quote line after a `+` inside a block quote continue the outer quote instead of attaching as a nested one, so the marker attaches nothing there (carve#1782). The oracle attaches it, like every other kind of block.
-419-a-definition-list-inside-a-footnote-body-carries-its-authored-base  carve#1781 assigns the quote to the innermost definition body
-419-a-definition-list-inside-a-footnote-body-carries-its-authored-base-3  carve#1781 keeps the surviving footnote quote structural
-422-a-recognized-opener-in-a-body-needs-no-blank-line-above-it-9  carve#1781 keeps the surviving footnote quote structural
-423-one-authored-base-rule-reaches-a-definition-nested-in-a-list-item  carve#1781 assigns the quote to the innermost definition body

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,6 +1,6 @@
 {
   "engine": "@markup-carve/carve",
-  "engineCommit": "40327a90276d999dd5fc3702f79546c59540b59c",
+  "engineCommit": "77792ef351613cb108cf85e481a81019f822fff5",
   "corpusDocuments": 1475,
   "htmlImportPopulation": {
     "completed": 1474,
@@ -11,7 +11,7 @@
     ]
   },
   "renderImportRoundTrips": {
-    "html": 638,
+    "html": 639,
     "markdown": 386
   }
 }


### PR DESCRIPTION
## What moves

`package.json` pins the `markup-carve/carve` dependency at carve-js `40327a9`, five commits behind carve-js `main`. This moves it to `77792ef` and refreshes the lockfile with `npm install`, so manifest and lock name the same commit.

## Why the drift file empties

Every row in `resources/engine-pin-drift.txt` described the pinned build rather than the engine. markup-carve/carve-js#1534 implemented the innermost-base ruling from #1781 and markup-carve/carve-js#1533 the continuation-marker ruling from #1782; both are ancestors of carve-js `main`. So all five rows were true of the pin and false of the engine, and moving the pin is what retires them:

```
427-the-continuation-marker-attaches-one-block-in-every-container-4
419-a-definition-list-inside-a-footnote-body-carries-its-authored-base
419-a-definition-list-inside-a-footnote-body-carries-its-authored-base-3
422-a-recognized-opener-in-a-body-needs-no-blank-line-above-it-9
423-one-authored-base-rule-reaches-a-definition-nested-in-a-list-item
```

`npm run engine:report -- --check` reports all five STALE against the new pin, then goes green once they are gone: 1475 corpus pairs, 1475 reproduced, 0 mismatched, 0 threw, 0 declared drift. Emptying the file is the end state its own header describes after a bump.

## The one other thing the bump surfaced

`resources/import-roundtrip-baseline.json` is a ratchet, and one of its counts moved. It moved **upward**, and its comment asks for the baseline to be bumped with the pin after inspecting every changed count - so that is done here rather than deferred.

Enumerating the round-tripping set under both pins isolates the change to a single document, gained, none lost:

```
old count 638  new count 639
GAINED: 427-the-continuation-marker-attaches-one-block-in-every-container-4.crv
LOST  : (none)
```

That is the same #1782 ruling seen from the import side: now that the marker attaches the block, the document's rendered HTML imports back to its canonical source. The corpus did not grow (1475 either way), so no other count moved, and `expectedRejections` is unchanged. `engineCommit` moves with the pin it records.

No new declaration was added anywhere. A row here would have been the opposite of the point.

## Gate results

`node scripts/declaration-audit.mjs` goes from **1 finding** to **0**:

```
DECLARATION AUDIT PASSED - every owed list is empty and every guard is two-directional.
```

The CI gates run clean locally: corpus build leaves `tests/corpus` and `tests/spec` unchanged, `npm test` is 3136 tests with 0 failures, and `html-import:check`, `escape:check`, `core:check` and `engine:report -- --check` all exit 0.

Making pin staleness *detectable* is #1771 and is deliberately not in scope here - that gate wires in after the audit is green, which is what this PR is for. No version change and no changelog entry; the pin move is prepare-only.
