### PR TITLE
docs: recommend bare-dot auto-numbered lists

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -452,12 +452,37 @@ markers in the source.
 
 #### Ordered
 ```
+. First item
+. Second item
+  - Sub-item
+  - Another
+. Third item
+```
+
+For an automatically numbered decimal list, prefer Carve's bare-dot marker
+`. `. It counts from 1 and stays two columns wide at every item, so nested
+content does not need to move when the rendered list crosses 9, 99, or 999.
+`carve fmt` preserves this spelling.
+
+Use explicit numbers when the source must also parse as Markdown or Djot, when
+visible source numbering is useful, or when the list must start somewhere other
+than 1:
+
+```
 1. First item
 2. Second item
-   1. Sub-item
-   2. Another
+
+   - Sub-item
 3. Third item
+
+11. Starts at eleven
+12. Continues at twelve
 ```
+
+Bare-dot markers are a Carve extension; CommonMark and Djot do not recognize
+them as ordered-list markers. The formatter preserves the form that opened the
+list: a bare-dot list stays bare-dot, while an explicitly numbered list stays
+numbered and has its marker values normalized.
 
 Ordered lists support **decimal, alphabetic (`a.`/`A.`), and roman
 (`i.`/`I.`)** markers, with either the `.` or `)` delimiter. The first item
@@ -492,17 +517,23 @@ like any list marker (the §10 rule above).
 
 **Auto-numbering:**
 ```
-1. First
-1. Second (auto-increments)
-1. Third
+. First
+. Second
+. Third
 ```
+
+Repeated `1.` markers also auto-increment, as in Markdown, but retain the wider
+numbered spelling when formatted. Bare dots are the native Carve convention
+when stable nesting indentation matters.
 
 #### Indentation and nesting
 
 Every list item has a **content column**: where its content begins, after the
-marker: `- ` / `* ` → column 2, `1. ` → 3, `10. ` → 4. A **task** item's checkbox
-is content, not marker, so its content column is the **bullet width (2)**, not
-the full `- [x] ` width.
+marker: `- ` / `* ` / `. ` → column 2, `1. ` → 3, `10. ` → 4,
+`100. ` → 5. Consequently, nested content under explicit numbers moves one
+column at each power of ten. Bare-dot auto-numbering avoids those transitions.
+A **task** item's checkbox is content, not marker, so its content column is the
+**bullet width (2)**, not the full `- [x] ` width.
 
 How a deeper marker inside an open list item is read - this is sub-list nesting,
 a different axis from the §10 paragraph rule (no list marker interrupts a

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -61,9 +61,10 @@ Bare delimiters work only at word boundaries; force one intraword with the brace
 
 ---                          (thematic break: --- *** ___)
 
-- unordered      1. ordered  (dialects: a. A. i. I. and the ) delimiter;
-- [ ] task        - [x] done  more task states: [-] [_] [>] [?])
-. bare dot                   (decimal from 1; only `.` may drop its value)
+- unordered      1. ordered  (numbered form is Markdown/Djot-portable;
+- [ ] task        - [x] done  dialects: a. A. i. I. and the ) delimiter)
+. auto-numbered              (preferred native Carve form; counts from 1 and
+                              keeps nested indentation stable at 10, 100, ...)
 -{.c} styled item            (attrs abutting the marker target the <li>)
 
 - step one                   (lone + attaches the next flush-left block

--- a/docs/divergence-from-djot.md
+++ b/docs/divergence-from-djot.md
@@ -904,7 +904,11 @@ as more than restyled Djot:
   from 1, the AsciiDoc-style shorthand for the list nobody numbers by hand. It
   is a spelling of decimal-dot, not a dialect, so it mixes with `1.` in one
   list; only `.` may drop its value, since a leading `) ` collides with prose
-  parentheticals far more often (grammar, ordered_marker).
+  parentheticals far more often (grammar, ordered_marker). Prefer the bare-dot
+  form for native Carve auto-numbering: its constant marker width keeps nested
+  content at the same indentation when the rendered count crosses 9, 99, or
+  999. Use numbered markers when the source must remain readable as Djot or
+  Markdown. `carve fmt` preserves whichever form opened the list.
 - **Boolean attributes** - a bare word in `{…}` (`[text]{featured}`,
   `{.note open}`) is a value-less attribute rendered `name=""`. Canonical djot
   rejects bare words (the whole block stays literal); carve accepts them,

--- a/docs/migrate-from-markdown.md
+++ b/docs/migrate-from-markdown.md
@@ -48,7 +48,7 @@ The table below covers the constructs you use most often. Items marked **same** 
 | Fenced code | `` `code fence` `` with a language | same | No-space info string is canonical; a space is also accepted |
 | Blockquotes | `> text` | same | Carve adds captions (see below) |
 | Unordered lists | `- item` or `* item` | same | Carve bullets are `-`/`*`; a Markdown `+` bullet is not a Carve bullet |
-| Ordered lists | `1. item` | same | |
+| Ordered lists | `1. item` | `1. item` or `. item` | Numbered markers are portable; prefer Carve's `. ` for native auto-numbering with stable nesting indentation |
 | Task lists | `- [ ] todo` / `- [x] done` | same | |
 | Thematic break | `---` | same | Contiguous `---`, `***`, or `___` (no spaced forms) |
 | **Italic** | `*italic*` or `_italic_` | `/italic/` | **Changed** - see below |


### PR DESCRIPTION
## Summary

- recommend `. ` as Carve's native spelling for auto-numbered decimal lists
- explain why its constant marker width keeps nested indentation stable across 9, 99, and 999
- retain explicit numbered markers as the portable Markdown/Djot form
- clarify that `carve fmt` preserves the form that opened the list

## Validation

- `node --test tests/doc-carve-samples.test.mjs tests/migration-claims.test.mjs tests/divergence-claims.test.mjs tests/portable-whitespace.test.mjs tests/repo-links.test.mjs`
- `git diff --check`
