### PR TITLE
docs: the Unreleased section reaches the last merge before the cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   belongs to the innermost container the opener reaches, so a nested body's
   opener is never a fresh sibling base. This unifies the definition- and
   footnote-body statements of carve#1729.
+- **A list item is a container the innermost-base rule reaches too**
+  (carve#1791, PART 9 §24 C3). An opener written at a nested list item's
+  content column is that item's block. A marker hands out a column even though
+  it opens no sub-block, so ownership does not follow the sub-block predicate.
 - **An unclosed container closes with its host, not at end of input**
   (carve#1778, PART 9 §12). End of input is the top-level case, not the rule.
 - **An ordered item's separator width sets its content column** (carve#1773).


### PR DESCRIPTION
The `[Unreleased]` section was backfilled in #1790 at 02:29Z, and work merged
on top of it afterwards. This carries the section to the last merge before the
release cut.

Three PRs merged since the backfill. One earns an entry:

- **#1791**, a normative ruling: a list item is a container PART 9 §24 C3
  reaches, so an opener at a nested item's content column is that item's block.
  Filed under Changed, beside the carve#1781 bullet it extends.

Two do not, on the rule that an entry describes something a consumer could
notice:

- **#1793** declares an ahead-of-pin constant for the canonical-form writer.
  Declaration bookkeeping; the audit's finding count is unchanged.
- **#1795** moves the carve-js pin past the two authored-base rulings and
  empties the drift file. Pin bookkeeping.

No version field is touched.
