### PR TITLE
spec: refresh canonical definition examples

### DIFF
--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -5451,7 +5451,7 @@ An item's own second paragraph after a blank still loosens it - non-propagation 
 
 ## Definition list as a first-class block opener
 
-A `:: term` definition-list opener is a block opener like every other (quote, heading, fence, table) under the content-column rule (PART 9 §24 C3): it *interrupts* an open list item at column 0, and *nests* at the item's content column. The two-line `:: `/`:  ` marker is recognized by look-ahead; only the `:: ` term line opens the block.
+A `:: term` definition-list opener is a block opener like every other (quote, heading, fence, table) under the content-column rule (PART 9 §24 C3): it *interrupts* an open list item at column 0, and *nests* at the item's content column. The two-line `:: `/`: ` marker is recognized by look-ahead; only the `:: ` term line opens the block.
 
 At the content column, the definition list nests inside the item.
 
@@ -5768,7 +5768,12 @@ Mentions and tags are inert stable spans that do not take attributes (they share
 
 ## Under-indented definition attaches, over-indented definition folds
 
-A `:  def` line is a lenient definition-list entry (PART 9 §24 C3): it attaches as a fresh `<dd>` to its open `:: term` when its column is at or below the term's, even under the item's content column. Only a definition line indented *above* the term folds into the term text as a lazy continuation.
+The accepted wider-separator spelling `:  def` is still a definition-list entry
+(PART 9 §24 C3): it attaches as a fresh `<dd>` to its open `:: term` when its
+column is at or below the term's, even under the item's content column. Only a
+definition line indented *above* the term folds into the term text as a lazy
+continuation. The canonical spelling is `: def`; this case deliberately keeps
+the wider separator while testing the marker's authored column.
 
 Under-indented (below the content column, still above column 0): the definition attaches.
 
@@ -5793,7 +5798,9 @@ Under-indented (below the content column, still above column 0): the definition 
 
 :::
 
-At column 0, the definition still attaches: the `:  ` marker is a lenient exception to the column-0 interrupt rule, so it does not end the item and orphan the definition.
+At column 0, the definition still attaches: this accepted wider-separator
+marker is a lenient exception to the column-0 interrupt rule, so it does not
+end the item and orphan the definition.
 
 ::: compare
 
@@ -30360,7 +30367,8 @@ more</li>
 `AND FLUSH-LEFT MEANS COLUMN 0` (§17 L3, markup-carve/carve#1436) gives the
 marker its own control: a line the `+` does not reach falls through to the
 ordinary column rules "exactly as if the `+` line had been a comment". In the
-FIRST-BLOCK form `:  +` no paragraph is open, so the `+` genuinely is a marker
+accepted wider-separator FIRST-BLOCK form `:  +` no paragraph is open, so the
+`+` genuinely is a marker
 and the clause reads its payload's column - and a payload at column 1 or 2 is
 not flush-left, so the marker is refused and the body ends where the comment
 ends it. It did not: the description reached out and put the payload in the
@@ -30508,7 +30516,8 @@ a rule.
 ## A leading continuation marker in a footnote body or a quote is text
 
 The FIRST-BLOCK form of the continuation marker (§17 L4) belongs to the LIST
-ITEM and the DEFINITION DESCRIPTION: `- +` and `:  +` open a body whose content
+ITEM and the DEFINITION DESCRIPTION: `- +` and the accepted wider-separator
+`:  +` open a body whose content
 is the following flush-left block, and over a column-1 line the marker is
 refused and the body ends. A FOOTNOTE BODY and a BLOCK QUOTE have no such form.
 A `+` that opens one of those two bodies is not a marker at all - it is ordinary
@@ -30665,7 +30674,7 @@ definition body the same way, and this is the same shape one construct over.
 The sentinel is an attribute block, so PART 9 §15 A4 drops it - a block-attribute
 line with no following block inside its own container reaches nothing - and the
 description is left empty. It claims NO line below it at any column, which is
-what separates it from `:  +`: the first-block marker attaches a following
+what separates it from the accepted wider-separator `:  +`: the first-block marker attaches a following
 flush-left block, so it spells an empty body only when a blank line follows.
 
 ::: compare
@@ -30706,7 +30715,8 @@ At end of input, where there is no following block at all.
 :::
 
 The line below it is not claimed even at column 0, which is the whole reason the
-sentinel needs no blank line after it. The same document spelled `:  +` puts
+sentinel needs no blank line after it. The same document spelled with the
+accepted wider-separator `:  +` puts
 `flush` inside the `dd`.
 
 ::: compare

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -424,14 +424,14 @@
         anywhere in the stack, which is S4's own "otherwise" and nothing new:
 
             - a                :: t
-              [r]: /u          :  a
-            tail                  [r]: /u
-                               tail
+              [r]: /u          : a
+            tail                 [r]: /u
+                              tail
 
         both end their container and publish `tail` at document level. A
         COMMENT at a definition body's content column ends the paragraph the
         same way and for the same reason (§10 I5 lists it too), so
-        `:  a` over `   %% c` over `tail` ends the `dd`.
+        `: a` over `  %% c` over `tail` ends the `dd`.
 
         AND THE DEFINITION REGISTERS, which is half of what I5 says and the
         half an implementation can pass this rule without: "A link or footnote
@@ -693,8 +693,8 @@
         -- one paragraph holding an unclosed inline verbatim run, not a code
         block. So at a container's content column
 
-            - q                 > q                 :  a
-              ```               > ```                  ```
+            - q                 > q                 : a
+              ```               > ```                 ```
             tail                tail                tail
 
         all three fold `tail` into the paragraph that is still open, and no
@@ -778,12 +778,13 @@
 
         AND A DEFINITION BODY IS SUCH A CONTAINER -- NORMATIVE (carve#956).
         The third indented-block collector answers the same way. A definition
-        body's `dd` demands indentation to column 3 (`definition_indent`), so a
-        fence opened on the `:  ` marker line whose body sits BELOW that column
+        body's canonical `dd` demands indentation to column 2
+        (`definition_indent`), so a fence opened on the `: ` marker line whose
+        body sits BELOW that column
         is the list spelling above with a different prefix:
 
             :: t
-            :  ```
+            : ```
             body
             ```
 
@@ -1435,11 +1436,11 @@ definition_entry = definition_term+, [blank_line], definition_body,
                    {[blank_line], definition_body} ;
 (* A blank line may separate a term from its definition, and one definition
    from the next, for readability -- the blank is a separator only (djot
-   parity). A blank NOT followed by a `:  ` definition ends the entry. *)
+   parity). A blank NOT followed by a `: ` definition ends the entry. *)
 definition_term = "::", space, inline_content, newline, {term_continuation_line} ;
 term_continuation_line = inline_content, newline ;
 (* A term folds a following plain line as a soft break; a blank line, a new
-   `::`/`:  ` marker, or a block opener ends it. A term holds inline content
+   `::`/`: ` marker, or a block opener ends it. A term holds inline content
    only -- no block body. (This used to read "like a heading", which was never
    the right comparison: a term is the KEY half of a key-value entry, not a
    title, and it is bound to the definition beneath it rather than to a section
@@ -1577,8 +1578,8 @@ definition_indent = whitespace, {whitespace} ;
    Thus the `>` on
 
        :: t
-       :  body
-           > q
+       : body
+          > q
 
    opens a block quote. The same rule covers headings, lists, tables, code/raw/
    colon fences, definitions, attributes followed by their target and comments,
@@ -1609,7 +1610,6 @@ definition_indent = whitespace, {whitespace} ;
    items and block quotes, matching djot). A blank line that is NOT followed by
    an indented continuation ends the body: the single-blank entry separator
    before the next `:: term` is preserved. *)
-
 (* --- Tables --- *)
 table = standard_row, [delimiter_row], {table_row}, [caption_slot] ;
 (* a table BEGINS with a standard row; a continuation row only ever follows
@@ -4640,9 +4640,9 @@ EOF = (* end of file *) ;
          standard row does:
 
              - | a |            > | a |            :: t
-               + b |            > + b |            :  | a |
-             tail               tail                  + b |
-                                                   tail
+               + b |            > + b |            : | a |
+             tail               tail                 + b |
+                                                  tail
 
          all end their container and leave `tail` a document paragraph, the
          same derivation S4's THE MARKER LINE'S CONTENT IS THE ITEM'S FIRST
@@ -6094,7 +6094,7 @@ EOF = (* end of file *) ;
 
          THE FIRST-BLOCK FORM IS THE ITEM AND THE DESCRIPTION -- NORMATIVE
          (carve#1821). The four containers above take the marker; only TWO of
-         them take it in the FIRST-BLOCK position. `- +` and `:  +` open a body
+         them take it in the FIRST-BLOCK position. `- +` and `: +` open a body
          whose content is the following flush-left block, and over a line that
          is not flush-left the marker is refused and the body ends. A FOOTNOTE
          BODY and a BLOCK QUOTE have no such form: `[^a]: +` and `> +` open a
@@ -6863,7 +6863,7 @@ EOF = (* end of file *) ;
          to the item. The block-opener set is UNIFORM and closed: block quote (`>` or
          `> `), heading (`#`), thematic break, fenced code, colon fence / admonition
          (`:::`), TABLE (a `|`-delimited row), and DEFINITION LIST (a `:: term`
-         opener; the two-line `:: `/`:  ` marker is recognized by the same
+         opener; the two-line `:: `/`: ` marker is recognized by the same
          look-ahead the top level uses, and only the `:: ` TERM line opens the
          block). None of these is special-cased: a def-list or table interrupts
          at column 0 and nests at content_column exactly as a quote or heading
@@ -8726,7 +8726,7 @@ EOF = (* end of file *) ;
       writer still does not use it. Inside a list item or a definition
       description there is no such spelling at any width: the marker's own
       content column absorbs the padding, so `- ![a](u)` and `-       ![a](u)`
-      are the same tree, and `:  ` behaves the same way. A writer preserving
+      are the same tree, and `: ` behaves the same way. A writer preserving
       the shape at one nesting level and losing it at the next, with nothing
       declaring the difference, is not a preservation rule; and the indented
       form emits meaning-bearing leading whitespace, which editors and
@@ -11220,8 +11220,8 @@ EOF = (* end of file *) ;
       closerless container:
 
           :: t
-          :  d
-             {.k}
+          : d
+            {.k}
           tail
 
       The `definition_list` ends where the description ends, not on the

--- a/resources/spec/01-layout.ebnf
+++ b/resources/spec/01-layout.ebnf
@@ -323,14 +323,14 @@
         anywhere in the stack, which is S4's own "otherwise" and nothing new:
 
             - a                :: t
-              [r]: /u          :  a
-            tail                  [r]: /u
-                               tail
+              [r]: /u          : a
+            tail                 [r]: /u
+                              tail
 
         both end their container and publish `tail` at document level. A
         COMMENT at a definition body's content column ends the paragraph the
         same way and for the same reason (§10 I5 lists it too), so
-        `:  a` over `   %% c` over `tail` ends the `dd`.
+        `: a` over `  %% c` over `tail` ends the `dd`.
 
         AND THE DEFINITION REGISTERS, which is half of what I5 says and the
         half an implementation can pass this rule without: "A link or footnote
@@ -592,8 +592,8 @@
         -- one paragraph holding an unclosed inline verbatim run, not a code
         block. So at a container's content column
 
-            - q                 > q                 :  a
-              ```               > ```                  ```
+            - q                 > q                 : a
+              ```               > ```                 ```
             tail                tail                tail
 
         all three fold `tail` into the paragraph that is still open, and no
@@ -677,12 +677,13 @@
 
         AND A DEFINITION BODY IS SUCH A CONTAINER -- NORMATIVE (carve#956).
         The third indented-block collector answers the same way. A definition
-        body's `dd` demands indentation to column 3 (`definition_indent`), so a
-        fence opened on the `:  ` marker line whose body sits BELOW that column
+        body's canonical `dd` demands indentation to column 2
+        (`definition_indent`), so a fence opened on the `: ` marker line whose
+        body sits BELOW that column
         is the list spelling above with a different prefix:
 
             :: t
-            :  ```
+            : ```
             body
             ```
 

--- a/resources/spec/03-blocks-core.ebnf
+++ b/resources/spec/03-blocks-core.ebnf
@@ -537,11 +537,11 @@ definition_entry = definition_term+, [blank_line], definition_body,
                    {[blank_line], definition_body} ;
 (* A blank line may separate a term from its definition, and one definition
    from the next, for readability -- the blank is a separator only (djot
-   parity). A blank NOT followed by a `:  ` definition ends the entry. *)
+   parity). A blank NOT followed by a `: ` definition ends the entry. *)
 definition_term = "::", space, inline_content, newline, {term_continuation_line} ;
 term_continuation_line = inline_content, newline ;
 (* A term folds a following plain line as a soft break; a blank line, a new
-   `::`/`:  ` marker, or a block opener ends it. A term holds inline content
+   `::`/`: ` marker, or a block opener ends it. A term holds inline content
    only -- no block body. (This used to read "like a heading", which was never
    the right comparison: a term is the KEY half of a key-value entry, not a
    title, and it is bound to the definition beneath it rather than to a section
@@ -679,8 +679,8 @@ definition_indent = whitespace, {whitespace} ;
    Thus the `>` on
 
        :: t
-       :  body
-           > q
+       : body
+          > q
 
    opens a block quote. The same rule covers headings, lists, tables, code/raw/
    colon fences, definitions, attributes followed by their target and comments,
@@ -711,4 +711,3 @@ definition_indent = whitespace, {whitespace} ;
    items and block quotes, matching djot). A blank line that is NOT followed by
    an indented continuation ends the body: the single-blank entry separator
    before the next `:: term` is preserved. *)
-

--- a/resources/spec/13-semantics-foundations.ebnf
+++ b/resources/spec/13-semantics-foundations.ebnf
@@ -395,9 +395,9 @@
          standard row does:
 
              - | a |            > | a |            :: t
-               + b |            > + b |            :  | a |
-             tail               tail                  + b |
-                                                   tail
+               + b |            > + b |            : | a |
+             tail               tail                 + b |
+                                                  tail
 
          all end their container and leave `tail` a document paragraph, the
          same derivation S4's THE MARKER LINE'S CONTENT IS THE ITEM'S FIRST

--- a/resources/spec/15-semantics-resolution-rendering.ebnf
+++ b/resources/spec/15-semantics-resolution-rendering.ebnf
@@ -307,7 +307,7 @@
 
          THE FIRST-BLOCK FORM IS THE ITEM AND THE DESCRIPTION -- NORMATIVE
          (carve#1821). The four containers above take the marker; only TWO of
-         them take it in the FIRST-BLOCK position. `- +` and `:  +` open a body
+         them take it in the FIRST-BLOCK position. `- +` and `: +` open a body
          whose content is the following flush-left block, and over a line that
          is not flush-left the marker is refused and the body ends. A FOOTNOTE
          BODY and a BLOCK QUOTE have no such form: `[^a]: +` and `> +` open a

--- a/resources/spec/16-semantics-comments-security.ebnf
+++ b/resources/spec/16-semantics-comments-security.ebnf
@@ -368,7 +368,7 @@
          to the item. The block-opener set is UNIFORM and closed: block quote (`>` or
          `> `), heading (`#`), thematic break, fenced code, colon fence / admonition
          (`:::`), TABLE (a `|`-delimited row), and DEFINITION LIST (a `:: term`
-         opener; the two-line `:: `/`:  ` marker is recognized by the same
+         opener; the two-line `:: `/`: ` marker is recognized by the same
          look-ahead the top level uses, and only the `:: ` TERM line opens the
          block). None of these is special-cased: a def-list or table interrupts
          at column 0 and nests at content_column exactly as a quote or heading

--- a/resources/spec/20-writer-invariants.ebnf
+++ b/resources/spec/20-writer-invariants.ebnf
@@ -260,7 +260,7 @@
       writer still does not use it. Inside a list item or a definition
       description there is no such spelling at any width: the marker's own
       content column absorbs the padding, so `- ![a](u)` and `-       ![a](u)`
-      are the same tree, and `:  ` behaves the same way. A writer preserving
+      are the same tree, and `: ` behaves the same way. A writer preserving
       the shape at one nesting level and losing it at the next, with nothing
       declaring the difference, is not a preservation rule; and the indented
       form emits meaning-bearing leading whitespace, which editors and

--- a/resources/spec/23-ast-foundations.ebnf
+++ b/resources/spec/23-ast-foundations.ebnf
@@ -613,8 +613,8 @@
       closerless container:
 
           :: t
-          :  d
-             {.k}
+          : d
+            {.k}
           tail
 
       The `definition_list` ends where the description ends, not on the


### PR DESCRIPTION
## Summary

- update generic definition-description examples to use the canonical `: description` separator
- move their continuation and nested-block examples from the former column 3 to canonical column 2
- retain wider-separator examples where the accepted noncanonical width is the behavior under test
- label those intentional wider forms explicitly in the edge-case prose
- regenerate the normative `resources/grammar.ebnf` aggregate

## Validation

- verified five representative column-shift rewrites preserve rendered HTML and format back canonically
- `node --test tests/normativity.test.mjs tests/grammar-citations.test.mjs tests/corpus.test.mjs tests/doc-carve-samples.test.mjs tests/fixture-bytes.test.mjs` (1,710 tests)
- `npm run corpus:build`
- `npm run spec:check`
- `npm run spec:rules:check`
- `git diff --check`
