### PR TITLE
Gate cross-engine differences in round-trip comparisons

### DIFF
--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -14,6 +14,7 @@ import {
 import { parseShard, selectShard } from './lib/shard.mjs'
 import { parseConverterLedger } from './lib/drift-ledger.mjs'
 import { phpDir, rustBinary, rustDir } from './lib/engine-locations.mjs'
+import { comparisonGateHasFailures } from './lib/comparison-gate.mjs'
 import { miscount, shortfall } from './spec/participants.mjs'
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)))
@@ -1673,6 +1674,9 @@ if (reportPath) {
 if (failOnDiff) {
   const failing = roundtrip ? roundtripDiffs : crossImplDiffs
   const label = roundtrip ? 'round-trip' : 'cross-implementation'
+  // A round-trip run also compares the engines with each other. Keep that
+  // independent count in the gate instead of reporting it and then exiting 0.
+  const crossImplementationFailures = roundtrip ? crossImplDiffs : 0
   // PART 11 §1's own invariants gate too, and separately from cross-engine
   // agreement. `to_html(fmt(x)) != to_html(x)` means ONE engine's formatter
   // changed what the document says - a corruption whether or not the others
@@ -1714,9 +1718,20 @@ if (failOnDiff) {
     )
     process.exit(1)
   }
-  if (failing > 0 || invariantFailures > 0 || mismatches > 0 || crossRead > 0) {
+  if (comparisonGateHasFailures({
+    selectedMode: failing,
+    crossImplementation: crossImplementationFailures,
+    invariants: invariantFailures,
+    fixtureMismatches: mismatches,
+    crossRead,
+  })) {
     if (failing > 0) {
       console.error(`\n${failing} ${label} difference(s) - see the DIFF lines above.`)
+    }
+    if (crossImplementationFailures > 0) {
+      console.error(
+        `${crossImplementationFailures} cross-implementation difference(s) - see the DIFF lines above.`,
+      )
     }
     if (mismatches > 0) {
       console.error(
@@ -1736,8 +1751,9 @@ if (failOnDiff) {
     }
     process.exit(1)
   }
+  const successLabel = roundtrip ? 'round-trip or cross-implementation' : label
   console.log(
-    `\nNo ${label} differences, no fixture mismatches, no PART 11 §1 invariant failures` +
+    `\nNo ${successLabel} differences, no fixture mismatches, no PART 11 §1 invariant failures` +
       `${roundtrip ? ', and no cross-read failures' : ''}.`,
   )
 }

--- a/scripts/lib/comparison-gate.mjs
+++ b/scripts/lib/comparison-gate.mjs
@@ -1,0 +1,9 @@
+/**
+ * Whether a completed comparison run contains a failure the CLI must gate on.
+ *
+ * Kept separate from presentation so every reported failure class is directly
+ * executable in a small regression test.
+ */
+export function comparisonGateHasFailures(counts) {
+  return Object.values(counts).some((count) => count > 0)
+}

--- a/tests/a-failed-engine-run-is-named.test.mjs
+++ b/tests/a-failed-engine-run-is-named.test.mjs
@@ -32,8 +32,35 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseShard, selectShard } from '../scripts/lib/shard.mjs'
+import { comparisonGateHasFailures } from '../scripts/lib/comparison-gate.mjs'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+test('a cross-implementation difference fails the round-trip comparison gate', () => {
+  assert.equal(
+    comparisonGateHasFailures({
+      selectedMode: 0,
+      crossImplementation: 1,
+      invariants: 0,
+      fixtureMismatches: 0,
+      crossRead: 0,
+    }),
+    true,
+  )
+})
+
+test('an entirely clean comparison passes the gate', () => {
+  assert.equal(
+    comparisonGateHasFailures({
+      selectedMode: 0,
+      crossImplementation: 0,
+      invariants: 0,
+      fixtureMismatches: 0,
+      crossRead: 0,
+    }),
+    false,
+  )
+})
 
 test('four formatter shards partition the corpus exactly once', () => {
   const corpus = Array.from({ length: 1384 }, (_, index) => index)


### PR DESCRIPTION
Fixes the comparison-gate reporting defect in #1802.

## What changed

- Makes a round-trip comparison fail when its already-computed cross-implementation count is non-zero.
- Reports that count explicitly instead of printing a false clean summary.
- Makes the success message name both gated comparison classes.
- Extracts the failure predicate and covers the cross-engine-only regression directly.

## Why

The round-trip run computes both semantic round-trip differences and engine-to-engine differences. Previously it gated only the first count, while the generated report correctly rejected the second. A failing run could therefore print a clean summary before the report checker failed later.

## Verification

- Focused gate and runner suite: 7 tests pass
- Full test run completed 3,143 tests; one unrelated nesting performance budget failed on Node 22 while the repository requires Node 24

No changelog entry is included to avoid conflicts with the pending release work.
