### PR TITLE
chore: a declared window is declared in the fmt ledger too

### DIFF
--- a/scripts/declaration-audit.mjs
+++ b/scripts/declaration-audit.mjs
@@ -873,6 +873,6 @@ console.log(
   `DECLARATION AUDIT PASSED (mode: ${mode}) - ` +
     (strict
       ? 'every owed list is empty, the pin is current, and every guard is two-directional.'
-      : 'every owed list is empty, every engine-pin window is declared, and every guard is two-directional.'),
+      : 'every owed list is empty, every engine-lag window is declared, and every guard is two-directional.'),
 )
 }

--- a/scripts/declaration-audit.mjs
+++ b/scripts/declaration-audit.mjs
@@ -55,20 +55,28 @@
  * `owed` list must be EMPTY and the carve-js pin must be current.
  *
  * `--mode=per-pr` answers "is this pull request defective?", which is a
- * different question, and the engine-pin ledger is where the two part company.
- * resources/engine-pin-drift.txt exists to DESCRIBE the window between a spec
- * rule landing and an engine shipping it - its own header says that window "is
- * normal and the report exists to describe it", and that it is "DECLARED
- * rather than tolerated". A release cannot ship with that window open; a PULL
- * REQUEST is how the window opens in the first place. Gating both on the same
- * emptiness made every leading spec ruling red by construction, which is what
- * carve#1811 ruled on.
+ * different question, and the two ENGINE-LAG ledgers are where the two part
+ * company. resources/engine-pin-drift.txt exists to DESCRIBE the window
+ * between a spec rule landing and an engine shipping it - its own header says
+ * that window "is normal and the report exists to describe it", and that it is
+ * "DECLARED rather than tolerated". A release cannot ship with that window
+ * open; a PULL REQUEST is how the window opens in the first place. Gating both
+ * on the same emptiness made every leading spec ruling red by construction,
+ * which is what carve#1811 ruled on.
+ *
+ * resources/engine-fmt-drift.txt describes THE SAME WINDOW from the writer
+ * side - the engine reads the new rule and writes the old spelling - and its
+ * own header points at the pin ledger for its retention rule. A declared
+ * window is declared regardless of which ledger describes it, so it is judged
+ * the same way. It held zero rows when carve#1811 landed, which is the only
+ * reason the omission was invisible: the difference bites the first time a
+ * ruling opens a writer-half window and not before.
  *
  * So in `per-pr` mode:
  *
- *   - the engine-pin ledger is judged as `declared`: a well-formed row PASSES,
- *     and a row that is not a declaration at all (no reason, or a key listed
- *     twice, so one of the two reasons is silently discarded) FAILS.
+ *   - both engine-lag ledgers are judged as `declared`: a well-formed row
+ *     PASSES, and a row that is not a declaration at all (no reason, or a key
+ *     listed twice, so one of the two reasons is silently discarded) FAILS.
  *   - pin staleness REPORTS instead of failing.
  *   - an engine checkout that is simply not there is SKIPPED rather than
  *     counted, because "no sibling clone" is a fact about the machine and not
