### PR TITLE
ci: make engine pins and hidden declarations fail visibly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  declarations:
+    name: declarations and engine pin are current
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out carve
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check out carve-js
+        uses: actions/checkout@v6
+        with:
+          repository: markup-carve/carve-js
+          path: engines/carve-js
+          fetch-depth: 0
+
+      - name: Check out carve-php
+        uses: actions/checkout@v6
+        with:
+          repository: markup-carve/carve-php
+          path: engines/carve-php
+          fetch-depth: 0
+
+      - name: Check out carve-rs
+        uses: actions/checkout@v6
+        with:
+          repository: markup-carve/carve-rs
+          path: engines/carve-rs
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Every declaration is visible and the reference build is current
+        env:
+          CARVE_JS_DIR: ${{ github.workspace }}/engines/carve-js
+          CARVE_PHP_DIR: ${{ github.workspace }}/engines/carve-php
+          CARVE_RS_DIR: ${{ github.workspace }}/engines/carve-rs
+        run: npm run declarations:check -- --no-fetch
+
   conformance:
     name: spec-corpus conformance
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#77792ef351613cb108cf85e481a81019f822fff5",
+        "@markup-carve/carve": "github:markup-carve/carve-js#f4c17da71bcbd78a128e4167bbff4627bc20910d",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,7 +986,7 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#77792ef351613cb108cf85e481a81019f822fff5",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#f4c17da71bcbd78a128e4167bbff4627bc20910d",
       "integrity": "sha512-ECYZjD3lw2T3Cq/vzbjUx7cy7H4i5eRBg1Gw8RPaxP+x3P8U36R3cfgSdRxst59Pw6Qt9DaU060rZp1DOSggBQ==",
       "dev": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#77792ef351613cb108cf85e481a81019f822fff5",
+    "@markup-carve/carve": "github:markup-carve/carve-js#f4c17da71bcbd78a128e4167bbff4627bc20910d",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
     "@mermaid-lint/cli": "^0.53.1",

