### PR TITLE
chore: move the carve-js pin past the footnote degradation order fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#983b4f24b8b8182c66f839f5bd32fe807f9cf08c",
+        "@markup-carve/carve": "github:markup-carve/carve-js#4a2f83891c65829c145fb6b23e0f1b14c607d591",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,8 +986,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#983b4f24b8b8182c66f839f5bd32fe807f9cf08c",
-      "integrity": "sha512-LhAJJdo3+CtCfxEJ0h/0187qOSEyypjDHQRmV+RYkl3/8CaIg8Noax7kv4wIPpF5I4hzb9OYcna6560u6eKn4g==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#4a2f83891c65829c145fb6b23e0f1b14c607d591",
+      "integrity": "sha512-OL5gg9VdDI2SAeFHTN6wa/8hf6TbJONQZnz0WY5yNtqCeC+D4OaYY4WSTlXJzoCSkajyR7bzFinMlU0OXDaSJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#983b4f24b8b8182c66f839f5bd32fe807f9cf08c",
+    "@markup-carve/carve": "github:markup-carve/carve-js#4a2f83891c65829c145fb6b23e0f1b14c607d591",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
     "@mermaid-lint/cli": "^0.53.1",


### PR DESCRIPTION
carve-js `4a2f8389` orders hoisted footnote definitions by source position in the markdown, plain and ansi writers - the engine half of markup-carve/carve#1802, merged as markup-carve/carve-js#1546.

The pin-staleness check added by markup-carve/carve#1798 is what asks for this: with the fix merged and the pin left at `983b4f24`, `declarations and engine pin are current` fails on every commit in this repo until the pin moves. It is currently failing on `main` for exactly that reason.

No golden moved - the corpus, fmt round-trip, cross-read, target and examples suites all pass unchanged against the new pin.