@@ -78,13 +86,17 @@
  * ledgers and the UNDECLARED sweep are NOT relaxed - they caught real holes
  * (carve#1793, carve#1794) and they stay owed per-PR.
  *
- * WHAT KEEPS THE LENIENCY FROM BEING A HOLE. The other half of the ledger's
+ * WHAT KEEPS THE LENIENCY FROM BEING A HOLE. The other half of each ledger's
  * contract - drift that is NOT declared, the carve#533 state of a pinned build
- * silently behind - is gated per-PR by `npm run engine:report -- --check`,
- * which fails in EITHER direction: an undeclared slug, or a declared slug the
- * pin has caught up on. `per-pr` mode defers to that check by name rather than
- * dropping the question, and tests/the-per-pr-audit-defers-to-a-live-check.test.mjs
- * fails if that step ever leaves the per-PR workflow.
+ * silently behind - is gated per-PR by a LIVE check that fails in EITHER
+ * direction, an undeclared slug or a declared slug the pin has caught up on.
+ * For the pin ledger that is `npm run engine:report -- --check`; for the fmt
+ * ledger it is tests/corpus-fmt-roundtrip.test.mjs, which reports undeclared
+ * writer drift and carries its own staleness ratchet over the writer-only
+ * file, and which runs per-PR under `npm test`. `per-pr` mode defers to those
+ * checks by name rather than dropping the question, and
+ * tests/the-per-pr-audit-defers-to-a-live-check.test.mjs fails if either step
+ * ever leaves the per-PR workflow.
  *
  * Exit 0 in release mode only when every `owed` list is empty, every entry was
  * reachable and parseable, and no declaration-shaped constant exists that this
@@ -196,13 +208,15 @@ const MANIFEST = [
   { repo: 'spec', path: 'resources/ast-span-divergence.txt', kind: 'txt', policy: 'owed', guard: 'two-way', owner: 'npm run ast:check' },
   { repo: 'spec', path: 'resources/ast-value-divergence.txt', kind: 'txt', policy: 'owed', guard: 'two-way', owner: 'npm run ast:check' },
   { repo: 'spec', path: 'resources/ast-extent-findings.txt', kind: 'txt', policy: 'owed', guard: 'two-way', owner: 'npm run ast:check' },
-  { repo: 'spec', path: 'resources/engine-fmt-drift.txt', kind: 'txt', policy: 'owed', guard: 'two-way', owner: 'npm run fmt:check' },
+  // ONE OF THE TWO ENGINE-LAG ENTRIES: see the `prPolicy` note on the
+  // engine-pin ledger below. Same window, described from the writer side.
+  { repo: 'spec', path: 'resources/engine-fmt-drift.txt', kind: 'txt', policy: 'owed', prPolicy: 'declared', guard: 'two-way', owner: 'npm run fmt:check' },
   { repo: 'spec', path: 'resources/converter-drift.txt', kind: 'txt', policy: 'owed', guard: 'two-way', owner: 'npm run compare:convert' },
-  // THE ONE ENTRY WHOSE VERDICT DEPENDS ON THE QUESTION BEING ASKED. Owed
-  // before a tag, declared inside a pull request: see the two-verdicts note at
-  // the top of this file (carve#1811). `prPolicy` is deliberately a per-entry
-  // opt-in rather than a blanket relaxation of `owed`, so relaxing a second
-  // ledger stays a visible edit here.
+  // THE OTHER ENGINE-LAG ENTRY, AND THE ONE THE RULE WAS WRITTEN FOR. Both
+  // are owed before a tag and declared inside a pull request: see the
+  // two-verdicts note at the top of this file (carve#1811). `prPolicy` is
+  // deliberately a per-entry opt-in rather than a blanket relaxation of
+  // `owed`, so relaxing a third ledger stays a visible edit here.
   { repo: 'spec', path: 'resources/engine-pin-drift.txt', kind: 'txt', policy: 'owed', prPolicy: 'declared', guard: 'two-way', owner: 'npm run engine:report -- --check' },
   { repo: 'spec', path: 'resources/oracle-divergence.txt', kind: 'txt', policy: 'owed', guard: 'two-way', owner: 'tests/the-oracle-reads-the-authored-documents.test.mjs' },
   // 132 rows, every one `permitted`: PART 12 §4 exempts a REASSEMBLED node

--- a/tests/the-per-pr-audit-defers-to-a-live-check.test.mjs
+++ b/tests/the-per-pr-audit-defers-to-a-live-check.test.mjs
@@ -2,19 +2,25 @@
  * THE PER-PR AUDIT IS LENIENT ABOUT ONE THING, AND ONLY WHILE SOMETHING ELSE
  * IS STRICT ABOUT IT.
  *
- * `scripts/declaration-audit.mjs --mode=per-pr` passes a DECLARED row in
- * resources/engine-pin-drift.txt, because that ledger exists to describe the
- * window between a spec rule landing and an engine shipping it - "normal", in
- * the file's own words, and "DECLARED rather than tolerated" (carve#1811). What
- * makes that safe rather than a hole is the OTHER half of the ledger's
- * contract, which lives in a different check: `npm run engine:report -- --check`
- * fails on a slug the pin does not reproduce and nobody wrote down - the
- * carve#533 state - and on a listed slug the pin has caught up on.
+ * `scripts/declaration-audit.mjs --mode=per-pr` passes a DECLARED row in the
+ * two ENGINE-LAG ledgers, because they exist to describe the window between a
+ * spec rule landing and an engine shipping it - "normal", in
+ * resources/engine-pin-drift.txt's own words, and "DECLARED rather than
+ * tolerated" (carve#1811). resources/engine-fmt-drift.txt describes the same
+ * window from the WRITER side and got the same verdict once a ruling actually
+ * opened a writer-half window; until then it held zero rows, which is why the
+ * asymmetry sat here unnoticed. What makes the leniency safe rather than a
+ * hole is the OTHER half of each ledger's contract, which lives in a different
+ * check, and which fails in BOTH directions - on a slug the pin does not
+ * reproduce and nobody wrote down (the carve#533 state) and on a listed slug
+ * the pin has caught up on. For the pin ledger that is
+ * `npm run engine:report -- --check`; for the fmt ledger it is
+ * tests/corpus-fmt-roundtrip.test.mjs, which runs per-PR under `npm test`.
  *
  * So the leniency has a precondition, and a precondition nobody checks is the
  * carve#755 shape: delete that step from the per-PR workflow and undeclared
  * drift becomes invisible in both directions, silently, with every gate green.
- * This file pins the precondition.
+ * This file pins the precondition, once per relaxed ledger.
  *
  * It also pins the two things about the lenient mode that are easy to get
  * wrong in the direction of a check that cannot fail:
@@ -63,14 +69,33 @@ test('the per-PR workflow still gates undeclared drift, which is what the lenien
     /npm run engine:report -- --check/,
     'ci.yml no longer gates undeclared engine-pin drift, so --mode=per-pr passing a declared window is now a hole',
   )
+  // The fmt ledger's live half. It is not a workflow step of its own: the
+  // roundtrip test reports undeclared writer drift and ratchets the ledger
+  // against staleness, and it runs under `npm test`. Both halves are asserted,
+  // because either one leaving would reopen the hole from one side.
+  assert.match(workflow, /run: npm test\b/, 'ci.yml no longer runs npm test per-PR')
+  const roundtrip = readFileSync(join(repo, 'tests/corpus-fmt-roundtrip.test.mjs'), 'utf8')
+  assert.match(
+    roundtrip,
+    /loadDeclaredFmtDrift/,
+    'the roundtrip test no longer reads the drift ledgers, so undeclared writer drift is ungated',
+  )
+  assert.match(
+    roundtrip,
+    /loadWriterOnlyDrift/,
+    'the roundtrip test no longer ratchets engine-fmt-drift.txt, so a stale line there excuses nothing forever',
+  )
 })
 
-test('exactly one manifest entry is judged differently per-PR, and it is the engine-pin ledger', () => {
+test('exactly two manifest entries are judged differently per-PR, and they are the engine-lag ledgers', () => {
   const relaxed = MANIFEST.filter((entry) => entry.prPolicy !== undefined)
   assert.deepEqual(
-    relaxed.map((entry) => [entry.path, entry.policy, entry.prPolicy]),
-    [['resources/engine-pin-drift.txt', 'owed', 'declared']],
-    'a second ledger now reads differently per-PR - carve#1811 relaxed the engine-pin ledger only',
+    relaxed.map((entry) => [entry.path, entry.policy, entry.prPolicy]).sort(),
+    [
+      ['resources/engine-fmt-drift.txt', 'owed', 'declared'],
+      ['resources/engine-pin-drift.txt', 'owed', 'declared'],
+    ],
+    'a third ledger now reads differently per-PR - only the two engine-lag ledgers describe a window a PR opens',
   )
   // The AST divergence ledgers and the rest stay owed in BOTH modes. Named
   // rather than counted, because the count is what a relaxation would keep.
@@ -81,7 +106,6 @@ test('exactly one manifest entry is judged differently per-PR, and it is the eng
     'resources/ast-span-divergence.txt',
     'resources/ast-value-divergence.txt',
     'resources/ast-extent-findings.txt',
-    'resources/engine-fmt-drift.txt',
     'resources/converter-drift.txt',
     'resources/oracle-divergence.txt',
   ]) {


### PR DESCRIPTION
## What

`scripts/declaration-audit.mjs` relaxed exactly one ledger in per-PR mode. The two engine-lag manifest rows were identical but for `prPolicy`:

```js
{ repo: 'spec', path: 'resources/engine-fmt-drift.txt', kind: 'txt', policy: 'owed',                        guard: 'two-way', owner: 'npm run fmt:check' },
{ repo: 'spec', path: 'resources/engine-pin-drift.txt', kind: 'txt', policy: 'owed', prPolicy: 'declared', guard: 'two-way', owner: 'npm run engine:report -- --check' },
```

This gives the fmt ledger the same `prPolicy: 'declared'`.

## Why

Both files describe the same window - a spec rule landing ahead of the engines - from the two sides of it. `engine-pin-drift.txt` is the first render, `engine-fmt-drift.txt` is the writer, and the fmt file's own header points at the pin file for its retention rule. #1811's reasoning does not distinguish them: a release cannot ship with the window open, and a pull request is how the window opens in the first place.

The asymmetry was invisible because the fmt ledger holds **0 rows**. It only bites when a writer-half window opens, and one just did: carve-js has shipped the reader half of the #1821 ruling and not the writer, and that drift had nowhere clean to sit.

## Measured

Engine checkouts pointed at a path that does not exist, so the run is deterministic. Exit codes captured immediately after each command.

| what | mode | exit | the entry's verdict line |
| --- | --- | --- | --- |
| one well-formed row, **script before this PR** | per-pr | **1** | `1  owed  two-way  <== OWED`, 1 finding |
| the same row, **script after this PR** | per-pr | **0** | `1 (1 declared)  declared  two-way` |
| the same row | release | **1** | `1  owed  two-way  <== OWED`, findings 30 -> 31 |
| a bare slug, no reason | per-pr | **1** | `1 (0 declared)  declared  <== UNDECLARED` |
| the same slug listed twice | per-pr | **1** | `2 (1 declared)  declared  <== UNDECLARED` |

Baseline for the deltas: with the ledger at its committed 0 rows, per-pr exits 0 with 0 findings and release exits 1 with 30 findings (all of them the absent engine checkouts). So each row above moves exactly the one entry.

The ledger's contents are untouched - the rows were appended and reverted for the measurement.

## What keeps it from being a hole

The same precondition the pin ledger leans on, and the fmt ledger has its own: undeclared writer drift and a stale line in `engine-fmt-drift.txt` both fail `tests/corpus-fmt-roundtrip.test.mjs`, which runs per-PR under `npm test`. `tests/the-per-pr-audit-defers-to-a-live-check.test.mjs` now pins that step for both ledgers, so deleting either one fails there rather than going quiet.

Untouched: the ledger's contents, the AST divergence ledgers, and the `UNDECLARED` sweep.