--- a/scripts/declaration-audit.mjs
+++ b/scripts/declaration-audit.mjs
@@ -183,6 +183,8 @@ const MANIFEST = [
 
   // -- carve-js --------------------------------------------------------------
   { repo: 'carve-js', path: 'test/corpus.test.ts', name: 'AHEAD_OF_PIN', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'test/corpus.test.ts' },
+  { repo: 'carve-js', path: 'test/canonical-ahead-of-pin.ts', name: 'CANONICAL_AHEAD_OF_PIN', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'test/corpus-canonical-form.test.ts and test/corpus-render-fixtures.test.ts' },
+  { repo: 'carve-js', path: 'test/ast-vocabulary.test.ts', name: 'PENDING_SPEC_DECISION', kind: 'js', policy: 'owed', guard: 'two-way', staleness: 'is pending only on types that still exist and still need a decision', owner: 'test/ast-vocabulary.test.ts' },
   { repo: 'carve-js', path: 'test/optional-corpus.test.ts', name: 'AHEAD_OF_PIN', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'test/optional-corpus.test.ts' },
   { repo: 'carve-js', path: 'test/optional-corpus.test.ts', name: 'DECLARED_UNIMPLEMENTED', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'test/optional-corpus.test.ts' },
   { repo: 'carve-js', path: 'test/html-import-conformance.test.ts', name: 'AHEAD_OF_PIN', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'mirrors spec PIN_LAG' },
@@ -212,6 +214,7 @@ const MANIFEST = [
   { repo: 'carve-rs', path: 'tests/corpus.rs', name: 'KNOWN_GAPS', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/corpus.rs' },
   { repo: 'carve-rs', path: 'tests/corpus.rs', name: 'AHEAD_OF_PIN', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/corpus.rs' },
   { repo: 'carve-rs', path: 'tests/corpus_canonical_form.rs', name: 'AHEAD_OF_PIN', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/corpus_canonical_form.rs' },
+  { repo: 'carve-rs', path: 'tests/corpus_render_fixtures.rs', name: 'FMT_AHEAD_OF_PIN', kind: 'rust', policy: 'owed', guard: 'two-way', staleness: 'the pin has caught up; delete its FMT_AHEAD_OF_PIN entry', owner: 'tests/corpus_render_fixtures.rs' },
   { repo: 'carve-rs', path: 'tests/optional_corpus.rs', name: 'DECLARED_UNIMPLEMENTED', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/optional_corpus.rs' },
   { repo: 'carve-rs', path: 'tests/optional_corpus.rs', name: 'AHEAD_OF_PIN', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/optional_corpus.rs' },
   { repo: 'carve-rs', path: 'tests/html_import.rs', name: 'BEHIND_THE_RULING', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'mirrors spec PIN_LAG' },
@@ -226,7 +229,49 @@ const MANIFEST = [
  * does not know about. Deliberately narrow: a list that silences a comparison
  * is named for what it excuses, and these are the shapes this org uses.
  */
-const DECLARATION_NAME = /^(PIN_LAG|AHEAD_OF_PIN|BEHIND_THE_RULING|UNMET|LAST_MEASURED|DECLARED_[A-Z_]+|KNOWN_[A-Z_]+|[A-Z_]*_(GAPS|DIVERGENCES|WAIVERS|LOSSES|PENDING|REMAINING|OVER_REACH|UNIMPLEMENTED))$/
+const DECLARATION_NAME = /(?:^|_)(?:PIN_LAG|AHEAD_OF_PIN|BEHIND_THE_RULING|UNMET|LAST_MEASURED|DECLARED_[A-Z_]+|KNOWN_[A-Z_]+|[A-Z_]*?(?:GAPS|DIVERGENCES|WAIVERS|LOSSES|PENDING|REMAINING|OVER_REACH|UNIMPLEMENTED))(?:_|$)/
+const isDeclarationName = (name) => DECLARATION_NAME.test(name)
+
+/** Classify `git rev-list --left-right --count PIN...MAIN`. */
+function classifyPinDistance(pinOnly, mainOnly) {
+  if (!Number.isSafeInteger(pinOnly) || pinOnly < 0 || !Number.isSafeInteger(mainOnly) || mainOnly < 0) {
+    return 'unverifiable'
+  }
+  if (pinOnly === 0 && mainOnly === 0) return 'current'
+  if (pinOnly === 0) return 'behind'
+  if (mainOnly === 0) return 'ahead'
+  return 'diverged'
+}
+
+function pinnedCarveJsSha() {
+  try {
+    const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'))
+    const value = pkg.devDependencies?.['@markup-carve/carve']
+    const match = typeof value === 'string' && value.match(/#([0-9a-f]{40})$/i)
+    return match ? match[1].toLowerCase() : new Error('package.json does not pin @markup-carve/carve to an exact 40-character SHA')
+  } catch (error) {
+    return new Error(`cannot read the carve-js pin: ${error.message}`)
+  }
+}
+
+function gitPinStatus(dir, pin, mainRef = 'origin/main') {
+  try {
+    execFileSync('git', ['-C', dir, 'cat-file', '-e', `${pin}^{commit}`], { stdio: 'ignore' })
+    const main = execFileSync('git', ['-C', dir, 'rev-parse', '--verify', `${mainRef}^{commit}`], { encoding: 'utf8' }).trim()
+    const counts = execFileSync('git', ['-C', dir, 'rev-list', '--left-right', '--count', `${pin}...${main}`], { encoding: 'utf8' })
+      .trim()
+      .split(/\s+/)
+      .map(Number)
+    return { pin, main, pinOnly: counts[0], mainOnly: counts[1], relation: classifyPinDistance(counts[0], counts[1]) }
+  } catch (error) {
+    return new Error(`cannot compare pin ${pin} with carve-js ${mainRef}: ${error.message}`)
+  }
+}
+
+function carveJsPinStatus(dir, mainRef = 'origin/main') {
+  const pin = pinnedCarveJsSha()
+  return pin instanceof Error ? pin : gitPinStatus(dir, pin, mainRef)
+}
 
 /** Test trees to sweep, per repo. */
 const TEST_DIRS = {
@@ -500,7 +545,7 @@ function listFiles(repo, dir) {
 
 /* ------------------------------------------------------------------- main */
 
-export const __internals = { blankComments, declarationIndex, bracketedBlock, topLevelEntries, liveRows, MANIFEST }
+export const __internals = { blankComments, declarationIndex, bracketedBlock, topLevelEntries, liveRows, classifyPinDistance, gitPinStatus, isDeclarationName, MANIFEST }
 
 if (process.env.CARVE_DECL_AUDIT_LIB === '1') {
   // Imported for its helpers by the self-test; do not run the audit.
@@ -529,6 +574,21 @@ const width = { repo: 9, path: 60, name: 32, rows: 20 }
 const pad = (s, n) => String(s).padEnd(n).slice(0, n)
 
 console.log(`Declaration audit - spec repo from this worktree, engines from ${ref}\n`)
+
+const pinStatus = carveJsPinStatus(REPOS['carve-js'].dir, ref === 'worktree' ? 'HEAD' : ref)
+if (pinStatus instanceof Error) {
+  console.log(`PIN STALENESS  UNVERIFIABLE - ${pinStatus.message}\n`)
+  failed += 1
+} else if (pinStatus.relation !== 'current') {
+  console.log(
+    `PIN STALENESS  ${pinStatus.relation.toUpperCase()} - @markup-carve/carve ${pinStatus.pin.slice(0, 8)} ` +
+      `vs carve-js ${ref} ${pinStatus.main.slice(0, 8)} ` +
+      `(pin-only ${pinStatus.pinOnly}, main-only ${pinStatus.mainOnly})\n`,
+  )
+  failed += 1
+} else {
+  console.log(`PIN STALENESS  current at carve-js ${pinStatus.main.slice(0, 8)}\n`)
+}
 console.log(`${pad('repo', width.repo)} ${pad('file', width.path)} ${pad('constant', width.name)} ${pad('rows', width.rows)} policy     guard`)
 console.log('-'.repeat(width.repo + width.path + width.name + width.rows + 24))
 
@@ -596,7 +656,7 @@ for (const [repo, dirs] of Object.entries(TEST_DIRS)) {
       const clean = blankComments(src, LANG_OF[path.endsWith('.php') ? 'php' : path.endsWith('.rs') ? 'rust' : 'js'])
       for (const m of clean.matchAll(/\b(?:const|static)\s+([A-Z][A-Z0-9_]{3,})\b/g)) {
         const name = m[1]
-        if (!DECLARATION_NAME.test(name)) continue
+        if (!isDeclarationName(name)) continue
         const key = `${repo}:${path}:${name}`
         if (!declared.has(key)) undeclared.push(key)
       }

--- a/tests/declaration-audit-counts-what-it-claims.test.mjs
+++ b/tests/declaration-audit-counts-what-it-claims.test.mjs
@@ -25,10 +25,14 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 process.env.CARVE_DECL_AUDIT_LIB = '1'
 const { __internals } = await import('../scripts/declaration-audit.mjs')
-const { liveRows, blankComments, MANIFEST } = __internals
+const { liveRows, blankComments, classifyPinDistance, gitPinStatus, isDeclarationName, MANIFEST } = __internals
 
 const rows = (kind, name, src) => {
   const out = liveRows({ kind, name }, src)
@@ -154,4 +158,52 @@ test('at least one guard is verified rather than merely claimed', () => {
   // subject of this file.
   const anchored = MANIFEST.filter((entry) => entry.staleness !== undefined)
   assert.ok(anchored.length > 0, 'no manifest entry verifies its guard claim against the file')
+})
+
+test('pin distance distinguishes every relation that must not read as current', () => {
+  assert.equal(classifyPinDistance(0, 0), 'current')
+  assert.equal(classifyPinDistance(0, 3), 'behind')
+  assert.equal(classifyPinDistance(2, 0), 'ahead')
+  assert.equal(classifyPinDistance(2, 3), 'diverged')
+  assert.equal(classifyPinDistance(-1, 0), 'unverifiable')
+  assert.equal(classifyPinDistance(Number.NaN, 0), 'unverifiable')
+})
+
+test('the git-backed pin gate observes current, behind, ahead, diverged and unverifiable histories', (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'carve-pin-audit-'))
+  t.after(() => rmSync(dir, { recursive: true, force: true }))
+  const git = (...args) => execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8' }).trim()
+  git('init', '-q')
+  git('config', 'user.email', 'audit@example.invalid')
+  git('config', 'user.name', 'Declaration audit')
+  writeFileSync(join(dir, 'state'), 'base\n')
+  git('add', 'state')
+  git('commit', '-qm', 'base')
+  const base = git('rev-parse', 'HEAD')
+  git('branch', 'side', base)
+  writeFileSync(join(dir, 'state'), 'main\n')
+  git('commit', '-qam', 'main')
+  const main = git('rev-parse', 'HEAD')
+  git('switch', '-q', 'side')
+  writeFileSync(join(dir, 'state'), 'side\n')
+  git('commit', '-qam', 'side')
+  const side = git('rev-parse', 'HEAD')
+
+  assert.equal(gitPinStatus(dir, main, 'master').relation, 'current')
+  assert.equal(gitPinStatus(dir, base, 'master').relation, 'behind')
+  assert.equal(gitPinStatus(dir, main, base).relation, 'ahead')
+  assert.equal(gitPinStatus(dir, side, 'master').relation, 'diverged')
+  assert.ok(gitPinStatus(dir, '0'.repeat(40), 'master') instanceof Error)
+})
+
+test('a decorated declaration name is swept and explicitly manifested', () => {
+  assert.equal(isDeclarationName('TOTALLY_NEW_AHEAD_OF_PIN'), true)
+  assert.equal(isDeclarationName('CANONICAL_AHEAD_OF_PIN'), true)
+  assert.equal(isDeclarationName('ORDINARY_TEST_FIXTURES'), false)
+  const entry = MANIFEST.find(
+    ({ repo, path, name }) => repo === 'carve-js' && path === 'test/canonical-ahead-of-pin.ts' && name === 'CANONICAL_AHEAD_OF_PIN',
+  )
+  assert.ok(entry, 'the canonical writer declaration is invisible to the manifest')
+  assert.equal(entry.policy, 'owed')
+  assert.equal(entry.guard, 'two-way')
 })


### PR DESCRIPTION
Closes #1771.
Closes #1794.

This turns the two audits from release-time intentions into CI gates:

- pins `@markup-carve/carve` to current carve-js `main` (`f4c17da7`, including the reverse guard from markup-carve/carve-js#1537)
- compares the exact package pin with carve-js `origin/main` and fails for behind, ahead, diverged, missing, or unverifiable histories
- checks out all three implementation repositories in a dedicated lightweight CI job and runs `declarations:check`
- recognizes decorated declaration names such as `CANONICAL_AHEAD_OF_PIN`, rather than only an exact known token
- registers the three declarations the broader sweep exposed: JS canonical writer, JS pending AST vocabulary, and Rust canonical render fixtures
- verifies the two newly local reverse guards by named assertions

Measured verification:

- declaration audit: passed, pin current, every owed list empty
- pinned engine report: 1475/1475 reproduced, zero mismatches, zero declared drift
- full spec suite: 3138 passed, 1 skipped, 0 failed
- focused audit suite: 17/17, including real temporary Git graphs for current/behind/ahead/diverged/unverifiable states
- markup-carve/carve-js#1537: 7/7 focused locally and all six CI jobs green

A local Claude CLI review was attempted after the final diff was assembled, but produced no output before its 120-second timeout; no GitHub review was requested.
