### PR TITLE
ci: hold the bump force-push to a lease

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -200,6 +200,16 @@ jobs:
           # fetch needed, so the fast path stays a shallow single-branch clone.
           # A missing branch makes the call fail -> same safe action as "no
           # commits ahead": recreate from main.
+          # The SHA this decision is made against. The scan below and the push
+          # at the end of the job are minutes apart -- a clone, a submodule
+          # update, a conformance run and possibly a codex attempt sit between
+          # them -- so anything landing in that window is invisible here.
+          # Captured now, it becomes the LEASE the push is held to. Empty means
+          # the branch does not exist yet, which the push treats as 'must still
+          # not exist'.
+          observed="$(gh api "repos/$REPO/git/ref/heads/automation/bump-spec" \
+                --jq '.object.sha' 2>/dev/null || true)"
+
           foreign=0
           if ahead="$(gh api "repos/$REPO/compare/main...automation/bump-spec" \
                 --jq '.commits[] | "\(.commit.author.email)|\(.commit.committer.email)"' 2>/dev/null)"; then
@@ -422,9 +432,35 @@ jobs:
             # overwriting whatever arrived in the meantime.
             git push origin automation/bump-spec
           else
-            # Branch was recreated from main and carries only this workflow's
-            # own commits, so replacing it loses nothing.
-            git push -f origin automation/bump-spec
+            # Branch was recreated from main and carried only this workflow's
+            # own commits WHEN THE SCAN RAN. A bare -f asserts that is still
+            # true minutes later, and it is not: an agent pushing into that
+            # window is overwritten silently. That happened three times in
+            # forty minutes on 2026-08-26, while three engine ports were in
+            # flight, each time discarding verified green work.
+            #
+            # The lease makes the scan and the push ONE decision, evaluated by
+            # the remote at the instant of the push. Anything that arrived
+            # after observed was read REJECTS the push instead of losing to it
+            # -- the same protection the preserve path above already gets from
+            # its plain push, which this branch of the if never had.
+            if [ -n "$observed" ]; then
+              lease="automation/bump-spec:$observed"
+            else
+              lease="automation/bump-spec:"
+            fi
+            if ! git push --force-with-lease="$lease" origin automation/bump-spec; then
+              lease_msg="Bump aborted for $REPO: automation/bump-spec moved after this run read it (lease ${observed:-<absent>}), so the push was refused rather than overwriting the new commits. Nothing was lost. Re-run the workflow to bump on top of them."
+              echo "::error::$lease_msg"
+              echo "$lease_msg" >> "$GITHUB_STEP_SUMMARY"
+              # A refusal nobody reads is the same defect one layer out, so put
+              # it where whoever pushed will see it.
+              late_pr="$(gh pr list --repo "$REPO" --head automation/bump-spec --state open --json number --jq '.[0].number // empty')"
+              if [ -n "$late_pr" ]; then
+                gh pr comment "$late_pr" --repo "$REPO" --body "$lease_msg" 2>/dev/null || true
+              fi
+              exit 1
+            fi
           fi
 
           body="$(printf '%s\n\n%s\n%s' \


### PR DESCRIPTION
## The defect

The recreate path pushed with a bare `-f`:

```
if [ -n "$preserve" ]; then
    git push origin automation/bump-spec        # plain push: REJECTED if the branch moved
else
    git push -f origin automation/bump-spec     # bare -f: overwrites whatever arrived
fi
```

The decision to take that path is made by an API scan near the **start** of the job. The push happens at the **end** - after a clone, a submodule update, a conformance run and possibly a codex implementation attempt. Anything landing in that window is invisible to the scan and is silently overwritten by the push.

On 2026-08-26 that discarded an agent's verified, green work on all three engine bump branches **three times in about forty minutes**, while three engine ports were in flight and `carve` main was taking spec commits every few minutes. One repo had all six checks green and lost it to a force-push.

The preserve path already had the right protection, and says so in its own comment:

> a plain push (no --force) is the safety net: if the branch moved since the API check above, the push is REJECTED rather than overwriting whatever arrived in the meantime

The recreate path never got the equivalent.

## The fix

Capture the branch head at scan time, and hold the push to it with `--force-with-lease`. The scan and the push become **one decision**, evaluated by the remote at the instant of the push. An empty capture means the branch did not exist, and the lease then says it must still not exist.

A re-check immediately before the push was considered and rejected: it narrows the window without closing it. The lease *is* the check, and the remote evaluates it atomically.

On refusal the run comments on the open PR, as the merge-conflict path already does. A refusal nobody reads is the same defect one layer out.

## Proven both directions

Against a local remote, with a bot clone and an agent clone:

| case | result |
| --- | --- |
| agent pushes inside the window | push **REFUSED**; remote head is still the agent's commit |
| nobody interferes | push **SUCCEEDS** |

The second case matters as much as the first - a lease that always refuses would wedge the automation instead of protecting it.

`yaml.safe_load` parses the workflow and `bash -n` is clean on the extracted `run:` block.
