### PR TITLE
docs: condense the normative grammar

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -116,21 +116,16 @@
            at the very start of the document is removed before the first line
            is read, so `<BOM># T` is a heading and not paragraph text. ONE, and
            only there: a U+FEFF anywhere else is an ordinary zero-width
-           character, which this file already says of a destination ("ZERO-WIDTH
-           characters (U+200B, U+FEFF) are NOT whitespace and ARE ordinary
-           destination characters").
+           character, and zero-width characters (U+200B, U+FEFF) are NOT
+           whitespace and ARE ordinary destination characters.
 
            A NULL IS REPLACED BEFORE THE FIRST LINE IS READ -- NORMATIVE.
            Every U+0000 in the source becomes U+FFFD REPLACEMENT CHARACTER,
            wherever it stands, before the first line is read. It is therefore
            not content, and it is the ONE C0 control PART 9 §29 does not make
-           content; §29 carries the carve-out and its reasons, and the
-           transform itself belongs here because it happens at this boundary
-           and for the same kind of reason as the mark above -- a document is
-           read over the OUTPUT of this layer, not over the bytes as authored.
-
-           EVERY occurrence is replaced. One U+0000 becomes one U+FFFD, so the
-           transform does not change source offsets (carve#1523).
+           content; §29 carries that carve-out. EVERY occurrence is replaced,
+           one U+0000 to one U+FFFD, so the transform does not change source
+           offsets (carve#1523).
 
            Column arithmetic is PART 9 §24 C1. A TAB IS SYNTAX ONLY IN THE
            LEADING RUN (PART 7).
@@ -322,10 +317,9 @@
         owner is selected before that leaf is continued.
 
         THE MARKER LINE'S CONTENT IS THE ITEM'S FIRST BLOCK -- NORMATIVE
-        (carve#1280). The clause above is spelled with an empty quote, which
-        reads as though EMPTINESS were the property doing the work. It is not,
-        any more than verbatimness is two clauses down. The parameter is the
-        one S4 names: does any container in the open stack hold an OPEN
+        (carve#1280). EMPTINESS is not the property doing the work. The
+        parameter is the one S4 names: does any container in the open stack
+        hold an OPEN
         PARAGRAPH. A block that leaves none leaves none wherever it was
         written, and `- # H` writes a HEADING as the item's first block exactly
         as `- ` plus an indented `# H` would. So each of
@@ -386,20 +380,6 @@
             tail             > > | b |          tail
                              tail
 
-        all end BOTH quotes and leave `tail` a top-level paragraph, for the
-        reason `> # H` / `tail` ends one. The reading that stopped at the outer
-        quote gave `tail` a paragraph in the outer quote CONTINUING NOTHING -
-        the outer quote's last block is the inner quote, and the inner quote's
-        is a heading, so there was no open paragraph anywhere in the stack for
-        S4's fold to carry out.
-
-        The one-level spelling already answered this way in every engine and
-        the two-level one did not in three of them, which makes it a
-        contradiction inside each of those readers rather than a gap in this
-        clause. `> > a` / `tail` still folds into the INNER quote, and
-        `> > # H` / `> > a` / `tail` folds too: those are the shapes with a
-        paragraph open, and depth was never the parameter.
-
         The rule reaches blocks written at an item's CONTENT COLUMN too. A
         heading there leaves no paragraph open, so a following below-column
         line cannot stay in that item. In a nested list the owner table is then
@@ -433,11 +413,10 @@
         same way and for the same reason (§10 I5 lists it too), so
         `: a` over `  %% c` over `tail` ends the `dd`.
 
-        AND THE DEFINITION REGISTERS, which is half of what I5 says and the
-        half an implementation can pass this rule without: "A link or footnote
-        definition belongs to an open list item only at that item's
+        AND THE DEFINITION REGISTERS, which is I5's other half: "A link or
+        footnote definition belongs to an open list item only at that item's
         `content_column`". Ending the container while DROPPING the definition
-        gets `tail` right by accident and fails the moment the column moves.
+        is not conforming.
         I5's other two columns are the controls and are UNCHANGED: at DOCUMENT
         column 0 the definition is a document-level interrupter, and at a
         nonzero column BELOW `content_column` it is lazy paragraph text that
@@ -448,8 +427,7 @@
         INVISIBLE LINE IS ONE CLASSIFICATION): recognized at document level
         only, so inside a container the line is not an invisible line at all --
         it is ordinary paragraph text and reopens the paragraph like any other
-        prose. Pinned in both bodies with a collector of their own by corpus
-        432-an-abbreviation-definition-outside-document-level-is-not-an-invisible-line.
+        prose.
 
         A QUOTE IS REACHED BY ITS MARKER, AND A COLUMN NEVER REACHES INTO ONE
         (carve#1384). I5's columns are read against the container a line is IN,
@@ -459,29 +437,9 @@
         so it is paragraph text: it renders where it was written and registers
         nothing.
 
-        The tell was that one line answered differently by what the quote HELD:
-
-            > x                > - x
-              [r]: /u            [r]: /u
-
-            See [r][].         See [r][].
-
-        Both second lines are identical and sit at the quote's content column,
-        and neither writes the marker. The left one folds into the quote's
-        paragraph as text in every reader. The right one was read as the INNER
-        ITEM's content column, where I5 makes a definition the item's, so this
-        implementation registered it and rendered it NOWHERE, and carve-js and
-        carve-php dropped it entirely -- render nothing and define nothing,
-        which is the one outcome carve#624 forbids. carve-rs folds both, and the
-        fold is what S4 already prescribes: the deepest open paragraph in the
-        stack is the inner item's, and the line continues it.
-
         WITH THE MARKER WRITTEN nothing about I5 changes: `> - x` over
-        `>   [r]: /u` registers at the inner item's content column in all four
-        readers, which is corpus
-        360-a-definition-behind-an-alternating-container-prefix-registers-at-the-innermost-content-column's
-        space. The marker is the parameter, and the quote's body is not.
-        Corpus 369.
+        `>   [r]: /u` registers at the inner item's content column. The marker
+        is the parameter, and the quote's body is not.
 
         PROSE REOPENS THE PARAGRAPH WHEREVER IT SITS AMONG THE ITEM'S BLOCKS,
         which is the general shape of that last sentence rather than a property
@@ -519,15 +477,8 @@
 
         end the item in the first two spellings and fold in the third, and the
         difference between them is the blank, never the missing closer. A
-        reader that made the closer decide answers one rule two ways inside a
-        single parse, which is what the executable spec did: it carried the
-        blank as container content and left the item's paragraph open across
-        it, so the flush-left line arrived at a div that should already have
-        been out of reach. carve-js, carve-php and carve-rs all end the item.
-        Corpus 362 pins it with two controls: the same input without the blank,
-        which still folds, and a following line at the item's content column,
-        which is the div's second block rather than the end of the item.
-        (carve#1379)
+        following line at the item's content column is the div's second block
+        rather than the end of the item. (carve#1379)
 
         THE COLUMN IS REACHED BY COMPOSING THE STRIPS, NOT BY WALKING THE
         PREFIX (carve#1368). Which container's `content_column` a line reaches
@@ -535,24 +486,21 @@
         own prefix and hands the residue down, so the question is asked of the
         INNERMOST container in the coordinates IT was handed. The shape of the
         prefix above it -- how many quotes and list items it alternates, in
-        what order, and how deep -- is not a parameter. Stated as a property
-        rather than as the list of prefixes that have been measured: two
-        container kinds already spell 62 of them by depth five, and the list
-        goes stale at depth six.
+        what order, and how deep -- is not a parameter.
 
         The DROP is the disappearance §24 C3 already forbids under AN INVISIBLE
-        LINE FOLDS LIKE ANY OTHER (carve-php#721): a definition may register, or
-        it may stay text, and half-folding it -- gone from the page, absent from
-        the tables -- is not an option the rule offers.
+        LINE FOLDS LIKE ANY OTHER: a definition may register, or it may stay
+        text, and half-folding it -- gone from the page, absent from the
+        tables -- is not an option the rule offers.
 
         AT A CONTAINER'S CONTENT COLUMN, A BLOCK ENDS THE PARAGRAPH IT SITS
-        UNDER -- NORMATIVE (carve#1350, carve#1357). The clause above names a
-        definition and a comment; this is the rule both are instances of, and
-        it is stated as a property because the instances are not enumerable.
+        UNDER -- NORMATIVE (carve#1350, carve#1357). The definition and the
+        comment above are instances; the rule is stated as a property because
+        the instances are not enumerable.
 
-        §24 C3 says the content column IS the container body's column 0: "a
-        block opener is recognized there exactly as a block opener is
-        recognized only at column 0 at the top level". So a line there is read
+        §24 C3 says the content column IS the container body's column 0: a
+        block opener is recognized there exactly as one is recognized only at
+        column 0 at the top level. So a line there is read
         as a BLOCK, and a block ends the paragraph above it. WHAT THE BLOCK
         RENDERS IS NOT A PARAMETER. A comment, a link or footnote definition
         and an attribute block all render nothing and all three end the
@@ -580,20 +528,11 @@
         marker line and a heading inside a quote. The line's position changes
         which container owns the heading, not whether the heading is a block.
 
-        THE §17 L1a OBJECTION DOES NOT REACH THIS. carve#621 and carve#625
-        ruled that an invisible line is NOT A PARAGRAPH for looseness. Whether
-        a line IS a paragraph and whether it ENDS one are different questions,
-        which is what the `dd` half of carve#1350 already turned on - and the
-        attribute block settles it by measurement rather than by argument,
-        since it is invisible, it ends the item, and every implementation
-        already agrees it does. An objection that would forbid that is an
-        objection to something nobody does.
-
         WHAT THIS DOES NOT REACH, and both are unchanged. BELOW the content
         column at a NONZERO column, the following line reaches the container
         only through S4's lazy fold, and §24 C3's comment exception keeps that
-        path open: `- a` / `  %% c` / ` b` keeps `b` in the item, and corpus
-        189 and 192 pin the nested spelling of it. A line at DOCUMENT column 0
+        path open: `- a` / `  %% c` / ` b` keeps `b` in the item. A line at
+        DOCUMENT column 0
         is not below a column - it is AT the enclosing context's own block
         position, the distinction C3 already draws for a definition. And a line
         AT the content column after the block is the container's own second
@@ -618,15 +557,9 @@
         THE LINK REFERENCE DEFINITION IS THE CONTROL, and it does not move. It
         has no body, so its block IS the one line: the blank after it falls
         OUTSIDE the block, the indented line below is the container's own
-        second paragraph, and the flush-left line folds into that. `- a` /
-        `  [r]: /u` / blank / `    more` / `tail` keeps both lines in the item,
-        which every implementation already does. So this turns on the block's
-        extent, the same thing the contiguous spelling turned on, and not on
-        indentation and not on blank lines.
-
-        The NESTED spelling (`- outer` / `  - inner` / `    [r]: /u` / `tail`)
-        is unanimous and belongs to the nested half this clause leaves open
-        above; it is not decided here.
+        second paragraph, and the flush-left line folds into that. So this
+        turns on the block's extent, not on indentation and not on blank
+        lines. The NESTED spelling is not decided here.
 
         A FENCED BODY IS NOT A PARAGRAPH -- NORMATIVE (carve#646). The same
         rule, with the unmatched container's last block a CODE FENCE opened on
@@ -645,39 +578,16 @@
         and `x` re-parses at document level -- where the trailing delimiter run
         is ordinary inline text.
 
-        AND THE FENCE KIND IS NOT A PARAMETER -- NORMATIVE (carve#980). The
-        clause above is named for a code fence, and reads as though
-        VERBATIMNESS were the property doing the work. It is not. The reach of a container
-        is not extended by what its innermost block happens to be, and the
-        parameter S4 actually consults is whether ANY container in the open
-        stack holds an OPEN PARAGRAPH -- explicitly regardless of how many
-        containers the line failed to match. The fence kind never enters.
-
-        Read that way the two fence kinds are ONE rule and the asymmetry
-        between them falls out of the paragraph:
-
-          - A CODE fence body cannot hold an open paragraph at all, so the
-            column-0 line always takes S4's otherwise and the container ends.
-            That is the clause above, with no exception to carry.
-          - A COLON fence body CAN hold one, so it takes the lazy branch when
-            it does and the same otherwise when it does not.
-
-        The second bullet is not a widening. An EMPTY colon fence already ends
-        the container today -- corpus 270's second document pins it and the
-        oracle produces it -- so the reach rule ALREADY reaches colon fences.
-        What it must not do is override an open paragraph, because S4's lazy
-        branch is what the reach rule is made of, not an exception to it.
-
-        S1 and S2 are why this needed saying. S1 MATCH PREFIXES stops the walk
-        at the ITEM and S2 FENCED BODY does not fire, in the colon spelling
-        exactly as in the code spelling. But stopping the walk only ROUTES the
-        line to S4; it does not decide it. Reading the stop as the decision
-        makes VERBATIMNESS look load-bearing when it only ever stood in for
-        "no paragraph is open", and that derivation reaches the opposite of
-        what corpus 270 and A REAL DIV IS A CONTAINER LIKE ANY OTHER already
-        require. Stated here because a clause that is silent about which
-        property governs leaves the wrong derivation available to the next
-        reader, which is how it was reached once already (carve#980).
+        AND THE FENCE KIND IS NOT A PARAMETER -- NORMATIVE.
+        VERBATIMNESS is not the property doing the work. The reach of a
+        container is not extended by what its innermost block happens to be,
+        and the parameter S4 consults is whether ANY container in the open
+        stack holds an OPEN PARAGRAPH. The fence kind never enters, so the two
+        fence kinds are ONE rule and the asymmetry between them falls out of
+        the paragraph: a CODE fence body cannot hold an open paragraph at all,
+        so the column-0 line always takes S4's otherwise and the container
+        ends, while a COLON fence body CAN hold one and takes the lazy branch
+        when it does.
 
         AND A FENCE THAT OPENED NO BODY IS NOT ONE EITHER (carve#1387). The
         first bullet presumes a code fence body EXISTS. §10 I4 decides that, and
@@ -697,16 +607,6 @@
               ```               > ```                 ```
             tail                tail                tail
 
-        all three fold `tail` into the paragraph that is still open, and no
-        container ends. The LIST spelling is the one that diverged: the
-        executable spec, carve-php and carve-rs ended the item while rendering
-        the same fence line as paragraph text, which is one line answered two
-        ways inside a single parse -- the shape PROSE REOPENS THE PARAGRAPH
-        already names. All three of them fold the quote spelling, and this
-        implementation folded the `dd` spelling too, so the contradiction was
-        inside each reader rather than between them. The fence CHARACTER is not
-        a parameter either: the tilde spelling is the same clause.
-
         THE CLOSER LOOKAHEAD DOES NOT STOP AT A BELOW-COLUMN LINE. §24 C3 folds
         such a line as lazy text while a paragraph is open, so a closer written
         below it is still written inside the container. Stopping there makes the
@@ -719,15 +619,13 @@
              y
               ```
 
-        differently from every engine, which ends the item at ` y` because this
-        fence does have its closer and a real body is open (corpus
-        276-a-fence-opened-on-a-list-marker-line-body-below-the-content-column).
+        wrongly: the item ends at ` y`, because this fence does have its closer
+        and a real body is open.
 
         A BLANK LINE and a TERMINATED fence are the controls, and both are
         unchanged: a blank closes the paragraph so S4's otherwise governs
         (carve#1379), and a fence with a closer is a BLOCK whose body leaves no
         paragraph open, which is the first bullet with its premise intact.
-        Corpus 367.
 
         AND NOTHING CLOSES MEANS THE CONTAINER GOES ON COLLECTING -- NORMATIVE
         (carve#980). S4's lazy branch says NOTHING closes, and that binds the
@@ -742,16 +640,11 @@
               b
               :::
 
-        On the left `a`, `d` and `b` are one paragraph in one div. Folding `d`
-        and then ending the container -- so that `b` lands beside the div
-        rather than inside it -- is the reach over-extended in the other
-        direction, and it renders a document nothing in the stack ever closed.
-        The right-hand document is the same rule with the fold as the last
-        line, which is the only spelling corpus 270 carried, and it is why a
-        reader could fold correctly and still get the left one wrong. Corpus
-        category 280 pins both, and the CONTROL beside them: with nothing in
-        the stack open, the flush-left line still ENDS the container and the
-        line after it is outside too.
+        On the left `a`, `d` and `b` are one paragraph in one div; `b` MUST NOT
+        land beside the div. The right-hand document is the same rule with the
+        fold as the last line. The CONTROL: with nothing in the stack open, the
+        flush-left line still ENDS the container and the line after it is
+        outside too.
 
         A REAL DIV IS A CONTAINER LIKE ANY OTHER -- NORMATIVE (carve#909). An
         unterminated `::: ` div in a container decides the same way, on the same
@@ -793,18 +686,9 @@
         governs, its lazy branch asks for an open PARAGRAPH, and a verbatim
         body is not one. So the containers close, the `dd` holds an EMPTY code
         block, and `body` re-parses at document level -- where the trailing
-        delimiter run is ordinary inline text, byte for byte the answer corpus
-        276 already pins for the `- ``` ` spelling.
+        delimiter run is ordinary inline text, byte for byte the answer the
+        `- ``` ` spelling gets.
 
-        This said "the innermost MATCHED context holds an OPEN PARAGRAPH",
-        which describes something no implementation does. A lazy line carries
-        no markers, so it matches ZERO containers and the innermost matched
-        context is the document root, which holds no open paragraph -- under
-        that wording `> a` / `b` would close the quote at depth 1. Every engine
-        folds there, and corpus 82-blockquote-lazy-continuation pins it. What
-        the wording did produce was a split at depth 2: carve-rs closed both
-        quotes where carve-js and carve-php folded into the nested one
-        (carve#506, carve-rs#452). Depth is not a parameter of this rule.
      S5 OPENERS. When S3/S4 classify the residue as a container opener (a
         quote marker; a list marker at an admissible column; a `+`
         continuation marker at the marker column, PART 9 §17 L3/L4; a fence
@@ -927,23 +811,13 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
    character that is not one BEGINS the heading. `##<SP><SP>h` is the heading
    `h`, not `<SP>h`.
 
-   TWO CLAUSES DECIDE IT, and neither of them counts engines. MARKER
-   SEPARATORS AND PADDING SLOTS (PART 2) defines a marker separator as what
-   stands between the marker and the content it introduces and rules that a
-   writer aligning in a column "is writing separator, not content"; the four
-   slots that clause narrows to exactly one space are PADDING slots, an
-   enumeration it closes, and the heading marker is not among them. And
-   PART 11 §1 names MARKER ALIGNMENT among the spellings `fmt` may normalize
-   while preserving what the document says -- which holds only if the run is
-   not content. All three writers already normalize `##<SP><SP>h` to
-   `##<SP>h`, so under the literal reading every one of them changed the
-   document on every pass.
-
-   NO GATE COULD REACH IT. No corpus document, no optional-corpus case and
-   none of the authored documents in the oracle comparison's population
-   spelled a heading with a second space after the marker.
-   `84-single-line-headings-5` is `#` and two spaces and NOTHING else, which
-   is a different rule and is answered below.
+   TWO CLAUSES DECIDE IT. MARKER SEPARATORS AND PADDING SLOTS (PART 2) makes
+   a marker separator what stands between the marker and the content it
+   introduces, and the four slots it narrows to exactly one space are PADDING
+   slots -- a closed enumeration the heading marker is not in. And PART 11 §1
+   names MARKER ALIGNMENT among the spellings `fmt` may normalize while
+   preserving what the document says, which holds only if the run is not
+   content: `fmt` writes `##<SP><SP>h` as `##<SP>h`.
 
    A TAB IS NOT SEPARATOR. `space = ' '`, so `#<SP><TAB>x` is a heading whose
    text BEGINS with the tab, and `#<TAB>x` is not a heading at all -- the
@@ -952,16 +826,12 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
 
    AND THE MARKER REQUIRES CONTENT after the run as well: hashes, the
    separator and nothing but whitespace open no heading, and the line is
-   ordinary paragraph text with its trailing run dropped. That half needs no
-   correction -- it is the one thing every reader including the executable
-   spec already had, which is why `84-single-line-headings-5` was never red.
+   ordinary paragraph text with its trailing run dropped.
 
    WHAT MOVES WITH THE TEXT, AND WHAT DOES NOT. The derived id does NOT
    change: slugging drops a leading run either way, so `##<SP><SP>a b` is
-   `a-b` under both readings, and a ticket predicting otherwise is predicting
-   from the text rather than from the slug. A CROSSREF's AUTO-TEXT does move,
-   because §19 takes the heading's own text -- `</#a-b>` rendered
-   `<SP>a b` under the literal reading and renders `a b` under this one. *)
+   `a-b`. A CROSSREF's AUTO-TEXT takes the heading's own text (§19), so
+   `</#a-b>` renders `a b`. *)
 
 (* SINGLE-LINE HEADINGS -- NORMATIVE (diverges from Djot). A heading ENDS AT
    THE NEWLINE. It has no continuation line, and nothing following it folds in:
@@ -974,18 +844,6 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
      ## A             -> two separate <h2> elements
      ## B
 
-   It also makes this grammar's own model true. A heading is described here as
-   "a bounded title, not an open paragraph"; with continuation lines it had
-   paragraph-style spill anyway. LAZY CONTINUATION now means exactly one thing
-   across the whole language: it continues an OPEN PARAGRAPH (in a blockquote,
-   list item or definition body). A heading is not a paragraph, so nothing
-   continues it.
-
-   WHAT IS LOST: source-wrapping a long heading. Headings are short by
-   construction, Markdown never offered it, and the rendered result was a raw
-   newline inside the `h1`. A Djot document that wraps a heading therefore
-   renders differently in Carve; `carve lint --from-djot` reports it.
-
    A `^ ` caption line is no exception: it does not fold in, and it does not
    attach either, because a heading is NOT one of §4's captionable hosts. It
    opens an ordinary paragraph of its own.
@@ -993,21 +851,12 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
      # H              -> <h1>H</h1> then <p>^ cap</p>
      ^ cap
 
-   This sentence used to read "a caption still attaches to a heading (§4)",
-   citing as its authority the very clause whose enumeration omits a heading,
-   and no engine attaches one. A false claim carrying a true citation is worse
-   than a bare one: a reader who checks the reference finds the opposite and has
-   no way to tell which of the two is the language (carve#991).
-
    NO TRAILING ATTRIBUTES (djot-strict). A heading line carries NO trailing
    `{...}` attribute block: a `{...}` at the end of a heading line is ordinary
    inline content (literal text unless it forms an inline construct), and the
    id derives from the full literal text. Attributes attach via a PRECEDING
    block-attribute line (PART 9 §15), the uniform block rule; an explicit
-   `#id` from that line lives on the `<section>` wrapper (PART 9 §13).
-   Pinned by corpus 02-headings (the preceding-line and literal-trailing
-   pairs) and 82-single-line-headings (the five cases that used to fold, kept
-   as the regression guard for the behavior that replaced them). *)
+   `#id` from that line lives on the `<section>` wrapper (PART 9 §13). *)
 
 (* HEADING IDENTIFIERS -- NORMATIVE. A heading without an explicit {#id} gets an
    automatic identifier from its TEXT CONTENT, GitHub/SSG-style. WHICH INLINES
@@ -1017,11 +866,7 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
    assigned before a cross-reference resolves or a symbol is looked up. Code
    spans, MATH runs, an image's alt text, a link's label and a superscript
    contribute; footnote references, cross-references and symbols `:name:` do
-   not, and a line comment ends the line it sits on. "Folded plain text" was the
-   older spelling here and is what let one engine drop math while keeping the
-   code span beside it: a plain-text projection that omits math supports that
-   reading, and nothing said the projection was not the rule. Corpus 332 pins
-   one document per inline kind. Then, on that text:
+   not, and a line comment ends the line it sits on. Then, on that text:
      - reverse smart-typography output to its ASCII source first, so the id does
        not depend on presentation (`Don’t` -> `Don-t`, `Step 1 → 2` -> `Step-1-2`);
      - replace each maximal run of non-alphanumeric ASCII characters with a single
@@ -1030,12 +875,7 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
      - PRESERVE CASE (Unicode-aware): NON-ASCII characters AND letter case pass
        through unchanged (`Café` -> `Café`, `日本語` unchanged). The text IS
        NFC-normalized before slugging (PART 9 §25), so a precomposed `é` and a
-       decomposed `e` + U+0301 give the SAME id. The clause used to deny this and
-       argue that the slug "needs no Unicode tables" - but §25 already required
-       the normalization for Trojan-Source reasons, the corpus fixture beside it
-       pins the composed id, and all three engines plus the oracle compose. The
-       tables are carried either way, so the rationale was inverted as well as the
-       rule (carve#705);
+       decomposed `e` + U+0301 give the SAME id (carve#705);
      - a leading-digit result is prefixed `s-` (a bare leading digit is a valid HTML
        id but an invalid CSS selector); an empty result becomes a generated `s-N`;
      - duplicates within a document get a numeric `-2`, `-3`, ... suffix.
@@ -1050,9 +890,9 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
    so the id is guaranteed to match `[0-9A-Za-z-]`. carve-js spells them `'fold'`
    and `'strict'`, carve-rs `AsciiHeadingIds::Fold` and `::Strict`; carve-php's
    extension is the STRICT one. The table itself is not normative -- what is, is
-   that the three engines carry the SAME table, so a folded id is byte-identical
-   across them. NOTE: carve PRESERVES case, matching djot.js / djot-php per #393;
-   cross-references resolve case-insensitively against the case-preserved id table. *)
+   that the three engines carry the SAME table. Carve PRESERVES case, matching
+   djot.js / djot-php per #393; cross-references resolve case-insensitively
+   against the case-preserved id table. *)
 
 (* --- Thematic Breaks --- *)
 thematic_break = (('-', '-', '-', {'-'}) | ('*', '*', '*', {'*'}) | ('_', '_', '_', {'_'})), newline ;
@@ -1069,27 +909,22 @@ fenced_code_block = code_fence_open, [space], [code_fence_info], newline,
 (* The space between the fence and the info string is OPTIONAL (lenient:
    both ```php and ``` php are accepted; Markdown writes no space, Djot writes
    the space). The no-space form (```php) is canonical and is what the X->Carve
-   converters emit. It is a PADDING SLOT, not a marker separator (PART 7) --
-   the fence run has already decided that this is a code block, and the info
-   string only names the language and carries metadata -- but both roles take
-   `space`: the slot sits after the fence run, and A TAB IS SYNTAX ONLY IN THE
-   LEADING RUN (PART 7). The same holds for the two slots inside
-   code_fence_info below. So ```` ```<TAB>php ```` is not a fence opener; the
-   backtick run is an ordinary inline verbatim run (carve#1285). A TAB WITH
-   NOTHING AFTER IT IS NOT THIS SLOT, by ruling (carve#1295): it is trailing
-   whitespace on a content line, PART 2 drops it, and ```` ```<TAB> ```` opens
-   an ordinary fence with no info string. Position decides which clause
-   governs, here and at `frontmatter_open`, and refusing both positions is the
-   separator rule applied twice. raw_block (PART 9 §20)
-   spells its otherwise identical slot the same way, for the additional reason
-   that the `=` after it SELECTS a raw block over a code block.
+   converters emit. It is a PADDING SLOT, not a marker separator (PART 7), but
+   both roles take `space`: the slot sits after the fence run, and A TAB IS
+   SYNTAX ONLY IN THE LEADING RUN (PART 7). The same holds for the two slots
+   inside code_fence_info below. So ```` ```<TAB>php ```` is not a fence opener;
+   the backtick run is an ordinary inline verbatim run. A TAB WITH NOTHING AFTER
+   IT IS NOT THIS SLOT: it is trailing whitespace on a content line, PART 2
+   drops it, and ```` ```<TAB> ```` opens an ordinary fence with no info string.
+   Position decides which clause governs, here and at `frontmatter_open`.
+   raw_block (PART 9 §20) spells its otherwise identical slot the same way, for
+   the additional reason that the `=` after it SELECTS a raw block over a code
+   block.
    CARDINALITY DIFFERS BETWEEN THIS SLOT AND THE TWO INSIDE code_fence_info,
    deliberately: this one is `[space]`, exactly one, and those are `space+`.
    So ``` ```<SP><SP>php ``` is not a fence opener at all -- the second space
    reaches `language_info`, whose class holds no space, and the INVALID-FENCE
-   FALLBACK applies. All three engines and the executable spec accepted a run
-   here until carve#912 held the production right; corpus 263 carries it with
-   its one-space control. *)
+   FALLBACK applies. *)
 (* CODE-FENCE INFO STRING -- NORMATIVE. After the optional language_info
    token the opener admits, in this fixed order, an optional "header" (a
    quoted_title -- the SAME token as the admonition header, PART 9 §12) and an
@@ -1144,10 +979,8 @@ code_fence_close = (backtick_fence | tilde_fence):close
      - A closing run indented PAST its opener is not a delimiter but code
        content -- which is exactly what lets an indented ``` line appear as
        sample text inside a fence.
-   Earlier drafts accepted 0-3 columns of indentation on a delimiter (a Markdown
-   inheritance, to disambiguate against the 4-space indented code block); Carve
-   has no such construct, so that tolerance is removed. The X->Carve converters
-   re-base an indented Markdown fence to its container's content column. *)
+   The X->Carve converters re-base an indented Markdown fence to its
+   container's content column. *)
 
 backtick_fence = '`', '`', '`', {'`'} ;
 tilde_fence = '~', '~', '~', {'~'} ;
@@ -1163,8 +996,7 @@ code_fence_info = ( language_info, [space+, quoted_title], [space+, label] )
    "title" and [label] slots carry: the fence has already decided the block --
    and padding takes `space`, by A TAB IS SYNTAX ONLY IN THE LEADING RUN
    (PART 7). The label slot appears in two alternatives and is one slot with
-   one role, so both spellings carry the same terminal -- otherwise ```js "T" [L] and ``` "T" [L]
-   would disagree about a tab for no reason a reader could state. *)
+   one role, so both spellings carry the same terminal. *)
 language_info = (letter | digit | '-' | '_' | '+' | '#' | '.' | '/')+ ;  (* a single token; the punctuation covers real language tags like c++, c#, f#, asp.net, text/html. May start with a digit. The `/` is normative across all impls (so `text/html`, `image/svg` are language tokens, not split). A token MUST NOT start with `=`: a leading `=` is the raw_block opener (above), not a language. *)
 label = '[', { character - ']' }, ']' ;  (* structured metadata, e.g. [Installation]; not part of the class *)
 code_content = (* any text until matching fence, preserved literally *) ;
@@ -1173,7 +1005,7 @@ code_content = (* any text until matching fence, preserved literally *) ;
    are not interchangeable. Tab display width is a presentation concern (CSS
    `tab-size`). Tab-to-space expansion is NOT a default behavior -- it is opt-in
    via a tab-normalize extension (flat replacement, default 2 spaces, content
-   only). Matches djot / CommonMark. Pinned by corpus tabs-in-code-preserved. *)
+   only). Matches djot / CommonMark. *)
 
 (* --- Blockquotes --- *)
 blockquote = blockquote_line, {blockquote_line | lazy_continuation_line | continuation_marker_block}, [caption_slot] ;
@@ -1224,25 +1056,12 @@ bullet_marker = '-' | '*' ;  (* `+` is NOT a bullet in Carve -- it is the list
    opens its block only when followed by that space AND non-empty content. A
    content-less marker line -- bare (`-`) or with trailing whitespace only
    (`- `, `-   `) -- is NOT a list: it is paragraph text. The rule ignores
-   trailing whitespace, so `-` and `- ` behave identically (an editor stripping
-   the trailing space cannot change the meaning). Carve is stricter than
-   CommonMark, which treats a bare `-` as an empty item; requiring content keeps
-   a lone dash (a prose dash / placeholder) from silently becoming a list.
-   Pinned by corpus content-less-marker-is-not-a-list.
+   trailing whitespace, so `-` and `- ` behave identically. Stricter than
+   CommonMark, which treats a bare `-` as an empty item.
 
-   EVERY SUCH MARKER, not only the two named here. The rule is stated in terms
-   of bullets and ordered markers because those are where it was first needed,
-   but the rationale is a property of the separator space and applies wherever
-   one appears -- including the definition-term marker `::` and the description
-   marker `:`.
-
-   That omission was not theoretical: with the rule read narrowly, `:: ` was a
-   paragraph and `::` followed by TWO spaces was a definition list, so stripping
-   one trailing space changed the document's structure -- the exact thing the
-   sentence above exists to prevent. Three engines carried three answers
-   (paragraph, `<dt></dt>`, and `<dt> </dt>`) with every gate green, because the
-   corpus case pinned bullets only. Pinned now by corpus
-   content-less-marker-is-not-a-list-2 (carve#512).
+   EVERY SUCH MARKER, not only bullets and ordered markers: the rule is a
+   property of the separator space and applies wherever one appears --
+   including the definition-term marker `::` and the description marker `:`.
 
    THE DESCRIPTION MARKER -- NORMATIVE (carve#1830). `definition_separator` is a
    separator space, so a `:` line carrying only whitespace opens no description.
@@ -1251,23 +1070,17 @@ bullet_marker = '-' | '*' ;  (* `+` is NOT a bullet in Carve -- it is the list
    tab-separated `:` are one document, and the separator's width carries no
    meaning where it positions nothing. The tab is refused a step earlier, at the
    separator itself (PART 1, MARKER SEPARATORS AND PADDING SLOTS), and lands in
-   the same place. Pinned by corpus
-   a-colon-followed-by-only-whitespace-is-not-a-description.
+   the same place.
 
    A TAB AS THE FIRST CHARACTER OF CONTENT is a different question from the one
-   above -- NORMATIVE. There the separator space itself is present, so the
-   marker is satisfied and a term forms; the tab is not part of the separator
-   at all, it is the first character of the term's inline content. That tab is
-   ordinary leading whitespace, and is stripped like any other leading
-   whitespace in that position -- it does not appear in the rendered `<dt>`,
-   the same way a bullet's own extra separator whitespace never reaches the
-   item's content: content_column is where the item's content actually
-   STARTS (PART 9 §24 C3), so anything before it, space or tab alike, is
-   structural, not text. This is NOT the TABS IN CODE rule (PART 2, above):
-   that verbatim-preservation guarantee covers fenced code content and inline
-   code spans only, never a term's or a paragraph's inline content, so
-   nothing protects this tab. `::` + space + TAB + `x` therefore renders
-   `<dl><dt>x</dt></dl>` (carve#698). *)
+   above -- NORMATIVE.
+   There the separator space is present, so the marker is satisfied and a term
+   forms; the tab is the first character of the term's inline content. It is
+   ordinary leading whitespace and is stripped like any other in that position:
+   content_column is where the item's content actually STARTS (PART 9 §24 C3).
+   The TABS IN CODE rule (PART 2, above) does not apply -- it covers fenced code
+   content and inline code spans only. `::` + space + TAB + `x` therefore
+   renders `<dl><dt>x</dt></dl>`. *)
 
 ordered_list = ordered_item+ ;
 ordered_item = ordered_marker, [item_attributes], space, list_item_content ;
@@ -1345,10 +1158,8 @@ roman_numeral = ('i' | 'v' | 'x' | 'l' | 'c' | 'd' | 'm')+
    - Free slot: `-{` and `1.{` / `1){` are NOT list markers today (bullet and
      ordered both require the space), so no existing input changes meaning.
    - Diverges from djot (which has no li-attribute form); deliberate Carve
-     extension. The lazy-continuation accident -- a trailing `{…}` line folded
-     onto a tight item, which carve-php attached to the `<li>` and carve-js
-     dropped -- is REJECTED as the mechanism: it was position-dependent (broke
-     once a sub-list intervened) and is not normative. *)
+     extension. A trailing `{…}` line folded onto a tight item is NOT a
+     li-attribute mechanism. *)
 item_attributes = attributes ;
 
 list_item_content = first_block_content
@@ -1365,10 +1176,7 @@ indent = whitespace, {whitespace} ;
    one-off lone item: following markers at the sub-list's content column MERGE
    into the same nested list, and a post-blank block indented to that column is
    ABSORBED into the open nested item as a lazy continuation. This matches
-   reference djot.js (`@djot/djot`) and CommonMark. It CORRECTS a narrower
-   reading carve inherited from djot-php (which did not persist the nested list);
-   it is a bug fix, NOT a carve divergence. Pinned by corpus
-   marker-line-nested-lists. *)
+   reference djot.js (`@djot/djot`) and CommonMark. *)
 (* Continuation marker (Carve addition; see PART 9 §17): a lone `+` at the
    current container's marker column attaches the following flush-left block to
    that container -- a list item OR a block quote -- with no blank line, marker
@@ -1396,28 +1204,19 @@ task_state = ' ' | 'x' | 'X' | '-' | '_' | '>' | '?' ;
    indented line below it when it does not.
      `- [ ] a`        -> `<li><input ...> a</li>`
      `- [ ] > q`      -> `<li><input ...> ` newline `  <blockquote>...`
-   The executable spec emitted the checkbox only where the first block was a
-   PARAGRAPH, so a quote, a code fence, a `:::` div, a table row, a heading and
-   a thematic break each rendered a plain `<li>` and the state the author wrote
-   was gone from the output while the item parsed correctly. One serializer
-   branch built the opener without it, and it was the branch every
-   non-paragraph lead takes. carve-js and carve-php write it in all of them.
-   Corpus 363 pins three leads and both states. (carve#1381)
+   A quote, a code fence, a `:::` div, a table row, a heading and a thematic
+   break as the first block each still get the checkbox. (carve#1381)
 
-   THE TASK BOX CARRIES AN ACCESSIBLE NAME -- NORMATIVE (carve#1468). The box
-   is an <input type="checkbox"> and the word beside it is a SIBLING TEXT
-   NODE - not a <label>, not an aria-label - so the input carried a STATE and
-   no NAME, and a reader met an unlabeled disabled checkbox with ordinary prose
-   next to it. The box takes an `aria-label` naming it with the item's own
-   visible text: the DERIVED TEXT of the item's first block (PART 9R R4's
-   derivation, the same one a heading id and a crossref clone read). A
-   paragraph spans LINES -- a soft wrap, or a lazy continuation folded into it
-   -- and a name is ONE line, so each run of ASCII whitespace in the derived
-   text collapses to a single space and the result is trimmed. A NO-BREAK space
-   is content and survives; the collapse is ASCII-only for that reason.
-   Deriving rather than inventing is what keeps this string out of the `labels`
-   map (PART 9 SS16a) - it is the AUTHOR's text, already on the page, so a host
-   translating the document translates it exactly once.
+   THE TASK BOX CARRIES AN ACCESSIBLE NAME -- NORMATIVE. The box is an
+   <input type="checkbox"> and the word beside it is a SIBLING TEXT NODE - not
+   a <label>, not an aria-label - so without a name a reader meets an
+   unlabeled disabled checkbox. The box takes an `aria-label` naming it with
+   the item's own visible text: the DERIVED TEXT of the item's first block
+   (PART 9R R4's derivation). A name is ONE line, so each run of ASCII
+   whitespace in the derived text collapses to a single space and the result is
+   trimmed; a NO-BREAK space is content and survives. Deriving rather than
+   inventing is what keeps this string out of the `labels` map (PART 9 SS16a) -
+   it is the AUTHOR's text, already on the page.
      `- [ ] unchecked`   ->  `<input type="checkbox" disabled
                               aria-label="unchecked">`
      `- [x] done with `c``  ->  `... checked disabled aria-label="done with c"`
@@ -1441,13 +1240,7 @@ definition_term = "::", space, inline_content, newline, {term_continuation_line}
 term_continuation_line = inline_content, newline ;
 (* A term folds a following plain line as a soft break; a blank line, a new
    `::`/`: ` marker, or a block opener ends it. A term holds inline content
-   only -- no block body. (This used to read "like a heading", which was never
-   the right comparison: a term is the KEY half of a key-value entry, not a
-   title, and it is bound to the definition beneath it rather than to a section
-   of the document. It KEEPS its fold. What made the heading's fold a defect was
-   having TWO ways to spill onto the next line, one of them silent -- a term has
-   exactly one, so a long key stays wrappable at no cost. §434's follow-up
-   question is answered here rather than left open.) *)
+   only -- no block body. Unlike a heading, a term KEEPS its fold. *)
 definition_body = (':', definition_separator, first_block_content)
                 | (':', definition_separator, inline_content, newline,
                    { definition_continuation
@@ -1467,54 +1260,30 @@ definition_separator = space, {space} ;
    C1), so the spellings differ only in how far their continuations indent,
    never in what they mean.
 
-   This is the rule a BULLET already follows: `-   first` puts its content
-   column at 4 and a continuation at 2 does not reach it. The definition body
-   was the one construct that measured its separator against a fixed width
-   instead, and the one that demanded two spaces where every other marker in
-   the language takes one -- `- item`, `1. item`, `> quote`, `:: term`.
-
    ONE SPACE IS CANONICAL. A wider separator is accepted and the formatter
    narrows it, which is what a formatter is for; nothing about the document's
    meaning depends on the author having picked the canonical width. Narrowing
    the separator narrows the body's column, so a canonical rewrite carries every
    continuation inside that body down by the same amount. A formatter that
    trims the separator and leaves the body where it was changes what the
-   document says.
-
-   What changed for the one-space spelling is that it now HAS a meaning. It used
-   to have none, and the engines disagreed about what to do with a line that had
-   none -- carve-js folded `: x` after a term into the `<dt>`, the oracle left it
-   a stray paragraph. A colon line inside a definition context has exactly one
-   reading now. *)
+   document says. *)
 definition_continuation = (definition_indent, inline_content, newline)
                         | (backslash, newline, definition_indent, inline_content, newline) ;
 definition_indent = whitespace, {whitespace} ;
-(* INDENTATION IS COLUMNS, NOT CHARACTERS -- NORMATIVE (carve#692, carve#888).
-   This production used to read `space, space, space`, which made a definition
-   body's continuation a literal three-SPACE requirement. That contradicted
-   PART 9 §24 C1, which already gives a tab a column value (to the next
-   multiple of 4), and it made the definition body the ONE continuation in the
-   language that counted characters where its siblings count columns: a
-   footnote body honors C1 (`footnote_indent`, carve#692) and so does a list
-   item (`list_continuation`'s `indent`).
+(* INDENTATION IS COLUMNS, NOT CHARACTERS -- NORMATIVE. A tab has a column
+   value (PART 9 §24 C1, to the next multiple of 4), and a definition body's
+   continuation counts columns exactly as a footnote body (`footnote_indent`)
+   and a list item (`list_continuation`'s `indent`) do.
 
    `definition_indent` is any whitespace run REACHING THE BODY'S AUTHORED
    CONTENT COLUMN -- the column its separator width establishes. For canonical
    `: x`, two spaces reach column 2; for accepted `:  x`, three spaces reach
-   column 3. A bare tab reaches column 4 and qualifies for either. The floor is
-   column arithmetic, stated here rather than
-   encoded character-by-character, exactly as `footnote_indent` states its
-   own. This is INDENTATION, not a marker SEPARATOR: it does not change the
-   separator run after the `:` marker (PART 7's
-   MARKER SEPARATORS AND PADDING SLOTS clause, which is A TAB IS SYNTAX ONLY
-   IN THE LEADING RUN (PART 7) applied to a slot that sits inline).
+   column 3. A bare tab reaches column 4 and qualifies for either. This is
+   INDENTATION, not a marker SEPARATOR: it does not change the separator run
+   after the `:` marker (PART 7's MARKER SEPARATORS AND PADDING SLOTS clause).
 
-   The BACKSLASH branch spells the same indentation and is respelled with it,
-   for consistency of the file rather than for behavior: that branch resolves
-   through the hard break, where all four readers already fold the next line in
-   regardless of its indentation, so nothing observable turns on it and no
-   fixture below pins it. Recorded so the untouched-looking half is not read as
-   an oversight.
+   The BACKSLASH branch spells the same indentation: it resolves through the
+   hard break, which folds the next line in regardless of its indentation.
 
    BELOW THE BODY'S COLUMN THE BODY ENDS -- NORMATIVE (carve#932). The three
    bands, in column order, so the rule can be read off once:
@@ -1533,9 +1302,8 @@ definition_indent = whitespace, {whitespace} ;
        column (§10, A COMMENT IS THE ONE EXCEPTION), and a definition or
        attribute line at a nonzero column below the column is lazy paragraph
        text of THIS body (§10 I5, AN INVISIBLE LINE FOLDS LIKE ANY OTHER). At
-       DOCUMENT column 0 they are interrupters and the body does end. Reading
-       this bullet alone gave the band four different answers across the five
-       kinds, none of them the plain-line control's (carve#1800, carve#1801).
+       DOCUMENT column 0 they are interrupters and the body does end.
+       (carve#1800, carve#1801)
      - AT the column, the line is the body's own block content, so a block
        opener opens inside the `dd`.
      - PAST the column, a recognized block opener establishes its authored
@@ -1543,24 +1311,7 @@ definition_indent = whitespace, {whitespace} ;
        paragraph-continuation behavior.
 
    `definition_indent` states the floor as column arithmetic; this states what
-   happens on the other side of it. Nothing else in the language gives a
-   sub-column indent a third meaning, and a rule that did would make
-   indentation depth mean two different things one column apart.
-
-   THE RULE IS UNCHANGED AND THE NAMING IS THE CHANGE. The bands were already
-   stated here in passing -- "AT the column the line is the body's own block
-   content and the quote opens; below it the body ends", in the clause below --
-   and being unnamed they were inventoried nowhere and pinned by nothing. An
-   engine that follows this clause is not being asked to follow new prose.
-
-   THE LADDER IS PINNED (carve#1772). The documents this clause deferred to
-   their own pass are corpus 425: column 0 and the two columns above it in the
-   BELOW band, the column itself, one column past it, a second opener kind, and
-   the plain line that is not an opener at all and folds from any column. Until
-   they landed, lowering a reader's floor changed nothing any corpus document
-   could see -- a line below the column fell through to the flush-left branch
-   and nested anyway -- so a corpus run reporting every golden reproduced was
-   true and said nothing about this band.
+   happens on the other side of it.
 
    THE SURVIVING CONTEXT IS WHATEVER HOLDS THE LIST. At the top level an opener
    must be written at column 0, so a `>` one or two columns in opens nothing and
@@ -1583,13 +1334,12 @@ definition_indent = whitespace, {whitespace} ;
 
    opens a block quote. The same rule covers headings, lists, tables, code/raw/
    colon fences, definitions, attributes followed by their target and comments,
-   with or without a preceding blank. Tabs participate by visual column.
-
-   An ordinary over-indented line which is not a recognized opener remains
-   paragraph text. A line below the minimum column keeps the existing ownership
-   result. The leading run is measured once; implementations MUST NOT probe
-   every possible dedent. Opaque payload indentation beyond `block_base` is
-   authored data, and a closer belongs to the base established by its opener.
+   with or without a preceding blank. Tabs participate by visual column. An
+   ordinary over-indented line which is not a recognized opener remains
+   paragraph text, and the leading run is measured once: implementations MUST
+   NOT probe every possible dedent. Opaque payload indentation beyond
+   `block_base` is authored data, and a closer belongs to the base established
+   by its opener.
 
    MIGRATION. This changes released 0.1.3 documents whose over-indented literal
    text begins with a block opener. A diagnostic SHOULD offer two safe fixes:
@@ -1635,27 +1385,20 @@ continuation_row = '+', table_cell, {'|', table_cell}, '|', newline ;
    2. A `+` CONTINUATION EXTENDS THE CELL, so a run left open by the row above
       is still open when the continuation is cut into cells: the pipes it spans
       there are its content too, and the block it reaches the end of is the
-      whole cell. Splitting a continuation row with a fresh scanner cuts inside
-      the run and drops what follows for want of a column to join it to, which
-      is content loss rather than a second answer.
+      whole cell.
 
    3. AN ESCAPED CLOSING PIPE IS STILL AN ESCAPE. `| a b \|` ends in a pipe, so
       the row closes there; the escape decides what the CELL holds, which is a
-      literal pipe rather than an orphaned backslash. Every reader already
-      honors `\|` in every other position of the same row, so reading it
-      everywhere EXCEPT the last position is a position exception with nothing
-      behind it -- and `\|` is the only way to write a literal pipe in a cell.
-      This does not widen what a row is: `| a | b`, with content dangling after
-      the last pipe, is prose exactly as before.
-
-   Pinned by corpus 328 and 332. *)
+      literal pipe rather than an orphaned backslash -- `\|` is the only way to
+      write a literal pipe in a cell, in every position of the row. This does
+      not widen what a row is: `| a | b`, with content dangling after the last
+      pipe, is prose exactly as before. *)
 
 (* Row-level attributes: a `{…}` attribute block GLUED to the row's closing `|`
    (no intervening space) sets the row's `<tr>` attributes -- the row-level twin
    of a cell's attribute block (cell_attributes). The two are NOT in the same
    position: a row's block follows the row's LAST `|`, a cell's follows the
-   cell's marker run (CELL ATTRIBUTES below). Row attributes are unaffected by
-   that rule and are stated here so the pair is not read as one. The whole
+   cell's marker run (CELL ATTRIBUTES below). The whole
    payload must be valid attribute syntax (§15); otherwise the `{` is ordinary
    content and the line is not a row attribute (see PART 9 §5, ROW
    ATTRIBUTES). *)
@@ -1702,22 +1445,13 @@ data_cell   =      [alignment_run], [cell_attributes], cell_padding, cell_conten
    text would leave this sentence with nothing to act on; `|{.x} < |` is
    `<td class="x">&lt;</td>`, never `<td>{.x} &lt;</td>`. The only stated route
    from a brace run to literal text is an INVALID payload, two sentences up.
-   This repo's own executable spec read it the other way for a while - it
-   cleared the attributes and re-read the whole segment - which is what
-   carve#1463 records and corpus 392 now pins. A computed rowspan/colspan/alignment is
-   authoritative, so an author copy of those keys is dropped. (corpus
-   99-table-cell-attributes, 319-cell-attributes-bind-after-the-kind-and-alignment-markers.)
+   A computed rowspan/colspan/alignment is authoritative, so an author copy of
+   those keys is dropped.
 
-   WHY LAST, AND NOT BEFORE THE MARKERS. Binding attributes to the opening `|`
-   ahead of the kind marker leaves an attributed header cell UNSPELLABLE: the
-   only shape available is `|{#x}=R|`, and that is ambiguous by construction --
-   readable either as an attributed header cell, or as a data cell whose
-   content begins with `=`. This grammar reads it the second way, so the shape
-   a canonical writer produced for an attributed header cell came back as
-   `<td id="x">=R</td>` and the PART 11 round-trip invariant failed on it.
-   Once `=` has committed the cell to header, everything after it is
-   unambiguous. Stating one order for both productions is what removes the
-   ambiguity, rather than giving header_cell a second, opposite one. *)
+   WHY LAST, AND NOT BEFORE THE MARKERS. `|{#x}=R|` is a DATA cell whose
+   content begins with `=`, not an attributed header cell: once `=` has
+   committed the cell to header, everything after it is unambiguous, and one
+   order for both productions is what removes the ambiguity. *)
 cell_attributes = attributes ;
 span_cell = rowspan_marker | colspan_marker ;
 
@@ -1767,30 +1501,20 @@ caption_continuation_line = inline_content, newline ;  (* a PLAIN line only *)
    that is not one BEGINS the caption. `^<SP><SP><SP>cap` is the caption `cap`,
    not `<SP><SP>cap`.
 
-   TWO CLAUSES DECIDE IT, neither of them a nose count. MARKER SEPARATORS AND
-   PADDING SLOTS (PART 2) defines a marker separator as what stands between the
-   marker and the content it introduces and rules that a writer aligning in a
-   column "is writing separator, not content"; the four slots that clause
-   narrows to exactly one space are PADDING slots, an enumeration it closes, and
-   the caret is not among them. And PART 11 §1 names MARKER ALIGNMENT among the
-   spellings `fmt` may normalize while preserving what the document says -- which
-   holds only if the run is not content. All three writers already normalize
-   `^<SP><SP><SP>cap` to `^<SP>cap`, so under the literal reading every one of
-   them changed the document on every pass.
+   TWO CLAUSES DECIDE IT. MARKER SEPARATORS AND PADDING SLOTS (PART 2) makes a
+   marker separator what stands between the marker and the content it
+   introduces, and the four slots it narrows to exactly one space are PADDING
+   slots -- a closed enumeration the caret is not in. And PART 11 §1 names
+   MARKER ALIGNMENT among the spellings `fmt` may normalize, which holds only
+   if the run is not content.
 
    A TAB IS NOT SEPARATOR. `space = ' '`, so `^<SP><TAB>cap` keeps the tab as
-   the caption's first character, exactly as a heading does at the same
-   position. MARKER REQUIRES CONTENT (PART 2) applies after the run as well:
-   a caret, the separator and nothing but whitespace opens no caption, and the
-   line is ordinary paragraph text.
+   the caption's first character. MARKER REQUIRES CONTENT (PART 2) applies
+   after the run as well: a caret, the separator and nothing but whitespace
+   opens no caption, and the line is ordinary paragraph text.
 
-   THE CONTINUATION LINE IS NOT TOUCHED BY THIS, and the two are different
-   positions rather than one rule read twice. A continuation line carries no
-   marker, so its leading run is INDENTATION and it is kept as written -- ruled
-   at carve#1561 on the ground that MULTI-LINE CAPTIONS enumerates only where a
-   caption ENDS and nothing in it, or in `caption_continuation_line`, dedents.
-   This clause is about the run that follows the CARET, which is the one
-   position on a caption where a separator exists at all. *)
+   THE CONTINUATION LINE IS NOT TOUCHED BY THIS. A continuation line carries no
+   marker, so its leading run is INDENTATION and it is kept as written. *)
 (* MULTI-LINE CAPTIONS -- NORMATIVE. A caption is multi-line inline CONTENT, so
    its text spills onto following lines exactly like a PARAGRAPH (§10), NOT like
    a heading. It ends the same way an open paragraph does:
@@ -1852,11 +1576,7 @@ colon_fence = ":::", {":"} ;
    makes the slot OPTIONAL because a bare `[label]` may sit flush against the
    fence (`:::[First]`); optional is a different property from a different
    role, and the slot answers the same way in all four openers whichever type
-   token follows it. Corpus 254 pins the slot PER OPENER, with a mixed-run case
-   beside each tab-first one, because implementations decide the one rule in
-   four separate places (carve#887, carve#900). Every implementation accepted a
-   tab here when carve#878 ruled on it; all three have since corrected it
-   (carve-js#794, carve-php#947, carve-rs#720). *)
+   token follows it. (carve#887, carve#900) *)
 colon_fence_close = colon_fence:close
                     where len(close) = len(open) ;
 (* FORMAL (PART 9 §12, now a guard): `open` is the colon_fence captured by
@@ -1872,10 +1592,6 @@ colon_fence_close = colon_fence:close
        documents and longer-inner ones both parse. `carve fmt` emits the
        inward-widening form (PART 11).
 
-   Earlier drafts used len(close) >= len(open), which made a container's
-   fence a quoting relation borrowed from the code fence. It forced a
-   canonical writer to know the maximum container depth of its whole
-   subtree, and it made equal-length nesting silently produce literal text.
    Code fences keep >= (PART 9 §2) because their length axis really is
    quoting: opaque content that never nests, which must be able to hold a
    shorter fence. *)
@@ -1889,15 +1605,9 @@ admonition = admonition_open, newline,
    a block still open when its HOST ends closes there, innermost first. The
    host is the ENCLOSING CONTAINER where there is one and the DOCUMENT
    otherwise, so "closes at end of input" is the top-level case rather than
-   the whole rule: corpus
-   271-the-flush-left-line-after-a-container-a-quoted-line-opened opens a
-   `::: note` inside a block quote, never closes it, and the container ends
-   WITH THE QUOTE -- the flush-left line below is a sibling paragraph outside
-   both, not content the div swallowed to the end of the file. This is
-   djot's behavior and it is the counterweight to the exact-length closer --
-   a mistyped closer leaves a container open, and the earlier rule (the
-   opener and everything after it degrade to literal text) turned one wrong
-   character into a corrupted document. An unclosed opener SHOULD be
+   the whole rule: a `::: note` opened inside a block quote and never closed
+   ends WITH THE QUOTE, and a flush-left line below is a sibling paragraph
+   outside both. This is djot's behavior. An unclosed opener SHOULD be
    diagnosed by lint and by the language server; it is not an error for the
    parser. Note this is NOT the `%%%` comment-block rule (§28), where an
    opener with no exact closer ahead opens nothing: a comment block is
@@ -1914,18 +1624,6 @@ admonition = admonition_open, newline,
        tail
                         tail
 
-   is literal item text on the left and an EMPTY div on the right. A blank
-   line is the container's own content, not a folded line, so an opener a
-   blank follows has opened an empty container exactly as one at end of input
-   has. The executable spec asked only whether the body was non-empty, which a
-   lone blank satisfies, and demoted the right-hand spelling to literal text
-   while answering the same opener correctly at end of input, with its closer,
-   with a body line, and inside a quote. That reads one blank line as content
-   in the collector and as absence of content in the block parser. carve-js,
-   carve-php and carve-rs open the div. Corpus 364 pins both sides, the second
-   as the control a fix that stopped asking about folding would flip.
-   (carve#1382)
-
    OPAQUE SPANS (PART 9 §12). `{block - admonition_close}` is a BLOCK
    sequence, so a fenced code block, a raw block and a comment block inside
    the body are single blocks and their lines are never examined for a
@@ -1935,38 +1633,29 @@ admonition = admonition_open, newline,
    span's opener BEFORE testing for its closer -- an opener with no info
    string (a bare code fence, a `%%%`) is closer-shaped itself, so testing it
    first ends the span on its own line and hands the span's contents back to
-   the block parser (carve#450). Under exact-length closers a miscount there
-   shifts the whole subtree, and a code fence is the only structural way to
-   quote a container fence, so this is the path every document that describes
-   Carve in Carve takes.
+   the block parser (carve#450).
 
    TOOLING FOR NEAR MATCHES (PART 9 §12). Exact length remains a parse rule,
    not a recoverable syntax error. A processor with diagnostics SHOULD report
    `colon-fence-length-mismatch` when a bare colon run does not close the
    innermost open container, would close it after resizing, and plausibly
    expresses closing intent. The finding names the authored and expected
-   widths, the opener position, and the line's actual parse outcome (a nested
-   container or literal text). It MUST NOT fire for typed openers, escaped
-   colons, opaque code/raw/comment payloads, or a different-width child fence
-   that has its own exact closer.
+   widths, the opener position, and the line's actual parse outcome. It MUST
+   NOT fire for typed openers, escaped colons, opaque code/raw/comment
+   payloads, or a different-width child fence that has its own exact closer.
 
    A tool MAY offer separate fixes to resize the run or preserve it as literal
    content. Neither is a canonical-formatting decision: `carve fmt` MUST NOT
    choose an intention. Editors SHOULD pair and highlight exact opener/closer
-   ranges from parser structure. Automatic paired edits stop after either side
-   is independently changed; proximity alone never licenses resizing a nested
-   fence. (carve#1727)
+   ranges from parser structure; proximity alone never licenses resizing a
+   nested fence.
 
    A CLOSER IS REQUIRED. Only a fence that closes is opaque. A ``` or ~~~
    opener with no closer ahead opens NO span: the container's own closer
    stays structural, and the lines after it are parsed normally. This is the
    same test PART 9 §10 I4 applies one level up -- an opener with no closer
    is not a fence -- and the same test the `%%%` rule above already states
-   ("an opener with no exact closer ahead opens nothing"). It was written
-   for the comment block and not for the code fence, and all three engines
-   implemented exactly what was written: `%%%` guarded, ``` not (carve#515).
-
-   Without it, one unclosed fence consumes the rest of the document. In
+   ("an opener with no exact closer ahead opens nothing") (carve#515). In
 
        ::: note
        ```
@@ -1974,10 +1663,8 @@ admonition = admonition_open, newline,
        :::
        after
 
-   the fence would take `x`, the `:::` AND `after`, closing the admonition
-   at end of input -- so a line written outside the container renders
-   inside it. With the guard the fence is not a span, the `:::` closes the
-   admonition, and `after` is a top-level paragraph.
+   the fence is not a span, the `:::` closes the admonition, and `after` is a
+   top-level paragraph.
 
    This does NOT change a fence with nothing to interrupt: `` ``` `` alone,
    or as the whole content of a blockquote, still opens a code block that
@@ -2043,7 +1730,7 @@ quoted_title = '"', {character - '"'}, '"' ;
    `table` end in, with the same one-optional-blank-line allowance. Two
    container kinds take it -- this one and `quote_block`, which captions like
    the block quote it is (§4) -- and a `^ ` line after any OTHER `:::` closer
-   is ordinary paragraph content (corpus 318-composite-figures-7). A group left
+   is ordinary paragraph content. A group left
    open at END OF INPUT closes there like any container (PART 9 §12) and, its
    closer line never having been written, has no caption position.
 
@@ -2199,9 +1886,7 @@ raw_block = code_fence_open, [space], "=", format_name, newline,
    raw). The closer follows the PART 9 §2 rule: same fence character, length
    >= opener. Content is verbatim; it is emitted UNESCAPED when the format
    matches the output format (html) and DROPPED otherwise -- the block parallel
-   of raw inline (PART 9 §20). This adopts djot's raw-block syntax; the earlier
-   ```raw FORMAT keyword form was removed (no English keyword; symbol-based and
-   symmetric with inline `{=format}`).
+   of raw inline (PART 9 §20). Adopts djot's raw-block syntax.
 
    THE INTERIOR IS VERBATIM, THE OPENING IS PLACED -- NORMATIVE. Inside a
    container, a renderer that indents its output indents the raw block's
@@ -2209,68 +1894,20 @@ raw_block = code_fence_open, [space], "=", format_name, newline,
    the raw content's own line structure. Every line after the first reaches the
    target with the columns the author gave it.
 
-   Both halves matter and neither is a formatting preference. Re-indenting an
-   interior line changes bytes the author wrote, and inside a `<pre>` those
-   columns are CONTENT -- the rendered code block then says something the
-   source did not. Leaving the block flush at column 0 instead would make
-   `raw_block` the one block kind whose placement ignores its container, which
-   is a second rule applying to one kind with nothing behind it.
-
-   THE `<pre>` HAZARD IS WHAT THIS RULE FORECLOSES, NOT WHAT IT REPAIRED, and
-   the difference matters to anyone arguing the clause later. Taken literally,
-   "indent every line" does corrupt a `<pre>`, and the oracle did exactly that.
-   No ENGINE did: every one of them already suspended re-indentation inside an
-   open `<pre>`, so all three agreed on every `<pre>` shape both before and
-   after this rule landed. What actually had to be settled was the ordinary
-   interior line, where the cost is changed bytes rather than changed rendered
-   content. Argue this clause from the rule; the `<pre>` example illustrates
-   it, and never distinguished the engines.
-
-   A FIXTURE FOR THIS RULE MUST BE AT LEAST TWO LINES WITH AT LEAST ONE OF THEM
-   OUTSIDE A `<pre>`. The corpus could not tell the readings apart because it
-   pinned only a SINGLE-LINE raw block -- a shape on which "indent the block"
-   and "indent every line" agree. The `<pre>` pair pins the placement half, but
-   an engine that re-indents only its non-`<pre>` interior lines passes that
-   pair, so it cannot stand in for the other. Three engines gave three answers
-   when carve#800 was filed; by the time the rule landed carve-js had moved and
-   it was one engine against two.
-
    THE PAYLOAD IS EVERY LINE BETWEEN THE DELIMITERS, blank lines included. A
    blank line is a line, and the last one is payload exactly as an interior one
-   is. This is the property corpus 291 already states for a fence -- a blank
-   line inside a fence is content, and the last one is content too, wherever
-   the fence ends -- and a raw block's verbatim body follows it for the same
-   reason a code block's does. Neither the container the block sits in nor
-   whether the closer was written is a parameter: an unterminated raw block
-   runs to the end of whatever encloses it, and its payload still ends on the
-   line before that end.
-
-   A RAW BLOCK WRITTEN LAST IN THE DOCUMENT CANNOT SHOW THIS, and that is a
-   property of the output's end rather than of the block. The payload's
-   trailing newlines land where the trailing-whitespace trim removes them, so
-   every reader prints the same bytes there whatever it does with the payload.
-   A fixture for this rule therefore needs a block AFTER the raw block, or a
-   container closing around it.
-
-   That shape is why the case looked unsettled. carve#1389 measured the
-   document-final spelling, read four readers agreeing there against three of
-   four inside a list item, and concluded the odd reader was the consistent
-   one. Measured with a paragraph after the block instead, the split is not
-   between the two contexts at all: the reader that drops the blank inside an
-   item drops it at document level too, and the other three keep it in both.
-   What decides it is not the count either way but a contradiction inside that
-   reader, which keeps the same trailing blank as content in a CODE fence --
-   corpus 291's four documents, which it reproduces -- and drops it from a raw
-   block. Corpus 366 pins the document-level and in-item shapes plus a
-   no-blank control.
+   is. Neither the container the block sits in nor whether the closer was
+   written is a parameter: an unterminated raw block runs to the end of
+   whatever encloses it, and its payload still ends on the line before that
+   end. At the END of the document the payload's trailing newlines land where
+   the trailing-whitespace trim removes them.
 
    AN ALL-BLANK PAYLOAD IS NOT AN ABSENT BLOCK. If the sole line between the
    delimiters is blank, that line is still the payload and contributes its
    newline when the raw format matches the output format. Zero payload lines
    contribute nothing; one blank payload line contributes one newline. An
-   implementation MUST NOT encode those two source shapes identically. Corpus
-   372 pins the distinction with a following paragraph so end trimming cannot
-   hide the newline (carve#1401).
+   implementation MUST NOT encode those two source shapes identically.
+   (carve#1401)
 
    RENDER-LOSS REPORTING -- NORMATIVE. Target routing may intentionally omit a
    raw node, but a checked renderer MUST make that omission observable. Its
@@ -2441,16 +2078,12 @@ code_span_content = (* any chars except a closing backtick_run of equal count *)
    trailing whitespace is stripped; no surrounding single-space strip, which
    applies only to a closed span). Such an unclosed run is OPAQUE -- an
    emphasis delimiter or link tail after it is verbatim content, so the
-   surrounding construct never closes. Matches djot upstream and carve-php.
-   (Pinned as the "Inline verbatim ..." corpus pair; was a carve-js
-   divergence, resolved.) *)
+   surrounding construct never closes. Matches djot upstream. *)
 (* A trailing `{…}` on a code span is the generic inline-attribute
    block, NOT a language tag -- EXCEPT the exact form `{=format}`, which is
-   raw inline passthrough (raw_inline below, PART 9 §20). For any OTHER
-   `{…}`: both impls consume AND apply it -- `\`c\`{.x}` ->
-   `<code class="x">c</code>`, and `#id`/`key=value` likewise. (Was an impl
-   divergence where carve-js dropped the attributes; RESOLVED -- both now
-   apply them identically.) The STRICT attribute rule (§14) applies here and
+   raw inline passthrough (raw_inline below, PART 9 §20). Any OTHER `{…}` is
+   consumed AND applied -- `\`c\`{.x}` -> `<code class="x">c</code>`, and
+   `#id`/`key=value` likewise. The STRICT attribute rule (§14) applies here and
    to IMAGE trailing attrs exactly as to any other inline attribute. Explicit
    ids and classes admit a leading ASCII digit; a digit-leading key or any
    otherwise invalid payload makes the block literal. *)
@@ -2517,11 +2150,7 @@ link_text = inline_content ;
 
    This is a property of the DOCUMENT, and therefore binds EVERY target that
    can express a link -- HTML, Markdown and ANSI alike, exactly as the
-   smart-typography switch above applies to every target. Nested output is
-   not merely redundant: `[see [H](#H)](/outer)` is not valid Markdown, so a
-   consumer reparsing it gets something other than what the document says,
-   and a nested ANSI link sequence ends with its own reset, which closes the
-   outer link's styling early.
+   smart-typography switch above applies to every target.
 
    An implementation that resolves a construct into a link AFTER the pass
    that enforces this -- a cross-reference is the usual case, since `</#id>`
@@ -2560,9 +2189,7 @@ unicode_url_char = (* any non-whitespace, non-ASCII Unicode character *) ;
    `unicode_url_char` says "non-whitespace" without qualifying it to ASCII.
    So a NARROW NO-BREAK SPACE, an IDEOGRAPHIC SPACE and a THIN SPACE end an
    inline destination exactly as a plain space does, and an unbracketed
-   destination cannot contain one. Stated explicitly because two engines read
-   it as ASCII-only and produced a link whose href carried an invisible
-   character (carve#404).
+   destination cannot contain one -- an href MUST NOT carry one (carve#404).
 
    ZERO-WIDTH characters (U+200B, U+FEFF) are NOT whitespace and ARE ordinary
    destination characters. The test is the Unicode White_Space property, not
@@ -2577,16 +2204,13 @@ unicode_url_char = (* any non-whitespace, non-ASCII Unicode character *) ;
    ends the destination at `https://e.com`, and `/path` is then left over. It
    is NOT ignored: the definition is anchored at end of line (carve#911), so a
    leftover makes the production fail and the whole line is an ordinary
-   paragraph -- exactly as `[r]: https://e.com /path` behaves. That sentence
-   used to read "ignored", which is what all four artifacts did and what the
-   production never said. Whitespace between the mandatory separator space and
-   the destination is leading whitespace and is skipped. A definition whose
-   destination is EMPTY once that is done is NOT a definition: the line stays
-   literal, as `[r]:` already does.
+   paragraph -- exactly as `[r]: https://e.com /path` behaves. Whitespace
+   between the mandatory separator space and the destination is leading
+   whitespace and is skipped. A definition whose destination is EMPTY once that
+   is done is NOT a definition: the line stays literal, as `[r]:` already does.
 
-   There is deliberately no "trim the ends, keep the interior" variant. It
-   reads as the friendlier rule and it contradicts `link_destination`, which
-   admits no whitespace at all -- leaving `[r]: a b` specified two ways. *)
+   There is no "trim the ends, keep the interior" variant: `link_destination`
+   admits no whitespace at all. *)
 (* Titles accept double OR single quotes -- a deliberate enhancement
    over djot (which has no single-quote titles; it would fold `'...'`
    into the URL). The non-delimiting quote may appear inside the title. *)
@@ -2599,14 +2223,10 @@ unicode_url_char = (* any non-whitespace, non-ASCII Unicode character *) ;
    (PART 7): a link is already a link once its destination has been read, and a
    reference definition is already a definition, so the title is optional
    trailing metadata in both. It is spelled `space` all the same, because A
-   TAB IS SYNTAX ONLY IN THE LEADING RUN (PART 7). The three engines accept a
-   tab here today and diverge from this production (carve#901). Cardinality is
-   exactly one character, at both sites, and that is a RULING rather than an
-   oversight: all three engines and the executable spec accepted a run here
-   until carve#912 held the production right and narrowed them. So
-   `[t](/u<SP><SP>"T")` is not a titled link, the quoted run is left
-   unconsumed, and the bracket run stays literal text. Corpus 262 carries it,
-   with the one-space form as its control. *)
+   TAB IS SYNTAX ONLY IN THE LEADING RUN (PART 7, carve#901). Cardinality is
+   exactly one character, at both sites (carve#912). So `[t](/u<SP><SP>"T")` is
+   not a titled link, the quoted run is left unconsumed, and the bracket run
+   stays literal text. *)
 link_title = space, ('"', {('\', '"') | (character - '"')}, '"')
            | space, ("'", {('\', "'") | (character - "'")}, "'") ;
 
@@ -2625,97 +2245,32 @@ reference_label = (character - ']' - '@'), {character - ']'} ;
        [t][@a]
        ![t][@a]
 
-   both render as the text the author typed. The image spelling is stated here
-   rather than beside `reference_image` because it is the same slot reading the
-   same production, not a parallel rule. Nothing in this is special to `@`; it
-   is the existing fallback reaching one more shape, which is why the ruling
-   needed no new mechanism (carve#1302).
-
    THE FALLBACK IS THE VERBATIM SOURCE RUN, NOT A RESCAN -- NORMATIVE. Which
    one it is decides the rendering, so it cannot be left to inference. The
    declining run is emitted as the characters the author typed; the parser does
    NOT hand the interior back to the inline scanner. That is already the rule
    for every other declining reference: `[t][*a*]` keeps its asterisks rather
-   than emphasizing `a`, and TRAILING ATTRIBUTES ON A DEFINITION's neighbor
-   case -- `[text][missing]{.wide}` -- keeps its braces as text rather than
-   parsing them as `attributes`, which is what carve#679 fixed by carrying the
-   SOURCE STRING through the reference sentinel instead of re-printing a parsed
-   list.
-
-   The distinction bites hardest here, because the interior is `@`-initial by
-   construction and `@a` is exactly what a rescan would claim. A rescan would
-   read `[t][@a]` as a `[t][` run, a MENTION, and a `]` -- and with the Tier-2
-   extension on it would read the now tail-less `[@a]` as a CITATION, since a
-   citation is a `[...]` holding a `@key` with no link/ref/span tail. Both
-   readings are wrong: the bracket run declined as ONE construct and is
-   restored as one, so the `@a` inside it is text and nothing else. That is
-   what the corpus rows and the optional control pin, on both sides of the
-   extension switch.
+   than emphasizing `a`, and `[text][missing]{.wide}` keeps its braces as text
+   rather than parsing them as `attributes`. So the `@a` inside a declining
+   `[t][@a]` is text and nothing else: it is NOT re-read as a mention, and NOT
+   as a citation with the Tier-2 extension on.
 
    THE CONTROL CARRIES THE RULE. `[@a]` on its own IS a citation with the
-   extension on, and that is the REASON the label slot rejects it rather than a
-   side effect of rejecting it: `@` at the first position already means
-   citation, so it cannot also mean label, and an implementation that made the
-   slot accept `@` would be taking the spelling away from citations to do it.
-   Corpus 334-a-label-beginning-with-an-at-sign-is-not-a-reference-label
-   carries both spellings; the citation half is Tier-2, so it is pinned in
-   tests/corpus-optional (`43-citations-at-label-in-reference-position`), where
-   the same two lines are still literal text with citations enabled.
+   extension on, and that is the REASON the label slot rejects it.
 
-   WHAT THE CORPUS PINS, AND WHAT IT CANNOT. The rows are HTML, and at that
-   layer this rule is INDISTINGUISHABLE from "the label is undefined": `@` at
-   the first position is the one spelling `reference_label` rejects, and
-   `[@a]: /u` is reserved for the citation definition, so a `@`-first label can
-   never be defined, and a declining reference renders as its verbatim source
-   either way. The rows state the outcome, which is what a corpus is for; they
-   do not separate the two readings, and nothing else does.
-
-   THE TREE SHAPE IS THE ONE PLACE THEY WOULD SEPARATE, and it is left open
-   here rather than settled in passing. Measured on fresh main builds --
-   carve-js 99af44b, carve-php 035dfcd, carve-rs 564a3b8 -- all three publish
-   an UNRESOLVED REFERENCE node for both spellings:
-
-       {"type":"link","href":"","ref":"@a","rawRef":"[t][@a]"}
-
-   and its `image` counterpart. PART 12 §3a admits `ref` "because the author
-   wrote a reference link", and under this clause no reference link was
-   written, which points at a `text` node carrying the run. Against that, an
-   `href`-less node plus `rawRef` is the vehicle §3a already gives a declining
-   reference for restoring its source, so an engine reaching for it here is not
-   obviously wrong either. Both readings render the corpus rows correctly, no
-   HTML fixture can fail on the difference, and the ruling this clause states
-   did not reach it -- so it is recorded, not decided (carve#1302).
-
-   THE READING NOT TAKEN. "Link text `t` pointing at citation `a`" is coherent
-   authoring intent and has no spelling today, but adopting it here would
-   INVENT A CONSTRUCT on the strength of one bracket pair -- its own AST node
-   or field, renderer behavior on every target, a canonical writer spelling --
-   and nothing else in the language pairs link text with a citation target.
-   That is a feature proposal against a later roadmap, not a reading of this
-   production.
-
-   The EMPTY-TEXT spelling `[][@a]` was settled separately and narrowly in
-   markup-carve/carve-js#1119, deliberately scoped so that `[t][@a]` was not
-   decided as a side effect of an unrelated fix. This clause is what that
-   scoping was waiting on, and it leaves it standing. *)
+   THE TREE SHAPE for a declining `[t][@a]` is left open here; the rendering is
+   the verbatim source run either way. *)
 (* Both roles appear on this one line (PART 7), and both take `space`. The
-   `']' ':'` separator is a MARKER SEPARATOR -- settled in the note below and
-   rejected by all four implementations for a tab -- while the slot before the
-   trailing `attributes` is PADDING: the definition is already complete at
-   `[a]: /url` and the attribute block is optional trailing metadata. The role
-   differs, the terminal does not, because A TAB IS SYNTAX ONLY IN THE LEADING
-   RUN (PART 7). What `attributes` admits INTERNALLY is a separate production
-   (PART 4).
-   Cardinality is exactly one space at BOTH, and at the padding slot that is
-   carve#912's ruling rather than an oversight. Where the rejected block goes
-   differs by run, and the two cases are NOT the same: a ZERO-space run glues
-   the braces to the destination (`[a]: /u{.c}` gives href `/u{.c}`, because
-   `link_destination` reads them), while a TWO-space run cannot -- whitespace
-   ends the destination -- so `{.c}` is DROPPED. That is the outcome this
-   clause names as the one to avoid, and it happened only because
-   `reference_definition` was not anchored at end of line. carve#911 anchored
-   it and the line now falls back to prose instead. Corpus 265 carries it with
-   its one-space control. *)
+   `']' ':'` separator is a MARKER SEPARATOR -- settled in the note below --
+   while the slot before the trailing `attributes` is PADDING: the definition
+   is already complete at `[a]: /url` and the attribute block is optional
+   trailing metadata. The role differs, the terminal does not, because A TAB IS
+   SYNTAX ONLY IN THE LEADING RUN (PART 7).
+   Cardinality is exactly one space at BOTH. The two rejected runs are NOT the
+   same: a ZERO-space run glues the braces to the destination (`[a]: /u{.c}`
+   gives href `/u{.c}`), while a TWO-space run cannot -- whitespace ends the
+   destination -- so the line is left over at the end-of-line anchor and falls
+   back to prose. *)
 reference_definition = '[', reference_label, ']', ':', space, link_destination,
                        [link_title], [space, attributes], newline ;
 (* ANCHORED AT END OF LINE -- NORMATIVE. The production ends in `newline`, and
@@ -2725,39 +2280,26 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
 
        [a]: /u zzz
 
-   is NOT a definition, and a `[a][]` below it does not resolve. All three
-   engines and the executable spec read it as a definition with trailing junk
-   until carve#911, and nothing in this grammar authorized that reading.
+   is NOT a definition, and a `[a][]` below it does not resolve (carve#911).
 
    THE LINE ENDING is `whitespace` -- `' ' | '\t'` -- the same terminal
-   `blank_line = {whitespace}` takes (PART 1; carve#890). So `[a]: /u<SP>` and
+   `blank_line = {whitespace}` takes (PART 1). So `[a]: /u<SP>` and
    `[a]: /u<TAB>` are still definitions, while `[a]: /u<NBSP>`,
-   `[a]: /u<U+2000>` and `[a]: /u<FF>` are not: every one of those is CONTENT
-   under that ruling, and content after the production is exactly what the
-   anchor rejects. An implementation spelling the ending as a Unicode
-   whitespace PROPERTY reads all five as a line ending, and a tab fixture
-   cannot see the difference, because a tab is inside the property too
-   (carve#888).
+   `[a]: /u<U+2000>` and `[a]: /u<FF>` are not: every one of those is CONTENT,
+   and content after the production is exactly what the anchor rejects. An
+   implementation spelling the ending as a Unicode whitespace PROPERTY reads
+   all five as a line ending, and a tab fixture cannot see the difference.
 
-   A TRAILING ZERO-WIDTH CHARACTER IS NOT ON THAT LIST, and listing it there
-   was an error carried from carve#911's ruling prose into this clause
-   (carve#953). `[a]: /u<U+FEFF>` and `[a]: /u<U+200B>` ARE definitions. The
-   anchor only ever sees what is left over after the production, and here
-   nothing is: U+FEFF and U+200B are not `White_Space`, so they do not END the
-   destination -- `link_destination` absorbs them as ordinary
-   `unicode_url_char`s, exactly as the note beside that production states, and
-   the character is in the href. The anchor is therefore never reached, and it
-   is `url_char` -- the AUTOLINK body, a different production -- that excludes
-   format characters, not `link_destination` (corpus 240). The row is the
-   reason a mutant widening the line ending to "any invisible character"
-   survived: it asserted a differing render, which was true because the HREF
-   carried the character rather than because the line was rejected.
+   A TRAILING ZERO-WIDTH CHARACTER IS NOT ON THAT LIST. `[a]: /u<U+FEFF>` and
+   `[a]: /u<U+200B>` ARE definitions: U+FEFF and U+200B are not `White_Space`,
+   so they do not END the destination -- `link_destination` absorbs them as
+   ordinary `unicode_url_char`s -- and the anchor is never reached. It is
+   `url_char`, the AUTOLINK body, that excludes format characters.
 
    WHAT THE ANCHOR DOES NOT REJECT. `[a]: /u{.c}` is still a definition, with
    destination `/u{.c}`: nothing is left over, because `link_destination`
    simply reads the braces. It is a different shape from `[a]: /u  {.c}`, not
-   another spelling of it. Corpus 266 carries every legal form as a control,
-   since the failure mode of an over-eager anchor is rejecting them.
+   another spelling of it.
 
    AN INVALID BLOCK IS NOT `attributes`, SO THE LINE IS NOT A DEFINITION --
    NORMATIVE (carve#933). `[space, attributes]` names the `attributes`
@@ -2770,21 +2312,12 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
    is NOT a definition. `{#}` is not `attributes` -- there is no identifier
    after the `#` -- so the line renders as the paragraph `[a]: /u {#}` and a
    `[a][]` below it does not resolve. The same holds for `[a]: /u { }` and
-   `[a]: /u {=}`.
-
-   THE DECIDING ARGUMENT IS THAT THE SAME CHARACTERS ALREADY READ THIS WAY
-   ELSEWHERE. `x {#}` in a paragraph keeps the braces as text, because
-   `attributes` rejects that block there too and inline content keeps what it
-   cannot parse. Two readings of `{#}` one construct apart is the thing being
-   removed, and the reading kept is the one the rest of the language already
-   has.
+   `[a]: /u {=}`. `x {#}` in a paragraph keeps its braces as text for the same
+   reason.
 
    THE COMPATIBILITY BREAK THIS ADDS, recorded: a definition line carrying an
-   unparseable attribute block stops defining, and a document relying on it
-   resolves one fewer reference. Accepted (carve#933 signoff). Corpus rows --
-   including the control that a VALID block still defines and still transfers
-   its attributes, which is the row an over-eager fix breaks -- belong with
-   corpus 266 and are deferred to their own pass. *)
+   unparseable attribute block stops defining. A VALID block still defines and
+   still transfers its attributes. *)
 (* TRAILING ATTRIBUTES ON A DEFINITION -- NORMATIVE. A `{...}` block at the end
    of the definition line attaches to the DEFINITION, and PART 9R R1 already
    says what that means: the attributes transfer to every link OR IMAGE that
@@ -2800,25 +2333,11 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
    the label up in the same `linkDefs` table and takes the same three fields, so
    `[ex]: /i.png {.wide}` gives `<img src="/i.png" alt="alt" class="wide">`.
 
-   Stated because leaving it implicit produced a rule nobody could say out loud.
-   The table is `label -> (url, title?, attrs?)`; an image reference already took
-   `url` and `title` from it in every engine, and `attrs` crossed in carve-php
-   and not in carve-js or carve-rs (carve#604's follow-up). Two of three fields
-   transferring is not a rule, it is where an implementation stopped. The
-   ergonomics point the same way: a class repeated at every use site is more
-   common for images -- sizing, floating, lazy-loading -- than for links, which
-   is the case the definition form exists to serve.
-
    THE MERGE IS §15 A3's, the one stacked attribute lists already use: the
    definition's list first, the link's second, so a repeated `id` or key takes
    the LAST value (the link's) and CLASSES ACCUMULATE in source order. So
    `[ex]: /u {.external #a}` with `[Example][ex]{.internal #b}` renders
    `class="external internal" id="b"`.
-
-   Reusing A3 rather than writing a second merge is the point: "link attributes
-   override per key" in R1 is exact only once "per key" names a merge, and the
-   language has one. A rule where the link's `class` REPLACED the definition's
-   would make this the only place in Carve where stacking classes drops one.
 
    NOT THE SAME AS THE LINE ABOVE. The two forms are different constructs and
    both are now well-defined:
@@ -2833,10 +2352,9 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
 
    THE DEFINITION IS A NODE, so these attributes are serialized ONCE on it
    rather than materialized onto every resolved link. PART 12 §10 adds
-   `link_reference_definition` to the vocabulary; three clauses wanted it (§3a,
-   §10a and this one) and the fourth reason was decisive: without the node, a
-   writer cannot reproduce the definition, so `parse(fmt(x)) == parse(x)` fails
-   for every resolved reference (carve#642). *)
+   `link_reference_definition` to the vocabulary: without the node, a writer
+   cannot reproduce the definition, so `parse(fmt(x)) == parse(x)` fails for
+   every resolved reference (carve#642). *)
 (* THE DEFINITION MARKER SEPARATOR -- NORMATIVE. The marker-to-content
    separator is the `space` terminal (U+0020) ONLY, in all three definition
    markers: `reference_definition`, `footnote_definition` and
@@ -2844,30 +2362,16 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
    so `[^a]:<TAB>x`, `[a]:<TAB>/url` and `*[HTML]:<TAB>x` are ordinary
    paragraphs, not definitions -- the marker line is preserved as text. This
    mirrors the heading, list and task markers, which likewise require a
-   literal space after the marker. carve-rs is the reference here.
+   literal space after the marker.
 
    AND THE SEPARATOR IS A RUN (carve#892). `footnote_definition` and
    `abbreviation_definition` spell it `space+`: one or more ASCII spaces, all
-   of them separator. This is a correction, not a widening -- both productions
-   said `space` while all four readers consumed a run, so the grammar forbade
-   a shape nothing rejected.
-
-   CARDINALITY HERE IS THE OPPOSITE ANSWER FROM carve#912's, and the two are
-   not in conflict because they govern different POSITIONS. A PADDING SLOT
-   sits between two tokens on a line whose construct is already fixed, and its
-   width means nothing, so the four slots spelled `space` mean exactly one. A
-   MARKER SEPARATOR is what stands between the marker and the content it
-   introduces, and a writer aligning definitions in a column is writing
-   separator, not content. Stated here so the two rulings are not read as
-   contradicting each other.
+   of them separator.
 
    WHAT THE RUN DOES NOT INCLUDE. It is ASCII spaces, so the first character
    that is not one ends the separator and BEGINS the content. A no-break space
    is content: `*[HTML]:<SP><NBSP>Hyper` expands to `<NBSP>Hyper`, and
    `[^f]:<SP><NBSP>note` is a footnote whose body starts with the character.
-   This is where all three engines disagreed, each in a different place, and
-   where the executable spec gave a fourth answer no engine gave -- it refused
-   `[^f]:` plus any non-ASCII whitespace as a definition at all (carve#892).
 
    A TAB AFTER THE RUN is content too, by the same rule, and the two markers
    then answer differently for a reason that is downstream of this clause
@@ -2886,9 +2390,7 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
    backslash-escape rule above: a `\"` inside the quoted run is a literal
    quote and does not end the title (`[y]: /u "a\"b\"c"` -> title
    `a"b"c`, emitted as `title="a&quot;b&quot;c"`). This matches the
-   inline-link title; the earlier carve-js divergence (ref-def title
-   stopping at the first raw quote) was fixed in the canonical oracle, and
-   the examples corpus now pins the ref-def escaped-quote form too. *)
+   inline-link title. *)
 (* A reference definition requires a NON-EMPTY `link_destination` (one or
    more `url_char`s after the `':' space`). A bare `[r]:` -- with nothing
    after the colon, or only trailing whitespace -- does NOT form a
@@ -2954,41 +2456,23 @@ control_char = (* any character in Unicode General_Category Cc *) ;
    internationalized domain written in its own script is an autolink, and
    so is a non-ASCII PATH.
 
-   The CONTROL half is not redundant with the ASCII enumeration, which is
-   the trap it was written around: `unicode_url_char` is "non-whitespace,
-   non-ASCII", so the C1 block U+0080-U+009F satisfies it. Those characters
-   are Cc, are not Cf, and only U+0085 is whitespace - so without this term
-   fourteen control characters would be `url_char`s while every C0 control
-   is excluded, which is not a rule anyone would state on purpose. The
-   executable spec admitted them until its own class test said so.
+   The CONTROL half is not redundant with the ASCII enumeration:
+   `unicode_url_char` is "non-whitespace, non-ASCII", so the C1 block
+   U+0080-U+009F satisfies it. Those characters are Cc, are not Cf, and only
+   U+0085 is whitespace -- so without this term fourteen control characters
+   would be `url_char`s while every C0 control is excluded.
 
-   WHY, since the ASCII enumeration was explicit. The same destination
-   written `[t](https://<IDN>/)` links in all three engines today, because
-   `link_destination` admits `unicode_url_char`. Two spellings of one
-   destination cannot answer differently on the character set, and the
-   inline form is the one with the corpus behind it, so the autolink
-   follows it. The exclusion also looks incidental rather than chosen: the
-   note above enumerates the punctuation `url_char` excludes and never
-   mentions non-ASCII, which is not what a decided exclusion reads like.
-
-   THE FORMAT-CHARACTER EXCLUSION IS THE PART THAT IS NEW RATHER THAN
-   PERMISSIVE. A format character (General_Category Cf: the byte order
-   mark, the zero-width space, the word joiner, the bidi marks) is
-   invisible by definition, so a host carrying one renders as the host
-   without it and links somewhere else. That is a spoofing surface, not an
-   authoring convenience, and no author types one on purpose. Stating it as
-   a PROPERTY rather than as a list of codepoints also makes the byte-order
-   -mark answer fall out of the rule: a host language whose own whitespace
-   class happens to hold U+FEFF gets the right answer for the wrong reason
-   and the wrong answer for U+200B, which is exactly the split carve#860
-   measured.
+   THE FORMAT-CHARACTER EXCLUSION. A format character (General_Category Cf:
+   the byte order mark, the zero-width space, the word joiner, the bidi
+   marks) is invisible by definition, so a host carrying one renders as the
+   host without it and links somewhere else -- a spoofing surface. It is
+   stated as a PROPERTY rather than as a list of codepoints, so U+FEFF and
+   U+200B answer the same way.
 
    THE ASCII HALF DOES NOT MOVE. The nine characters the note above
-   enumerates are still not `url_char`s: they are exclusions with a stated
-   reason, and all four artifacts agree on them today. The rule reads
-   `unicode_url_char - format_char` for that reason -- spelling it "any
-   non-whitespace, non-control character" would additionally re-admit those
-   nine and move every implementation on a question nobody asked.
+   enumerates are still not `url_char`s, which is why the rule reads
+   `unicode_url_char - format_char` rather than "any non-whitespace,
+   non-control character".
 
    `link_destination` IS UNCHANGED. It admits `unicode_url_char` in its own
    right, so a format character in an inline destination or a reference
@@ -2999,16 +2483,7 @@ control_char = (* any character in Unicode General_Category Cc *) ;
 
    `scheme` IS UNCHANGED AND IS ASCII. Only the BODY admits non-ASCII; a
    scheme is `letter, {letter | digit | '+' | '-' | '.'}` and `letter` is
-   the enumerated ASCII alphabet. The executable spec accepted a non-ASCII
-   scheme because ohm's built-in `letter` is Unicode-aware, and is corrected
-   under this clause rather than beside it.
-
-   Engine state when this landed, measured on fresh mains: carve-rs makes
-   EVERY non-ASCII autolink literal and moves on the first half
-   (markup-carve/carve-rs#755); carve-js and carve-php link format
-   characters and control characters and move on the second
-   (markup-carve/carve-js#834, markup-carve/carve-php#983). No
-   implementation had both halves. *)
+   the enumerated ASCII alphabet. *)
 
 (* --- Images --- *)
 (* An image has the same three forms as a link (inline / reference / collapsed
@@ -3019,12 +2494,9 @@ reference_image = '!', '[', alt_text, ']', '[', reference_label, ']', [attribute
 collapsed_reference_image = '!', '[', alt_text, ']', '[', ']', [attributes] ;
 alt_text = {character} ;
 (* SEMANTIC CONSTRAINT: the alt text ends at the matching `]` -- THE SAME
-   close as `link_text`, balanced-bracket, escape- and LITERAL-SPAN-aware, and
-   for the same reason: the sentence above this block says an image has the
-   same three forms as a link and that only the leading `!` and the `<img src>`
-   output differ. The bracketed run is not one of the things that differ. Not
+   close as `link_text`, balanced-bracket, escape- and LITERAL-SPAN-aware. Not
    expressible context-free, which is why this production reads `{character}`
-   and defers to the constraint rather than pretending to enumerate it.
+   and defers to the constraint.
 
    The VALUE is not `inline_content`. `alt` is an HTML attribute, so nothing
    inside the run is inline-parsed and no smart typography applies:
@@ -3167,28 +2639,13 @@ forced_content    = (inline_element | text_run | literal_special)+ ;
 
      {//}  {**}  {__}  {~~}  {^^}  {,,}  {==}  {++}  {##}
 
-   all render literally. This is not a new rule -- it is the one already
-   written here and in docs/parsing-ambiguities.md §16 ("`{^^}` # Not
-   superscript (no content)"), and the two engines that read it that way,
-   carve-js and carve-rs, were the ones in conformance. The oracle and
-   carve-php emitted empty elements: `<em></em>`, `<sup></sup>`, `<mark></mark>`.
-
-   IT APPLIES TO THE EDITORIAL FAMILY TOO, whose content slots are the same
-   `+` repetition. `{++}` was an `<ins>` inserting nothing and `{##}` a comment
-   saying nothing to anybody; `{--}` was a `<del>` deleting nothing, and the
-   string it freed is the braced en dash (PART 9 §8).
-
-   AN EMPTY ELEMENT IS NOT THE HARM -- the harm is that the braces vanish. An
-   author who wrote `{^^}` sees their four characters replaced by nothing
-   visible, in the output only, which is the same silent-loss shape the hyphen
-   flanking rule refuses. Reading them back as text loses nothing.
+   all render literally. IT APPLIES TO THE EDITORIAL FAMILY TOO, whose content
+   slots are the same `+` repetition; the string `{--}` this frees is the
+   braced en dash (PART 9 §8).
 
    THE ONE FORM LEFT ALONE is a fully empty SUBSTITUTION, `{~~>~}`, which still
-   renders an empty del followed by an empty ins. Substitution is an open
-   divergence (see Editorial Markup below), and the same `+` on both of its
-   halves would also refuse `{~a~>~}` and `{~~>b~}` -- a deletion with no
-   replacement and an insertion replacing nothing, which are ordinary edits.
-   It needs its own decision rather than this one. *)
+   renders an empty del followed by an empty ins: substitution is an open
+   divergence (see Editorial Markup below) and needs its own decision. *)
 
 (* TRAILING ATTRIBUTES -- each emphasis-family span MAY carry a trailing
    `[attributes]` block: the generic inline-attribute carrier that attaches
@@ -3197,24 +2654,18 @@ forced_content    = (inline_element | text_run | literal_special)+ ;
    `<strong class="real">x</strong>`. It is the SAME `[attributes]` slot
    every other inline carrier uses (code_span, link, image, inline_span,
    extension_inline, autolink). Pinned by corpus
-   80-trailing-attribute-block-edge-cases; both reference impls agree. *)
+   80-trailing-attribute-block-edge-cases. *)
 
 (* Content MAY contain the delimiter character: a delimiter that does not
    satisfy the close condition (PART 9 §1) is literal content, not the span
-   boundary. The span ends at the matched closer only. Subtracting the
-   delimiter here would make e.g. "/usr/local/" -> <em>usr/local</em>
-   ungrammatical, contradicting edge-cases.md §1. The boundary is a semantic
-   constraint (PART 9 §1, §9), not a context-free one. *)
+   boundary. The span ends at the matched closer only. The boundary is a
+   semantic constraint (PART 9 §1, §9), not a context-free one. *)
 emphasis_content = (inline_element | text_run | literal_special)+ ;
 strong_content = (inline_element | text_run | literal_special)+ ;
 bi_content = (inline_element | text_run | literal_special)+ ;
 underline_content = (inline_element | text_run | literal_special)+ ;
 strike_content = (inline_element | text_run | literal_special)+ ;
 highlight_content = (inline_element | text_run | literal_special)+ ;
-
-(* The former prose pseudo-productions emphasis_open_condition /
-   emphasis_close_condition are SUPERSEDED by the formal bare_opener(d) /
-   bare_closer(d) templates above. *)
 
 (* --- Footnotes (PART 9 §16) --- *)
 (* Both implemented forms: the REFERENCE form `[^label]` resolving against a
@@ -3236,9 +2687,7 @@ footnote_label = {character - ']' - newline}+ ;
 inline_footnote = "^[", inline_content, ']' ;
 (* the closing `]` is the balanced, escape- and LITERAL-SPAN-aware close
    (PART 9 §16) -- the same scan `link_text` states, and the same three spans
-   it skips. This read "code-span-aware", naming only the first of the three,
-   which is the spelling carve#403 replaced at `link_text` and did not replace
-   here; footnote recognition is DISABLED inside the content *)
+   it skips; footnote recognition is DISABLED inside the content *)
 
 footnote_definition = "[^", footnote_label, "]:", space+, inline_content, newline,
                       {footnote_continuation | continuation_marker_block} ;
@@ -3249,78 +2698,44 @@ footnote_indent = whitespace, {whitespace} ;
    PART 9 §17), the same continuation marker lists, block quotes and definition
    bodies use.
 
-   INDENTATION IS COLUMNS, NOT CHARACTERS -- NORMATIVE (carve#692). The prior
-   spelling of `footnote_indent` as `space, space` made this production a
-   literal two-SPACE requirement, contradicting its own adjacent comment
-   ("indented by >= 2 spaces", a column claim) and PART 9 §24 C1, which
-   already gives a tab a column value (to the next multiple of 4). This
-   production widens to any whitespace run reaching column 2: a bare tab
-   (column 0 -> 4) or a space then a tab (column 1 -> 4) both qualify, exactly
-   as two literal spaces do; a single space (column 1) does not. This is
-   INDENTATION, not a marker SEPARATOR -- it does not touch the literal
-   `space` the def line's own `]:` separator requires (unchanged, PART 9 §24
-   C2's sibling rule for markers). `footnote_indent` above is therefore
-   deliberately loose (any run of `whitespace`, PART 2's own idiom for
-   `list_continuation`'s `indent`) -- the actual column-2 floor is column
-   arithmetic, stated here rather than encoded character-by-character.
+   INDENTATION IS COLUMNS, NOT CHARACTERS -- NORMATIVE (carve#692). Any
+   whitespace run REACHING COLUMN 2 indents the body: a bare tab (column 0 ->
+   4) or a space then a tab (column 1 -> 4) qualify exactly as two literal
+   spaces do; a single space (column 1) does not. PART 9 §24 C1 gives a tab its
+   column value (to the next multiple of 4). This is INDENTATION, not a marker
+   SEPARATOR -- it does not touch the literal `space` the def line's own `]:`
+   separator requires (unchanged, PART 9 §24 C2's sibling rule for markers).
+   `footnote_indent` above is therefore deliberately loose; the column-2 floor
+   is column arithmetic, not a character-by-character encoding.
 
    `inline_content` above describes THE SHAPE OF A LINE that belongs to the
    body, not how the collected body is parsed. The body is parsed AS BLOCKS
    (PART 9 §16: "parsed as blocks"), so a note may hold a table, a list, a code
    block or a quote, and the indentation beyond the body's own is theirs to
-   read. Taking the production literally reads as an inline-only body, which is
-   the opposite of what every implementation does and of what the corpus pins
-   ("A footnote body holds blocks", carve#691) -- and an engine written from
-   this line alone would flatten exactly the structure the indent carries
-   (carve-rs#611).
+   read.
 
    THE BODY'S OWN COLUMN IS TWO -- NOT the first continuation line's actual
    indent. A reader first consumes that minimum and then applies PART 0's ONE
    AUTHORED BLOCK BASE. Two is a floor for the body, not a ceiling for its
    blocks; this construct adds no second rebase rule. *)
 
-(* DISMISSED (not reserved, no production): a sidenote form
-     sidenote = "[>", inline_content, ']' ;
-   was proposed and declined -- margin placement is CSS over the existing
-   footnote/endnote output, so it does not warrant core syntax. The `[>`
+(* DISMISSED (not reserved, no production): a sidenote form `[>content]` --
+   margin placement is CSS over the existing footnote/endnote output. The `[>`
    opener is therefore UNCLAIMED and `[>foo]` is literal text (pinned by the
    corpus). Rationale: docs/dismissed-syntax.md. *)
 
 (* --- Citations (PART 9 §22, Tier-2 extension; issue #90) --- *)
 (* TIER-2, OFF BY DEFAULT. A `[...]` whose content contains a `@key` and which
-   has NO link/ref/span tail (`(url)` / `[ref]` / `{attrs}`) is a citation.
-   Bare `@key` stays a mention (PART 19); `\@` is literal. Items are
-   `;`-separated; each is `[prefix] [-] @key [, locator]` (`-` suppresses the
-   author in author-date mode). Bibliography entries are defined in-document:
-   `[@key]: {author= year=}? entry` (the `{…}` is optional, feeds author-date;
-   a leading `@` label is reserved here, never a link definition - see
-   reference_definition). Numbered output (default) emits `[1]` + an ordered
-   references list; author-date (configuration) emits `(Author Year)` + an
-   alphabetical list. The references list is appended at document end or
-   injected into a `::: references` block.
-
-   INTEGRAL MARKER (issue #226): a single leading `+` immediately after `[`
-   marks the whole citation cluster as integral (author-in-text). The `+` is
-   a group-level flag - there is no per-item integral mode. An integral cluster
-   is wrapped in `<span class="citation" data-cite-mode="integral">…</span>`.
-   The vocabulary (`integral` / `non-integral`) matches CSL / Citum `CitationMode`.
-   Example: `[+@smith2020]`, `[+see @smith2020, p. 12]`.
-
-   TYPED LOCATORS (issue #226): the locator text after the first `,` in an item
-   is parsed into a citeproc `{label, value}` structure plus a trailing suffix.
-   Longest-match, boundary rule: a term matches only when followed by end-of-locator,
-   whitespace, a digit, `§`, or `¶`. On a leading digit with no preceding term,
-   the default label is `page`. Trailing `,`, `&`, `-`, `.` are trimmed from the
-   value; the remainder is the suffix. Canonical labels with recognized abbreviations:
-     book (bk.) | chapter (chap., chaps.) | column | figure | folio |
-     issue (no.) | line (l., ll.) | note (n., nn.) | opus | page (p., pp.) |
-     paragraph (para., ¶) | part | section (sec., §) | sub verbo (s.v.) |
-     verse (v., vv.) | volume (vol.)
-
-   DATA-* HTML CONTRACT (issue #226): each citation anchor carries, in order,
-   only the attributes that apply: `data-cite-key`, `data-suppress-author`,
-   `data-cite-prefix`, `data-locator-label`, `data-locator`, `data-suffix`.
-   Prefix and suffix are flattened plain text.
+   has NO link/ref/span tail (`(url)` / `[ref]` / `{attrs}`) is a citation; a
+   bare `@key` stays a mention (PART 19) and `\@` is literal. Items are
+   `;`-separated; each is `[prefix] [-] @key [, locator]`. Bibliography entries
+   are defined in-document: `[@key]: {author= year=}? entry` -- the `{…}` is
+   optional and feeds author-date, and a leading `@` label is RESERVED here,
+   never a link definition (see reference_definition). NUMBERED output is the
+   DEFAULT: `[1]` plus an ordered references list. AUTHOR-DATE output
+   (configuration) emits `(Author Year)` plus an alphabetical list. The
+   references list is appended at document end, or injected into a
+   `::: references` block.
 
    Undefined behavior (impls MAY differ, NOT corpus-pinned): same-author-year
    disambiguation letters (e.g. `2020a` / `2020b`) are out of scope for v1 -
@@ -3328,33 +2743,35 @@ footnote_indent = whitespace, {whitespace} ;
    items); such a bracket falls back to literal text.
    Failure-mode handling IS pinned (tests/corpus-optional): a group with any
    undefined key renders the verbatim source; a `[@k]{...}` is a span, not a
-   citation; a `[@k, a; b]` with a `;` in the locator is literal text.
-   Pinned in tests/corpus-optional (features citations-numbered /
-   citations-author-date and the failure-mode cases, plus typed-locator,
-   integral, and suppress-author enrichment cases 13-24). *)
+   citation; a `[@k, a; b]` with a `;` in the locator is literal text. *)
 citation_group = '[', ['+'], citation_item, {';', citation_item}, ']' ;
 citation_item = [inline_content], ['-'], '@', citation_key, [',', space, inline_content] ;
 (* A single leading `+` immediately after `[` sets the whole citation cluster to
    integral mode (CSL/Citum CitationMode: integral = author-in-text; absent =
-   non-integral/parenthetical). This is the Djot draft `[+@foo, p. 15]` form.
-   Mode is a GROUP property; there is no per-item `+`. A bare `+` before `@key`
-   inside a multi-item bracket (e.g. `[@a; +@b]`) is parsed as prefix text on
-   that item, not as an integral marker.
+   non-integral/parenthetical), the Djot draft `[+@foo, p. 15]` form. Mode is a
+   GROUP property; there is no per-item `+`. A bare `+` before `@key` inside a
+   multi-item bracket (e.g. `[@a; +@b]`) is parsed as prefix text on that item,
+   not as an integral marker. An integral cluster wraps the ENTIRE citation
+   group output in `<span class="citation" data-cite-mode="integral">`.
    `-` before `@key` suppresses the author for that item (per-item; applies in
    both numbered and author-date modes via `data-suppress-author="true"`).
-   The locator (text after the first `,` in an item) is parsed into a typed
-   citeproc label + value + trailing suffix: longest-match label from the fixed
-   vocabulary (book/chapter/column/figure/folio/issue/line/note/opus/page/
-   paragraph/part/section/sub verbo/verse/volume, with abbreviations), matching
-   only at a boundary (end of string, whitespace, ASCII digit, `§`, or `¶`); no
-   label but a leading ASCII digit defaults to `page`; value is the leading run
-   of digits/roman/`.,&-` with trailing separators trimmed; the remainder is the
-   suffix. A roman numeral locator with no label produces no data-locator-label.
+   TYPED LOCATOR: the locator (text after the first `,` in an item) is parsed
+   into a citeproc label + value + trailing suffix. The label is the LONGEST
+   match from the fixed vocabulary below, and matches ONLY at a boundary --
+   end of locator, whitespace, an ASCII digit, `§`, or `¶`. Canonical labels,
+   with their recognized abbreviations:
+     book (bk.) | chapter (chap., chaps.) | column | figure | folio |
+     issue (no.) | line (l., ll.) | note (n., nn.) | opus | page (p., pp.) |
+     paragraph (para., ¶) | part | section (sec., §) | sub verbo (s.v.) |
+     verse (v., vv.) | volume (vol.)
+   No label but a leading ASCII digit defaults to `page`; a roman-numeral
+   locator with no label produces NO `data-locator-label`. The value is the
+   leading run of digits/roman/`.,&-`, with trailing `,`, `&`, `-`, `.` trimmed
+   off it; the remainder is the suffix.
    The structure is surfaced as `data-*` attributes on the rendered citation
-   anchors (`data-cite-key`, `data-suppress-author`, `data-cite-prefix`,
-   `data-locator-label`, `data-locator`, `data-suffix`) and, for an integral
-   cluster, a `<span class="citation" data-cite-mode="integral">` wrapper around
-   the entire citation group output. *)
+   anchor, IN THIS ORDER and only where each applies: `data-cite-key`,
+   `data-suppress-author`, `data-cite-prefix`, `data-locator-label`,
+   `data-locator`, `data-suffix`. Prefix and suffix are flattened plain text. *)
 citation_key = (letter | digit | '_'), {citation_key_char} ;
 (* Pandoc-compatible key charset (carve-js `KEY`): after the first char, any of
    these internal punctuation marks are allowed. *)
@@ -3363,10 +2780,7 @@ citation_key_char = letter | digit | '_' | ':' | '.' | '#' | '$' | '%' | '&'
 citation_definition = '[@', citation_key, "]:", space, [attributes], inline_content, newline ;
 (* The line is a NODE in the serialized tree -- `citation_definition`, carrying
    the key, the entry's inline content and the metadata block (PART 12 §18).
-   Like the other definition kinds it renders nothing where it sits, which is
-   exactly why it is a node: it was written somewhere, and neither consuming it
-   at parse time nor leaving it a paragraph of citation-shaped literal text can
-   put it back (carve#1276). *)
+   Like the other definition kinds it renders nothing where it sits. *)
 
 (* --- Extensions --- *)
 extension_inline = ':', extension_name, '[', extension_content, ']', [attributes] ;
@@ -3398,45 +2812,28 @@ comment_content = (* any text until the matching `#}`, preserved literally;
                      Forced Intraword Emphasis *) ;
 (* CONTENT IS LITERAL -- NORMATIVE. Nothing inside is parsed as markup, spaces
    are preserved, and no escape is resolved: `{# a *b* c #}` holds the eight
-   characters ` a *b* c ` and renders them, asterisks included. This says what
-   all three implementations already do; the production read `inline_content`,
-   which none of them implemented.
-
-   It follows from what the construct is. An editorial comment is the author's
-   aside about the text, not more text -- emphasis inside it would be markup
-   the reader never sees rendered, and a formatter could not tell it from
-   emphasis the author wrote outside. It is also what lets `link_text`'s scan
-   skip the span: with no escape available, a `]` inside is uncloseable any
-   other way.
+   characters ` a *b* c ` and renders them, asterisks included. It is also what
+   lets `link_text`'s scan skip the span: with no escape available, a `]`
+   inside is uncloseable any other way.
 
    `addition` and `deletion` are NOT literal: they take `inline_content`, and
    `{+a *b* c+}` really does emphasize `b`.
 
-   AN ADDITION'S AND A DELETION'S CONTENT IS NON-EMPTY, and the productions
-   ALREADY SAID SO: `inline_content` is a `+` repetition. `comment_content` now
-   says it too. `{++}`, `{--}` and `{##}` are therefore text, under the same
-   empty-brace clause the forced spans carry (carve#1447); `{---}` is still
-   `<del>-</del>` and `{-x-}` is still `<del>x</del>`. The string `{--}` freed
-   is the braced en dash (PART 9 §8).
+   AN ADDITION'S AND A DELETION'S CONTENT IS NON-EMPTY -- `inline_content` is a
+   `+` repetition, and `comment_content` says it too. `{++}`, `{--}` and `{##}`
+   are therefore text, under the same empty-brace clause the forced spans carry
+   (carve#1447); `{---}` is still `<del>-</del>` and `{-x-}` is still
+   `<del>x</del>`. The string `{--}` freed is the braced en dash (PART 9 §8).
 
-   `substitution` is NOT widened. Both of its halves are spelled
-   `inline_content`, but a half-empty substitution is a real edit -- `{~a~>~}`
-   deletes and `{~~>b~}` inserts -- so requiring content on each half would
-   refuse them, and requiring it across the pair is a different production.
-   The fully empty `{~~>~}` therefore still renders two empty elements, and
-   that sits with substitution's open divergence rather than with this
-   clause.
-
-   `substitution` is an OPEN divergence, deliberately left alone here. Its
+   `substitution` is NOT widened: a half-empty substitution is a real edit --
+   `{~a~>~}` deletes and `{~~>b~}` inserts -- so the fully empty `{~~>~}` still
+   renders two empty elements. `substitution` is an OPEN divergence: its
    production says `inline_content`, and all three implementations render
-   `{~*b*~>*e*~}` with the asterisks literal - so either the production or
-   every engine is wrong, and which one is a behavior question rather than a
-   transcription error. Not folded into this clause. *)
+   `{~*b*~>*e*~}` with the asterisks literal. *)
 (* ATTRIBUTES -- NORMATIVE: an addition / deletion is an ordinary inline node,
    so a trailing `{...}` attribute block attaches to its `<ins>` / `<del>`,
    exactly like a span, code span, link, or emphasis: `{+a+}{.a}` ->
-   `<ins class="a">…</ins>`. (All three impls agreed only after this was
-   pinned; carve-js dropped the block, carve-rs kept it literal.) *)
+   `<ins class="a">…</ins>`. *)
 (* DISAMBIGUATION (PART 9 §22). `{~ … ~}` is editorial SUBSTITUTION when it
    contains a top-level `~>`, and forced STRIKETHROUGH otherwise. `{# … #}`
    stays editorial comment (`#` is not an emphasis delimiter, no collision). *)
@@ -3480,15 +2877,7 @@ name_word = (letter | digit | '_' | '-')+ ;
    block after a mention stays literal (corpus
    153-attribute-block-after-a-mention-stays-literal), so `@alice{.x}` never
    produces an attributed mention. The slot is filled by a decoded wire
-   payload, the ProseMirror bridge (a stock Tiptap mention carries an id), or
-   an application building the node. Each implementation pins this in its own
-   suite; the corpus cannot, because the corpus renders source.
-
-   The rule exists because the alternative loses on round-trip: a writer that
-   spells an attributed mention as `[*\@alice*]{.mention #keepme}` only
-   satisfies toHtml(fmt(x)) == toHtml(x) if those attributes render, and a
-   writer that drops them instead satisfies it by deleting the data from both
-   sides. Resolved in carve-php#575. *)
+   payload, the ProseMirror bridge, or an application building the node. *)
 
 (* Boundary rules (PSEUDO-PRODUCTIONS -- prose conditions on `mention` /
    `tag` / `symbol`, normative in PART 9 §7, not reachable grammar symbols):
@@ -3547,86 +2936,46 @@ braced_en_dash = "{--}" ;   (* → – *)
 ellipsis = "..." ;    (* → … *)
 (* A BRACED HYPHEN PAIR IS AN EN DASH, NOT AN EMPTY DELETION -- NORMATIVE
    (carve#1447). `{--}` renders a single EN DASH and the braces are consumed.
-
    It exists because the flanking rule below leaves a position an author cannot
-   spell. A run with whitespace before it and a non-whitespace character after
-   it is flag-shaped and stays literal, which is right for `git log --oneline`
-   and wrong for the author who meant a dash there -- `x ---That`, `x ---(p)`
-   and `x ---, y` are all refused by that rule, and only the first of them is
-   plausibly a flag. `{--}` is the way to say "a dash, here, whatever stands
-   next to it", and it follows the braced precedent that forced spans already
-   set: a collision-prone bare form keeps a braced spelling that never
-   collides.
+   spell: a run with whitespace before it and a non-whitespace character after
+   it is flag-shaped and stays literal, so `x ---That`, `x ---(p)` and
+   `x ---, y` are all refused by that rule.
 
-   THE SPELLING WAS TAKEN, AND WHAT IT COST IS NOTHING. `{--}` rendered
-   `<del></del>`: the `{-` opener meeting its `-}` closer with no content, a
-   deletion that deletes nothing. `deletion` never permitted that -- its
-   content slot is `inline_content`, a `+` repetition -- so no conforming
-   document loses anything, and exactly one string moves: `{---}` is still
-   `<del>-</del>`, `{-x-}` is still `<del>x</del>`.
-
-   Every other empty brace pair reads back as TEXT rather than as a dash: see
-   the empty-brace clause under Forced Intraword Emphasis. `{--}` is the one
-   that becomes something, because a dash wanted the spelling and nothing
-   wants `{++}`.
-
-   There is NO braced EM dash. `{---}` is a deletion of a hyphen, which is a
-   thing an author writes, and taking it would cost what taking `{--}` did not.
-   So a tight em dash -- the Spanish, French and Russian dialogue convention,
-   `---That is mine.` -- still has no shorthand and is written as the literal
+   Exactly one string moves: `{---}` is still `<del>-</del>` and `{-x-}` is
+   still `<del>x</del>`. Every other empty brace pair reads back as TEXT rather
+   than as a dash (see the empty-brace clause under Forced Intraword Emphasis).
+   There is NO braced EM dash -- `{---}` is a deletion of a hyphen -- so a
+   tight em dash still has no shorthand and is written as the literal
    character. *)
 (* A HYPHEN RUN OPENING A WORD AFTER WHITESPACE IS A FLAG, NOT A DASH --
    NORMATIVE (carve#1443). A run of hyphens PRECEDED by whitespace (or the
    start of the inline content) and FOLLOWED by a non-whitespace character
    does not convert. It is literal text. Every other position converts as
-   before.
+   before. The case is a long CLI flag: `git log --oneline` rendered
+   `git log –oneline`, silently and in the output only.
 
-   The case is a long CLI flag, which is ordinary technical prose.
-   `git log --oneline` rendered `git log –oneline`, silently and in the output
-   only: the author saw their flag, the reader got a command that does not run,
-   and nothing warned. `--force-with-lease` failed the same way.
-
-   THE RULE IS DELIBERATELY NARROW, and the two obvious wider ones are both
-   wrong:
-
-   Requiring whitespace on BOTH sides removes the damage and the feature
-   together, because every canonical dash use is unspaced -- `pages 1--10`,
-   `the Mon--Fri window`, a tight `thought---interrupted---resumes`. A numeric
-   range is the reason en dashes exist.
-
-   Requiring the two SIDES TO MATCH in kind also fails, on a case the corpus
-   already pins: `a---- b----- c------` (19-smart-typography-dashes-and-quotes-7)
-   is alphanumeric on the left and whitespace on the right, and it converts. So
-   is a trailing dash on an interrupted clause. Only the LEFT-FLANKING-ONLY
-   shape -- whitespace before, word after -- is the one no dash wants and every
-   flag has.
+   THE RULE IS DELIBERATELY NARROW. Requiring whitespace on BOTH sides removes
+   every canonical dash use, which is unspaced -- `pages 1--10`, `the Mon--Fri
+   window`, a tight `thought---interrupted---resumes`. Requiring the two SIDES
+   TO MATCH in kind fails on `a---- b----- c------`, which is alphanumeric on
+   the left and whitespace on the right and converts. Only the
+   LEFT-FLANKING-ONLY shape -- whitespace before, word after -- is the one no
+   dash wants and every flag has.
 
    THE SPACE CLASS IS PART 7'S, and that is not the host language's `\s`. A
    VERTICAL TAB and a FORM FEED are CONTENT in Carve, so `---<VT>` converts or
-   stays literal exactly as `---!` does; a rule spelled with `\s` answered the
-   two differently, which is the divergence carve-php's whitespace-definition
-   sweep exists to catch. A NO-BREAK SPACE counts as a space here, because the
-   question asked is "does a space stand before this run" - the same question
-   quote flanking asks, and a nbsp is a space to the reader.
+   stays literal exactly as `---!` does. A NO-BREAK SPACE counts as a space
+   here, the same question quote flanking asks.
 
    ELLIPSIS IS NOT COVERED. `wait... really` is the ordinary use and it is
    word-then-whitespace; an ellipsis terminates a clause where a dash joins two
-   things, so their natural positions differ and the rule follows the construct.
+   things, so the rule follows the construct.
 
-   NOT FIXED BY THIS, and stated so it is a known limit rather than a
-   discovery: an HTML comment survives NEITHER half, and each half is lost to a
-   different rule. `<!-- c -->` renders `&lt;!– c →`. The OPENING run is
-   preceded by `!` rather than whitespace, so this clause does not reach it and
-   it converts to a dash. The CLOSING run was flag-shaped and literal under this
-   clause until the arrow set took the doubled run (§8 ARROWS, carve#1442), and
-   an arrow is matched before a hyphen run is decomposed.
-
-   That order is deliberate. Guarding `-->` for this one context would put a
-   context-sensitive exception into a set whose whole argument is that it has
-   none, and Carve escapes raw HTML by default: a literal HTML comment in prose
-   is a document ABOUT HTML rather than HTML, where an author who wants the
-   characters can escape one of them. Recognising the whole construct is what
-   the opening half wants; a wider dash rule would cost the numeric range.
+   NOT FIXED BY THIS: an HTML comment survives NEITHER half. `<!-- c -->`
+   renders `&lt;!– c →`. The OPENING run is preceded by `!` rather than
+   whitespace, so this clause does not reach it and it converts to a dash; the
+   CLOSING run is taken by the arrow set (§8 ARROWS, carve#1442), and an arrow
+   is matched before a hyphen run is decomposed.
 
    Composes with the run decomposition below rather than replacing it: this
    decides WHETHER a run converts, the length decides INTO WHAT. *)
@@ -3656,32 +3005,19 @@ smart_quote = '"' | "'" ;
 arrow = "<--" | "-->" | "<-->"      (* → ← → ↔, canonical *)
       | "<==" | "==>" | "<=>"       (* → ⇐ ⇒ ⇔ *)
       | "<-" | "->" | "<->" ;       (* deprecated, still rendered *)
-(* THE DOUBLED RUN IS THE CANONICAL ARROW, IN BOTH FAMILIES -- NORMATIVE
-   (carve#1442). Matched longest-first, as `<->` already beats `<-`, so `<==`
-   beats `<=` and `-->` beats the hyphen run.
+(* THE DOUBLED RUN IS THE CANONICAL ARROW, IN BOTH FAMILIES -- NORMATIVE.
+   Matched longest-first, as `<->` already beats `<-`, so `<==` beats `<=` and
+   `-->` beats the hyphen run.
 
-   The single-line family was complete and the double-line family was not:
-   `->`, `<-` and `<->` all existed, `=>` existed, and there was no `<=` arrow
-   because `<=` is the comparison. `<=>` -- the common spelling of "if and only
-   if", and the one a writer who has just met `=>` reaches for -- rendered
-   `≤>`.
-
-   `<=` KEEPS ≤, and that is what forces the answer. In technical prose `<=` is
-   far more often a comparison than a leftward implication, so the left double
-   arrow has to grow a character. Once it does, the family is spelled at one
-   width throughout rather than two, which is why the doubled run is canonical
-   everywhere rather than only where it had to be.
+   `<=` KEEPS ≤: in technical prose it is far more often a comparison than a
+   leftward implication, so the left double arrow grows a character.
 
    `->`, `<-` AND `<->` ARE DEPRECATED, NOT REMOVED. They keep rendering and
-   the canonical spelling is the doubled form; a document written before this
-   goes on working.
+   the canonical spelling is the doubled form.
 
-   `=>` IS REMOVED, and that is a behavior change rather than a deprecation.
-   It is the one form that was actively harmful instead of merely
-   non-canonical: `key => value`, `x => x + 1` and `Some(x) => x` are ordinary
-   prose about code, and every one of them silently became ⇒. So the two
-   families are treated differently on purpose, and each exception has a reason
-   that fits in a line -- `<=` is a comparison, and `=>` is code. *)
+   `=>` IS REMOVED, and that is a behavior change rather than a deprecation:
+   `key => value`, `x => x + 1` and `Some(x) => x` are ordinary prose about
+   code, and every one of them silently became ⇒. *)
 comparison = "!=" | "<=" | ">=" ;
 (* NOT the `:name:` symbol above -- these are the fixed typographic
    replacements (© ® ™ ±). Named `typographic_symbol` so the two do not
@@ -3716,12 +3052,6 @@ attribute_list = attribute, {space+, attribute} ;
    this one. The distinction is POSITIONAL, not per-construct - inline
    padding is space-only everywhere, and a continuation line's leading run
    is indentation like any other leading run.
-
-   `opt_ws` was ONE name for both roles, used at five sites, and the two
-   are split rather than substituted so no site can keep the old meaning by
-   accident: `attr_pad` is the inline one, `opt_ws` now serves only
-   `opt_pad`, `attr_separator` and `continuation`, all three of which are
-   block-level.
 
    Two neighbouring questions are explicitly NOT decided here and have
    their own tickets: a NEWLINE inside a quoted value, where this file and
@@ -3874,16 +3204,6 @@ quoted_value = '"', { escaped_char | (character - '"' - '\' - newline) }, '"'
    same slot: ONE production, two normative answers, which is this ticket's
    subject rather than a consequence of any other clause.
 
-   It is settled the ohm file's way because the alternative falsifies a
-   sentence this grammar already states. `attributes` cannot span lines --
-   carve#897 ruled that an inline block stops at the newline, and since
-   carve#906 its padding is `attr_pad = {space}` and its separator `space+`,
-   neither of which admits one. The quoted VALUE was the last way through,
-   so `*x*{k="a` + newline + `b"}` was an attribute block under the EBNF
-   and literal text under the ohm. Narrowing here is what makes the note at
-   `block_attributes` -- "an inline block does not span lines in any
-   engine" -- true of the productions as well as of the engines.
-
    THE BLOCK-ATTRIBUTE LINE FOLLOWS, and that is the part with a cost.
    `block_attributes` reads the same `quoted_value`, so a line break inside
    a quoted value ends that block too. A block attribute may still span
@@ -4003,31 +3323,9 @@ digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' ;
    PART 2. MARKER SEPARATORS AND PADDING SLOTS below is 3 applied to every
    whitespace slot in this grammar that sits inline.
 
-   CONSOLIDATING THE STATEMENT DOES NOT REMOVE THE MEASUREMENT. A tab advances
-   to a stop rather than by a fixed amount, so computing a line's content
-   column still needs the per-line indentation walk. Nor does it make a
-   tab-indented source and a space-indented source the same document: the
-   source records what the author wrote (carve#817, carve#966). A
-   whole-document tab-expanding pre-pass could not be written in any case,
-   because 4 preserves tabs inside verbatim content, so the leading run still
-   has to be identified line by line. NO SEMANTIC CHANGE IS INTENDED and no
-   corpus document moves: the four sentences are what the twelve restatements
-   said between them, and not one production changes spelling. That is a claim
-   about this file, NOT a claim that every engine conforms -- the divergences
-   this file already records against these slots (carve#901 at the frontmatter
-   token, the fence info string and `link_title`) are unaffected, neither
-   settled nor widened by saying the rule once.
-
-   WHY ONCE. This was written twelve times, once per construct. A rule spelled
-   per construct is a rule that can drift per construct, and a construct added
-   later inherits eleven precedents for spelling it a twelfth way. That is the
-   hazard ONE WHITESPACE DEFINITION, IN EVERY CONSTRUCT below was written
-   against (carve#963), one layer up: forty-two productions each spelling a
-   whitespace run for themselves is what let three engines reach into three
-   host languages for three different answers, and a carve-php sweep then
-   found fourteen spellings where its ticket named three. The count behaved
-   the same way here -- the ticket named five sites and the sweep found
-   twelve. (carve#984) *)
+   Computing indentation still requires a per-line tab-stop walk. Source
+   spelling remains preserved, and tabs inside verbatim content are never
+   expanded. *)
 
 (* MARKER SEPARATORS AND PADDING SLOTS -- NORMATIVE. A TAB IS SYNTAX ONLY IN
    THE LEADING RUN, the clause directly above. Two consequences settle every
@@ -4294,42 +3592,25 @@ EOF = (* end of file *) ;
 
       THE SEVENTH IS THE SECOND SPELLING OF THE SECOND. A `quote_block` IS a
       block quote (PART 2), so it captions like one and a captioned quote is a
-      FIGURE either way -- the two spellings cannot differ here without the
-      fenced form being a worse quote than the prefixed one, which is the whole
-      premise of admitting it. The slot hangs on the CLOSING fence, as
-      `figure_group`'s does, because that is where a fenced container's last
-      line is. So TWO `:::` kinds now take a closer caption, and a `^ ` line
-      after any OTHER `:::` closer is still ordinary paragraph content.
+      FIGURE either way. The slot hangs on the CLOSING fence, as
+      `figure_group`'s does. So TWO `:::` kinds now take a closer caption, and
+      a `^ ` line after any OTHER `:::` closer is still ordinary paragraph
+      content.
 
-      WHERE THAT ALLOWANCE IS WRITTEN DOWN differs, and saying so is the point
-      of this paragraph. For FIVE hosts it is STRUCTURAL -- `code_block`,
-      `blockquote`, `table`, `figure_group` and `quote_block` each end in
-      `[caption_slot]`
-      (PART 2; on `figure_group` the slot hangs on the closing fence), and
-      caption_slot's single optional blank_line IS the rule. For the IMAGE
-      PARAGRAPH and the STANDALONE DISPLAY-MATH BLOCK it is PROSE: this
-      clause is the rule, and PART 3 already says so beside `image` ("there
-      is no separate grammar production for the pair").
+      WHERE THAT ALLOWANCE IS WRITTEN DOWN differs. For FIVE hosts it is
+      STRUCTURAL -- `code_block`, `blockquote`, `table`, `figure_group` and
+      `quote_block` each end in `[caption_slot]` (PART 2; on `figure_group`
+      the slot hangs on the closing fence), and caption_slot's single optional
+      blank_line IS the rule. For the IMAGE PARAGRAPH and the STANDALONE
+      DISPLAY-MATH BLOCK it is PROSE: this clause is the rule, and PART 3
+      already says so beside `image` ("there is no separate grammar production
+      for the pair").
 
       NOT AN OVERSIGHT. Neither of those two has a production to hang the slot
-      on. Both ARE a `paragraph` (PART 2), and what distinguishes them -- a
-      paragraph whose whole content is one image, a paragraph that is solely
-      the display-math span -- is a condition on that paragraph's inline
-      content, the same not-context-free class as PART 7's cell_content ("may
-      not contain an unescaped `|`") and §15's block_attributes. Two ways to
-      formalize it fail on inspection: hanging `[caption_slot]` on `paragraph`
-      itself would make EVERY paragraph captionable, which this enumeration
-      denies and no engine does; and a separate image / math paragraph
-      production would duplicate `paragraph` ambiguously AND inherit its
-      trailing `[blank_line]`, so the one blank line the slot exists to
-      account for could be consumed by either optional -- structural in
-      spelling and undecided in fact.
-
-      One rule, two spellings, not two rules. An engine implements this
-      clause; it does not implement four productions and then guess at the
-      remaining two hosts. This paragraph used to end "structural now, not
-      prose", which was true of three hosts out of the five it then named and
-      read as true of all five (carve#991).
+      on. Both ARE a `paragraph` (PART 2), and what distinguishes them is a
+      condition on that paragraph's inline content, the same not-context-free
+      class as PART 7's cell_content and §15's block_attributes. `paragraph`
+      itself is NOT captionable: this enumeration is closed.
 
    4b. WHAT A CAPTION MAKES OF ITS HOST -- EXPLANATORY. The `figure` node is
       the GENERIC captioned wrapper, not the semantic notion "figure". A
@@ -4341,25 +3622,6 @@ EOF = (* end of file *) ;
       counter bucket key (PART 2, CAPTION NUMBER PLACEHOLDER) -- and never from
       the host's node type. `^ Listing #: …` on a code block yields "Listing 1"
       because the author wrote "Listing", not because a code block is a listing.
-
-      SO A QUOTE IS NOT A SPECIAL HOST. carve#1161 briefly made a caption on a
-      quote an `attribution` rendered as a `<footer>` INSIDE the `<blockquote>`,
-      on the argument that a figure is a numbered thing and `figure` was doing
-      two jobs. Both halves are wrong. `figure` does one job here, as the code
-      block above shows; and a caption with no bare `#` takes no number under
-      either model, so a quote captioned `^ William Shakespeare` never entered a
-      counter. That clause is withdrawn (carve#1213), and the PART 11 clause
-      that carried the attribution onto the other three targets goes with it.
-      Its number is retired, not reused, which is why PART 11 runs 10c, 10e.
-
-      HTML AGREES, AND IN THE OTHER DIRECTION. The HTML Standard's `blockquote`
-      section requires that "attribution for the quotation, if any, must be
-      placed outside the `blockquote` element", and gives a `<figure>` wrapping
-      the quote with a `<figcaption>` as the way "to clearly relate a quote to
-      its attribution (which is not part of the quote and therefore doesn't
-      belong inside the `blockquote` itself)". So the withdrawn clause was not
-      one valid spelling among two: it put the attribution in the one place the
-      HTML Standard names as wrong.
 
    4c. A COMPOSITE FIGURE GROUPS ITS PANELS UNDER ONE CAPTION -- NORMATIVE
       (governs `figure_group` in PART 2; carve#1122). A bare `::: figure`
@@ -4381,10 +3643,8 @@ EOF = (* end of file *) ;
       matches `admonition_open` instead and stays a generic Tier-2 container
       -- `<div class="figure">`, title and label preserved losslessly, the
       pre-§4c shape -- and `carve lint` reports
-      `figure-group-opener-metadata` (corpus 318-composite-figures-8). The
-      group has no title or label slot BY DESIGN: its one authored metadata
-      channel is the caption, and a second spelling for "the text above the
-      figure" would be claimed from carve#1121's design space.
+      `figure-group-opener-metadata`. The group has no title or label slot BY
+      DESIGN: its one authored metadata channel is the caption.
 
       PANELS ARE THE DIRECT CHILDREN THE INNER RULES ALREADY MAKE CAPTIONABLE
       THINGS OF. After the body parses under the UNCHANGED §4 rules, the
@@ -4395,37 +3655,26 @@ EOF = (* end of file *) ;
       source order. Everything else -- paragraphs, lists, uncaptioned
       quotes, nested containers -- is plain group content, PRESERVED IN
       PLACE between the panels; a strict profile lints it, and no renderer
-      may silently drop or re-attach it (318-composite-figures-5). Two
+      may silently drop or re-attach it. Two
       consequences worth naming:
 
         - AN UNCAPTIONED QUOTE inside the group is plain content, which is
           how a quotation carries a figure number without a caption of its
-          own: leave the quote bare and caption the GROUP
-          (318-composite-figures-10):
-
-            ::: figure
-            > To be
-            :::
-            ^ Figure #: A pull quote
-
-            <figure class="carve-figure-group">
-              <blockquote><p>To be</p></blockquote>
-              <figcaption>Figure 1: A pull quote</figcaption>
-            </figure>
-
-          A CAPTIONED quote is a `figure` whose target is the quote (§4b)
-          and panels like any other captionable host -- the quote is not a
-          special host inside the group either.
+          own: leave the quote bare and caption the GROUP, and the group's
+          `<figure class="carve-figure-group">` holds the `<blockquote>` and
+          the group `<figcaption>`. A CAPTIONED quote is a `figure` whose
+          target is the quote (§4b) and panels like any other captionable
+          host -- the quote is not a special host inside the group either.
         - A TABLE PANEL keeps its own caption as the table's `<caption>`;
           the panel wrapper adds nothing to it.
 
       THE GROUP CAPTION ATTACHES AT THE CLOSER, THIS KIND ONLY. A `^ ` line
       (or multiline caption block, the normal `caption` rules) adjacent to or
       exactly one blank line below the group's CLOSING fence is the group
-      caption; two blank lines detach it into an ordinary paragraph
-      (318-composite-figures-6). Every other `:::` kind keeps today's
-      behavior -- a `^ ` line after a `::: note` closer is ordinary paragraph
-      content (318-composite-figures-7). Captions INSIDE the fence attach
+      caption; two blank lines detach it into an ordinary paragraph. Every
+      other `:::` kind keeps today's behavior -- a `^ ` line after a
+      `::: note` closer is ordinary paragraph content. Captions INSIDE the
+      fence attach
       only to their local host, unchanged.
 
       THE GROUP IS ONE NUMBERING UNIT (PART 9R R5). A `#` placeholder in the
@@ -4438,8 +3687,8 @@ EOF = (* end of file *) ;
       entry. For CROSS-REFERENCES (PART 9R R4), a panel with an id resolves
       `</#id>` with the group's number plus a letter by panel order among the
       panels -- "Figure 2a", letters a..z then aa, ab, ... -- and the group's
-      own id resolves as the plain "Figure 2"
-      (318-composite-figures-2). The letters exist in crossref text only:
+      own id resolves as the plain "Figure 2". The letters exist in crossref
+      text only:
       this version generates no visible `(a)` label inside the panel (authors
       write panel letters in panel captions; the mechanism is reserved).
       Panel ids register only when the group itself drew a number -- an
@@ -4454,22 +3703,16 @@ EOF = (* end of file *) ;
       content -- a captioned figure inside an admonition inside the group,
       say -- which draws AFTER the group even though its caption line sits
       above the group's in the source: the inner figure is "Figure 2" and
-      the group "Figure 1" (corpus 318-composite-figures-11). That
-      construction is already the stray content a strict profile lints.
-      Caption-line order was considered and rejected: under it, editing a
-      group's INTERIOR could renumber the group itself, and a group's number
-      should be stable under edits to what it contains. All four
-      implementations of record -- the oracle, carve-js, carve-php and
-      carve-rs -- agree on the pre-order result, so this clause writes down
-      the answer they already share rather than choosing between them.
+      the group "Figure 1". That construction is already the stray content a
+      strict profile lints. Caption-line order is NOT the rule: a group's
+      number is stable under edits to what it contains.
 
       GROUPS DO NOT NEST. A bare `::: figure` opener anywhere inside an open
       group's body -- any depth -- is a generic Tier-2 container
       (`<div class="figure">`), not an inner group, and lints as
-      `figure-group-nested` (318-composite-figures-9). Rejected initially
-      rather than specified halfway: nested numbering ("Figure 2a.iii"?) is a
-      design question carve#1122 explicitly defers, and a generic container
-      is the lossless degradation.
+      `figure-group-nested` (318-composite-figures-9). Nested numbering is a
+      design question carve#1122 explicitly defers, and a generic container is
+      the lossless degradation.
 
       LINT, NOT PARSE. The five findings this clause names are diagnostics
       over a valid parse: `figure-group-opener-metadata` and
@@ -4498,10 +3741,7 @@ EOF = (* end of file *) ;
       what the element admits -- no intermediate `div` is needed to make the
       shape valid, and none is emitted. This is also the shape Pandoc's
       writers produce for its native subfigures, which keeps HTML
-      import/export symmetric with the Pandoc bridge. The initial draft of
-      this clause wrapped the panels in a `<div class="carve-figure-panels">`;
-      that form was revised to the flat one before any release, so no
-      shipped document ever carried the wrapper.
+      import/export symmetric with the Pandoc bridge.
 
       The class is FIRST on the group and on each panel, exactly the typed-
       container convention (`admonition note`): `carve-figure-group` leads,
@@ -4512,7 +3752,7 @@ EOF = (* end of file *) ;
       with `carve-figure-panel` leading its classes the same way. No group
       caption -> no trailing `<figcaption>`. Zero panels -> the group
       `<figure>` holds the preserved content directly; a consumer selects
-      panels by the `carve-figure-panel` class, never by position, so the
+      panels by the `carve-figure-panel` class, never by position.
       shape needs no branch on child count.
 
    5. TABLE MODEL -- OPERATIONAL SEMANTICS (cell split, row validity,
@@ -4589,31 +3829,24 @@ EOF = (* end of file *) ;
 
          - and the block above `+ b |` at the item's own column is a
          blockquote. T6 declines, the line is ordinary prose, and prose reopens
-         the item's paragraph (PART 1 S4's clause on that). No reader joins the
-         cell, so a reader that consults the quote's table anyway declines the
-         join and still ends the paragraph, which reads one line as prose and
-         as a table row in the same parse. Corpus 361 pins it, with the
-         same-column spelling `- | a |` / `  | b |` as its control: there the
-         row above IS the item's own, it joins, and no paragraph opens.
-         (carve#1370)
+         the item's paragraph (PART 1 S4's clause on that). The control is the
+         same-column spelling `- | a |` / `  | b |`: there the row above IS the
+         item's own, it joins, and no paragraph opens. (carve#1370)
 
-         HEADER-NESS IS NOT THE DISCRIMINATOR, and reading it as one gets 115
-         right for the wrong reason. The executable spec declined whenever the
-         row above was ALL-HEADER, which answers three neighbouring documents
-         wrongly and all three engines agree it does:
+         HEADER-NESS IS NOT THE DISCRIMINATOR. Declining whenever the row above
+         is ALL-HEADER answers three neighbouring documents wrongly:
 
              |=a |=b |          | a |            |=a |
              + cont |           |=b |            | - |
                                 + c |            + cont |
 
-         The first two JOIN in every reader - onto a native header row, and
-         onto an all-header row that is not the table's first - and the third
-         DECLINES in every reader, on a NATIVE header row, because a delimiter
-         row sits between the two lines. Header-ness answers all three
-         backwards; the delimiter row answers all three. T9 already says the
-         rest outright: a `^` rowspan MAY reach a header cell, so a header
-         cell is an ordinary cell in every other table mechanism, and nothing
-         here makes it less of a row.
+         The first two JOIN - onto a native header row, and onto an all-header
+         row that is not the table's first - and the third DECLINES, on a
+         NATIVE header row, because a delimiter row sits between the two lines.
+         Header-ness answers all three backwards; the delimiter row answers all
+         three. T9 already says the rest outright: a `^` rowspan MAY reach a
+         header cell, so a header cell is an ordinary cell in every other table
+         mechanism.
 
          AN ALL-EMPTY CONTINUATION ROW IS A CONTINUATION ROW. T2's "at least
          one cell lies between" is written of `valid_row`, the predicate that
@@ -4628,8 +3861,7 @@ EOF = (* end of file *) ;
              | a | b |          | a |
              + | |              + |
 
-         the first absorbed and the second published as a paragraph. All three
-         engines absorb both.
+         Both are absorbed.
 
          IT LEAVES NO PARAGRAPH OPEN, LIKE THE ROW IT APPENDS TO -- NORMATIVE.
          PART 1 S4 asks what a container's last BLOCK is, and the answer here
@@ -4660,15 +3892,12 @@ EOF = (* end of file *) ;
          ending on a continuation row is decided by the run inside the quote
          and not by the line that carries it. An implementation that peels the
          `>` off ONE line loses that run, and the same quote then answers
-         differently bare and wrapped in a definition body - which is the
-         defect carve-rs shows today, in the direction opposite to the other
-         two engines.
+         differently bare and wrapped in a definition body.
 
-         A QUOTE INSIDE A QUOTE IS ASKED THE SAME QUESTION, ruled at carve#1355
-         and stated in PART 1 S4 rather than here, since it is not about a
-         continuation row: an outer quote's last block may be an inner quote,
-         and then the INNER quote's own last block answers. `> > # H` over
-         `tail` ends both quotes for the reason `> # H` over `tail` ends one.
+         A QUOTE INSIDE A QUOTE IS ASKED THE SAME QUESTION, stated in PART 1
+         S4 rather than here since it is not about a continuation row: an
+         outer quote's last block may be an inner quote, and then the INNER
+         quote's own last block answers.
       T7 GFM DELIMITER ROW -- NORMATIVE. delimiter_row(R) := R is EXACTLY
          the SECOND row of the table AND every cell matches delimiter_cell
          (optional ws, optional `:`, one or more `-`, optional `:`,
@@ -4710,23 +3939,16 @@ EOF = (* end of file *) ;
          `<tbody>` (corpus 09-tables-7) -- so the attribute states an
          association the table already has rather than adding a concept.
 
-         IT IS NOT DECORATION. Without it a screen reader guesses the
-         association from position, and guesses wrong on any table with both
-         kinds of header; `scope` is the mechanism WCAG 1.3.1 names for
-         programmatically determined relationships. Carve emits real `<table>`
-         markup precisely so assistive technology can read it, and this was the
-         one part of that markup the language left to inference.
-
          AN AUTHORED `scope` REPLACES THE DEFAULT rather than joining it. A
          cell block naming `scope` suppresses the emitted one, so
          `|={scope="colgroup"} a |` -- a header cell carrying attributes,
          which is grammatical because of T10 and was not before it -- is
          `<th scope="colgroup">` and not
          `<th scope="col" scope="colgroup">`. That is how `colgroup` and
-         `rowgroup`, which have no marker spelling here, stay reachable. The
-         duplicate was the first thing this rule produced when the default was
-         emitted unconditionally: two attributes of one name, which is not
-         valid HTML and is not an override.
+         `<th scope="colgroup">` and not
+         `<th scope="col" scope="colgroup">`. That is how `colgroup` and
+         `rowgroup`, which have no marker spelling here, stay reachable: two
+         attributes of one name is not valid HTML and is not an override.
 
          THE TEST IS CASE-INSENSITIVE, which is the one place this rule departs
          from Carve's case-sensitive attribute names. `{Scope="colgroup"}` is a
@@ -4754,45 +3976,9 @@ EOF = (* end of file *) ;
          makes it ordinary content (T4's `{.x} <` is unchanged), and the
          validity rule is T8's.
 
-         WHAT THIS RULE EXISTS TO FIX. With the block bound to the opening
-         `|` instead, an attributed HEADER cell has no spelling at all. The
-         one shape available, `|{#x}=R|`, is ambiguous by construction: an
-         attributed header cell, or a data cell whose content starts with
-         `=`. §5 T1/T3 resolve it as the second, so a canonical writer that
-         emitted it for an attributed header cell round-tripped
-         `<th id="x">R</th>` into `<td id="x">=R</td>` -- a PART 11 §1
-         failure the corpus could not see, because the only document
-         pinning cell attributes (99-table-cell-attributes) carries no
-         marker, and every order agrees on a cell with no marker. Once `=`
-         has committed the cell to header, everything after it is
-         unambiguous, so binding last is the only placement under which the
-         shape is expressible.
-
-         THE COST, STATED. This CHANGES an already-released spelling on
-         `data_cell`: `|{#x}< content |` was documented as attributes then a
-         left-alignment marker, and under T10 the `<` is no longer in a
-         marker position, so it is literal content and the cell is not
-         aligned. (T11 moves that same spelling once more: with no space
-         after the closing brace there is no run, so the braces are content
-         too.) That source REINTERPRETS rather than erroring, which is
-         the outcome to be careful about. It is accepted here for the
-         uniform shape over the preserved special case, on a `0.x` line, and
-         it ships WITH its migration rather than a deprecation window: a
-         canonical writer rewrites the old spelling to the new one. Row
-         attributes (T8) do not move.
-
-         WHAT WAS ACTUALLY MEASURED, so the migration is not sized from the
-         prose. Against this repo's own oracle (scripts/spec) and the
-         `@markup-carve/carve` build package.json pins, `|{#x}< content |`
-         ALREADY renders `<td id="x">&lt; content</td>` -- neither reads the
-         `<` as alignment, so neither ever implemented the order this rule
-         replaces. The other half -- an attribute block after a marker --
-         is what was new, and both this repo's oracle and the pinned
-         `@markup-carve/carve` build read it. So the reinterpretation risk
-         falls on documents written to the retired PROSE, and the engine
-         work was to start reading the marker-run position, not to stop
-         reading the old one. Pinned by corpus
-         319-cell-attributes-bind-after-the-kind-and-alignment-markers.
+         The canonical writer uses this order. The retired
+         `|{#x}< content |` spelling is parsed as unaligned literal content;
+         row attributes (T8) are unaffected.
 
       T11 A MARKER RUN ENDS AT A SPACE -- NORMATIVE. A cell's marker run is
          the kind marker `=`, the alignment run and the attribute block, in
@@ -4808,16 +3994,6 @@ EOF = (* end of file *) ;
 
          A cell with NO run is unchanged -- `| a |`, `|a|` and `||` all mean
          what they meant.
-
-         THE RUN HAD NO TERMINATOR, SO IT TOOK CONTENT INSTEAD. `|=hot= |` is
-         a cell whose author wrote a highlight and got a header cell holding
-         `hot=`: the marker ate the opening `=` and nothing said so. Carve
-         resolves this class by making the failure VISIBLE -- `- {.notattr}
-         Milk` renders its braces rather than guessing -- and the table cell
-         was the outlier. The alignment run already required the space, and
-         a doubled marker (`|=<< Note |`) already fell back to content for
-         want of one; this states the rule ONCE, for the whole run, instead
-         of for one of its three parts.
 
          THE CLOSING PIPE IS NOT A TERMINATOR. `|=|` and `|{#x}|` carry no
          run; an empty marked cell is `|= |` and `|{#x} |` -- which is what
@@ -4835,20 +4011,16 @@ EOF = (* end of file *) ;
          line for one rule over three, and it ships WITH its migration: §6e's
          canonical writer already emits a space after every prefix, so a
          formatted document is already conformant, and the glued form is what
-         a linter can name. Pinned by corpus
-         390-a-table-cell-s-marker-run-ends-at-a-space.
+         a linter can name.
 
-         THE LINTER NAMES IT `table-marker-run-padding` -- NORMATIVE
-         (carve#1464). One id for the whole run, because T11 is one rule for
-         the whole run: it reports a glued kind marker, a glued alignment run
-         and a glued attribute block alike, and `fmt --migrate` repairs any of
-         them by inserting the space. It SUPERSEDES
-         `table-alignment-run-padding`, which named the middle part only -
-         which is how the one part of the run that reinterprets existing
-         documents, the kind marker, ended up the part with no diagnostic.
-         A lint id is spec surface (docs/validation.md carries the row), so it
-         is agreed here BEFORE an engine emits it, rather than two engines
-         picking different names for it.
+         THE LINTER NAMES IT `table-marker-run-padding` -- NORMATIVE. One id
+         for the whole run, because T11 is one rule for the whole run: it
+         reports a glued kind marker, a glued alignment run and a glued
+         attribute block alike, and `fmt --migrate` repairs any of them by
+         inserting the space. It SUPERSEDES `table-alignment-run-padding`,
+         which named the middle part only. A lint id is spec surface
+         (docs/validation.md carries the row), so it is agreed here BEFORE an
+         engine emits it.
 
    6. REFERENCE RESOLUTION -- FORMAL STATEMENT MOVED TO PART 9R (rules
       R1-R3; this §-anchor stays for existing references). Summary: link
@@ -4886,9 +4058,7 @@ EOF = (* end of file *) ;
         or glyph extension (a German / Swiss quote set, say) selects WHICH
         characters are emitted; it does NOT decide WHETHER the substitution
         runs, and removing such an extension does not disable the
-        transform. Stated explicitly because the existence of a
-        smart-quotes extension otherwise reads as "the transform is that
-        extension" -- it is not (carve#338).
+        transform.
       - OPTIONAL OFF SWITCH -- NORMATIVE WHERE OFFERED. A host MAY expose
         one document-global switch, `smartTypography`, defaulting to TRUE
         (idiomatic spellings: `smartTypography: false` in carve-js and
@@ -4899,11 +4069,7 @@ EOF = (* end of file *) ;
         document is configured when it is not, which is worse than the
         rejection an unimplemented option should produce. Omitting and
         implementing are both fine; the silent middle is the one state this
-        clause forbids. Measured on each engine's main: carve-php raises
-        `Unknown named parameter $smartTypography`, carve-rs has no such
-        method, and carve-js accepts the option and ignores it -- so the
-        reference is the only one currently non-conformant here, and it is
-        non-conformant in the direction a host cannot detect (carve#560).
+        clause forbids (carve#560).
 
         Where it IS offered and set to FALSE:
         * PARSING IS UNCHANGED. The nodes below are still produced, so the
@@ -4965,11 +4131,9 @@ EOF = (* end of file *) ;
             author typed as a typographic character is not a
             `smart_punctuation` node and is emitted unchanged either way.
           Rationale: Markdown is the target generated for machines to read,
-          and the glyph breaks exact-match search against the source - a
-          quote substituted around a code-ish value (`= 'verification-link-
-          sent'`) can no longer be found by searching for what the author
-          wrote, and the reader cannot undo it because the glyph is all that
-          survives. Pinned in tests/corpus-optional (feature
+          and the glyph breaks exact-match search against the source, which
+          the reader cannot undo because the glyph is all that survives.
+          Pinned in tests/corpus-optional (feature
           `markdown-typography-source`, target `markdown`).
         * KIND NAMES ARE SPEC SURFACE -- an implementation inventing its own
           spelling breaks every AST consumer. The fourteen table-resolved
@@ -5065,9 +4229,7 @@ EOF = (* end of file *) ;
          "x = 5 \n * 3 + 17"; a blank line starts the list. (Deliberate
          change from the earlier bullet/ordered asymmetry: an ordered
          marker is too common in prose, and the symmetric rule removes the
-         hard-wrapped-bullet false positive. Pinned by corpus 05-lists-12/13,
-         76-paragraph-interruption, 77-blockquote-lazy-continuation,
-         82-single-line-headings.) TIGHT NESTED LISTS UNAFFECTED: an
+         hard-wrapped-bullet false positive.) TIGHT NESTED LISTS UNAFFECTED:
          indented marker inside an open list ITEM opens a sublist with no
          blank line -- that is §24 C3 (content column), not this relation.
       I3 IMAGE EXCLUDED. A line that is only a bare image ("![alt](url)")
@@ -5083,10 +4245,8 @@ EOF = (* end of file *) ;
          A `:::` OPENER IS NOT GUARDED. It interrupts whether or not a closer
          follows, and an unterminated one closes with its host -- the
          enclosing container's boundary, or end of input at the top level
-         (§12; the citation here read §25, which is the security section and
-         says nothing about it). Pinned by
-         corpus 81-paragraph-interruption-20: `Text` / `:::` / `stuff` is a
-         paragraph followed by a div holding `stuff`.
+         (§12). Pinned by corpus 81-paragraph-interruption-20: `Text` /
+         `:::` / `stuff` is a paragraph followed by a div holding `stuff`.
 
       I5 INVISIBLE CONSTRUCTS interrupt AND are consumed: a reference
          definition (link `[r]: url`, footnote `[^r]: …`, abbreviation
@@ -5175,16 +4335,11 @@ EOF = (* end of file *) ;
          in scope versus retain pending metadata -- and the column that selects
          the band does not.
 
-         WHICH CONTAINER, NOT ONLY THAT IT IS TEXT (carve#1800). "Lazy
-         paragraph text" names an operation on an OPEN PARAGRAPH, so the text
-         lands in the container that holds that paragraph, and a reader that
-         ends the container and then publishes the same characters one level out
-         has not carried the sentence out -- it has produced text in a place the
-         sentence does not name. The definition-description host is where the
-         two readings came apart: a link or footnote definition one or two
-         columns below the description's content column ended the `dd` and was
-         published as a DOCUMENT-level paragraph, one line after a plain line at
-         the identical column folded into the `dd`. Pinned per kind by corpus
+         WHICH CONTAINER, NOT ONLY THAT IT IS TEXT. "Lazy paragraph text" names
+         an operation on an OPEN PARAGRAPH, so the text lands in the container
+         that holds that paragraph; a reader that ends the container and then
+         publishes the same characters one level out has produced text in a
+         place the sentence does not name. Pinned per kind by corpus
          430-below-a-definition-body-s-column-an-invisible-line-folds-as-text.
 
          A DEFINITION COLLECTED AT content_column ENDS THE ITEM'S OPEN
@@ -5221,14 +4376,8 @@ EOF = (* end of file *) ;
          about a caption, stated separately from item 2's "a line that
          interrupts a paragraph" precisely because a caret line is not one of
          those. Item 4 would be redundant if it were.
-         WHY IT NEEDED WRITING DOWN. Only the INDENTED spelling was in the
-         corpus (158-indented-image-and-caption-stay-literal), where both
-         readings agree because an indented line opens no top-level block at
-         all. The executable spec ended the paragraph on EVERY caret line, all
-         three engines folded it in, and nothing failed until the canonical
-         writer stopped force-escaping a line-initial caret and `oracle(fmt(x))`
-         parted from `oracle(x)` (carve#1046). Pinned by corpus
-         286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption.
+         An INDENTED caret line opens no top-level block at all, so both
+         readings agree there. (carve#1046)
 
    11. LIST MARKER CHANGE STARTS A NEW LIST -- OPERATIONAL (governs `list`
       in PART 2). §10 decides FIRST whether marker lines establish a list
@@ -5260,24 +4409,16 @@ EOF = (* end of file *) ;
            - oranges
          AT EVERY LEVEL. The boundary is not restricted to the top level: it
          applies wherever a list is, including a list nested in a list item
-         and a list inside a quote or a div. A rule that fired at the top
-         level and not inside an item would make one spelling mean two
-         things depending on where it sits, which Design Principle 1 exists
-         to prevent, and the marker's own container has nothing to do with
-         what the run separates.
+         and a list inside a quote or a div.
          THE RUN CLOSES NOTHING ON ITS OWN. It denies a FOLLOWING SIBLING
          MARKER the right to join; it does not end the item. A run followed
          by a continuation at the item's content column continues that item,
          at any run length -- which is SS17's content-column model unchanged,
          and is why three blank lines before indented text still leave one
          loose item.
-         WHY THREE AND NOT TWO. Two fires on decoration. Sampling 8000
-         Markdown files for the shape that would change -- a list open above
-         the run, a compatible sibling marker after it -- found 30 sites at
-         two blank lines and NONE at three, and every one of the 30 was
-         generator output or a changelog's spacing rather than an author
-         separating two lists. A released line needs a threshold that fires
-         on nothing already written.
+         WHY THREE AND NOT TWO. Two fires on decoration -- generator output
+         and changelog spacing routinely spell two blank lines between
+         compatible sibling markers.
       N2 ORDERED DIALECT. A list's dialect (decimal / lower- or upper-alpha
          / lower- or upper-roman) and delimiter are fixed by its FIRST
          item; a later marker outside the dialect, or with the other
@@ -5299,9 +4440,7 @@ EOF = (* end of file *) ;
       on the type identifier (below). A BARE `:::` opener with NO type
       word is a GENERIC DIV: a plain `<div>` (no class added), i.e. djot's
       generic container. An EMPTY one closes on the next line --
-      `<div>` newline `</div>`, the exception PART 10 §4 states -- not
-      `<div></div>`, which no engine emits and which this line claimed
-      until carve#531 measured it.
+      `<div>` newline `</div>`, the exception PART 10 §4 states.
 
       INLINE OPENER ATTRIBUTES -- STRICT (djot). The opener line carries NO
       inline attributes: it is the colon fence, an optional type word, and
@@ -5328,26 +4467,18 @@ EOF = (* end of file *) ;
       may hold `::: tip`, the inner line being an opener rather than a closer
       on account of its label. Only a bare equal-length line closes.
 
-      Compatibility history for the retired equal-or-greater closer and
-      literal-unclosed readings lives in docs/spec-history.md. The current rule
-      is fully stated above and pinned by carve#770 and carve#1717.
-
       THE CANONICAL WIDTH IS A FUNCTION OF DEPTH, AND THAT COSTS O(depth^2)
       BYTES (carve#1553). The exact-length guard leaves the DIRECTION free --
       longer-outer documents and longer-inner ones both parse -- and `carve
       fmt` writes the inward one: the outermost container is `:::` and each
       level inward adds one colon (PART 11; the `colon_fence` note in PART 2).
       So the writer sizes each fence from the depth it is ALREADY CARRYING. It
-      needs no lookahead and no scan of the subtree it has not written yet, and
-      the widths it emits cannot collide with one another, because along any
-      one chain they are STRICTLY INCREASING: a container's closer is wider
-      than every fence enclosing it and narrower than every fence it encloses.
-      (A fence-shaped line in TEXT is a different problem, answered by PART 11
-      §5's escaping rather than by this width.)
+      needs no lookahead, and the widths it emits cannot collide, because along
+      any one chain they are STRICTLY INCREASING. (A fence-shaped line in TEXT
+      is a different problem, answered by PART 11 §5's escaping.)
 
       A nest d containers deep spends d^2 + 5d bytes on opener and closer
-      markers. This accepted canonical-size trade is recorded in
-      docs/spec-history.md (carve#1553).
+      markers -- the accepted canonical-size trade (docs/spec-history.md).
 
       A COLON-FENCE LINE THAT FAILS THE OPENER TEST LEAVES THE PARAGRAPH
       EXPECTING A CLOSER -- NORMATIVE. A `:::` line that is not a valid opener
@@ -5403,13 +4534,8 @@ EOF = (* end of file *) ;
       that holds it (corpus
       270-a-real-div-in-a-container-and-the-flush-left-line-after-it), which is
       end of input only when the item runs that far.
-      The corpus pins these
-      (resources/examples/edge-cases.md "Fence opener with a nested-list body inside a list
-      item").
-
-      The retired missing-closer reading and its compatibility evidence live in
-      docs/spec-history.md. The current host-closing rule applies unchanged in
-      a list item and is pinned by carve#1722.
+      (resources/examples/edge-cases.md "Fence opener with a nested-list body
+      inside a list item" pins these.)
 
       The two tiers for a typed block:
 
@@ -5452,12 +4578,10 @@ EOF = (* end of file *) ;
            An explicitly empty `""` still counts as a supplied (empty)
            title. Applies to both tiers.
 
-      AN ADMONITION LANDMARK CARRIES AN ACCESSIBLE NAME -- NORMATIVE
-      (carve#1468). A Tier-1 block renders `<aside>`, which is a COMPLEMENTARY
-      LANDMARK, and a landmark with no name is an anonymous row in a reader's
-      landmark list -- the same defect as the unnamed backlink SS16 records, one
-      element up. Tier 2 renders `<div>`, is not a landmark, and takes nothing
-      here.
+      AN ADMONITION LANDMARK CARRIES AN ACCESSIBLE NAME -- NORMATIVE. A
+      Tier-1 block renders `<aside>`, which is a COMPLEMENTARY LANDMARK, and a
+      landmark with no name is an anonymous row in a reader's landmark list.
+      Tier 2 renders `<div>`, is not a landmark, and takes nothing here.
 
         TITLED: the name is the title the author already wrote. The
         `<p class="admonition-title">` takes an `id` and the aside points at it
@@ -5533,8 +4657,7 @@ EOF = (* end of file *) ;
         `jgm/djot.js#43` the other way (all attributes migrate to the
         section) and then implemented that resolution only when an
         explicit id is present, so djot's two id cases disagree with
-        each other (`jgm/djot.js#144`). Carve's two cases agree. See
-        divergence-from-djot.md.
+        each other. Carve's two cases agree. See divergence-from-djot.md.
       - HEADINGS INSIDE CONTAINERS DO NOT WRAP. The algorithm walks
         TOP-LEVEL blocks (and the sections it opens), so a heading
         inside a blockquote, div, admonition, list item, definition,
@@ -5580,9 +4703,7 @@ EOF = (* end of file *) ;
       - The two-pass id resolution (collect explicit ids first, then
         auto-slug headings with collision-dedup) is unaffected by this
         rule -- only the EMISSION site of the id moves from <h*> to
-        <section>. Existing crossref (`</#id>`) and implicit-heading
-        ref (`[Heading][]`) resolution continue to target the same
-        slug; the fragment URL `#{slug}` resolves to <section id> the
+        <section>. The fragment URL `#{slug}` resolves to <section id> the
         same way browsers resolve to <h* id>.
       - Carve does NOT add `<section>` wrappers around non-heading
         top-level blocks. Headings are the only trigger.
@@ -5614,12 +4735,11 @@ EOF = (* end of file *) ;
           attributes.
         - empty or SPACE-only (`[text]{}`, `[text]{ }`) -> a valid EMPTY
           block: a bare `<span>text</span>`. A TAB inside it is not padding
-          and the block is unrecognized (carve#906, the A7 position of THE
-          INLINE INTERIOR IS SPACE-ONLY in PART 4). Both reference impls
-          agree on the space form, even
-          though the bare `attribute_list` production nominally needs >= 1
-          attribute; the empty block is a blessed exception so a
-          default-attribute processor can target the span.
+          and the block is unrecognized (the A7 position of THE INLINE
+          INTERIOR IS SPACE-ONLY in PART 4). The empty block is a blessed
+          exception -- the bare `attribute_list` production nominally needs
+          >= 1 attribute -- so a default-attribute processor can target the
+          span.
         - unrecognized non-empty content (`[text]{???}`, `[text]{=y=}`) -> NOT
           an attribute block: the `]` and the `{...}` render literally. The
           inner bracket content is still inline-parsed, so `[*x*]{???}` ->
@@ -5639,7 +4759,7 @@ EOF = (* end of file *) ;
       with id/class/key=value in source order; multiple are allowed; a
       digit-first bare word is not a valid name (the block stays literal, as for
       any digit-first identifier). All impls support it (a carve extension
-      beyond canonical djot, matching djot-php; corpus 97-boolean-attributes).
+      beyond canonical djot, matching djot-php).
       THE THREE NAMES OF PART 9 §9 ARE THE EXCEPTION TO `name=""`: on an
       ordinary span, `abbr`, `time` and `kbd` are consumed into an HTML
       element instead of reaching the output as an attribute, so `[Tab]{kbd}`
@@ -5647,20 +4767,17 @@ EOF = (* end of file *) ;
       semantic names -- `samp`, `var`, `cite` and `dfn` -- are NOT core: a
       conformant core leaves them as ordinary boolean attributes
       (`<span samp="">x</span>`), and only the Tier-2 SemanticSpan extension
-      consumes them (§10; corpus 45-inline-extensions-10 pins the core render).
-      All seven are boolean attributes everywhere else,
+      consumes them (§10). All seven are boolean attributes everywhere else,
       including in the AST and in the canonical writer, which writes the span
       back as `[Tab]{kbd}` -- a value-less attribute is spelled bare there
-      (PART 11 §6c), so the consumed name comes back in the form the author
-      wrote it.
+      (PART 11 §6c).
       A COLON is not an `identifier` character, so a colon-bearing name is
       unrecognized in every form -- `{xml:lang="en"}`, `{.sm:hover}`, `{#a:b}`
-      and a bare `{a:b}` all leave the run literal, in every engine (corpus
-      248-an-attribute-name-admits-no-colon). It stays legal one position over,
-      inside an unquoted VALUE (`{k=a:b}`), which `unquoted_value` admits.
-      (A `{% ... %}` block is NOT a comment in Carve -- comments
-      are `%%` / `%%%` only, PART 9 -- and a `%`-bearing attribute block is an
-      invalid attribute that renders literally in ALL impls.)
+      and a bare `{a:b}` all leave the run literal. It stays legal one position
+      over, inside an unquoted VALUE (`{k=a:b}`), which `unquoted_value` admits.
+      (A `{% ... %}` block is NOT a comment in Carve -- comments are `%%` /
+      `%%%` only, PART 9 -- and a `%`-bearing attribute block is an invalid
+      attribute that renders literally in ALL impls.)
 
    15. BLOCK ATTRIBUTE LINES -- OPERATIONAL SEMANTICS (governs
       `block_attributes` in PART 2; matches djot). STATE: pending := the
@@ -5685,15 +4802,6 @@ EOF = (* end of file *) ;
              [^f]: note
 
              e
-
-         is `<p id="i">e</p>`. The attribute is the author's instruction about
-         a rendered element; attaching it to a construct that emits nothing
-         silently discards it, and A4 reserves discarding for the cases where
-         there is genuinely nothing left -- end of document, and end of the
-         container that holds the attribute (carve#1281). Neither is silent:
-         both are reported as `unattached-block-attribute`. This clause is about
-         floating PAST something invisible, which is a different question from
-         running out of blocks to float to.
 
       A3 MERGE (over all pending blocks, source order):
          * id -> last one wins;
@@ -5727,10 +4835,6 @@ EOF = (* end of file *) ;
          line onto a document-level paragraph; `- {.k}` / `# H` leaves the
          heading outside the item rather than pulling it in to be attributed.
 
-         The failure mode of the other reading is the argument against it. An
-         attribute reaching content the author did not write it next to is the
-         worst of the answers available, and it is the one carve-php shipped.
-
          DROPPING SILENTLY IS THE ONE THING THIS MAY NOT DO. Both dangling
          cases are a lint diagnostic, `unattached-block-attribute`
          (docs/validation.md), in the same family as the other constructs that
@@ -5744,9 +4848,8 @@ EOF = (* end of file *) ;
          has nothing left for the attribute.
 
          OUT OF SCOPE, and left open deliberately: what a container that ends up
-         EMPTY renders. carve-rs emits an empty `<blockquote>` for `> {.k}` /
-         `tail`; that is a rendering question about empty containers in general
-         and is not settled here.
+         EMPTY renders. That is a rendering question about empty containers in
+         general and is not settled here.
       A5 MULTI-LINE BLOCK. One block may wrap across lines ({#id\n .foo} is
          one block: id `id`, class `foo`). A BLANK line inside the braces
          ends the attempt -- the text is then literal, not a
@@ -5778,12 +4881,7 @@ EOF = (* end of file *) ;
          start after a marker, and A1/A2 apply to it exactly as they would
          at the top level -- a container does not get its own attribute
          rules.
-         Decided in carve#454. The two halves were each pinned (corpus
-         90-list-item-attributes-7 for the literal form, 84 for A1/A2) and
-         their boundary was not, so carve-rs read the marker line as
-         literal while carve-js, carve-php and the executable spec read it
-         as an attribute line. None of them could be shown wrong until the
-         boundary was stated.
+         Decided in carve#454.
    ============================================================================ *)
 (* ============================================================================
    16. FOOTNOTES -- NORMATIVE (governs `footnote` / `footnote_definition`
@@ -5826,31 +4924,25 @@ EOF = (* end of file *) ;
         repeat uses `fnref{n}-{k}` and adds another backlink. The
         backlink glyph is the plain return arrow `↩` (Carve's choice;
         djot appends a variation selector).
-        THE BACKLINK CARRIES AN ACCESSIBLE NAME -- NORMATIVE (carve#1455).
-        The `role` alone was right and the NAME was the glyph, so a screen
-        reader announced the character's Unicode name ("leftwards arrow with
-        hook") or skipped the link outright: correct semantics, no way to know
-        where the link goes. `{name}` is the `footnoteBacklink` label (PART 9
-        §16a) followed by WHAT THE LINK VISIBLY SAYS -- the label alone for a
-        lone backlink (`↩`, so `aria-label="Back to reference"`), the label
-        plus k for the k-th of several (`↩<sup>k</sup>`, so
-        `aria-label="Back to reference 2"`). Matching the visible text is WCAG
-        2.5.3, and it is why the number here is the REFERENCE ORDINAL and not
-        the note number: the note number appears nowhere in this link's text.
-        The name is TEXT and is attribute-escaped.
-        THE ENDNOTES SECTION CARRIES AN ACCESSIBLE NAME -- NORMATIVE
-        (carve#1468). The rule above names the LINKS and left the REGION they
-        sit in anonymous: `<section role="doc-endnotes">` says what the region
-        is and nothing said what it is called, so a landmark list held an
-        unnamed entry for exactly the reason the backlink did. The section
-        takes `aria-label`, the string is the `endnotes` label (SS16a), and it
-        is escaped the same way:
+        THE BACKLINK CARRIES AN ACCESSIBLE NAME -- NORMATIVE. The `role` alone
+        was right and the NAME was the glyph, so a screen reader announced the
+        character's Unicode name or skipped the link outright. `{name}` is the
+        `footnoteBacklink` label (PART 9 §16a) followed by WHAT THE LINK VISIBLY
+        SAYS -- the label alone for a lone backlink (`↩`, so
+        `aria-label="Back to reference"`), the label plus k for the k-th of
+        several (`↩<sup>k</sup>`, so `aria-label="Back to reference 2"`).
+        Matching the visible text is WCAG 2.5.3, and it is why the number here
+        is the REFERENCE ORDINAL and not the note number. The name is TEXT and
+        is attribute-escaped.
+        THE ENDNOTES SECTION CARRIES AN ACCESSIBLE NAME -- NORMATIVE. The rule
+        above names the LINKS and left the REGION they sit in anonymous. The
+        section takes `aria-label`, the string is the `endnotes` label (SS16a),
+        and it is escaped the same way:
             <section role="doc-endnotes" aria-label="Footnotes">
         The default is "Footnotes" rather than "Endnotes" because that is the
-        word the rest of this grammar uses for the construct, and a reader
-        meeting the region should hear the name the document's own prose uses
-        for it. A host that renders them at the end and calls them endnotes
-        sets the label; that is what the map is for.
+        word the rest of this grammar uses for the construct. A host that
+        renders them at the end and calls them endnotes sets the label; that is
+        what the map is for.
       - BACKLINK PLACEMENT WHEN THE BODY DOES NOT END IN A PARAGRAPH. "The
         note's last paragraph" above presumes there is one. When the note
         body's LAST BLOCK is not a paragraph (a code block, a block quote, a
@@ -5864,11 +4956,8 @@ EOF = (* end of file *) ;
         (or otherwise contained) content, not to the note's own backlink, so
         appending there would misattribute the backlink to the quotation. A
         note body consisting ONLY of a non-paragraph block still gets the
-        synthesized trailing <p>. Decided in carve#688: appending to
-        whatever paragraph happens to be last is undefined when the last
-        block has no paragraph, and where a literal reading of the old rule
-        DOES find one (inside a block quote, or nowhere, leaving the anchor
-        a bare inline child of <li>) it is wrong for the reason just given.
+        synthesized trailing <p>. Appending to whatever paragraph happens to
+        be last is undefined when the last block has no paragraph.
       - INLINE FOOTNOTE `^[content]` (pandoc form; a deliberate carve
         extension -- canonical djot has no inline footnotes). A `^`
         IMMEDIATELY before `[` opens an anonymous note whose content is the
@@ -5984,12 +5073,6 @@ EOF = (* end of file *) ;
                ```
              - c
 
-         is tight in every reader. Reading the PAYLOAD instead of the position
-         was the alternative, and it fails on its own terms: it would make a
-         structural answer depend on a detail readers already spell
-         differently, since carve-php drops the trailing blank from a raw
-         block and keeps it in a code block.
-
       L2 COMPACT LIST BLOCKS -- Carve deviation from djot/CommonMark. A
          blank line before an item's sub-BLOCK (sub-list, block quote,
          fenced code, fenced div, heading, table) does NOT loosen: the item
@@ -6046,9 +5129,7 @@ EOF = (* end of file *) ;
          This is a BREAK against released carve-js 0.1.3, which attached to the
          boundary, and it is deliberate: the boundary reading is the same
          absorb-flush-left-blocks-until-something-stops-you behavior that PART 1
-         S4 refuses one clause over, and taking it here would reject that shape
-         in the layout section and reinstate it in this one. carve-rs already
-         attaches one.
+         S4 refuses one clause over.
          THE MARKER IS ONE OPERATION IN EVERY CONTAINER -- NORMATIVE
          (carve#1782). The clause above is the WHOLE definition of `+`:
          ownership of the next flush-left block passes to the container, and
@@ -6059,14 +5140,6 @@ EOF = (* end of file *) ;
          set above hold in EVERY container in L4, not only in the two that had
          them spelled out.
 
-         This is stated because the readers disagreed while the clause did
-         not. The executable spec measured the extent in FOUR places and
-         narrowed it to one block in three of them, so `+` / `para` / `> q`
-         attached one block in a list item and both blocks in a footnote body
-         and in a definition description; a fourth place tested for a quote
-         line, so a `+` inside a block quote attached NOTHING when a quote
-         followed it, which the same clause forbids one sentence up ("the
-         marker only ATTACHES").
       L4 CONTAINERS THAT TAKE THE MARKER:
          - LIST ITEM (pinned by corpus list-continuation-marker): `+` at
            the item's marker column attaches the block to the item (for
@@ -6117,14 +5190,8 @@ EOF = (* end of file *) ;
 
          That is a DIFFERENT ANSWER from "place the payload by its column", not
          a narrower one, which is why it is stated rather than left to the
-         reader of L3. The executable spec instead REFUSED the whole document,
-         `stray continuation marker`, at every payload column -- one reader of
-         four, while carve-js, carve-php and carve-rs rendered the text and
-         agreed byte for byte. The refusal was not a conservative version of the
-         shipped form either: it fired at COLUMN 0 too, the one column where the
-         first-block form attaches cleanly in the two containers that have it.
-         Extending the form to the other two was the alternative, and it is not
-         what this clause does. Corpus 437 pins all six documents.
+         reader of L3. Extending the first-block form to the other two
+         containers was the alternative, and it is not what this clause does.
       L5 NOT CONTINUATION CONTAINERS (a lone `+` keeps its plain meaning):
          - fenced containers (admonition / generic div / line block) --
            their bodies already hold flush-left blocks; a lone `+` inside
@@ -6154,14 +5221,8 @@ EOF = (* end of file *) ;
          covered by the same rule without a new clause here: enumerating
          "which containers collect" was considered and rejected, because an
          enumeration re-opens the question for every container invented
-         afterward and leaves a silent gap exactly where nobody has
-         measured yet -- which is how the `+`-attached position went
-         unmeasured until three engines gave three different answers, one
-         of them leaving a blank line inside the item where the attached
-         definition used to be (carve#665), and how the `dd` position went
-         unmeasured until two engines produced the combination this rule
-         forbids on ANY reading -- the line renders nowhere AND defines
-         nothing, so the author's text is simply gone (carve#666).
+         afterward and leaves a silent gap exactly where nobody has measured
+         yet.
 
          "No trace" is about OUTPUT, not about block structure -- it does
          not exempt a definition line from §10 I5, which already governs
@@ -6179,12 +5240,10 @@ EOF = (* end of file *) ;
          A footnote definition sitting on a list item's OWN line, followed
          by a plain continuation line, is this exact shape: the item holds
          TWO paragraph blocks with no blank between them and renders both
-         bare, `<li>first\n  second\n</li>` (carve#668). Treating the
-         definition as if it both interrupted AND merged -- attaching the
-         following line back onto the block it just ended -- would need a
-         rule found nowhere else in this grammar; treating it as loosening
-         the item on its own would contradict L2 directly. Three engines
-         each did one of those two things; neither is this rule.
+         bare, `<li>first\n  second\n</li>`. Treating the definition as if it
+         both interrupted AND merged would need a rule found nowhere else in
+         this grammar; treating it as loosening the item on its own would
+         contradict L2 directly.
 
       L7 ONE CONSUMED BOOLEAN SPELLS THE LOOSENESS NO BLANK LINE CAN --
          NORMATIVE (carve#1612). A container's preceding BLOCK-ATTRIBUTE LINE
@@ -6205,24 +5264,14 @@ EOF = (* end of file *) ;
              </ul>
 
          THE KEY IS NOT LIST-SPECIFIC, and writing it as if it were would have
-         been the first of at least two one-off keys. Measured over every
-         container that can suppress a paragraph wrapper:
-
-             list item, tight              no <p>    <li>x</li>
-             list item, loose              has <p>   <li><p>x</p></li>
-             definition description        no <p>    <dd>x</dd>
-             definition description, 2 blocks  has <p>  <dd><p>x</p><p>y</p></dd>
-             table cell                    no <p>    no wrapped alternative
-             caption                       no <p>    no wrapped alternative
-             block quote, div, line block, footnote body   always <p>
-
-         So the tight/loose axis exists in exactly TWO places, and this key
-         applies wherever it exists: a LIST (L1) and a DEFINITION LIST (PART 2,
-         definition lists) today, and any container a later clause gives the
-         axis to, with no second key to invent. On a container with no such axis
-         the name has no special meaning and renders `loose=""` like any other
-         boolean. This clause adds a meaning at the positions that have one and
-         reserves the name nowhere else.
+         been the first of at least two one-off keys. The tight/loose axis
+         exists in exactly TWO places, and this key applies wherever it exists:
+         a LIST (L1) and a DEFINITION LIST (PART 2, definition lists) today, and
+         any container a later clause gives the axis to, with no second key to
+         invent. A table cell and a caption suppress the paragraph wrapper with
+         no wrapped alternative at all; a block quote, div, line block and
+         footnote body always wrap. On a container with no such axis the name
+         has no special meaning and renders `loose=""` like any other boolean.
 
          WHAT IS UNSPELLABLE WITHOUT IT. Looseness is spelled with a blank line,
          and a blank line needs two things to stand between, so the shape with
@@ -6235,39 +5284,19 @@ EOF = (* end of file *) ;
              inside the description wraps it -- so `<dd><p>x</p></dd>` is
              unspellable at every entry count, not just at one.
 
-         The definition list is therefore worse off than the list, which is the
-         measurement that made the general key the cheaper answer: a list-only
-         key would have left the container with NO looseness mechanism at all
-         still without one.
-
-         THE SHAPE ARRIVES FROM ORDINARY HTML, which is why it earns syntax
-         rather than an interchange-only declaration. `<li><p>...</p></li>` is
-         what WordPress, TinyMCE and Google Docs export emit, so an importer
-         meets it on routine input (carve#1607). The alternative -- keep the
-         tree, report `structure-unspellable`, carry the shape through AST
-         encode/decode by PART 12 §6, exactly how multiple table bodies already
-         work -- costs no syntax and was rejected for that reason: the
-         diagnostic would fire on ordinary imports and tell the author only that
-         Carve cannot say what their document said.
 
          THERE IS NO `tight` TWIN, and its absence is a decision rather than an
          omission. TIGHT IS ALWAYS SPELLABLE: remove the blank lines. Only loose
          has an unspellable case, so a `tight` key would be surface with no
-         shape behind it -- and it would introduce the one genuinely ambiguous
-         document this asymmetric design does not have, where the blank lines
-         say loose and the attribute says tight. Symmetry is the instinct here
-         and it buys a contradiction.
+         shape behind it -- and it would introduce a genuinely ambiguous
+         document, where the blank lines say loose and the attribute says tight.
 
-         THE NAME IS THE TERM OF ART, on purpose. A name describing the tree --
-         `block-children` and its neighbours -- would name the wrong fact: the
-         children are already block nodes in both spellings, and what moves is
-         how they RENDER. A name describing the output -- `paragraphs`,
-         `wrapped` -- would be an HTML artifact, and this axis has to mean
-         something on the Markdown, plain and terminal targets too. `loose` is
-         what CommonMark, djot and Markdown Extra all call this distinction, in
-         lists and in definition lists alike, and L1 above already spells the
-         axis LOOSE. A second vocabulary for one axis inside one grammar costs
-         more than the imperfect fit of "a loose `<dd>`".
+         THE NAME IS THE TERM OF ART, on purpose. A name describing the tree
+         would name the wrong fact -- the children are already block nodes in
+         both spellings, and what moves is how they RENDER -- and a name
+         describing the output would be an HTML artifact, where this axis has to
+         mean something on the Markdown, plain and terminal targets too. `loose`
+         is what CommonMark, djot and Markdown Extra all call this distinction.
 
          REDUNDANT USE IS A NO-OP. `loose` on a list the blank lines already
          made loose is legal and changes nothing, and so is `loose` on a
@@ -6280,55 +5309,34 @@ EOF = (* end of file *) ;
          `footer-rows` when they are present" rather than deriving them onto
          every table, and PART 11 §2, which spends a mark only where omitting it
          would change the re-parsed document. On a multi-item loose list the
-         blank lines already say it, so the key would be an idle mark by exactly
-         that test. The alternative -- emit it on every loose container -- would
-         rewrite a large share of the corpus and of every document anyone has
-         written, for nothing gained.
+         blank lines already say it, so the key would be an idle mark.
 
-         THE TEST IS A RE-PARSE, AND IT IS OVER THE DOCUMENT (markup-carve/carve-rs#1305).
-         Write the container's body without the key, read it back, and emit the
-         key exactly where the container's own looseness field did not survive
-         that trip. The equality is PART 11 §1's, taken over the re-parsed
-         document; taking it over the RENDER instead answers a different
-         question and gets the definition list wrong, below.
+         THE TEST IS A RE-PARSE, AND IT IS OVER THE DOCUMENT. Write the
+         container's body without the key, read it back, and emit the key
+         exactly where the container's own looseness field did not survive that
+         trip. The equality is PART 11 §1's, taken over the re-parsed document;
+         taking it over the RENDER instead answers a different question.
 
-         THE ITEM COUNT IS NOT THE TEST. "Two or more items already say it" is
-         true, so the converse -- fewer than two items, therefore write the key
-         -- reads like the same rule backwards, and it is not: a ONE-ITEM list
-         is loose whenever the blank line sits INSIDE that item, and there the
-         blank-line spelling did express the looseness. Corpus document
-         `05-lists-11` is exactly that shape -- one ordered item holding two
-         paragraphs -- so a writer keyed on the item count rewrites it and fails
-         `parse(fmt(x)) == parse(x)` on a document that was never lossy. The
-         count is sound as a SHORTCUT IN ONE DIRECTION ONLY: two or more items
-         always re-parse loose, so the read may be skipped there, which keeps it
-         off almost every list in the corpus. Corpus
-         `408-the-writer-spells-looseness-only-where-a-blank-line-cannot` pins
-         the multi-item case and `-2` the one-item case, both through a `.fmt`
-         sidecar, because the HTML is identical under both spellings and no HTML
-         fixture can see the difference.
+         THE ITEM COUNT IS NOT THE TEST. A ONE-ITEM list is loose whenever the
+         blank line sits INSIDE that item, and there the blank-line spelling did
+         express the looseness, so a writer keyed on the item count rewrites
+         such a document and fails `parse(fmt(x)) == parse(x)`. The count is
+         sound as a SHORTCUT IN ONE DIRECTION ONLY: two or more items always
+         re-parse loose, so the read may be skipped there.
 
-         THE COUNT IS ALSO WRONG IN THE OTHER DIRECTION, which is why it is a
-         different rule rather than a shortcut to be repaired. A definition
-         list's entries count as two or more on any list worth writing, and a
-         blank line between two ENTRIES does not loosen a `<dl>` at any count -
-         so a writer keyed on the count OMITS the key from the container that
-         needs it most. Corpus
-         `407-one-consumed-boolean-spells-the-looseness-no-blank-line-can-2` is
-         that document: two entries, and unspellable without the key.
+         THE COUNT IS ALSO WRONG IN THE OTHER DIRECTION. A definition list's
+         entries count as two or more on any list worth writing, and a blank
+         line between two ENTRIES does not loosen a `<dl>` at any count - so a
+         writer keyed on the count OMITS the key from the container that needs
+         it most.
 
          ON A DEFINITION LIST THE ANSWER IS UNCONDITIONAL: the writer emits the
          key on every definition list carrying `loose`. PART 12 §8 publishes
          `definition_list.loose` ONLY where the looseness was SPELLED, so a body
          written without the key can never read back with the field set, and the
          re-parse test says "emit" every time. A description that already holds
-         two blocks does not change it. There the key is redundant in the RENDER
-         -- both spellings wrap the `<dd>`, which is why redundant use is a
-         no-op above -- and it is not redundant in the TREE, and the tree is what
-         the equality is taken over. That is the same asymmetry the two fields
-         have: `list.tight` is total and derived from the source, so the writer
-         has a real question to answer, while a definition list's field records
-         only what its own derivation misses.
+         two blocks does not change it: there the key is redundant in the RENDER
+         and not in the TREE, and the tree is what the equality is taken over.
 
          ORDERED AND NESTED CONTAINERS TAKE THE SAME KEY AT THE SAME PLACEMENT,
          at the nested container's own indent, so this needs no rediscovering:
@@ -6367,24 +5375,18 @@ EOF = (* end of file *) ;
       Author `{attrs}` after the span merge onto the <span> (the base
       `math …` class is kept; see PART 10 §1).
 
-      A MATH SPAN CARRIES ROLE MATH -- NORMATIVE (carve#1468). The delimiters
-      are written for a typesetter to find. Until one runs -- and if none ever
-      does, which is the default, since no engine ships one -- the span is a
-      plain `<span>` full of backslashes and carets, and a reader announces
-      them as prose: "backslash paren E equals m c caret 2". `role="math"` says
-      the run IS MATHEMATICS whether or not the script arrives, and a reader
-      that understands the role can hand the content to a math view instead of
-      spelling it.
+      A MATH SPAN CARRIES ROLE MATH -- NORMATIVE. The delimiters are written
+      for a typesetter to find. Until one runs -- and if none ever does, which
+      is the default -- the span is a plain `<span>` full of backslashes and
+      carets, and a reader announces them as prose. `role="math"` says the run
+      IS MATHEMATICS whether or not the script arrives.
 
       THE NAME STAYS THE AUTHOR'S, and no key is added to §16a for it. A
-      formula's spoken form is not a string the engine could know -- it is
-      per-formula content, not an engine word -- and the seam for it already
-      exists: `{attrs}` merge onto this same span, so a trailing
-      {aria-label="E equals m c squared"} on the formula needs nothing new. An
-      author who spells their own `role` keeps it -- under any ASCII casing,
-      for the reason SS12 states: the name is emitted verbatim, HTML attribute
-      names are case-insensitive, so a case-SENSITIVE test writes a duplicate of
-      the very attribute it is checking for.
+      formula's spoken form is per-formula content, not an engine word, and the
+      seam for it already exists: `{attrs}` merge onto this same span, so a
+      trailing {aria-label="E equals m c squared"} needs nothing new. An author
+      who spells their own `role` keeps it -- under any ASCII casing, for the
+      reason SS12 states.
 
       `role` is written LAST, after the merged author attributes, so adding it
       never moves an attribute the author placed (the ordering PART 10 §1
@@ -6407,10 +5409,8 @@ EOF = (* end of file *) ;
       THE ROUND-TRIP ARGUMENT IS REAL AND LOSES ANYWAY. A math-block extension
       WRITES that div, so the fence is an exact round trip of the document that
       produced the HTML. But an importer's job is to produce a document that
-      means what the HTML meant, not to reconstruct the document that happened
-      to generate it -- and it cannot know that an extension generated it at
-      all. HTML from anywhere else carrying those classes gets the same
-      treatment.
+      means what the HTML meant, and it cannot know that an extension generated
+      it at all.
 
       THE CONDITIONAL FORM IS REJECTED ON PURPOSE. Emitting the fence when the
       extension is registered and the core form otherwise makes the importer's
@@ -6424,19 +5424,7 @@ EOF = (* end of file *) ;
       its `alttext` is written `` $`E = mc^2` `` inline and ``` $$`E = mc^2` ```
       for `display="block"`, with no `$` or `$$` after the closing backtick. A
       trailing delimiter is literal text, and it renders as a stray dollar sign
-      beside the formula. carve-php carried that defect and removed it in
-      markup-carve/carve-php#1546; carve-js and carve-rs were measured and
-      never had it.
-
-      (Pinned twice, because the two halves need different readers. Converter
-      corpus 33-html-block-math-imports-as-the-core-form compares the RENDER of
-      the produced Carve, which is where the two spellings of the div are
-      distinguishable at all: the fence renders a `language-math` code block
-      where the core form renders the math span. The MathML half has no such
-      render difference -- a stray `$$` is only a stray dollar sign -- so it is
-      pinned on the BYTES, by the `tests/html-import/math-block-and-mathml`
-      fixture, which carries both halves and whose `expected.crv` is compared
-      exactly.)
+      beside the formula.
 
    19. CROSSREF AUTO-TEXT + DEFAULT-ON / PROCESSOR FEATURES -- NORMATIVE
       (resolution formalized as PART 9R rules R4/R5; behavior detail here).
@@ -6537,14 +5525,10 @@ EOF = (* end of file *) ;
         node says which one produced it (`delimited: true` for this form, PART
         12). Without that field a writer reading the tree back has one spelling
         for two constructs, and `foo {% bar %} baz` formats to `foo %% bar` --
-        the trailing form swallowing `baz`. Silent loss through the formatter,
-        on the one construct whose output is invisible.
-      - THIS IS A BEHAVIOR CHANGE. `foo {% bar %} baz` used to render its braces
-        literally. `carve lint` reports a braced comment in a document that also
-        carries template tags (`{% raw %}`, `{% endif %}`), which is the one
-        shape where a Liquid or Nunjucks source reaches the parser as text.
-      (corpus: prose, inside emphasis, table cell, link text, multi-line,
-      unterminated, verbatim span, and an fmt round trip.)
+        the trailing form swallowing `baz`.
+      - `carve lint` reports a braced comment in a document that also carries
+        template tags (`{% raw %}`, `{% endif %}`), which is the one shape
+        where a Liquid or Nunjucks source reaches the parser as text.
 
    22. FORCED INTRAWORD EMPHASIS -- NORMATIVE (governs the forced_* productions
       in PART 3). The brace-pair family is the escape hatch for emphasis where a
@@ -6597,11 +5581,8 @@ EOF = (* end of file *) ;
         `<br>`, however the boundary is spelled. The additive reading would
         have to SYNTHESIZE a break node no production yields, and it would
         make the container ADD a line to the layout this block exists to
-        preserve. It also reaches the markdown, plain and ansi targets, where
-        nothing rules on a second break. Ruled at carve#1334, superseding a
-        note on carve-rs#1026 that counted engines rather than citing a clause
-        (PART 0, THE EXECUTABLE ARTIFACTS DECIDE NOTHING) and whose two
-        witnesses have since changed.
+        preserve. It holds on the markdown, plain and ansi targets too
+        (carve#1334).
 
         THE BACKSLASH STILL HAS A JOB HERE, so it is not redundant syntax the
         writer may drop. PART 7 makes the whitespace run before it INTERIOR,
@@ -6619,35 +5600,22 @@ EOF = (* end of file *) ;
         whether a `soft_break` NODE is there. Nothing conditions the rule on
         what ENCLOSES that node, and an emphasis run, a link label or a
         semantic span spanning a boundary encloses one: the newline is a node
-        BESIDE the construct's text, not part of it. So
-
-          ::: |
-          *a
-          b*
-          :::
-
-        holds `<strong>a<br>` over `b</strong>`, the same break the same two
-        lines get with no emphasis around them.
+        BESIDE the construct's text, not part of it. So a stanza holding `*a`
+        over `b*` gives `<strong>a<br>` over `b</strong>`, the same break the
+        same two lines get with no emphasis around them.
 
         THE CONVERSION IS IN THE TREE, NOT ONLY IN THE HTML. A stanza's bare
         newline is a `hard_break` NODE (PART 12), which is what lets PART 11
         §7c spell one as a bare newline at all - "re-reading that newline
-        yields the SAME TREE" is a statement about nodes. So the conversion
-        runs at every depth for the same reason the render does, and an
-        engine's own AST is where the other reading is easiest to see: all
-        three yield `hard_break` between two body lines and `soft_break`
-        between the same two lines inside a `strong`, one document answered
-        two ways by an enclosure no clause names.
+        yields the SAME TREE" is a statement about nodes.
 
-        THE TWO EXEMPTIONS ABOVE ARE DIFFERENT IN KIND, NOT IN DEPTH, which
-        is why neither ever needed a depth stated. A backslash is exempt
-        because `hard_break` consumes its own newline. A verbatim run is
-        exempt because it carries the newline as its own CONTENT (carve#1282;
-        BUT IT DOES NOT SURVIVE A RUN THAT ATE ITS LINE below draws the
-        consequence in these words: "there is no boundary left in the tree").
-        Both leave NO NODE. A run that closes on a LATER line is exempt for
-        that same reason and not for closing, the newline being inside its
-        value either way:
+        THE TWO EXEMPTIONS ABOVE ARE DIFFERENT IN KIND, NOT IN DEPTH. A
+        backslash is exempt because `hard_break` consumes its own newline. A
+        verbatim run is exempt because it carries the newline as its own
+        CONTENT (BUT IT DOES NOT SURVIVE A RUN THAT ATE ITS LINE below: "there
+        is no boundary left in the tree"). Both leave NO NODE. A run that
+        closes on a LATER line is exempt for that same reason and not for
+        closing, the newline being inside its value either way:
 
           ::: |
           a `b
@@ -6657,19 +5625,6 @@ EOF = (* end of file *) ;
         keeps the newline as content while the emphasis above hardens. The
         two documents differ only in WHICH CONSTRUCT spans the boundary, and
         that is the difference the rule turns on.
-
-        WHAT THE OTHER READING COST. It made the block answer by the SPELLING
-        of a boundary, which the clause above forbids outright: all three
-        engines emit the `<br>` inside the `<strong>` for `*a\` over `b*` and
-        nothing for `*a` over `b*` - one boundary, one container, two
-        answers. It made a single stanza harden one boundary and not the next,
-        `*a` over `b*` over `c` giving a bare newline and then a `<br>`. And
-        it let any emphasized couplet lose the per-line layout this block
-        exists to preserve. Ruled at carve#1351, superseding four rows pinned
-        on carve-js#1127 whose argument was that the reference engine is
-        unambiguous (PART 0, THE EXECUTABLE ARTIFACTS DECIDE NOTHING) and
-        whose premise - that an inline construct CONSUMED the newline - the
-        `soft_break` node that same parser emits contradicts.
       - STANZAS. A blank line ends a stanza; each stanza is its own `<p>` inside
         the single `<div class="line-block">`.
       - LEADING WHITESPACE. Each body line's leading whitespace is PRESERVED
@@ -6705,24 +5660,21 @@ EOF = (* end of file *) ;
         line block has.
 
         A COMMENT IS THE ONE EXCEPTION, and the exception is about TIMING
-        rather than about what a comment is. This clause used to say "a
-        comment is not a block construct", which is false: `comment_line` IS
-        a block, listed in PART 1 among the INVISIBLE blocks and ruled by §10
-        I5 to interrupt an open paragraph and be consumed. The real reason it
-        survives the suppression above is that it is the only construct on
-        that list whose recognition PRESERVES the verse instead of rewriting
-        it. A definition or a fence opener CLAIMS the line and changes what
-        renders; a comment-only body line leaves an EMPTY verse line - the
-        line was written, so the stanza keeps its shape.
+        rather than about what a comment is. `comment_line` IS a block, listed
+        in PART 1 among the INVISIBLE blocks and ruled by §10 I5 to interrupt
+        an open paragraph and be consumed. It survives the suppression above
+        because it is the only construct on that list whose recognition
+        PRESERVES the verse instead of rewriting it: a definition or a fence
+        opener CLAIMS the line and changes what renders, while a comment-only
+        body line leaves an EMPTY verse line.
 
         IT IS REMOVED AT THE BLOCK LAYER -- NORMATIVE. The line is decided
         with the other block-layer decisions, BEFORE any inline content
         exists. No inline run can reach it, so whether an EARLIER line left a
-        verbatim run open cannot change whether a line is a comment. Leaving
-        this unsaid let §21's verbatim exclusion claim the line and PUBLISH
-        the comment's own text, which is the one outcome a comment may never
-        have, on a document whose only defect is a stray backtick somewhere
-        above it (carve#1333):
+        verbatim run open cannot change whether a line is a comment. Otherwise
+        §21's verbatim exclusion claims the line and PUBLISHES the comment's
+        own text -- the one outcome a comment may never have -- on a document
+        whose only defect is a stray backtick above it (carve#1333):
 
           ::: |
           a `b
@@ -6739,24 +5691,19 @@ EOF = (* end of file *) ;
         emits it back UNCHANGED and at the SAME column. A writer that indents
         it by a space to stop the line re-reading as a comment publishes the
         very text the removal exists to hide, because in verse a leading run
-        is CONTENT (below) and an indented `%%` line is ordinary text. That is
-        a PART 11 §1 failure, and it is what the pinned build does today.
+        is CONTENT (below) and an indented `%%` line is ordinary text: a
+        PART 11 §1 failure.
 
         THE NODE'S SURVIVAL DOES NOT DEPEND ON HOW THE BOUNDARY ABOVE IT WAS
         SPELLED -- NORMATIVE. `a` over `%% c` and `a \` over `%% c` are the
         same document but for a backslash on the line above, and the comment
-        is a node in both. An engine that asks the question of the SOFT-break
-        conversion asks it where a `\` never arrives -- A BACKSLASH BREAK IS
-        NOT ADDITIVE consumed the newline before the conversion ran -- so the
-        note is kept under one spelling and dropped under the other. The
-        boundary that OPENS the comment's line is there either way, which is
-        the only thing the line needs to exist.
+        is a node in both. The boundary that OPENS the comment's line is there
+        either way, which is the only thing the line needs to exist.
 
         BUT IT DOES NOT SURVIVE A RUN THAT ATE ITS LINE. What an unclosed
-        verbatim run carries across an emptied line is the NEWLINE, the same
-        thing it carries across every boundary it swallows, so there is no
-        boundary left in the tree for a `comment` node to sit on and the run's
-        value holds an EMPTY LINE instead. Appending the node anyway puts its
+        verbatim run carries across an emptied line is the NEWLINE, so there
+        is no boundary left in the tree for a `comment` node to sit on and the
+        run's value holds an EMPTY LINE instead. Appending the node anyway puts its
         span before the run that contains it and after the node that follows
         it, which PART 12 containment refuses. The writer's answer for that
         empty line is PART 11 §7c.
@@ -6765,11 +5712,9 @@ EOF = (* end of file *) ;
         the last one. A tree records no closer for a verbatim run (PART 12 §3
         gives `code` a value and nothing else), so PART 11 §6's second half
         hands that spelling to the writer, which CLOSES what the author left
-        open -- in an ordinary paragraph too, where a lone opener comes back
-        with a closer beside the run's end. Inside verse the closer occupies a
-        LINE, so §7c's `%%` is written for every emptied line the run still
-        spans and not for the one the closer lands on. Written as source over
-        the form the writer emits for it:
+        open. Inside verse the closer occupies a LINE, so §7c's `%%` is
+        written for every emptied line the run still spans and not for the one
+        the closer lands on -- source over the form the writer emits for it:
 
           ::: |     ->     ::: |          the emptied line is INTERIOR: the
           `                `              run spans past it to `x`, so §7c
@@ -6782,24 +5727,15 @@ EOF = (* end of file *) ;
           %%               `              closer takes the emptied line and
           :::              :::            no empty line is left to spell
 
-        Both preserve the tree and the HTML. Corpus
-        380-a-terminal-comment-line-still-leaves-an-empty-verse-line and its
-        `.fmt` file pin the second form (carve#1472).
+        Both preserve the tree and the HTML.
 
         A TRAILING COMMENT IS A DIFFERENT CONSTRUCT and this clause does not
         reach it. `x %% secret` is `inline_comment` (PART 3, §21), not
         `comment_line`, and §21's third bullet governs it: inside a verbatim
         run there is no comment there at all, only two percent characters in
-        content -- exactly what PART 3's UNCLOSED RUN clause already rules for
-        an emphasis delimiter or a link tail after the same opener. That holds
-        in a line block for the same reason it holds in a paragraph, where
-        the one line
-
-          a `b %% secret
-
-        publishes the same text with no container involved.
-        The asymmetry is deliberate: an engine may leave a `%%` standing
-        inside a verbatim run, and may never delete author bytes out of one.
+        content. The asymmetry is deliberate: an engine may leave a `%%`
+        standing inside a verbatim run, and may never delete author bytes out
+        of one.
 
         LEADING WHITESPACE IS CONTENT HERE, so `comment_line`'s optional
         `[whitespace]` prefix has nothing to consume in verse: ONLY a body
@@ -6813,12 +5749,7 @@ EOF = (* end of file *) ;
         the break that already separates it from the line before: `a` over
         `%% c` is `a<br>` and a stanza that is nothing but a comment is an
         EMPTY paragraph. Anything else would put two breaks on one boundary,
-        which is what A BACKSLASH BREAK IS NOT ADDITIVE refuses above. Written
-        down because "leaves an EMPTY verse line" reads, at a stanza's end,
-        as though the line owed a break of its own.
-
-        A line block preserves authored layout: nothing inside it is claimed
-        and nothing is dropped unless it is a comment (carve#510, carve#573).
+        which is what A BACKSLASH BREAK IS NOT ADDITIVE refuses above.
 
       (corpus 41-line-blocks*.)
 
@@ -6836,6 +5767,7 @@ EOF = (* end of file *) ;
       - NO WHITESPACE PRESERVATION. Unlike `::: |`, leading whitespace has no
         special visual-preservation rule. Ordinary paragraph parsing trims or
         folds it as usual.
+
       (corpus 41-line-blocks*.)
 
    24. TABS AND INDENTATION -- FORMALIZED COLUMN ARITHMETIC (governs
@@ -6902,28 +5834,19 @@ EOF = (* end of file *) ;
                - after a BLANK LINE, the item is already ended by the clause
                  above, so the branch is never reached at all.
 
-             Two things are NOT settled by this sentence, and both are recorded
-             rather than decided (carve#682):
+            Two things are NOT settled by this sentence, and both are recorded
+            rather than decided:
 
                - the paragraph closed by a construct that leaves the ITEM's fate
-                 open. A closed CODE fence is the measured one: carve-js and
-                 carve-rs nest a sublist, carve-php and the executable spec open
-                 a sibling list at the top level. That row turns on whether the
-                 item survives the fence, which no clause here states.
+                 open, a closed CODE fence being the case in point: that turns
+                 on whether the item survives the fence, which no clause here
+                 states.
                - the comment's own COLUMN. The comment exception is written
                  without reference to a column, but the two spellings answer
                  differently: at the content column the marker opens a sublist,
                  while BELOW it the following line reaches the item only through
-                 the lazy fold, so ending the paragraph would take that path
-                 away. Corpus 189 and 192 pin the below-column answer (`- - a` /
-                 ` %% c` / ` b` keeps `b` in the INNER item, carve#618), so
-                 aligning the two means moving a pin, not tidying a clause.
-
-             The BLOCK QUOTE row is the control that shows this is the
-             mechanism and not a coincidence: a quote leaves ITS OWN paragraph
-             open, so the fold IS available and all readers agree the marker
-             folds into the quote. Every row where a paragraph is open is
-             unanimous; the disagreements are all rows where none is.
+                 the lazy fold. Corpus 189 and 192 pin the below-column answer,
+                 so aligning the two means moving a pin, not tidying a clause.
 
              AN INVISIBLE LINE FOLDS LIKE ANY OTHER -- NORMATIVE. "Every other
              line" includes the ones that are not block-SHAPED. This is the
@@ -6935,57 +5858,44 @@ EOF = (* end of file *) ;
              on the page, definition in the tables -- is not an option the
              rule offers.
 
-             A BLOCK-ATTRIBUTE LINE FOLDS THE SAME WAY, and for the same
-             reason: it is on I5's interrupter list with the definitions, and
-             below the column it reaches no opener column either. So it is text
-             -- the authored braces render as characters -- and it attaches
-             nothing. Half-folding an attribute is the same unavailable option
-             one construct over, and its failure mode is worse than a wrong
-             shape: an attribute recognized below the column has no visible
-             block left in the container to attach to, so §15 A4 discards it and
-             the author's characters reach neither the page nor any table. That
-             is what carve#1801 measured in a definition description, where the
-             identical line one host over folds as literal text.
+            A BLOCK-ATTRIBUTE LINE FOLDS THE SAME WAY, and for the same
+            reason: it is on I5's interrupter list with the definitions, and
+            below the column it reaches no opener column either. So it is text
+            -- the authored braces render as characters -- and it attaches
+            nothing. Half-folding an attribute is the same unavailable option
+            one construct over: an attribute recognized below the column has no
+            visible block left in the container to attach to, so §15 A4
+            discards it and the author's characters reach neither the page nor
+            any table (carve#1801).
 
-             THE FOLD IS INTO THE CONTAINER, in every host, which is the half
-             this clause used to leave to the reader. "Folds as TEXT" and
-             I5's "lazy paragraph text" name one operation on one open
-             paragraph, and that paragraph belongs to the container whose
-             content column the line fell below. Ending the container and
-             emitting the characters at document level satisfies neither
-             sentence (carve#1800).
+            THE FOLD IS INTO THE CONTAINER, in every host, which is the half
+            this clause used to leave to the reader. "Folds as TEXT" and
+            I5's "lazy paragraph text" name one operation on one open
+            paragraph, and that paragraph belongs to the container whose
+            content column the line fell below. Ending the container and
+            emitting the characters at document level satisfies neither
+            sentence (carve#1800).
 
-               - - a
-                [^f]: x
+              - - a
+               [^f]: x
 
-             renders `a` and the literal `[^f]: x` inside the inner item. The
-             failure this guards against is not a wrong shape but a
-             DISAPPEARANCE: a definition that fell past the fold branch was
-             pushed trimmed into the item stream, landed at the item's own
-             column 0, and was skipped there as already-extracted, so the
-             author's line rendered as nothing at all (carve-php#721).
+            renders `a` and the literal `[^f]: x` inside the inner item.
 
-             A COMMENT IS THE ONE EXCEPTION -- NORMATIVE. The first of the two
-             exceptions to §10 I5's classification, and it is a question of
-             MEMBERSHIP: it decides which lines are invisible below a column,
-             not how an invisible line behaves. A comment is recognized at ANY
-             column, above the content column, at it, or below it, and stays
-             invisible. BOTH SPELLINGS: the `%%` line form
-             and the `%%%` fence form, whose body and closer travel with its
-             opener. Leaving the fence out made the same rule answer twice one
-             delimiter apart -- the line form invisible, the fence form
-             VISIBLE text -- which is what carve#629 reported and carve#634
-             settled (corpus 186). Folding it would make the comment VISIBLE, which
-             is the one outcome a comment may never have, and an indented
-             comment at the top level is already invisible for the same
-             reason. It does not close the ITEM either: a following line still
-             belongs to the item rather than parsing at document level
-             (carve#618). It does end the open PARAGRAPH, though, so that line
-             begins the item's SECOND paragraph rather than continuing the
-             first. One sentence used to make both claims and only the first
-             was true; nothing pinned the difference, because it shows only in
-             a LOOSE list -- in a tight one both readings render the same
-             (carve#677).
+            A COMMENT IS THE ONE EXCEPTION -- NORMATIVE. The first of the two
+            exceptions to §10 I5's classification, and it is a question of
+            MEMBERSHIP: it decides which lines are invisible below a column,
+            not how an invisible line behaves. A comment is recognized at ANY
+            column, above the content column, at it, or below it, and stays
+            invisible. BOTH SPELLINGS: the `%%` line form
+            and the `%%%` fence form, whose body and closer travel with its
+            opener (corpus 186, carve#634). Folding it would make the comment
+            VISIBLE, which is the one outcome a comment may never have, and an
+            indented comment at the top level is already invisible for the same
+            reason. It does not close the ITEM either: a following line still
+            belongs to the item rather than parsing at document level
+            (carve#618). It does end the open PARAGRAPH, though, so that line
+            begins the item's SECOND paragraph rather than continuing the
+            first -- a difference visible only in a LOOSE list (carve#677).
            - AT OR ABOVE content_column: a block opener nests and a list marker
              opens a sublist. Recognized non-list blocks apply PART 0's ONE
              AUTHORED BLOCK BASE; this item clause defines only containment and
@@ -7058,21 +5968,13 @@ EOF = (* end of file *) ;
         SPACE before reading a scheme, and nothing else. A destination
         beginning with any other format character -- ZERO WIDTH SPACE
         (U+200B), LEFT-TO-RIGHT MARK (U+200E), WORD JOINER (U+2060), SOFT
-        HYPHEN (U+00AD) -- therefore FAILS to parse as a URL at all, and a
-        consumer resolving it against a base gets a relative path, never a
-        `javascript:` navigation. Measured against the WHATWG parser: each of
-        those prefixes yields a parse failure, while a TAB or SPACE prefix
-        yields `javascript:` -- which is exactly the set already stripped.
-
-        So the probe strips what an eventual URL parser would strip (plus the
-        Unicode spaces and the BOM, which some parsers historically tolerated),
-        and it deliberately does NOT strip the wider `Cf` category: a
-        `<U+200B>javascript:` destination stays in the document as written and
-        is inert where it lands. Widening the class to all of `Cf` would blank
-        destinations that were never dangerous, and would make the rendered
-        `href` differ from the author's bytes for no gain (carve#782). A `data:` exception for images, if offered, MUST be
-        opt-in. An attribute-block `href`/`src` override (PART 4) MUST NOT
-        reintroduce a rejected scheme.
+        HYPHEN (U+00AD) -- therefore FAILS to parse as a URL at all. So the
+        probe strips what an eventual URL parser would strip (plus the Unicode
+        spaces and the BOM), and it deliberately does NOT strip the wider `Cf`
+        category.
+        A `data:` exception for images, if offered, MUST be opt-in. An
+        attribute-block `href`/`src` override (PART 4) MUST NOT reintroduce a
+        rejected scheme.
 
         THIS APPLIES TO EVERY TARGET THAT EMITS A RESOLVABLE URL, not only to
         the HTML renderer. A Markdown target's link and image destinations are
@@ -7083,21 +5985,14 @@ EOF = (* end of file *) ;
 
         "EMITS A RESOLVABLE URL" IS ABOUT THE URL REACHING A READER THAT
         RESOLVES IT, not about the target emitting a hyperlink construct. The
-        TERMINAL target is bound: it prints a link's destination beside the text,
-        and every current terminal emulator autolinks a URL in its output and
-        hands the scheme to the OS handler when the reader clicks it -- the same
-        one step as Markdown, reached without any anchor or OSC 8 sequence being
-        written. This needed saying because the two text targets differ only by
-        accident of their formats: plain text drops the destination and so never
-        faces the question, while the terminal printed it, and all three engines
-        printed `javascript:` and the OS-handler class there while blanking both
-        in Markdown (carve#765).
+        TERMINAL target is bound: it prints a link's destination beside the
+        text, and every current terminal emulator autolinks a URL in its output
+        and hands the scheme to the OS handler when the reader clicks it.
 
         WHAT IS BLANKED IS THE DESTINATION, NOT THE TEXT. A denied autolink's
-        visible text IS its URL, and every target shows it: HTML inside
-        `<a href="">`, Markdown as the label of `[...]()`, plain text and the
-        terminal as the characters themselves. Blanking there would edit what the
-        author wrote rather than withhold a destination, and it is not required.
+        visible text IS its URL, and every target shows it. Blanking there
+        would edit what the author wrote rather than withhold a destination:
+        not required.
       - ATTRIBUTE NAME/VALUE HARDENING. On EVERY rendered element -- including
         elements emitted by extensions -- an HTML renderer MUST drop
         attributes whose name begins with `on` (case-insensitive) and the
@@ -7114,8 +6009,8 @@ EOF = (* end of file *) ;
         NORMATIVE. The probe above reads the value's LEADING scheme, which
         vouches for the whole value only where the whole value is ONE URL.
         Four attributes carry a LIST of URLs: `srcset`, `imagesrcset`, `ping`
-        and `attributionsrc`. So a dangerous scheme in any position but the
-        first went unread. The first two -- on `img`/`source` and on `link`
+        and `attributionsrc`, so a dangerous scheme in any position but the
+        first goes unread. The first two -- on `img`/`source` and on `link`
         -- are comma-separated image candidate strings, each a URL plus an
         optional `w`/`x` descriptor; `ping`, on `a` and `area`, is a
         space-separated set of URLs the user agent POSTs to on activation;
@@ -7130,18 +6025,12 @@ EOF = (* end of file *) ;
         THE TOKEN PASS IS IN ADDITION TO THE VALUE-WIDE PROBE, NOT INSTEAD OF
         IT. These four names keep the leading-scheme probe on the WHOLE value
         as well, and the value is blanked when EITHER the whole value probes
-        dangerous OR any token does. Reading the token pass as a replacement
-        would make these four names deny LESS than the leading rule already
-        denied, which is the opposite of what this paragraph is for: the
-        value-wide probe strips the ASCII whitespace the SPLIT breaks on, so
-        `ping="java script:alert(1)"` is two harmless tokens -- `java` carries
-        no scheme and `script` is not denylisted -- and one denied value. That
-        shape is pinned, in both separator sets (resources/examples/edge-cases.md
-        "URL-list attributes are probed token-wise").
+        dangerous OR any token does: the value-wide probe strips the ASCII
+        whitespace the SPLIT breaks on, so `ping="java script:alert(1)"` is
+        two harmless tokens and one denied value.
         THE NAME MATCH IS CASE-INSENSITIVE, like the `on` prefix above: an
-        attribute block may spell the name in any case and the element still
-        carries the author's spelling, so matching on the exact bytes would
-        leave `SRCSET` unprobed.
+        attribute block may spell the name in any case, so matching on the
+        exact bytes would leave `SRCSET` unprobed.
 
         THE SEPARATORS ARE THE ONES THE ATTRIBUTE'S OWN GRAMMAR USES, and the
         set splits in two on this. `ping` and `attributionsrc` split on ASCII
@@ -7157,73 +6046,47 @@ EOF = (* end of file *) ;
         THE COMMA SPLIT OVER-BLANKS ONE SHAPE AND THAT IS THE CHOSEN SIDE. A
         srcset URL may itself contain a comma, so
         `srcset="https://example.com/a,data:x 1x"` is ONE candidate to a
-        consumer and is blanked here anyway. Reading it exactly would mean
-        requiring the HTML candidate-list algorithm, descriptor scan and
-        paren-awareness included, from three engines that have to agree byte
-        for byte -- a large ask to buy back a URL that embeds a comma
-        immediately followed by a denylisted scheme. Erring toward blanking is
-        also the safe direction HERE specifically, because it can only reach a
-        URL-list attribute and never prose. Both shapes are pinned, so the
-        engines cannot each pick a different tokenization.
+        consumer and is blanked here anyway: erring toward blanking can only
+        reach a URL-list attribute and never prose.
 
-        THE STRIP IS PER TOKEN, NOT ONCE AT THE FRONT of the value, so the
-        preceding paragraphs' reasoning composes rather than being bypassed:
-        each token is control-stripped and Unicode-whitespace-stripped on its
-        own before its scheme is read, and a `<U+202F>javascript:` candidate
-        blanks wherever it sits. The `Cf` decision composes unchanged too --
-        a token beginning `<U+200B>javascript:` is left alone at EVERY
-        position, for the reason already given: it fails WHATWG URL parsing
-        and lands inert. Note that the whitespace the STRIP removes is wider
-        than the whitespace the SPLIT breaks on, and deliberately so:
+        THE STRIP IS PER TOKEN, NOT ONCE AT THE FRONT of the value: each token
+        is control-stripped and Unicode-whitespace-stripped on its own before
+        its scheme is read, and a `<U+202F>javascript:` candidate blanks
+        wherever it sits. The `Cf` decision composes unchanged -- a token
+        beginning `<U+200B>javascript:` is left alone at EVERY position, since
+        it fails WHATWG URL parsing and lands inert. The whitespace the STRIP
+        removes is wider than the whitespace the SPLIT breaks on, deliberately:
         `a<U+202F>javascript:x` is ONE token to a consumer, because both
         grammars put their boundaries at ASCII whitespace, and it resolves as
-        a relative URL rather than a navigation. Same measured basis as the
-        rest of this clause.
+        a relative URL rather than a navigation.
 
         WHAT IS BLANKED IS THE WHOLE VALUE, NOT THE OFFENDING CANDIDATE.
         Excising one candidate would make the rendered attribute differ from
         the author's bytes, which this clause already declined to do for the
-        `Cf` case (carve#782), and it would give one value a THIRD outcome --
-        kept, blanked, or silently rewritten -- when the defect being fixed
-        is that one value already had two. Measured before this was written,
-        on all three engines and identical byte for byte in each:
-        `srcset="javascript:alert(1) 1x, safe.png 2x"` blanked while
-        `srcset="safe.png 1x, javascript:alert(1) 2x"` rendered verbatim, and
-        `ping` split the same way (carve#1320). The point is that the SAME
-        VALUE got two answers depending on where the scheme sat. A browser
-        navigates neither -- it does not run `javascript:` in an image
-        context and it pings http(s) only -- so what this fixes is a defense
-        that was positionally inconsistent and a guarantee this clause states
-        but did not keep, for the consumers of Carve's HTML that are not
-        browsers and have no image-context protection of their own.
+        `Cf` case, and it would give one value a THIRD outcome -- kept,
+        blanked, or silently rewritten. A browser navigates neither, so what
+        this protects is the consumers of Carve's HTML that are not browsers.
 
         THE SET IS CLOSED BY A CRITERION rather than by taste: an attribute
         whose value grammar is a LIST of URLs that a consumer RESOLVES OR
         FETCHES. THE CRITERION GOVERNS, NOT THE DOCUMENT AN ATTRIBUTE HAPPENS
-        TO LIVE IN -- three of the four come from the HTML Standard's
-        attribute index, and `attributionsrc` from the Attribution Reporting
-        API, which browsers ship and which sends a request to every URL in
-        the list. An attribute admitted to the language and fetched by a
-        consumer is in scope wherever it was specified.
+        TO LIVE IN -- `attributionsrc` comes from the Attribution Reporting
+        API rather than the HTML Standard's attribute index, and is in scope
+        because a consumer fetches every URL in the list.
 
-        The exclusions are named so the set is not widened by
-        pattern-match. `itemtype` and `itemprop` are space-separated
-        absolute-URL token lists, but the standard forbids dereferencing
-        them, so they are identifiers and not sinks; `itemid` is a single URL
-        and the leading rule already reaches it; `archive` on `object` is
-        non-conforming and no longer carries a URL-list value type; `for` on
-        `output` and `headers` on `td`/`th` list IDs, not URLs. A single URL
-        embedded at a NON-LEADING position inside a structured value is a
-        neighboring class and not this one: `style` is that class and
-        already has its own named rule above, and a `meta` refresh `content`
-        is that class but no renderer emits `meta` from document content.
+        The exclusions are named so the set is not widened by pattern-match.
+        `itemtype` and `itemprop` are space-separated absolute-URL token lists,
+        but the standard forbids dereferencing them, so they are identifiers
+        and not sinks; `itemid` is a single URL and the leading rule already
+        reaches it; `archive` on `object` is non-conforming and no longer
+        carries a URL-list value type; `for` on `output` and `headers` on
+        `td`/`th` list IDs, not URLs. A single URL embedded at a NON-LEADING
+        position inside a structured value is a neighboring class and not this
+        one: `style` is that class and already has its own named rule above.
         PROSE ATTRIBUTES ARE NOT IN THE SET AND MUST NOT BE TOKENIZED --
         `title`, `alt` and `aria-label` legitimately contain colons, and a
         blanket "any token that looks like a scheme" test would refuse
-        ordinary text. The corpus pins BOTH directions: a dangerous scheme in
-        a non-leading candidate is blanked, and a prose value carrying a
-        colon is not (resources/examples/edge-cases.md "URL-list attributes are
-        probed token-wise").
+        ordinary text.
       - RAW PASSTHROUGH OPT-OUT. Raw blocks (```=FORMAT, PART 2) and raw
         inline (`{=format}`, §20) emit verbatim UNESCAPED content. An
         implementation MUST provide a mode in which raw passthrough is NOT
@@ -7269,8 +6132,7 @@ EOF = (* end of file *) ;
 
         "Degrades to literal text" is the whole rule; nothing about being
         past the cap makes a line group differently from the same characters
-        typed by an author, and a degrade path that invented its own block
-        structure would be a second paragraph rule to specify and to test.
+        typed by an author.
 
         Recursive RENDER / RESOLVE /
         FILTER passes over a programmatically constructed tree MUST be
@@ -7291,15 +6153,10 @@ EOF = (* end of file *) ;
         uses, container depth (one step per nesting level) or AST node
         levels among them, and the conversion factor between units is NOT 1:
         a list level costs ONE container-depth step but TWO AST node levels
-        (`list`, then `list_item`) before its body reads as a further level
-        down. A margin sized for one unit does not carry over to the other.
-        This repo's reference counts container depth, where MAX_NESTING_DEPTH
-        + 32 = 232 covers the blocks a container subtree adds; restating that
-        SAME NUMBER in an AST-node-counting implementation understates what
-        that unit actually needs by roughly half, and an ordinary 120-level
-        list ladder -- well inside the parse cap of 200 -- reached such a
-        ceiling and silently dropped the innermost content (carve#650). An
-        implementation MUST THEREFORE DERIVE its margin from the worst
+        (`list`, then `list_item`). A margin sized for one unit does not carry
+        over to the other. This repo's reference counts container depth, where
+        MAX_NESTING_DEPTH + 32 = 232 covers the blocks a container subtree
+        adds. An implementation MUST THEREFORE DERIVE its margin from the worst
         per-level cost of ITS OWN unit (as PART 12 §9(c) already requires for
         the ingest bound), and MUST NOT adopt another implementation's number
         without redoing that derivation.
@@ -7307,14 +6164,8 @@ EOF = (* end of file *) ;
         HOW THE MARGIN IS SPELLED IS NOT THE REQUIREMENT. A multiple of
         MAX_NESTING_DEPTH and an offset added to it are the same statement
         once the offset has been shown to cover the worst per-level cost of
-        the unit in question: `+ 32` DERIVED for container depth satisfies
-        this clause, and the identical `+ 32` COPIED into an
-        AST-node-counting implementation does not. This paragraph previously
-        required the multiple FORM, which the reference itself did not use --
-        so the clause stated a rule its own reference broke, and an
-        implementation could satisfy the letter of it by writing
-        MAX_NESTING_DEPTH * 1.16 without anyone having thought about the
-        unit. The unit is what went wrong in carve#650 (carve#754).
+        the unit in question. The FORM is not the requirement; the derivation
+        is.
 
         AT THE RENDER CEILING, A RENDERER REFUSES -- NORMATIVE. Reaching it
         MUST produce a typed, documented failure naming the depth bound. NOT
@@ -7330,55 +6181,21 @@ EOF = (* end of file *) ;
         travels. A ceiling derived per the margin rule above exceeds
         MAX_NESTING_DEPTH BY CONSTRUCTION IN ITS OWN UNIT, so no tree from
         `parse` can reach it, and §9(b) already refuses an ingested tree
-        deeper than the parser's own limit. "By construction" is a property
-        of the DERIVATION, not of any single borrowed number -- a ceiling
-        that copies another implementation's margin instead of deriving its
-        own is not exceeding anything by construction, it is a coincidence
-        that holds for one unit and fails for another. What is left is a
-        tree built through the API, where the caller is the one who built it
-        and is the one who can act on the error.
+        deeper than the parser's own limit. What is left is a tree built
+        through the API, where the caller is the one who built it and is the
+        one who can act on the error.
 
         Truncation is not the safe default it looks like. The parse path
         degrades VISIBLY -- an over-cap opener becomes literal text the reader
         can see -- while a renderer that stops emitting produces a document
-        that looks complete and is not. The failure mode a formatter must
-        never have is deleting content without saying so, which is what
-        carve#517 moved the ceiling out of reach to prevent; leaving
-        truncation as the answer at the ceiling reinstates it for every tree
-        that arrives over the wire or through a builder.
+        that looks complete and is not, the canonical writer included.
 
-          depth  renderMarkdown  renderCarve  renderPlainText  renderAnsi  renderHtml
-          231    content kept    kept         kept             kept        kept
-          232    DROPPED         DROPPED      DROPPED          empty       kept
-          1000   DROPPED         DROPPED      DROPPED          empty       kept
-
-        The ceiling itself is in the right place -- above MAX_NESTING_DEPTH,
-        as the paragraph above requires. What happens AT it is the problem.
-        Three of the five emit the nested markers and delete only the BODY, so
-        the output looks complete and is not; one returns an empty string; and
-        renderHtml has no ceiling at all, recursing until the host stack gives
-        out (`RangeError: Maximum call stack size exceeded` at depth 2000).
-        That last one is the "crashing" this section already forbids, and it
-        makes the reference engine's primary renderer the one that behaves
-        unlike every other renderer in the ecosystem, including its own
-        siblings.
-
-        Silent truncation is the worse half even though it looks tidier. One
-        of the three is renderCarve, the canonical writer: a tree built
-        through the API and formatted comes back as a document whose body is
-        gone, with nothing in the return value to say so. (carve#526)
-
-        The cost is real and is not hidden: this makes a renderer FALLIBLE in
-        implementations whose signature says it cannot fail, which is a
-        breaking change to those signatures rather than an internal one. It
-        was preferred anyway, because the alternative -- a diagnostic channel
-        alongside a still-infallible return -- needs a channel every renderer
-        signature can carry, which none of them have either, and leaves a
-        caller that ignores it exactly where it is today. It MUST bound abbreviation, reference,
-        footnote, and crossref expansion so total work stays O(n): in
-        particular an empty abbreviation term is rejected, a reference is not
-        resolved by rescanning the whole output per occurrence, and a crossref
-        target is not cloned without bound.
+        The cost is accepted knowingly: this makes a renderer FALLIBLE in
+        implementations whose signature says it cannot fail. An implementation
+        MUST bound abbreviation, reference, footnote, and crossref expansion so
+        total work stays O(n): in particular an empty abbreviation term is
+        rejected, a reference is not resolved by rescanning the whole output
+        per occurrence, and a crossref target is not cloned without bound.
       - NON-HTML TARGETS. The Markdown, plain-text, and terminal (ANSI)
         renderers MUST NOT become injection vectors either. The TERMINAL
         target MUST strip text, code, math AND URL values of every control
@@ -7498,12 +6315,10 @@ EOF = (* end of file *) ;
    29. C0 CONTROLS ON THE RENDER TARGETS -- NORMATIVE (governs what each
       target may emit; the companion to PART 7's ONE WHITESPACE DEFINITION,
       IN EVERY CONSTRUCT, which governs what the LANGUAGE reads). The two
-      questions are different and were being answered as one: PART 7 makes a
-      character CONTENT, and a target then deleted it on the way out. Twice
-      in one day that strip was read as a PART 7 violation and nearly
-      "fixed" as one, by two agents independently, which is why it is
-      written down here rather than left as an implementation habit
-      (carve#963, carve#979).
+      questions are different: PART 7 makes a character CONTENT, and a target
+      then decides whether to emit it. Read as one, a target's strip looks
+      like a PART 7 violation, which is why it is written down here rather
+      than left as an implementation habit.
 
       THE SUBJECT IS A CLASS, NOT TWO CHARACTERS. After carve#963 the
       whitespace of this language is exactly U+0020, U+0009, U+000A and
@@ -7528,27 +6343,6 @@ EOF = (* end of file *) ;
       holding a NUL has skipped the parse boundary, not found an exception
       here.
 
-      WHY THE ONE CARVE-OUT, since a rule with an exception has to say why
-      the exception does not spread. Three reasons, none of which reaches
-      another C0 control:
-      - A NUL IS NOT VALID IN AN HTML DOCUMENT. T1's argument for emitting
-        the rest is that the consumer is a parser which treats a stray
-        control as inert character data. That is the argument that fails for
-        this one character, and it fails on the consumer's own terms rather
-        than on a general worry about control characters -- which is exactly
-        the shape T4 already uses to reach one target and no other.
-      - THE IMPORTER ALREADY REPLACES IT. CommonMark 2.3 mandates the
-        replacement and Carve's Markdown importer performs it
-        (markup-carve/carve-js#1293). A language that strips the character on
-        the way in and emits it on the way out is incoherent at its own
-        boundary, and the incoherence is not fixable in the importer: the
-        authored NUL would still reach the output.
-      - THE ENGINES ALREADY AGREED, DELIBERATELY. All three replace it and
-        none said so, while the executable spec kept it -- the same shape as
-        the byte order mark (carve#872), down to why it stayed invisible: no
-        corpus document carried the byte, so neither behavior was pinned.
-        This is not three independent accidents being ratified.
-
       T1 HTML EMITS THEM. The HTML target does not strip a non-whitespace C0
          control from rendered text. That is the status quo, and the
          asymmetry with T4 is DELIBERATE rather than an oversight: it is
@@ -7561,21 +6355,15 @@ EOF = (* end of file *) ;
          is not.
 
       T2 MARKDOWN EMITS THEM. The Markdown target does not strip them
-         either. A target that silently removes content is lossy in exactly
-         the way carve#817 rejected for the wire, and the reason first
-         offered for the strip -- that a Markdown reader would reclassify
-         these characters as whitespace, so emitting them changes meaning at
-         the boundary -- was measured and did not hold. FOUR READERS WERE
-         MEASURED: the CommonMark reference implementation, and markdown-it
-         in default, commonmark and typographer modes. All four KEEP U+000B
-         and U+000C inline, on a lone line between paragraphs, inside a code
-         span, after a list marker and after an ATX hash. The sharpest case
-         is that `-<VT>item` opens no list in any of them, which it would if
-         the character were whitespace to that reader. They are dropped in
-         exactly two positions, leading and trailing on a line, which is
-         where Carve drops whitespace too. So the downstream reader agrees
-         with carve#963, and stripping makes Carve the lossy party for no
-         reason the consumer requires.
+         either. A target that silently removes content is lossy, and the
+         reason first offered for the strip -- that a Markdown reader would
+         reclassify these characters as whitespace, so emitting them changes
+         meaning at the boundary -- does not hold. Downstream readers KEEP
+         U+000B and U+000C inline, on a lone line between paragraphs, inside a
+         code span, after a list marker and after an ATX hash; `-<VT>item`
+         opens no list, which it would if the character were whitespace to
+         that reader. They are dropped in exactly two positions, leading and
+         trailing on a line, which is where Carve drops whitespace too.
 
       T3 PLAIN TEXT EMITS THEM, FOLLOWING MARKDOWN. This row is a JUDGEMENT
          and is recorded as one rather than as a measurement: plain text is
@@ -7601,38 +6389,17 @@ EOF = (* end of file *) ;
 
       T5 WHAT THIS SECTION DOES NOT SETTLE, stated so its silence is not
          read as agreement:
-         - PANDOC HAS NOW BEEN MEASURED, and it agrees. pandoc 3.5 keeps
-           U+000B and U+000C in all five positions T2 names -- inline, on a
-           lone line between paragraphs, inside a code span, after a list
-           marker and after an ATX hash -- in its `commonmark`, `gfm` and
-           `markdown` readers alike, and `-<VT>item` opens no list in any of
-           them. T2's finding therefore rests on five readers rather than
-           four. What it still does NOT claim is that EVERY reader agrees: a
-           reader that reclassified these characters as whitespace would be a
-           reason to revisit T2, and none measured so far does.
-         - CARVE-RS HAS NOW BEEN MEASURED, and it conforms. Driving both
-           U+000B and U+000C through the five positions T2 names, on each
-           target: carve-rs keeps them on HTML, Markdown and plain text and
-           strips them on ANSI -- T1, T2, T3 and T4 respectively, ten of ten
-           on each row. carve-js and carve-php were measured the same way at
-           the same time and agree with it on all four. So the three engines
-           are uniform here and the row's worry -- that carve-rs might be
-           doing something else unseen -- did not hold. Assuming it was wrong
-           would have been the error this row was written to prevent.
          - DEL (U+007F) AND THE C1 CONTROLS are outside this section, which
-           is about C0. The sweep that prompted this note found them reaching
-           Markdown output in carve-js and carve-rs while carve-php refused
-           them; that has since been fixed, and re-measuring finds all three
-           engines identical -- DEL, CSI (U+009B), OSC (U+009D) and U+0080 are
-           stripped on Markdown, plain text and ANSI alike. §25's NON-HTML
-           TARGETS requirement is met on those three.
-           WHAT IS STILL OPEN is the CANONICAL WRITER: all three engines let
-           every one of those characters through on the `carve` target. That
-           may be right -- a writer that drops content is lossy, and the
-           round-trip invariant is what that target answers to -- but §25 says
-           "non-HTML targets" without saying whether the canonical writer is
-           one, and the same question is open for §26's bidi overrides
-           (carve#1076). Deciding it once would settle both.
+           is about C0. DEL, CSI (U+009B), OSC (U+009D) and U+0080 are
+           stripped on Markdown, plain text and ANSI alike, so §25's
+           NON-HTML TARGETS requirement is met on those three.
+           WHAT IS STILL OPEN is the CANONICAL WRITER: every one of those
+           characters passes through on the `carve` target. That may be right
+           -- a writer that drops content is lossy, and the round-trip
+           invariant is what that target answers to -- but §25 says "non-HTML
+           targets" without saying whether the canonical writer is one, and
+           the same question is open for §26's bidi overrides. Deciding it
+           once would settle both.
 *)
 
 
@@ -7668,63 +6435,30 @@ EOF = (* end of file *) ;
      admonitionExample  "Example"
      admonitionQuote    "Quote"
 
-   THE SET IS SMALL BECAUSE THE ENGINE WRITES LITTLE. Every key here names a
-   string a READER HEARS and no author can spell: an accessible name on an
-   element the author never wrote. That is the whole test for admission, and it
-   is why the set grew from one key to ten in a single sweep (carve#1468) and
-   is expected to stay near that size. The map exists rather than a
-   per-construct option because core has no extension to hang an option on, and
-   because a new such string needs a place to land that the three engines
-   already agree on.
+   WHAT DOES NOT BELONG HERE: a string the AUTHOR already wrote is never a key.
+   A task box is named by its item's own text and an admonition with a title is
+   named by that title (PART 2 `task_marker`, §12), both DERIVED rather than
+   written, so neither adds a key. Only where there is nothing on the page to
+   read does a label appear -- the untitled admonition's type word, and the two
+   footnote strings.
 
-   WHAT DOES NOT BELONG HERE, restated because the sweep tested it four times:
-   a string the AUTHOR already wrote is never a key. A task box is named by its
-   item's own text and an admonition with a title is named by that title
-   (PART 2 `task_marker`, §12), both DERIVED rather than written, so neither
-   adds a key. A host that translates the document translates those once, in
-   the document. Only where there is nothing on the page to read does a label
-   appear -- the untitled admonition's type word, and the two footnote
-   strings.
-
-   AN EXTENSION WRITES INTO THE SAME MAP -- NORMATIVE (carve#1508). The map is
-   the renderer's, not core's: Extensions §1.5 states which strings an
-   EXTENSION contributes to it, and those keys are part of the same map a host
-   passes once. So the list above is what CORE defines and not the whole map an
-   engine honors -- measured against the pinned build, `indexBackref`,
-   `tabsGroup` and `codeGroup` are honored beside the ten. A fourth,
-   `tocNav` (Extensions SS8b.1, carve#1509), is STATED and not yet honored by
+   AN EXTENSION WRITES INTO THE SAME MAP -- NORMATIVE. The map is the
+   renderer's, not core's: Extensions §1.5 states which strings an EXTENSION
+   contributes to it, and those keys are part of the same map a host passes
+   once. So the list above is what CORE defines and not the whole map an engine
+   honors -- `indexBackref`, `tabsGroup` and `codeGroup` are honored beside the
+   ten. A fourth, `tocNav` (Extensions SS8b.1), is STATED and not yet honored by
    any engine: the table-of-contents nav is a navigation landmark and carries an
-   accessible name, and until an engine ships it the key is declared ahead of
-   the pin rather than measured. A host translating a
-   document therefore sets ONE map, which is the whole reason the map exists
-   rather than a per-construct option.
-
-   THE EARLIER READING WAS THE OPPOSITE, and is recorded so a reader of the
-   history is not left with two rules. This clause said extension-written
-   strings STAY with their extension, because moving one into the map would
-   give it two spellings and no rule for which wins. §1.5 supplies exactly
-   that rule -- the author's attribute, then the extension's own option, then
-   the map, then the default -- so the objection no longer holds, and three
-   extension-written strings live under it with both a key and an option.
+   accessible name. A host translating a document therefore sets ONE map.
 
    AN EXTENSION MAY read the map for a string it shares with core; it MUST NOT
    require the host to configure the same text twice. Two extension-written
    strings have no key and are options only -- the heading-permalink label and
    the table-of-contents summary (which is the `<details>` disclosure's VISIBLE
-   text, and not the nav's name: that one is the `tocNav` key above, on a shape
-   the summary never shares) (carve-js `ariaLabel` / `summary`, carve-php
-   `$ariaLabel`, carve-rs `aria_label`). That is now the RULE and not merely the
-   state (carve#1510): a string the extension already exposes as an option is
-   configured there, and §1.5's admission sentence has been narrowed to say so
-   instead of reading on these two. Adding a key would give one string two
-   spellings where the extension already had one.
-
-   EVERY DOCUMENTED KEY REACHES THE OUTPUT, and that is checked rather than
-   asserted (carve#1508). No fixture in the spec repo renders with a non-default
-   map, so every key was verified at its English default only and an engine that
-   hard-coded all of them would have passed every check. The key names are read
-   off this list and off §1.5's table and each is rendered with a sentinel, so
-   a key documented in neither, or documented and inert, fails.
+   text, and not the nav's name: that one is the `tocNav` key above). That is
+   the RULE and not merely the state: a string the extension already exposes as
+   an option is configured there, and §1.5's admission sentence has been
+   narrowed to say so.
 
    WHAT THIS DOES NOT DO: it is not localization. There is no locale name and
    no built-in table beyond the English defaults, because a locale table is
@@ -7744,30 +6478,24 @@ EOF = (* end of file *) ;
    PROVENANCE IS NOT THE TEST, and cannot be. Nothing in the HTML says who
    wrote an attribute. But where the value EQUALS the generated one the output
    is identical whichever of them wrote it, so a value-matched drop is a no-op
-   for what a reader hears: the document rebuilds byte-identical at the default
-   labels. That is why the `scope` rule is phrased as "matches the value the
-   renderer derives" rather than as a test of who wrote it, and it is why this
-   rule cannot repeat the accessibility regression a blanket `aria-label` drop
-   caused. A name that DIFFERS from the derived one is kept, always.
+   for what a reader hears. That is why the `scope` rule is phrased as "matches
+   the value the renderer derives" rather than as a test of who wrote it. A
+   name that DIFFERS from the derived one is kept, always.
 
    WHAT THE DROP BUYS is the only thing keeping the `labels` map alive across a
    round trip. A kept `aria-label="Note"` is indistinguishable from an authored
-   one, and §12's author-wins rule then makes it WIN on the next render: the
-   same source re-rendered with `admonitionNote` set to `Hinweis` still emits
-   `aria-label="Note"`. Dropping it emits `Hinweis`. So an import that keeps a
-   derived name has permanently unlocalized the document while changing no
-   byte of today's output.
+   one, and §12's author-wins rule then makes it WIN on the next render, so an
+   import that keeps a derived name has permanently unlocalized the document
+   while changing no byte of today's output.
 
    NOTHING IS LOST, SO NOTHING IS DIAGNOSED. The renderer writes the value
    back, so a value-matched drop is not a lossy decision and emits no
-   `attribute-dropped` -- the same reason the `<figure>` and `<blockquote cite>`
-   imports report nothing. A drop of the OTHER kind, where the value could not
-   be represented, is diagnosed as it always was.
+   `attribute-dropped`. A drop of the OTHER kind, where the value could not be
+   represented, is diagnosed as it always was.
 
    BYTE-STABILITY IS THEREFORE NOT THE TEST EITHER. A round trip over that
-   admonition is byte-identical while the defect is present, so a round-trip
-   assertion passes and nothing is learned. The assertion has to be that a
-   DERIVED NAME IS ABSENT from the imported source.
+   admonition is byte-identical while the defect is present, so the assertion
+   has to be that a DERIVED NAME IS ABSENT from the imported source.
 
    TWO LIMITS, both accepted rather than closed:
 
@@ -7823,14 +6551,10 @@ EOF = (* end of file *) ;
    the element being READ, not of what the import goes on to do with it. Both
    halves of §16's endnotes section are covered: the REFERENCED form is consumed
    into footnote definitions and the renderer writes the section back, while the
-   REFERENCE-LESS form degrades to the `<hr>` and `<ol>` it is built from
-   (carve#1558) and the renderer writes no section for it at all. The second
-   still reports nothing, because the author still wrote none of it. An importer
-   that instead asks its own EMITTED document whether the value came back
-   answers no for the degraded form -- correctly, and about the wrong question,
-   which is the measurement carve#1502 records: a report built that way
-   contradicts the conversion beside it and calls every value an extension
-   derives a loss.
+   REFERENCE-LESS form degrades to the `<hr>` and `<ol>` it is built from and the
+   renderer writes no section for it at all. The second still reports nothing,
+   because the author still wrote none of it. An importer that instead asks its
+   own EMITTED document whether the value came back answers the wrong question.
 
    WHAT IS STILL REPORTED is everything the element carried that this property
    does not reach. An authored `class` on an endnotes section is reported when
@@ -7904,31 +6628,17 @@ EOF = (* end of file *) ;
       linkDefs entry is unresolved and renders as literal source text; it
       does not fall through to the heading index at ANY spelling, folded
       or exact.
-      THE ASYMMETRY IS THE ONE THE PARAGRAPH ABOVE ALREADY GIVES. It is
-      the stated reason the two matchings differ in the first place: a
+      THE ASYMMETRY IS THE ONE THE PARAGRAPH ABOVE ALREADY GIVES: a
       collapsed label is the author quoting prose from elsewhere in the
       document, which is why its matching is loose, and an explicit label
       is an identifier the author wrote twice and can keep identical,
       which is why its matching is exact. An identifier that names nothing
-      names nothing; it is not retried as prose. Reading the fallback as
-      covering both forms deletes that distinction while leaving the
-      sentence that justifies it in place.
-      PROSE IS NORMATIVE AND A READER IS AN IMPLEMENTATION. Measured at
-      the time of this ruling, three of the four readers resolved a shape
-      this rule does not offer -- two of them on both the folded and the
-      exact spelling, one on the exact spelling only -- and one read the
-      rule as written. Which three is a measurement and belongs on the
-      implementation tickets, not here; that they were a majority is not
-      an argument (PART 0's THE EXECUTABLE ARTIFACTS DECIDE NOTHING). If
-      the explicit form SHOULD reach the index, that is a deliberate
+      names nothing; it is not retried as prose.
+      If the explicit form SHOULD reach the index, that is a deliberate
       widening with its own clause, not a retrofit to the engines.
       THE COMPATIBILITY BREAK, recorded: a document whose
       `[text][Some Heading]` resolves today renders the bracketed run
-      literally instead. Accepted (carve#742 signoff). Corpus rows -- with
-      the control that the collapsed form still reaches the index, and the
-      control that an explicit label matching a real linkDefs entry still
-      resolves, since a fix keyed on "unresolved" rather than on "collapsed"
-      breaks the second -- are deferred to their own pass.
+      literally instead.
       ON THIS PATH THE LABEL ENTERS AS ITS RENDERED PLAIN TEXT, the same
       string kind the heading side already enters as. The index is keyed
       by the heading's rendered plain text, so `# *bold* heading` is
@@ -7960,18 +6670,12 @@ EOF = (* end of file *) ;
       heading even though the heading is now reachable.
       NFC and NOT NFKC: canonical equivalence only, so `ﬁle` does not
       match `file` and `① one` does not match `1 one` -- compatibility
-      folding would change which text an author is quoting, not just how it
-      is spelled. NFC belongs in the list for two reasons. The id side is
-      ALREADY NFC (§25), so without it a document publishes `id="Café"`
-      and then declines `[Café][]` against the heading that produced it --
-      the same alphabet on one side of the resolution and not the other.
-      And NFC is a WEAKER fold than the case fold this list already
-      admits: case folding relates codepoints Unicode calls distinct,
-      while NFC relates sequences Unicode DEFINES as the same, so
-      admitting the stronger one and refusing the weaker one is backwards.
-      The two spellings are also indistinguishable on screen, so a
-      reference that misses has no visible cause (carve#725, where
-      carve-rs folded and the other three did not). The index holds
+      folding would change which text an author is quoting. NFC belongs in the
+      list for two reasons. The id side is ALREADY NFC (§25), so without it a
+      document publishes `id="Café"` and then declines `[Café][]` against the
+      heading that produced it. And NFC is a WEAKER fold than the case fold
+      this list already admits, so admitting the stronger one and refusing the
+      weaker one is backwards. The index holds
       headings at top level and
       inside divs, admonitions, list items, and definitions, but
       DECLINES any heading with a blockquote ancestor, in either
@@ -7999,13 +6703,6 @@ EOF = (* end of file *) ;
       invisible constructs interrupt), so it is never a lazy line there. No
       document distinguishes this clause's answer from section 7's for that kind.
       The link and footnote kinds are the ones this clause governs on its own.
-
-      This is a consequence of NO OPEN PARAGRAPH, NO LAZY LINE, stated here
-      because collection runs BEFORE block structure in every implementation and
-      three engines each got a different answer without it: one deleted the
-      definition's text and left the marker, one registered it while also
-      rendering it, and one half-collected a footnote into the paragraph it was
-      written in.
 
       HOW AN ENGINE MAY DECIDE IT. Collection is a pre-pass over lines, so the
       answer is not local to the line. An implementation MAY ask the block
@@ -8045,15 +6742,6 @@ EOF = (* end of file *) ;
       document. A matcher whose answer depends on where it sits in the whole
       document, or on lines the array does not contain, is NOT CONFORMING.
 
-      THIS IS NOT A PROPERTY OF THE PROBE. R1a's pre-pass parses the run back to
-      the last blank line, and that run is re-based -- but so is every container
-      body, with no definition anywhere in the document. Measured on all three
-      engines: a four-line document whose list item holds two lines invokes the
-      matcher with a TWO-LINE array at index 0, then with the whole document at
-      index 3; a block quote and a `:::` container do the same. Scoping the rule
-      to the probe would leave the identical hazard unstated for every container,
-      which is where an extension author meets it first.
-
    R2 FOOTNOTES (rendering in PART 9 §16). Footnote labels use the same
       ASCII-whitespace-normalized, case-sensitive key as R1. A [^label] use
       with a matching footnoteDefs entry is numbered by FIRST-REFERENCE order from
@@ -8075,12 +6763,9 @@ EOF = (* end of file *) ;
       section is written on its account.
       RESOLUTION ORDER IS NOT THE ANSWER. An implementation that numbers
       footnotes before it knows whether the reference resolved counts the
-      discarded use, and the numbering then says so out loud: the note a
-      reader can see is numbered fnref{n}-2, a repeat of a reference the
-      document does not contain, and a lone one leaves an endnote whose
-      backlink names an id no element carries. Which pass runs first is a
-      property of a pipeline rather than of the language, and ratifying it
-      would make an ordering artifact into a rule (carve#1198 signoff).
+      discarded use, and the numbering then says so out loud. Which pass runs
+      first is a property of a pipeline rather than of the language, and
+      ratifying it would make an ordering artifact into a rule.
       WHAT IS COUNTED IS WHAT THE OUTPUT HOLDS, which decides the cases
       either side of this one the same way. A note in a reference that DOES
       resolve is an ordinary reference, because the resolved link text is
@@ -8099,42 +6784,30 @@ EOF = (* end of file *) ;
       link text is then LABEL + NUMBER, e.g. "Figure 1", markup preserved).
       Resolution is ONE LEVEL: cloned heading text is not re-expanded, so
       self-references and cycles are safe. Unresolved -> literal.
-      WHAT IS CLONED IS THE HEADING'S INLINE NODES -- NORMATIVE (carve#915).
+      WHAT IS CLONED IS THE HEADING'S INLINE NODES -- NORMATIVE.
       "Cloned heading text" means the nodes, not a rendered string. A node
       carries its SOURCE RUN, and a string does not, so an implementation that
       flattens the heading to glyphs while building its id index has destroyed
-      the run before any renderer is invoked. Smart typography's SOURCE mode
-      (§8) then cannot recover it on ANY target, and no renderer change reaches
-      the loss -- the label was materialized in the wrong subsystem. The same
-      argument covers every other run a renderer may want back: a code span, an
-      escape, an inline literal. "markup preserved" already said this for the
-      caption side; it holds for the heading side too, and for the source
-      spelling as much as for the markup.
-      DERIVED DISPLAY TEXT CLONES THE SAME NODES -- NORMATIVE (carve#957).
-      The clause above binds every consumer that derives display text from
-      a heading, not the crossref alone. A render-stage transform may not
-      undo a core resolution rule, so wherever anything builds visible text
-      from a heading -- a numbered cross-reference label, an index term's
-      display, a table-of-contents entry -- it clones the same inline
-      NODES. Flattening to a string at the derivation site destroys the
-      source run exactly as flattening at the index site does, and no
-      renderer downstream can recover it. Stated once here rather than
-      per consumer, because the reach of R4 is what is at issue and the
-      next consumer that derives display text inherits the answer.
+      the run before any renderer is invoked, and no renderer change reaches
+      the loss. The same argument covers every other run a renderer may want
+      back: a code span, an escape, an inline literal.
+      DERIVED DISPLAY TEXT CLONES THE SAME NODES -- NORMATIVE. The clause
+      above binds every consumer that derives display text from a heading, not
+      the crossref alone: a numbered cross-reference label, an index term's
+      display, a table-of-contents entry. Flattening to a string at the
+      derivation site destroys the source run exactly as flattening at the
+      index site does. Stated once here rather than per consumer.
       THE LABEL IS TAKEN BEFORE ANY RENDER-STAGE INJECTION. A heading's
       cloned nodes are its AUTHORED inline content. Whatever a render-stage
       transform later adds to the heading -- a `section-number` span, a
       permalink anchor -- is not part of the label and never appears in
       derived text, so an implementation that resolves cross-references
       AFTER such a transform must clone from the PRISTINE heading and not
-      from the live one.
-      That sentence is normative rather than incidental because two
-      implementations may differ HERE BY CONSTRUCTION rather than by
-      defect: one resolves cross-references before the numbering transform
-      runs, the other after it. Both follow the same words and produce
-      different labels -- one numbered, one plain -- unless the words say
-      which side of the injection the label comes from. Naming the side is
-      therefore the whole content of this half of the clause.
+      from the live one. That is normative rather than incidental because two
+      implementations may differ HERE BY CONSTRUCTION: one resolves
+      cross-references before the numbering transform runs, the other after
+      it, and both follow the same words unless the words say which side of
+      the injection the label comes from.
       NUMBERING, PREFIXING AND JOINING REMAIN THE EXTENSION'S OWN
       BUSINESS. This governs what the TITLE part is made of, not the label
       word, not the number, and not the separator around them.
@@ -8167,11 +6840,9 @@ EOF = (* end of file *) ;
       does not merely leave a paragraph behind; it takes the caption line into
       it.
 
-      That binding is resolution-dependent BY DESIGN, and it is the half worth
-      stating outright, because the alternative reads cleaner and is wrong.
-      Binding on the SOURCE SHAPE would put a `<figure>` around a paragraph of
-      literal `![a][r]` -- output no engine writes and no clause asks for. So
-      the caption is a property of the same resolved tree the image is.
+      That binding is resolution-dependent BY DESIGN. Binding on the SOURCE
+      SHAPE would put a `<figure>` around a paragraph of literal `![a][r]` --
+      output no engine writes and no clause asks for.
 
       A DISPLAY-MATH HOST HAS NOTHING TO WAIT FOR. §4's other prose-spelled
       captionable host, a paragraph whose whole content is one display-math
@@ -8181,18 +6852,7 @@ EOF = (* end of file *) ;
       settles nothing else -- an unresolved reference image is
       captionable-SHAPED, and it is not a block image.
 
-      WHAT THIS REPLACES, so the shape is not rebuilt by accident. The answer
-      used to be reached four times: a syntactic pre-filter in the block layer,
-      a post-pass that took apart a figure the block layer had built
-      speculatively (carrying the undo data on the node to do it), a probe
-      render whose output was discarded, and the paragraph serializer's own
-      render-and-test. Resolution fed the structural decision from four
-      directions, and a fifth consumer -- an importer with no access to any of
-      them -- guessed the rule a third time. An implementation that attaches
-      the caption optimistically and detaches it later is passing this clause's
-      tests while keeping the defect it exists to remove.
    ============================================================================ *)
-
 (* ============================================================================
    PART 10: HTML SERIALIZATION CONVENTIONS (NORMATIVE)
    ============================================================================
@@ -8226,18 +6886,14 @@ EOF = (* end of file *) ;
       A structural CLASS instead merges into the class slot at its FRONT,
       which is the mandatory-base-class rule above said from the other
       side (`task-list`, math's `math inline|display`).
-      This matches reference djot (measured, 0.3.2) on every shape tried --
+      This matches reference djot on every shape tried --
       `<ol type="a" class="attr">`, `<ol start="5" class="attr">`,
       `<a href="…" class="c" id="i" k="v">`, `<img alt="a" src="…"
       class="c">`, `<ul class="task-list c">` -- and it is the same
       placement PART 10 §1 already states for a mention, where the
       structural `href` precedes the author's `data-role` and `id`.
       SO THE DISCRIMINATOR IS THREE-WAY, not two: structural leads,
-      authored follows in source order, engine-minted follows that. Reading
-      a structural attribute as "generated" put carve-rs alone against
-      carve-js, carve-php and djot on `{.attr}` / `a. alpha`
-      (markup-carve/carve#1090); nothing pinned it, which is why the two
-      readings survived side by side.
+      authored follows in source order, engine-minted follows that.
 
       A GENERATED ATTRIBUTE JOINS AT THE END. The two rules above cover
       an all-authored Attrs and an all-programmatic one; the MIXED case
@@ -8263,12 +6919,10 @@ EOF = (* end of file *) ;
         > ## Nested   -> <h2 id="Nested" data-source-line="1">
       This is a THIRD category, and stating it is what stops an engine
       from being conformant and divergent at once. An engine that
-      appends the stamp at RENDER time (carve-js) gets the order for
-      free, because the stamp is written outside the attribute walk. An
-      engine that attaches it at PARSE time (carve-rs) carries it inside
-      the authored run, where the "generated last" rule alone would put
-      the id behind it -- which is exactly what carve-rs did until it
-      was caught by a test rather than by this text.
+      appends the stamp at RENDER time gets the order for free, because the
+      stamp is written outside the attribute walk; an engine that attaches it
+      at PARSE time carries it inside the authored run, where the "generated
+      last" rule alone would put the id behind it.
 
       TEXT-BLOCK ALIGNMENT IS A SEMANTIC ATTRIBUTE. On `<p>`, `<div>` and
       `<h1>` through `<h6>`, an authored `align` key whose trimmed,
@@ -8490,31 +7144,18 @@ EOF = (* end of file *) ;
       in what the author wrote to get there.
 
       Without that clause the first invariant would be unattainable by
-      construction, not merely unmet. §5 requires the writer to escape `"` and
-      `'` UNCONDITIONALLY: a bare quote reaching the writer as text would
-      otherwise re-derive as smart punctuation (PART 9 §8) and change the
-      document. So a text node holding a quote MUST come back carrying an
-      escape, which parses to `escaped_text`. Read strictly, §1 and §5 would
-      contradict each other for every document containing a quote.
-
-      This is also the comparison §4 already performs internally: the two
-      renders it weighs differ precisely in their escaping, so telling them
-      apart BY the escaping would escalate every document. The invariant and
-      the strategy therefore ask the same question -- does dropping the escapes
-      change anything ELSE?
+      construction. §5 requires the writer to escape `"` and `'`
+      UNCONDITIONALLY: a bare quote reaching the writer as text would otherwise
+      re-derive as smart punctuation (PART 9 §8) and change the document, so a
+      text node holding a quote MUST come back carrying an escape, which parses
+      to `escaped_text`. It is also the comparison §4 already performs
+      internally -- the two renders it weighs differ precisely in their
+      escaping, so telling them apart BY the escaping would escalate every
+      document.
 
       What escaping still MUST preserve is the rendered result: the escape is
       authoring syntax, so `to_html(fmt(x)) == to_html(x)` admits no such
       latitude, and neither does idempotence.
-
-      KNOWN GAP -- the first invariant is not met by every implementation on
-      every input. The four constructs first recorded here (a table carrying a
-      colspan, a doubled alignment marker, a list-item attribute form and a
-      line-block shape) are fixed; a corpus-wide sweep finds others, tracked in
-      carve#369. Nothing caught any of them because every existing check
-      compares rendered HTML, which is equal in all of those cases. It is
-      stated rather than left implied: an implementation that satisfies §2 can
-      still fail §1, and §4's comparison is built to be unaffected by that.
 
    1a. THE INVARIANT OUTRANKS THE PER-CONSTRUCT RULES -- NORMATIVE. §1 states
       what the writer must ACHIEVE; §2 through §11 state how it SPELLS each
@@ -8539,9 +7180,7 @@ EOF = (* end of file *) ;
       parse(x)` is the requirement. `to_html(fmt(x)) == to_html(x)` is a
       consequence of it and is strictly weaker -- §2a already says that holding
       is necessary, not sufficient -- so a writer satisfying only the HTML form
-      still fails this section. The distinction is easy to lose because the
-      HTML form is what a person can SEE, and reports of these defects are
-      usually written against it; the rule is stated over the parse.
+      still fails this section.
 
       IT IS NOT A LICENSE TO RESPELL. §2a and §6 are unchanged. What this
       section permits is the SMALLEST departure that restores the invariant,
@@ -8583,30 +7222,13 @@ EOF = (* end of file *) ;
       side exists at all, not what characters happen to sit on one.
 
       THE FAILURES ARE ONE FAILURE, and only some of them have a visible face.
-      Re-measured 2026-08-18 against carve-js `099db2cc`, carve-php `925f7dcf`
-      and carve-rs `3f8bde7b`, each built from a clone made for the run and each
-      flattening a `<figcaption>` holding two paragraphs. carve-rs emits the
-      separator on every row since markup-carve/carve-rs#1094; carve-js and
-      carve-php agree with each other on every row and lose the boundary:
+      A `<figcaption>` holding two paragraphs flattens with the boundary lost:
 
         <p>one</p><p>two</p>                    ->  onetwo
         <p><strong>a</strong></p>
         <p><strong>b</strong></p>               ->  *a**b*
         <p><code>a</code></p>
         <p><code>b</code></p>                   ->  `a``b`
-
-      The first loses the boundary as CONTENT: `onetwo` re-reads as one word
-      and the reader sees a misspelling. The second and third lose it as
-      STRUCTURE: `*a**b*` re-reads as one strong run holding a literal
-      asterisk, and the third as one code span holding the joined
-      delimiters. Nothing is DROPPED in any of them, which is why no diagnostic
-      fires for any of them -- an importer's unwrap note reports that a `<p>`
-      was unwrapped and says nothing about what the unwrapping joined.
-
-      The third row was not among the two reported at carve#1325. It is the
-      reason the rule is a property: a ruling written to the two shapes in hand
-      would have left the code span for the next release, and the caption slot
-      is not the only inline-only slot either.
 
       THE UNIT IS THE TOKEN, NOT THE NODE, and that difference is the whole
       rule. A node test passes `onetwo` and `one two` alike -- both are a
@@ -8616,9 +7238,7 @@ EOF = (* end of file *) ;
 
       IT IS §23's TEST READ BACKWARDS. PART 9 §23 states the forward half for a
       LINE boundary: ONE boundary produces ONE node, "however the boundary is
-      spelled", and a backslash break and a verbatim run are exempt for one
-      reason -- both leave NO NODE, so there is no boundary left in the tree to
-      convert. A flatten is that situation arriving from the other side. The
+      spelled". A flatten is that situation arriving from the other side. The
       block boundary leaves no node either, because the slot has nowhere to put
       one, so it survives only in the BYTES -- and the bytes are read by a
       tokenizer.
@@ -8638,23 +7258,15 @@ EOF = (* end of file *) ;
       per report: a character that was TEXT in one of the blocks and becomes a
       live delimiter once its neighbour is beside it is an ESCAPING question,
       and §2 read through §1a already answers it -- the writer reads its own
-      OUTPUT, and escapes what would otherwise change the document. That is
-      already the behavior: `<p>a *b</p><p>c* d</p>` flattens to `a \*bc\* d`
-      in all three engines, with the asterisks correctly escaped and only the
-      word boundary lost. This clause supplies the space and nothing else;
-      §1b and §2 are answering two halves of the same join.
+      OUTPUT, and escapes what would otherwise change the document. This clause
+      supplies the space and nothing else; §1b and §2 are answering two halves
+      of the same join.
 
-      REFUSING TO FLATTEN IS NOT AN ANSWER. The slot cannot hold blocks, so a
+      REFUSING TO FLATTEN IS NOT AN ANSWER: the slot cannot hold blocks, so a
       producer that refuses emits nothing where the author's document has
-      content. That is a strictly larger loss than the one this clause closes,
-      and silent in exactly the same way.
-
-      NEITHER IS ESCAPING THE COLLISION. `*a*\*b*` writes a character the
-      author did not, against §2's if-and-only-if: nothing in either block's
-      own content needs protecting, and the collision exists only at the join.
-      An escape is also per-character where the defect is per-boundary, so it
-      would be re-derived for every delimiter pair two blocks might meet on,
-      where the separator is derived once.
+      content. NEITHER IS ESCAPING THE COLLISION: `*a*\*b*` writes a character
+      the author did not, against §2's if-and-only-if, and an escape is
+      per-character where the defect is per-boundary.
 
       WHAT IS NOT REQUIRED. The flatten need not be REVERSIBLE. Two paragraphs
       written into a caption come back as one paragraph and no spelling of the
@@ -8698,26 +7310,22 @@ EOF = (* end of file *) ;
       §10j is. Two shapes have the property today, and they share no node type,
       no vocabulary list and no reason beyond the spelling: a `paragraph` whose
       whole content is one `image`, which writes `![a](u)` and reads back as
-      the standalone image (PART 9 §4's image-paragraph host is a condition on
-      a paragraph's inline content, so the two trees have ONE spelling between
-      them); and a `paragraph` whose whole content is one `comment`, which
-      writes `%% c` and reads back as the block comment. `image` is in the
-      INLINE vocabulary and `comment` is in the BLOCK one (docs/profiles.md),
-      so a rule written over the types would have had to name them one at a
-      time and would not reach the next one. A block whose content spells
-      anything ELSE -- a second node beside it, a text run, a NO-BREAK SPACE
-      (§7) -- keeps its wrapper and no ceiling is reached.
+      the standalone image; and a `paragraph` whose whole content is one
+      `comment`, which writes `%% c` and reads back as the block comment.
+      `image` is in the INLINE vocabulary and `comment` is in the BLOCK one
+      (docs/profiles.md), so a rule written over the types would have had to
+      name them one at a time. A block whose content spells anything ELSE -- a
+      second node beside it, a text run, a NO-BREAK SPACE (§7) -- keeps its
+      wrapper and no ceiling is reached.
 
       DECIDED ON THE SPELLING, NEVER ON RESOLUTION -- and PART 9R R7 does not
-      change that (carve#1784). R7's promotion phase reads the RESOLVED tree;
-      this clause reads what a shape SPELLS, and the two are deliberately
-      independent. A writer that consulted resolution would write the same
-      paragraph differently depending on whether a definition appears somewhere
-      else in the document, possibly far away -- a bad property for a formatter,
-      and the reason `paragraph.blockImage` (PART 12 §23) is a field the writer
-      does not read. So a document whose reference is never defined still writes
-      back as itself, and this clause's ceiling is reached by `![a](u)` and by
-      `![a][r]` alike, defined or not.
+      change that. R7's promotion phase reads the RESOLVED tree; this clause
+      reads what a shape SPELLS, and the two are deliberately independent. A
+      writer that consulted resolution would write the same paragraph
+      differently depending on whether a definition appears somewhere else in
+      the document -- the reason `paragraph.blockImage` (PART 12 §23) is a
+      field the writer does not read. So this clause's ceiling is reached by
+      `![a](u)` and by `![a][r]` alike, defined or not.
 
       THE CEILING IS UNIFORM AND NOT POSITIONAL, which is the half that decides
       the shape rather than merely describing it. At top level the image
@@ -8726,22 +7334,15 @@ EOF = (* end of file *) ;
       writer still does not use it. Inside a list item or a definition
       description there is no such spelling at any width: the marker's own
       content column absorbs the padding, so `- ![a](u)` and `-       ![a](u)`
-      are the same tree, and `: ` behaves the same way. A writer preserving
-      the shape at one nesting level and losing it at the next, with nothing
+      are the same tree, and `: ` behaves the same way. A writer preserving the
+      shape at one nesting level and losing it at the next, with nothing
       declaring the difference, is not a preservation rule; and the indented
       form emits meaning-bearing leading whitespace, which editors and
-      pipelines strip. So the wrapper is lost EVERYWHERE, and one sentence
-      describes the writer at every depth.
+      pipelines strip. So the wrapper is lost EVERYWHERE.
 
-      WHY NOT REFUSE. §1's KNOWN GAP and the refusal a writer already owes for
-      a value no source can carry make refusal the honest-looking answer, and
-      it is what an implementation does for an empty raw inline. It loses on
-      two counts. It would fail an editor's round trip on a tree the renderer
-      accepts -- §10j's own reason for bounding a loss rather than rejecting
-      the document, on the path that can least afford it -- and it contradicts
-      a clause that already exists, since `docs/html-import.md` says this exit
-      REPORTS the loss rather than failing. Overturning that needs its own
-      fallback story and is a larger change than the shape asks for.
+      WHY NOT REFUSE. Refusing would fail an editor's round trip on a tree the
+      renderer accepts, and `docs/html-import.md` already says this exit
+      REPORTS the loss rather than failing.
 
       THE WRAPPER IS STILL LOST, and this clause does not pretend otherwise. It
       bounds the loss TO the wrapper -- the content, its attributes and its
@@ -8789,21 +7390,17 @@ EOF = (* end of file *) ;
       wrapper, and the fixture is then evidence of nothing. The clause is the
       definition; a fixture is at most an instance of it.
 
-      WHERE THE SET IS SOURCED FROM IS FREE, and the two engines that reached
-      this first source it differently: one states a predicate over what the
-      shape spells and is bounded by construction, the other derives the set
-      from the corpus documents whose pinned canonical form re-parses
+      WHERE THE SET IS SOURCED FROM IS FREE. One engine states a predicate over
+      what the shape spells and is bounded by construction, another derives the
+      set from the corpus documents whose pinned canonical form re-parses
       differently and applies the bound explicitly. Both conform. The bound is
-      the rule; the sourcing is not, and neither spelling is owed a conversion
-      to the other.
+      the rule; the sourcing is not.
 
       A CHECKER THAT WIDENS THE BOUND CANNOT DETECT ITS OWN WIDENING, so the
       width is pinned separately or it is not pinned at all. The dissolution is
       applied to BOTH trees, so widening it can only ever HIDE a difference and
-      never create one: whatever extra shape it swallows, it swallows
-      identically on each side and the two still agree. A corpus sweep
-      therefore stays green under any widening whatsoever, and only a direct
-      assertion on the predicate says how wide it is.
+      never create one, and a corpus sweep stays green under any widening
+      whatsoever.
 
    2. THE ESCAPING RULE -- NORMATIVE. A character is escaped IF AND ONLY IF
       omitting the escape would change the re-parsed AST.
@@ -8816,12 +7413,9 @@ EOF = (* end of file *) ;
 
       THE UNIT IS THE OPENER, NOT THE CHARACTER. Where a construct opens on a
       RUN of characters, the whole run is escaped. `--` opens an en dash
-      (PART 9 §8), and `\--` suppresses it just as `\-\-` does, so a
-      character-at-a-time reading of the rule would call the second escape
-      unnecessary and require `\--`. It does not: the escaped form of a
-      suppressed opener is the whole opener escaped. A half-escaped run is a
-      shape that happens to work rather than one that says what it means, it
-      breaks as soon as the surrounding text shifts what the run abuts, and
+      (PART 9 §8), and `\--` suppresses it just as `\-\-` does; the escaped
+      form of a suppressed opener is the whole opener escaped. A half-escaped
+      run breaks as soon as the surrounding text shifts what the run abuts, and
       `\.\.\.` versus `\...` is the same question with the same answer.
 
       So the escape decision is taken per OPENER OCCURRENCE: would omitting the
@@ -8847,13 +7441,6 @@ EOF = (* end of file *) ;
       is what it falls back to -- per occurrence now rather than per unit. A
       fallback that spends more escapes than this test asks for is wider than
       the minimum and never narrower, which is the only direction §1 tolerates.
-
-      (Pinned by corpus
-      403-an-idle-escape-does-not-spread-from-the-occurrence-that-needed-one.
-      Like corpus 396 one clause down, its `.fmt` sidecar is the only fixture
-      that can see it: `\{\.note\}` renders the same HTML, re-parses to the
-      same tree and is happily idempotent, so every other gate in every engine
-      was green on the wider form.)
 
    2a. THE WRITER DOES NOT SUBSTITUTE ONE CONSTRUCT FOR ANOTHER -- NORMATIVE.
       §2 governs ESCAPING. It does not license rewriting a construct into a
@@ -8906,11 +7493,8 @@ EOF = (* end of file *) ;
       rules out re-parsing a LINE on its own, because a line has lost the
       document's link-reference and footnote definitions and reports a
       difference escaping never caused. That argument is about what the writer
-      PARSES in order to decide, and it stands unchanged. This section is about
-      which BYTES the decision then selects. A writer renders and re-parses
-      WHOLE documents, and takes the conservative spelling only where the
-      minimal one failed -- so the definitions are present for the comparison
-      and the escalation is still local.
+      PARSES in order to decide; this section is about which BYTES the decision
+      then selects.
 
       THE UNIT NESTS, AND IT IS TRIED SMALLEST FIRST. The inline run carrying
       the occurrence is tried before the block that holds it. A failure that
@@ -8925,12 +7509,6 @@ EOF = (* end of file *) ;
       IT DOES NOT LOOSEN §2 ANYWHERE. A unit that fails is escaped in full, by
       §2's THE UNIT IS THE OPENER: `\#\# H` and not `\## H`. What narrows is
       the reach of the fallback, not the strength of the escape it applies.
-
-      (Pinned by corpus
-      396-an-idle-escape-does-not-spread-from-the-block-that-needed-one, whose
-      `.fmt` sidecar is the only fixture that can see this: both spellings
-      render the same HTML and re-parse to the same tree, which is why three
-      writers carried the wider scope with every gate green.)
 
    3. WHY A STATIC CHARACTER TABLE CANNOT IMPLEMENT §2. Whether a character
       is significant depends on the line, not on the character:
@@ -8953,8 +7531,7 @@ EOF = (* end of file *) ;
       §2 is the rule worth keeping, because it is the one an author can see the
       difference in, and because §3's argument does not lead here: it shows a
       static character TABLE cannot implement §2, not that per-character
-      decisions are impossible. A writer that knows whether a construct would
-      START at a given position decides exactly, and two engines do.
+      decisions are impossible.
 
       The procedure, then, as a strategy:
 
@@ -8972,20 +7549,6 @@ EOF = (* end of file *) ;
          A unit is not one knob: the occurrences that survive escaped are the
          ones that failed, not the ones that shared a block with a failure.
 
-      W5 IS WHERE THE STRATEGY COSTS, AND THE COST IS BOUNDED BY SEARCHING
-      RATHER THAN BY ENUMERATING. Offering the occurrences ONE AT A TIME is a
-      render and a re-parse of the whole document per candidate, which is
-      quadratic in the document -- and on ordinary input, not adversarial:
-      a paragraph of indented table rows puts a load-bearing occurrence beside
-      an idle one on every line. Offering a GROUP its bare form and halving the
-      group only where that fails costs a number of renders proportional to how
-      many occurrences FAIL rather than to how many there are. Measured on that
-      shape at 50 / 100 / 200 / 400 rows, in RENDERS rather than in
-      milliseconds: 249 / 499 / 999 / 1999 offering one at a time, flat at
-      about 5 renders per row, against 64 / 72 / 80 / 88 searched -- eight more
-      renders per doubling of the input, which is the logarithm the halving
-      buys. The same bound applies to W4's own search over units.
-
       A WRITER MAY STOP THE SEARCH SHORT, and §2b's fallback is what it returns
       to when it does: the occurrences it did not get to stay escaped. That is
       WIDER than §2's minimum and never narrower, so a spent budget costs
@@ -8995,38 +7558,28 @@ EOF = (* end of file *) ;
 
       Two forms and one comparison, with the choice made by the parser rather
       than by a table -- so the writer cannot drift from the grammar as the
-      grammar grows. What it buys is safety without a table; what it costs is
-      precision, and §2 is where the precision is required.
+      grammar grows.
 
       WHY THE COMPARISON IS DOCUMENT-SCOPED, FOR AN IMPLEMENTATION THAT USES
-      IT. An earlier draft decided per line. That cannot be implemented: a line
-      re-parsed on its own has lost the document's link-reference and footnote
-      definitions, so a paragraph carrying `[text][ref]` comes back with an
-      empty destination and reports a difference escaping never caused. Any
-      COMPARISON at a scope smaller than the document has the same defect for
-      the same reason, so W1 and W3 render and parse whole documents.
+      IT. A line re-parsed on its own has lost the document's link-reference
+      and footnote definitions, so a paragraph carrying `[text][ref]` comes
+      back with an empty destination and reports a difference escaping never
+      caused. Any comparison at a scope smaller than the document has that
+      defect, so W1 and W3 render and parse whole documents.
 
       THAT IS NOT A REASON TO ESCALATE THE WHOLE DOCUMENT, and reading it as
       one is what §2b now forbids. Where the two parses differ, they differ
       SOMEWHERE, and W4 takes the conservative spelling only for the smallest
-      unit that fails. The definitions the comparison needs are present either
-      way, because nothing about the comparison changed.
-
-      What remains true is the rest of the trade: this is a strategy rather
-      than the requirement, and an implementation that instead asks, per
-      position, whether a construct would start there needs neither the
-      comparison, nor the scope, nor W5's search.
+      unit that fails.
 
       WHY THE TWO RENDERS ARE COMPARED WITH EACH OTHER, and not the minimal
       render with the document being written. The writer is not required to be
-      AST-faithful for every construct, and in practice is not: a table with a
-      colspan, a doubled alignment marker, some list-item attribute forms and
-      one line-block shape all re-parse to a DIFFERENT document while rendering
-      identical HTML. Comparing against the source document would inherit those
-      defects, flip the escaping decision between passes and break §1's
-      idempotence for a reason that has nothing to do with escaping. Comparing
-      the two renders isolates the only question this decision asks: does
-      dropping the candidate escapes change anything?
+      AST-faithful for every construct: a table with a colspan, a doubled
+      alignment marker, some list-item attribute forms and one line-block shape
+      all re-parse to a DIFFERENT document while rendering identical HTML.
+      Comparing against the source document would inherit those defects and
+      break §1's idempotence for a reason that has nothing to do with
+      escaping.
 
    5. THE TWO SETS.
 
@@ -9055,27 +7608,18 @@ EOF = (* end of file *) ;
         weighs the mark; it is not a license to EMIT an escape §2 does not
         ask for. §4 pins the output on §2 and yields to it wherever the two
         differ, and §10g already restates the reach in those terms -- "§5's
-        unconditional set escapes a LEADING caret in TEXT". §2a has filed the
-        other direction as a defect, on `}^p`, where the caret leads nothing,
-        dropping the escape re-derives the same document, and carve-rs and
-        carve-php escape it anyway. So "always escaped in a text node" is the
-        set's membership rule, and §2 is the test the emitted byte answers to.
+        unconditional set escapes a LEADING caret in TEXT". So "always escaped
+        in a text node" is the set's membership rule, and §2 is the test the
+        emitted byte answers to.
 
         THE MARK IS THE PROMOTION, NOT A FIELD, which is why the LEADING case
         needs no exception to §2. `resources/ast-schema.json` declares no
-        field for it and carve-rs publishes none: what the escape changes
-        there is whether the block comes back a PARAGRAPH or a FIGURE, and
-        that is a difference §2 already sees. An engine that reads the
-        paragraph above as promising a field has read a mechanism where the
-        rule is about an outcome.
+        field for it: what the escape changes there is whether the block comes
+        back a PARAGRAPH or a FIGURE, and that is a difference §2 already sees.
 
-        SO THE LEADING CASE IS UNMOVED, and corpus
-        394-a-leading-escaped-caret-keeps-its-escape pins it against the
-        reading that takes the bare `{^^}` above for a general permission.
-        An image over `\^ not a caption` keeps the backslash in all three
-        engines; bare, the same two lines are a `figure` with a
-        `figcaption`. That is §2 requiring the escape, not §5 excusing it,
-        and it is the difference between the two documents.
+        SO THE LEADING CASE IS UNMOVED. An image over `\^ not a caption` keeps
+        the backslash; bare, the same two lines are a `figure` with a
+        `figcaption`. That is §2 requiring the escape, not §5 excusing it.
 
       CANDIDATE -- escaped only when W4 selects the conservative form:
         `* _ ~ / = ,`        emphasis and the braced pair delimiters
@@ -9104,61 +7648,27 @@ EOF = (* end of file *) ;
       choices and the AST records them; changing one would satisfy §1 while
       still surprising the author.
 
-      FENCE LENGTH WAS A THIRD EXAMPLE HERE AND IS NOT ONE (carve#1000). It is
-      removed rather than implemented, on this section's own second half: a
-      spelling is the author's to keep BECAUSE THE AST RECORDS IT, and
-      `code_block` records no fence at all (PART 12 §3). Neither the length of
-      the run nor the character it is made of survives the tree, so
+      FENCE LENGTH WAS A THIRD EXAMPLE HERE AND IS NOT ONE. It is removed
+      rather than implemented, on this section's own second half: a spelling is
+      the author's to keep BECAUSE THE AST RECORDS IT, and `code_block` records
+      no fence at all (PART 12 §3). Neither the length of the run nor the
+      character it is made of survives the tree.
 
-        ```js        all three publish the SAME node, and the writer
-        `````js      has nothing to reproduce
-        ~~~js
-
-      That is §6a's objection to the thematic break, reached one construct over:
-      a rule that cannot be applied leaves the question open rather than
-      answering it. The difference between the two is only that one was noticed.
-
-      THE WRITER COMPUTES THE WIDTH IT NEEDS, which is why removing the example
-      costs no document. A fence is widened to clear the longest fence-character
-      run in its content and narrowed when nothing requires the extra width, and
-      §1 holds through both: content carrying a three-backtick run keeps a
-      four-backtick opener, while plain content under a four-backtick opener
-      comes back as three. Measured in all three engines, and the narrowing row
-      is the one that matters -- it is the behavior this section forbade in
-      words and every engine performed, with the round trip intact through it.
-
-      So the mention was decorative. Had the writer instead relied on the
-      AUTHOR's length, removing it would have broken every document whose
-      content contains its own fence character, and the example would have been
-      load-bearing by accident rather than by design.
+      THE WRITER COMPUTES THE WIDTH IT NEEDS. A fence is widened to clear the
+      longest fence-character run in its content and narrowed when nothing
+      requires the extra width, and §1 holds through both.
 
       The AST therefore RECORDS the combined form -- a `strong` parsed from
       `bold_italic` carries `boldItalic` (PART 12 §3) -- and the writer
-      reproduces it. Without that mark the rule could not be stated as an
-      author's choice at all, because there would be nothing to preserve.
+      reproduces it. `/*x*/` is also the spelling Carve teaches, so normalizing
+      it away would rewrite the documented form into one documented nowhere.
 
-      `/*x*/` is also the spelling Carve teaches (docs/cheatsheet.md,
-      docs/migrate-from-markdown.md), so normalizing it away rewrote the
-      documented form into one documented nowhere. That is the concrete harm
-      behind the general rule.
-
-      THE THEMATIC BREAK JOINS IT ON THE SAME TERMS (carve#976), and needed the
-      same catching up. `---`, `***` and `___` are three spellings of one
-      construct; until now `thematic_break` recorded none of them, so this
-      section's second half was false for it and could not be applied, and §6a
-      pinned `---` in the meantime rather than leaving three writers to pick
-      separately. The AST RECORDS the character now -- `marker` (PART 12 §3) --
-      and the writer reproduces it, so `***` comes back as `***` and `___` as
-      `___`. §6a is REMOVED with the pin it held, which is what its own text
-      said would happen.
-
-      THE MARKER IS THE CHARACTER, NOT THE RUN LENGTH (carve#1000). `***` and
-      `*****` are ONE spelling here and both come back as `***`: three
-      characters is the width §6a already pinned, applied to whichever character
-      the field names. The argument for recording a length was this section's
-      own mention of FENCE length by analogy, and that mention is the one
-      removed above -- so the analogy points at nothing, and no construct's run
-      length is recorded anywhere.
+      THE THEMATIC BREAK JOINS IT ON THE SAME TERMS. `---`, `***` and `___` are
+      three spellings of one construct, and the AST RECORDS the character --
+      `marker` (PART 12 §3) -- so the writer reproduces it. THE MARKER IS THE
+      CHARACTER, NOT THE RUN LENGTH: `***` and `*****` are ONE spelling here
+      and both come back as `***`. No construct's run length is recorded
+      anywhere.
 
       EXCEPT WHERE `---` WOULD OPEN FRONTMATTER. A `---` line at byte 0 of the
       EMITTED document is the frontmatter opener, not a break. Spelling this
@@ -9168,40 +7678,26 @@ EOF = (* end of file *) ;
       by the literal reading of this clause it renders NOTHING -- with any
       paragraph standing between them lost too. Where that would happen the
       writer spells the break `***` instead, and that deviation is §1a's --
-      §1's invariant outranks a per-construct rule, and this is the case §1a
-      was reached for.
-      It is CONFORMANT. It is not a divergence from this section, and an
-      implementation that has it is not to be corrected back.
+      §1's invariant outranks a per-construct rule. It is CONFORMANT and not a
+      divergence from this section.
 
       THE CONDITION IS THE WHOLE EMITTED DOCUMENT, NOT ITS FIRST LINE. An
       opener needs a closer, so three hyphens at byte 0 open nothing unless a
       later line closes them -- `***` alone, and `***` above a paragraph, are
-      both written `---` with no exception at all. The document that survives
-      and the document that is destroyed are IDENTICAL on line 1 and differ
-      several lines down, which is why the check this clause most invites, a
-      pattern match on the first line, answers a different question than the
-      one asked. What an implementation owes is §1a's test: read the emitted
-      bytes with its own parser.
+      both written `---` with no exception at all. What an implementation owes
+      is §1a's test: read the emitted bytes with its own parser.
 
       WHICH break moves is not pinned, because more than one departure
       restores §1 and §1a already says to take the smallest. Usually it is the
-      break at byte 0. Where the writer itself PROMOTED something else there --
-      hoisting a definition below the body can leave a paragraph at the head --
-      the text at byte 0 is not the writer's to respell, and the departure
-      available is to respell the CLOSER instead. What IS pinned is the
-      spelling a moved break takes, `***`, for the reason this clause exists at
-      all: a construct left with two admissible spellings normalizes two ways,
-      and an exception is no more exempt from that than the rule is.
+      break at byte 0; where the writer itself PROMOTED something else there,
+      the departure available is to respell the CLOSER instead. What IS pinned
+      is the spelling a moved break takes: `***`.
 
       AN ABSENT MARKER IS `---`, which is what a tree assembled by hand or by a
       converter carries and what every document written before the field means.
-      That default is not arbitrary: `---` is the spelling Carve teaches
-      (docs/cheatsheet.md writes it and names `***` and `___` as its
-      alternatives), so a break with no authored choice to preserve is written
-      the documented way. §1a still outranks this, and the one deviation it
-      licenses here is real -- a `---` the writer emits at byte 0 can gain a
+      §1a still outranks this: a `---` the writer emits at byte 0 can gain a
       frontmatter closer from a later break, and respelling every break in the
-      document is the smallest departure that restores the invariant.
+      document is then the smallest departure that restores the invariant.
 
    6b. A FRONTMATTER OPENER IS WRITTEN `---yaml` -- NORMATIVE. The canonical
       writer spells the format token on the opening delimiter for EVERY
@@ -9210,28 +7706,18 @@ EOF = (* end of file *) ;
       `---toml`; nothing about the writer's output turns on which format the
       document named.
 
-      This is §6's REMAINING gap, and the same one the thematic break had until
-      carve#976 closed it: `---` and `---yaml` open the
-      same frontmatter (PART 1, "a bare `---` defaults to `yaml`"), so the two
-      are synonyms with nothing in the tree to tell them apart.
-
-      PART 1 ALREADY NAMES THE FORM. That production calls `---yaml` canonical
-      in as many words, and PART 11 is the canonical writer -- so the writer
-      emits it. The counter-reading is that the word sits in a sentence about
-      the optional SPACE and therefore settles `---yaml` against `--- yaml`
-      only. It does not survive contact with what the sentence names: the
-      string it calls canonical is a WHOLE OPENER, not the space inside one,
-      and reading it to reach one of the two ways an opener can differ from it
-      but not the other takes an argument the sentence does not make.
+      `---` and `---yaml` open the same frontmatter (PART 1, "a bare `---`
+      defaults to `yaml`"), so the two are synonyms with nothing in the tree to
+      tell them apart. PART 1 ALREADY NAMES THE FORM: that production calls
+      `---yaml` canonical in as many words, and it calls a WHOLE OPENER
+      canonical, not the space inside one.
 
       A READER'S LENIENCY IS NOT A WRITER'S LICENSE, which is what the bare
       form would be. "A bare `---` defaults to `yaml`" tells the PARSER what
       to do with an opener that names nothing; the writer is not parsing, it
       is choosing, and `frontmatter_format` is one production over every
-      format with no default case in it. So a writer that omits the token for
-      `yaml` special-cases a value the grammar distinguishes nowhere except in
-      that leniency rule -- and §2 already refuses the mirror of that move,
-      where the writer emits the shortest form that happens to survive
+      format with no default case in it. §2 already refuses the mirror of that
+      move, where the writer emits the shortest form that happens to survive
       re-parsing rather than the form that says what it means.
 
    6c. A VALUE-LESS ATTRIBUTE IS WRITTEN AS A BOOLEAN -- NORMATIVE. An
@@ -9244,14 +7730,6 @@ EOF = (* end of file *) ;
       (carve#1450). `_x_=""` stays `{_x_=""}`: emitting `{_x_}` would write a
       forced underline, and `{_u}` would write text. The rule is "use the
       dedicated production where the production applies", and here it does not.
-
-      NOTHING EXTRA PINS THIS, on purpose. §1's `parse(fmt(x)) == parse(x)` is
-      already gated over the corpus for every engine, and corpus
-      389-a-boolean-attribute-does-not-start-with-an-underscore-4 holds
-      `[x]{_u=""}`, so an engine that shortens it breaks its own round-trip the
-      day it ships the reading rule - and not one day earlier, which is what a
-      `.fmt` fixture would have done to a writer that is still correct for the
-      grammar it implements.
 
       THE WRITER USES THE DEDICATED PRODUCTION, which is the one rule behind
       all three of these:
@@ -9266,32 +7744,15 @@ EOF = (* end of file *) ;
 
       THIS IS NOT §6b'S MIRROR. That clause makes the writer spell `---yaml`
       rather than the shorter `---`, and its reason is that a bare `---` is
-      NOT a production for yaml frontmatter: it is an opener that names no
-      format, which a PARSER leniency rule then defaults. Leaning on that
-      leniency is what §6b refuses. A boolean attribute is the opposite case --
-      the grammar has a production for exactly this shape, and no default is
-      being relied on. `{kbd=""}` is not more explicit than `{kbd}`; it says
-      the value is an empty STRING, where the tree says the attribute has no
-      value at all.
-
-      THREE `.fmt` FIXTURES ARE WITHDRAWN, not updated, and come back with the
-      pin bump: `297-the-language-sigil-takes-no-padding`,
-      `97-boolean-attributes` and `45-inline-extensions-9`. Those fixtures
-      are read THROUGH the pinned build by
-      `tests/corpus-fmt-roundtrip.test.mjs`, and by the engines through their
-      own `spec` submodule, so a fixture carrying the NEW bytes fails in both
-      places until every writer ships this clause, while one carrying the OLD
-      bytes fails afterwards. There is no spelling of it that is green on both
-      sides of the change, so it is absent for the length of the rollout rather
-      than wrong at one end of it.
+      NOT a production for yaml frontmatter. A boolean attribute is the
+      opposite case -- the grammar has a production for exactly this shape.
+      `{kbd=""}` says the value is an empty STRING, where the tree says the
+      attribute has no value at all.
 
       A COMPACT SEMANTIC SPAN IS WHERE IT SHOWS. `[Tab]{kbd}` is the form PART
-      9 §10 documents and the form an author writes; a writer that returned
-      `[Tab]{kbd=""}` rewrote the documentation's own example into a shape the
-      documentation never shows, and did it for a name whose VALUE is discarded
-      (§10: values on `samp`, `var`, `kbd` and `cite` only
-      select the wrapper). An empty value there is not just longer, it points
-      at a slot that does nothing.
+      9 §10 documents and the form an author writes, and it is a name whose
+      VALUE is discarded. An empty value there points at a slot that does
+      nothing.
 
    6d. A CODE FENCE OPENER IS WRITTEN GLUED TO ITS INFO STRING -- NORMATIVE.
       The canonical writer emits NO padding space between the fence run and
@@ -9311,25 +7772,13 @@ EOF = (* end of file *) ;
       spelling canonical in as many words and records that it is what the
       X->Carve converters emit; the READER is lenient and takes either, which
       is a leniency and not a writer's license (§6b makes the same
-      distinction one construct over). This clause is the writer half of that
-      sentence, which nothing stated.
+      distinction one construct over).
 
       THE TREE RECORDS NO SLOT, which is why the writer has to be told. §6
       leaves a spelling to the author BECAUSE THE AST RECORDS IT, and
       `code_block` records the padding slot no more than it records the fence
       length or the fence character (PART 12 §3) -- so the writer has nothing
-      to reproduce and must CHOOSE, exactly as §6b and §6c must. Left
-      unchosen, it was chosen twice: carve-js and carve-php normalize to the
-      glued form, carve-rs to the spaced one (carve#1219).
-
-      NOTHING PINNED IT, and the reason is the one this project keeps
-      rediscovering. The fmt corpus held no document whose canonical form
-      contains an info string at all -- twenty-nine `.fmt` fixtures, and the
-      two carrying a code fence carry a BARE one. So the three writers met
-      only on the shape the corpus pins and drifted on the shape it does not,
-      and the drift was invisible to every gate: the HTML is identical, §1's
-      round trip holds for either spelling, and `compare:impls` had no
-      expected bytes to adjudicate between them. A corpus case pins it now.
+      to reproduce and must CHOOSE, exactly as §6b and §6c must.
 
    6e. A TABLE CELL'S CONTENT IS PADDED -- NORMATIVE.
       The canonical writer emits every cell as its PREFIX glued to the opening
@@ -9354,16 +7803,8 @@ EOF = (* end of file *) ;
       THE TREE RECORDS NO SLOT, the same reason §6d gives: `table_cell` records
       its padding no more than `code_block` records the space before its info
       string (PART 12 §3), so the writer has nothing to reproduce and must
-      CHOOSE. Left unchosen it was chosen twice -- carve-js and carve-rs glued
-      a prefixed cell, carve-php glued it except when the cell carried
-      attributes, and carve-php padded those.
+      CHOOSE.
 
-      THE FIXTURES MOVE IN TWO STEPS, as §6d's did. `284-a-ragged-table-keeps-
-      each-row-s-cell-count-2`, `-3` and `285-adjacent-block-openers-in-an-
-      attached-run-stay-separate-2` spell the old form; they are WITHDRAWN with
-      this clause and come back with the engine pin bump, because a fixture
-      carrying the new bytes fails in every engine that has not shipped the
-      clause yet and one carrying the old bytes fails in every engine that has.
 
    6f. PADDING IS NOT AN ESCAPE WHERE THE PRODUCTION ADMITS PADDING --
       NORMATIVE (carve#1601). §6e retires the writer's `<`/`>`/`~`/`{` guards
@@ -9385,9 +7826,7 @@ EOF = (* end of file *) ;
       wherever omitting the escape would make the cell re-read as something
       other than content, which is §2 run over the CELL rather than over the
       line. Naming `^` and `<` here would be an enumeration that goes stale the
-      next time a cell-level marker is added, and §6e's own history is what
-      that costs: each writer answered the alignment-sigil class with its own
-      slightly different list of characters.
+      next time a cell-level marker is added.
 
    7. NO WHITESPACE-ONLY LINE -- NORMATIVE. `fmt` never emits a line whose only
       content is ASCII spaces or tabs. Such a line is emitted EMPTY.
@@ -9412,20 +7851,16 @@ EOF = (* end of file *) ;
 
       The case this decides is a blank line INSIDE a list item, where the item's
       continuation is indented. Indenting the blank line to the content column
-      keeps the block structure visible in the source, and carve-rs and
-      carve-php did that; carve-js emitted an empty line (carve#375).
+      would keep the block structure visible in the source; the empty line wins
+      anyway.
 
       The empty line is required. A whitespace-only line is not stable: editors
       that strip trailing whitespace on save, `git apply --whitespace=fix`, and
       CI whitespace checks all rewrite it, so a formatter emitting one produces
-      output that ordinary tooling changes behind it -- and `fmt` then reports a
-      diff on a file nobody edited. A formatter whose output cannot survive the
-      tools it will be stored under is not idempotent in practice, whatever §1
-      says about it in isolation.
+      output that ordinary tooling changes behind it, and is not idempotent in
+      practice whatever §1 says about it in isolation.
 
-      AND IT DOES EXTEND to whitespace at the end of a line that HAS content,
-      which is a correction: this text said the opposite twice, and both times
-      it was measurably false.
+      AND IT DOES EXTEND to whitespace at the end of a line that HAS content.
 
         `a` + SPACE + newline + `b`   renders  `<p>a\nb</p>`
         `a` + newline + `b`           renders  `<p>a\nb</p>`
@@ -9433,18 +7868,12 @@ EOF = (* end of file *) ;
       The two are the same document. PART 2's NO TRAILING WHITESPACE clause
       drops the run on EVERY content line, including one before a soft break,
       so a writer that strips it changes nothing about
-      `to_html(fmt(x)) == to_html(x)` -- and the rule this clause already ends
-      with, "where the PARSER discards trailing whitespace the writer may too",
-      now reaches every line rather than only the ones that end a block.
+      `to_html(fmt(x)) == to_html(x)`.
 
       A trailing NO-BREAK space is a different matter and IS content, not
       layout -- the author wrote it and it renders as `&nbsp;` -- so an
       implementation whose whitespace test treats U+00A0 as whitespace must
-      exclude it here. That is the same two-character `whitespace` terminal
-      PART 2's clause names, and it is why the rule is simple rather than a
-      list of exceptions. Corpus case 141-trailing-whitespace-boundaries-4 pins
-      it (this text said case 139, which has been an inline-literal category
-      for some time).
+      exclude it here.
 
       THE SAME LINE DECIDES WHAT AN IMPORT KEEPS -- NORMATIVE (carve#1628).
       An HTML importer meeting a BLOCK ELEMENT whose text content is entirely
@@ -9474,15 +7903,10 @@ EOF = (* end of file *) ;
       THE DROP IS REPORTED because it is a real loss: an element the input had
       contributes nothing, which is `element-dropped` and needs no new code.
       KEEPING owes nothing and reports nothing, since a kept character survives
-      the write intact. That asymmetry is what decides the two rows against
-      each other where taste would not: `parse(htmlToCarve(h)) == htmlToAst(h)`
-      holds on the first row with no special case, and holds on the second only
-      because the node was never built.
+      the write intact. `parse(htmlToCarve(h)) == htmlToAst(h)` holds on the
+      first row with no special case, and holds on the second only because the
+      node was never built.
 
-      THE SPACER ARGUMENT IS REAL AND IS NOT THIS RULE. Word, CKEditor and
-      TinyMCE emit `<p>&nbsp;</p>` as layout, so a migration may well want it
-      gone -- but that is an OPT-IN on the importer, not a silent default that
-      discards content the language can spell.
 
    7a. AN EMPTY CONTAINER BODY IS A BLANK LINE HERE TOO -- NORMATIVE. A COLON
       FENCE whose body is empty is written with a BLANK LINE between its
@@ -9507,28 +7931,15 @@ EOF = (* end of file *) ;
       THE SIBLING CLAUSE ALREADY DECIDED THIS QUESTION one layer out and chose
       the blank line. PART 10 §4 asks what a container whose body renders
       nothing serializes to, and this asks the same of the same document at
-      the other target. Nothing about the emptiness differs between them, so
-      answering it twice with two answers would be a difference the document
-      cannot account for -- and one rule for "an empty body" across both
-      targets is one rule to maintain.
+      the other target, so one rule for "an empty body" serves both.
 
-      THE EXCEPTION IS NOT IMPORTED WITH IT, and §4 is where the reason is
-      written. §4 says of its bare-div exception, in its own words, that it
-      "has no principle behind it", that the split is on "a property of the
-      RENDERING PATH and not of the document", and that a uniform rule "would
-      be easier to state and to implement". What carries the exception there
-      is none of those: it is that overturning a settled three-way agreement
-      to fix a cosmetic inconsistency is the worse trade. That is a reason
-      about the state of §4's own target, and a reason of that shape does not
-      travel to a target it was never about. What is left of §4 once it is set
-      aside is the uniform rule §4 itself prefers, and that is what this clause
-      takes.
-
-      SO THE TWO TARGETS AGREE ON THE RULE AND DIFFER ON ONE SHAPE, which is
-      stated rather than smoothed over: a bare `:::` div closes compactly in
-      HTML and takes the blank line here. That is the cost of §4 keeping an
-      exception it calls principle-free, and it is confined to the one shape
-      §4 names.
+      THE EXCEPTION IS NOT IMPORTED WITH IT. §4 says of its bare-div exception,
+      in its own words, that it "has no principle behind it" and that the split
+      is on "a property of the RENDERING PATH and not of the document". What
+      carries the exception there does not travel to a target it was never
+      about, so this clause takes the uniform rule §4 itself prefers. The two
+      targets therefore agree on the rule and differ on one shape: a bare `:::`
+      div closes compactly in HTML and takes the blank line here.
 
    7b. A FOOTNOTE DEFINITION WITH NO BLOCKS IS WRITTEN WITH THE SENTINEL
       `{empty}` -- NORMATIVE. A `footnote_definition` whose body holds NO
@@ -9546,11 +7957,8 @@ EOF = (* end of file *) ;
       §1a IS THE RULE THIS SERVES. Spelling the construct by its own rule
       emits bytes that do not re-parse to the tree they were written from, so
       §1 wins and the writer takes the smallest departure that restores it.
-      THE PARSE RULE IS UNCHANGED HERE: `[^f]:` stays a paragraph, as corpus
-      267-a-definition-marker-s-separator-is-a-space-and-it-is-a-run-9 and
-      corpus 134-footnote-definition-requires-an-inline-body pin it. What this
-      clause governs is what the WRITER emits, which is the half that was
-      defective in two engines (carve#999).
+      THE PARSE RULE IS UNCHANGED HERE: `[^f]:` stays a paragraph. What this
+      clause governs is what the WRITER emits.
 
       THE SENTINEL MUST BE A VALID ATTRIBUTE BLOCK, and this is the part a
       later reader gets wrong, because the two spellings that LOOK like the
@@ -9564,10 +7972,8 @@ EOF = (* end of file *) ;
       `block_attributes` requires AT LEAST ONE attribute and there is no
       block-level blessed-empty form -- PART 4 says it of `{}` in as many
       words, and `{ }` is blessed INLINE only -- so on this line neither run
-      is an attribute block. Both stay CONTENT, the body then holds a text
-      node the author never wrote, and §1 fails exactly as it does for the
-      bare marker: a different shape, the same defect. Measured in all three
-      engines rather than derived.
+      is an attribute block. Both stay CONTENT, and §1 fails exactly as it does
+      for the bare marker.
 
       SO EVERY AVAILABLE SPELLING CARRIES MEANING. `{empty}` is a BOOLEAN
       ATTRIBUTE (PART 9 §14): a bare identifier with no value, rendered
@@ -9576,10 +7982,8 @@ EOF = (* end of file *) ;
       because a footnote definition's body is its own container, and a
       block-attribute line with no following block inside that container is
       dropped (PART 9 §15 A4) -- the attribute reaches neither the endnote
-      `<li>`, nor the next block, nor the next definition. That is a PARSE
-      RULE and not a property of the word: nothing about `empty` is
-      semantically empty, and it is stated here so the inertness does not
-      read as accidental.
+      `<li>`, nor the next block, nor the next definition. That is a PARSE RULE
+      and not a property of the word.
 
    7c. A LINE BLOCK'S HARD BREAK IS WRITTEN BARE ONLY WHERE THE BARE NEWLINE
       RE-DERIVES IT -- NORMATIVE. A line block hardens every line boundary of
@@ -9589,8 +7993,8 @@ EOF = (* end of file *) ;
       form. The depth half is load-bearing and not decoration: a reading under
       which a boundary inside an emphasis run stays soft takes the permission's
       own premise away, and this writer rule then LOSES the break on `*a\` over
-      `b*` while claiming §1 preservation - which is what the pinned build does
-      today (carve#1351). The permission is not general, and it is stated as
+      `b*` while claiming §1 preservation (carve#1351). The permission is not
+      general, and it is stated as
       the PROPERTY it rests on rather than as a list of the places it runs out:
 
         THE WRITER SPELLS A `hard_break` INSIDE A LINE BLOCK AS A BARE
@@ -9613,8 +8017,7 @@ EOF = (* end of file *) ;
 
       WHAT THE PROPERTY EXCLUDES -- CONSEQUENCES, NOT THE RULE. A case that is
       not in this list is decided by the property above, not by the absence of
-      a bullet. This clause was first written as a list of the two unsafe
-      cases, and the first entry below is the one it did not reach:
+      a bullet:
 
         - THE LAST BODY LINE, WHATEVER IT ENDS IN. §23 hardens the boundary
           BETWEEN lines, and the body's end is not one. So a `hard_break`
@@ -9632,11 +8035,10 @@ EOF = (* end of file *) ;
           GAPS) and survives on its own, so it needs no backslash INSIDE a
           stanza -- at the stanza's end the entry above governs it instead.
 
-      Every condition is visible in the tree with NO new field, so this costs
-      no AST change: the first is a `hard_break` that is the last node of the
-      stanza's own inline sequence, the second is two adjacent `hard_break`
-      nodes with no text between them, the third is a text node whose value
-      ends in one space.
+      Every condition is visible in the tree with NO new field: the first is a
+      `hard_break` that is the last node of the stanza's own inline sequence,
+      the second is two adjacent `hard_break` nodes with no text between them,
+      the third is a text node whose value ends in one space.
 
       A LINE WHOSE LAST NODE IS A COMMENT IS EXEMPT -- NORMATIVE. `%%` runs to
       the END OF ITS LINE, so a trailing space there is INSIDE the note and
@@ -9653,9 +8055,6 @@ EOF = (* end of file *) ;
       same exemption reaching the first consequence. A body line whose content
       ends in an `inline_comment` carries NO `hard_break` at the body's end,
       so THE LAST BODY LINE has nothing to spell there and nothing is written.
-      A writer that instead appends `\` to whatever it emitted last on the
-      final line writes it inside the note by the same mechanism, on a line
-      where there was no break to protect in the first place.
 
       WHICH LINE IS LAST IS DECIDED BY THE BREAKS, HOWEVER THEY WERE SPELLED.
       A `hard_break` ENDS the body line it stands at the end of, and what
@@ -9669,10 +8068,7 @@ EOF = (* end of file *) ;
 
       the last body line is the COMMENT, not `a `, so the backslash on `a ` is
       there under CONTENT ENDING IN A LONE SPACE and not under THE LAST BODY
-      LINE, and the comment is written back as its own line below it. A writer
-      that treats a boundary the AUTHOR spelled as the end of the body answers
-      one document two ways depending on which spelling reached it: the same
-      note is kept under `a` and dropped under `a \`.
+      LINE, and the comment is written back as its own line below it.
 
       AN EMPTY LINE INSIDE A VERBATIM RUN IS SPELLED `%%`, because there the
       backslash is not a break but content. A run left unclosed on an earlier
@@ -9683,18 +8079,14 @@ EOF = (* end of file *) ;
       exactly ONE spelling that does not: a comment line, which the block
       layer removes before the run exists, so `%%` re-reads to the empty line
       it was written for and to nothing else. The author's own comment TEXT is
-      not recoverable here and is not required to be: the run consumed it, and
-      §1 is about the tree.
+      not recoverable here and is not required to be.
 
       THIS IS §1a, NOT AN EXEMPTION FROM IT. The per-construct spelling emits
       bytes that do not re-parse to the tree they were written from, so §1
       wins and the spelling yields to "another spelling of the SAME
-      construct", which for a `hard_break` is its own PART 3 form. Measured on
-      all three engines, the bare newline destroyed a rendered space, split
-      one stanza into two, and dropped a trailing `<br>` from a block's last
-      line, with the three engines settling on three different canonical
-      byte strings for the first of them (carve#1334). The sibling writers
-      already do this: a paragraph and a `::: \` block both emit the backslash.
+      construct", which for a `hard_break` is its own PART 3 form: unguarded,
+      the bare newline destroys a rendered space, splits one stanza into two,
+      and drops a trailing `<br>` from a block's last line.
 
    7d. AN EMPTY DESCRIPTION BODY IS WRITTEN WITH THE SENTINEL `{empty}` --
       NORMATIVE (carve#1827). A `definition_description` whose body holds NO
@@ -9728,20 +8120,16 @@ EOF = (* end of file *) ;
         : %%        holds a `comment` child                      -- not written
 
       `: +` IS THE FIRST-BLOCK FORM (PART 9 §17 L4) with nothing flush-left
-      under it. It ATTACHES a following column-0 block -- `:: t` / `: +` /
-      `flush` is a description whose body is `flush` -- so it spells an empty
+      under it. It ATTACHES a following column-0 block, so it spells an empty
       body only when a blank line follows, and a writer emitting it must look
       ahead at the next block to know whether that blank line is required. The
-      sentinel needs no lookahead, and a rule that cannot be got wrong is
-      preferred to one that must be got right.
+      sentinel needs no lookahead.
 
       `: %%` FAILS §1 RATHER THAN LAYOUT. An empty comment renders nothing and
       the rendered HTML matches, so the failure is not visible at the HTML. Its
       `definition_description` carries a `comment` CHILD the source does not
-      have, where the canonical spelling carries an empty children list. PART
-      10's import ceiling forbids that in its own words -- an importer "may add
-      nothing at all" -- and §1 quantifies over `parse`, not over the render, so
-      a spelling that round-trips the HTML and not the TREE does not satisfy it.
+      have, where the canonical spelling carries an empty children list, and §1
+      quantifies over `parse`, not over the render.
 
    8. THE MARKDOWN TARGET'S ESCAPING -- NORMATIVE. The Markdown renderer is not
       the canonical writer and does not follow §2. It has a different
@@ -9759,11 +8147,8 @@ EOF = (* end of file *) ;
       typographer, pandoc's default) would NOT read an en dash. Emitting `--`
       bare loses the author's intent exactly where it was explicit, and the
       characters this matters for -- `"` `'` `-` `.` -- are not Markdown
-      metacharacters, so M1 does not cover them. This was divergent across
-      implementations with nothing to notice it (carve#350).
-
-      A document that escapes nothing gains no backslashes from M2, so the
-      cost falls only on documents that asked for it.
+      metacharacters, so M1 does not cover them (carve#350). A document that
+      escapes nothing gains no backslashes from M2.
 
       An implementation whose AST has no `escaped_text` node cannot honour M2:
       it cannot tell an escaped character from a literal one. That is a defect
@@ -9802,19 +8187,11 @@ EOF = (* end of file *) ;
           THE HAZARD IS RAW HTML, and it is real. CommonMark and GFM both admit
           it, so a document whose text contains `<b>` emits a line a reader
           turns into a tag -- the author's text silently becomes markup, which
-          is the corruption §8 exists to prevent. Measured through a CommonMark
-          reader:
-
-            a <b> c        ->  a <b> c          the tag opens
-            a </b> c       ->  a </b> c         so does a closing one
-            a <!-- c -->   ->  a <!-- c -->     and a comment
-            a <?php ?>     ->  a <?php ?>       and a processing instruction
-
-          Those four next-characters are the whole hazard. Everything else is
-          inert:
-
-            a < b          ->  a &lt; b         a bare `<` is not markup
-            x > y          ->  x &gt; y         nor is a mid-line `>`
+          is the corruption §8 exists to prevent. An opening tag, a closing
+          tag, a comment and a processing instruction all open through a
+          CommonMark reader; those four next-characters are the whole hazard.
+          Everything else is inert: a bare `<` before a space renders `&lt;`,
+          and so does a mid-line `>`.
 
           ESCAPING THE `<` ALONE IS SUFFICIENT. The closing `>` needs no escape
           of its own, because a tag that cannot open cannot be closed:
@@ -9822,88 +8199,55 @@ EOF = (* end of file *) ;
             a \<b> c       ->  a &lt;b&gt; c
 
           A BACKSLASH, NOT AN ENTITY. Every engine wrote `&lt;` and `&gt;` here
-          and no clause said so (carve#1148). The reason it could not be derived
-          from this section is that it is not the operation this section
-          describes: M2 and M3 are written in terms of ESCAPING -- protecting a
-          character so it survives as itself -- and `&lt;` does not protect `<`,
-          it replaces it with a different sequence that happens to render
-          alike. `\<` protects it, and a CommonMark reader gives the character
-          back.
+          and no clause said so (carve#1148). M2 and M3 are written in terms of
+          ESCAPING -- protecting a character so it survives as itself -- and
+          `&lt;` does not protect `<`, it replaces it with a different sequence
+          that happens to render alike. `\<` protects it, and a CommonMark
+          reader gives the character back.
 
           CONDITIONAL, BECAUSE M1b ALREADY ARGUES FOR IT. `<` is the same shape
           as `_`, `#` and `[`: significant before a tag name, inert before a
-          space. Rewriting every `<` in a document -- the overwhelming majority
-          of them harmless -- is the character-table answer M1b abandoned, and
-          the test belongs on the emitted line like every other one here.
+          space, and the test belongs on the emitted line like every other one
+          here.
 
       THE FINDING IS §3'S, ONE TARGET OUT. §3 records, for the canonical
       writer, that "whether a character is significant depends on the line,
-      not on the character", and §4 is that section's answer to it. M1 was the
-      opposite choice, and a deliberate one: §2's test is answered by the
-      Carve parser, this target has no Markdown parser to hand, and a
-      character table was what remained. But §3's finding is about lines and
-      characters, not about which writer is asking. The Markdown writer builds
-      a line too, and what stands on that line is what decides whether a bare
-      metacharacter is read as markup downstream. So the test here is stated
-      over the EMITTED LINE, as §3 says it has to be, and M1b is this
-      section's §4.
+      not on the character". M1 was the opposite choice, taken because this
+      target has no Markdown parser to hand. But the Markdown writer builds a
+      line too, so the test here is stated over the EMITTED LINE and M1b is
+      this section's §4.
 
       THE ASTERISK DIFFERS IN KIND, NOT IN DEGREE, which is what M1a is for.
-      This writer emits `*` as an emphasis delimiter. So the asterisk is not a
+      This writer emits `*` as an emphasis delimiter, so the asterisk is not a
       character that MIGHT meet markup on the line; it is the character the
-      line's markup is made of, and a collision with it is the ordinary case
-      rather than the corner one.
+      line's markup is made of, and a collision with it is the ordinary case.
 
       A document whose emphasis contains two literal asterisks is written
-      under M1 as
-
-        *\*\**
-
-      A narrowing that weighs the delimiter runs in the block sees one
-      four-character run flanking nothing, and drops both escapes:
-
-        ****
-
-      Through a CommonMark reader those are not two spellings of one
-      document:
+      under M1 as `*\*\**`. A narrowing that weighs the delimiter runs in the
+      block sees one four-character run flanking nothing and drops both
+      escapes, giving `****` -- and through a CommonMark reader those are not
+      two spellings of one document:
 
         *\*\**  ->  <p><em>**</em></p>
         ****    ->  <hr />
 
-      Emphasis containing two asterisks is published as a thematic break. The
-      run being weighed was partly the writer's OWN delimiters, which the
-      escaped literals had merged into, and nothing about the character said
-      so. That is a property of this target's output read by this target's
-      consumers, so it holds for any implementation that narrows the asterisk,
-      whichever one writes it first (carve#970).
-
-      M1b would hold this document on its own terms -- both literals are
-      adjacent to a delimiter the writer wrote. M1a is stated anyway, and it
-      is PERMANENT rather than a fix deferred: for `*` the adjacency is not an
-      accident of one document but the shape of the target, and a condition
-      that holds for every document of a construct is better spelled as an
-      exemption than rediscovered per document. It lapses only if this writer
-      stops spelling emphasis with `*`.
+      The run being weighed was partly the writer's OWN delimiters, which the
+      escaped literals had merged into. M1b would hold this document on its own
+      terms, but M1a is stated anyway and is PERMANENT: for `*` the adjacency is
+      the shape of the target rather than an accident of one document.
 
       WHY ADJACENCY IS THE TEST THAT OWES NO PER-READER ARGUMENT. This target
       answers to a re-parser Carve does not control, and there are several of
-      them -- CommonMark, GFM, markdown-it with typographer, pandoc. That is
-      why M1 was blunt, and the reason does not go away: an escape that
-      protects nothing under one of them may protect something under another,
-      so dropping one is an argument owed once per reader. The adjacency case
-      owes none. Every one of those readers resolves a delimiter by RUN
-      LENGTH, so an escape sitting next to a live delimiter of the same
-      character is holding a run boundary apart under all of them at once.
-      M1b keeps exactly those escapes, and that is why the minimum is stated
-      at this width and not another.
+      them, so an escape dropped is an argument owed once per reader. The
+      adjacency case owes none: every one of those readers resolves a delimiter
+      by RUN LENGTH, so an escape sitting next to a live delimiter of the same
+      character holds a run boundary apart under all of them at once.
 
       THE BOUNDARY IS THE CLAUSE, NOT A FLOOR. M1b is written as an
       if-and-only-if on purpose. An escape it drops is dropped and an escape
       it keeps is kept; it is not a minimum an implementation may build a
       wider narrowing on top of, and it is not a permission one engine may
-      take up before another. Three engines implement this clause, and a
-      permissive reading of it yields three outputs -- which is the failure
-      this question came out of, not a latitude worth preserving.
+      take up before another.
 
       SO A WIDER NARROWING IS NOT AUTHORIZED HERE. Not for a fourth
       character, and not for a laxer test on these three. Anything further has
@@ -9919,9 +8263,8 @@ EOF = (* end of file *) ;
       it AS AN ESCAPE whatever the character, untouched by anything above. So
       a document that MEANT `[a](b)` as text carries the author's escapes in
       the tree and gets them back on this target under M2, and M1b never sees
-      it. That does not make the two grammars agree and is not claimed to; it
-      takes out of the question every case where the author said which reading
-      they meant, which is where guessing wrong costs the most.
+      it. That does not make the two grammars agree; it takes out of the
+      question every case where the author said which reading they meant.
 
    ============================================================================ *)
 (* ============================================================================
@@ -9947,10 +8290,6 @@ EOF = (* end of file *) ;
       M2c NOTHING ELSE NARROWS. M1, M3 and §8a are untouched, and a character
           Markdown reads as markup at that position keeps M2 as written.
 
-      WHAT M2 IS FOR SURVIVES INTACT. §8 states M2 for smart punctuation, and
-      that part is load-bearing at every position. Measured through a reader
-      with substitution on:
-
         a -- b        ->  a – b
         a \-\- b      ->  a -- b
 
@@ -9958,84 +8297,22 @@ EOF = (* end of file *) ;
       reached them and M1's narrowing cannot either. M2a names them so the
       clause that narrows M2 cannot be read as dropping the reason M2 exists.
 
-      THE COST IS ON IDENTIFIERS, AND IT IS THE COST §8a WAS RAISED OVER.
-      carve#970 opened with two examples:
-
-        C\# is a language
-        issue \#123 fixed
-
-      Both are `escaped_text`. In Carve a bare `#` before a word opens a tag,
-      so text holding one can only be spelled as an escape, so neither example
-      was ever an M1 case and §8a's narrowing did not reach the documents that
-      raised it. A backslash inside an identifier breaks exact-match search on
-      the published document, which is the objection §2 calls decisive for the
-      canonical writer: "Escaping MORE than that is a defect, not a safe
-      default."
-
-      THE TARGET ALREADY DISCARDS THE DISTINCTION THE ESCAPE WAS PRESERVING.
-      Markdown has no construct for a tag or a mention, so this target emits
-      the characters and drops the node:
-
-        #tag rest        ->  #tag rest
-        hi @name ok      ->  hi @name ok
-
-      So under M2 as written this target emits a bare `#` for the construct
-      and a backslashed one for text that merely resembles it. No reader acts
-      on that difference, and the document carrying the backslash is the one
-      that never asked for markup.
-
       THE `[` CASE §8a LEANS ON IS UNTOUCHED, and M2a is written positionally
-      so that it is. §8a's account of the link grammars ends by resting on M2:
-      an author who meant `[a](b)` as text carries escapes in the tree and
-      gets them back here, so M1b never has to guess. A `[` can open a link at
-      any position on a line, so M2a keeps its escape everywhere and that
-      argument stands unchanged. `#` is the character that differs, because
+      so that it is. A `[` can open a link at any position on a line, so M2a
+      keeps its escape everywhere. `#` is the character that differs, because
       its reading is positional and every position but one is inert.
 
       A CONTAINER PREFIX IS PART OF THE LINE, WHICH IS WHY M2b MEASURES ON IT.
       M2b's position is the ONLY narrowing in this clause -- M2a keeps the
-      escape by default and M2c closes the set -- so the whole of §8b turns on
-      where that position is. Read as an offset into the BLOCK'S CONTENT it
-      answers a question no reader asks: the string a reader parses is the
-      emitted line, and the two differ by exactly the prefix the writer put in
-      front. Measured on all three engines, which agreed:
+      escape by default and M2c closes the set. Read as an offset into the
+      BLOCK'S CONTENT it answers a question no reader asks: the string a reader
+      parses is the emitted line, and the two differ by exactly the prefix the
+      writer put in front. §10 already decided this one character over, escaping
+      a continuation line whose text reads as a list marker only because item
+      alignment stands in front of it -- "§2 governs whether a character is
+      escaped GIVEN the line the writer emits; §10 fixes the line."
 
-        > \# heading
-
-      emitted as
-
-        > # heading
-
-      and read back, through this project's own importer, as a heading:
-
-        before:  <blockquote><p># heading</p></blockquote>
-        after:   <blockquote><h1 id="heading">heading</h1></blockquote>
-
-      The author escaped the hash so it would stay text, and a round trip
-      returned it as structure. That is content corruption rather than a
-      rendering difference, and it is the case M2 exists to remove: §8a's
-      closing argument rests on M2 taking "out of the question every case
-      where the author said which reading they meant" (carve#1330).
-
-      §10 ALREADY DECIDED THIS, ONE CHARACTER OVER. A list item's continuation
-      line is aligned to the marker's width and kept literal by ESCAPING it:
-
-        1. outer
-           1\. inner
-
-      The inner line's text is `1. inner`, which is a list marker nowhere in
-      isolation. It is one only because three spaces of item alignment stand
-      in front of it, and §10 escapes it for that reason -- "§2 governs
-      whether a character is escaped GIVEN the line the writer emits; §10
-      fixes the line." So this project has already ruled that the escape test
-      is answered against the line as the reader receives it, and has already
-      rejected the alternative that reasons about the content alone: §10
-      refuses to indent less "because its correctness depends on the WIDTH of
-      the marker above it". The reading that produced this defect carries the
-      same dependency and does not notice it.
-
-      STATED OVER THE LINE, NOT AS A LIST OF CONTAINERS THAT COUNT. Two
-      consequences, both measured on all three engines:
+      STATED OVER THE LINE, NOT AS A LIST OF CONTAINERS THAT COUNT:
 
       - A container this target FLATTENS contributes no prefix and needs no
         exemption. A colon fence emits no marker and a definition-list body
@@ -10046,81 +8323,32 @@ EOF = (* end of file *) ;
         without naming any of them.
 
       An enumeration would have to be revisited every time the writer gains a
-      prefix. The line does not.
-
-      THE LAZY CASE IS NOT A CASE. Lazy continuation is a PARSER concept: a
-      line belonging to a container without carrying its marker. This writer
-      re-prefixes every line of the container, so M2b always sees the emitted
-      prefix. A rule for source laziness would describe a line this target
-      never writes.
+      prefix. The line does not. Lazy continuation is not a case either: it is
+      a PARSER concept, and this writer re-prefixes every line of the
+      container, so M2b always sees the emitted prefix.
 
       NARROWING BY POSITION IS UNCHANGED, WHICH IS THE HALF THAT IS EASY TO
       LOSE. Moving the position does not widen M2b into "an escape behind a
-      prefix is kept". The two documents carve#970 opened with keep their
-      narrowing inside a container exactly as they had it outside one, because
-      the hash is not at the content position there either:
+      prefix is kept". The narrowing holds inside a container exactly as it
+      does outside one, and so does a hash that stands AT the content position
+      but opens no heading, since M2b's reading is CommonMark's and a run
+      closed by a letter is not one:
 
         > C\# is a language      ->  > C# is a language
         - issue \#123 fixed      ->  - issue #123 fixed
-
-      and so does a hash that stands AT the content position but opens no
-      heading, since M2b's reading is CommonMark's and a run closed by a
-      letter is not one:
-
         > \#tag rest             ->  > #tag rest
-
-      Both directions are pinned in the corpus. The first is what the clause
-      is for; the second is what stops the correction being taken too far.
-
-      WHAT IS LOST IS BOUNDED BY §1. Carve source through this target and back
-      stops recording which hash was text. §1 already defines the round-trip
-      invariant MODULO ESCAPING (carve#370) -- `escaped_text` and `text`
-      compare equal -- and the invariants that admit no latitude,
-      `to_html(fmt(x)) == to_html(x)` and idempotence, are inside the Carve
-      target, which this clause does not touch.
-
-      The importers re-derive what they need, which is why the backslash in
-      the Markdown was not what carried it:
-
-        md-in: Bau #64748b       ->  carve: Bau \#64748b
-        md-in: C# is a language  ->  carve: C# is a language
-
-      The escape comes back where a construct would form and stays absent
-      where none would. The loss is also already taken in the other direction:
-      a tag node does not survive a round trip through this target today,
-      since the writer flattens it and an importer escapes it back to text.
-      This clause makes the two directions agree rather than adding an
-      asymmetry.
-
-      A KNOWN LIMIT, STATED RATHER THAN SOLVED. GFM as deployed on one host
-      autolinks a bare `#` before digits to an issue, and a bare `@` before a
-      name to a user. That exposure is not created here: this target emits
-      both bare today whenever the document holds the construct, and M2's
-      escape covered only the half of the traffic that was text. If it matters
-      it wants a host-aware profile covering both halves, not an
-      unconditional escape covering one.
 
    9. THE MARKDOWN TARGET'S HARD BREAK -- NORMATIVE. A `hard_break` is emitted
       as a BACKSLASH before the newline, never as two trailing spaces.
 
-      Both spellings mean the same thing to a CommonMark reader:
-
-        `a` SPACE SPACE newline `b`   ->  <p>a<br />b</p>
-        `a` BACKSLASH newline `b`     ->  <p>a<br />b</p>
-
-      The difference is what survives handling. Trailing whitespace is removed by
-      editors that strip it on save, by `git apply --whitespace=fix`, and by CI
-      whitespace checks -- and removing ONE of the two spaces is enough:
-
-        `a` SPACE newline `b`         ->  <p>a b</p>
-
-      so the break does not degrade, it VANISHES, silently, in a file nobody
-      edited. The backslash form cannot be damaged that way, and it is the only
-      hard-break spelling this target emits that ordinary tooling will not touch.
-
-      The cost is pre-CommonMark processors, which show a literal backslash
-      instead of a break. That is a visible artifact in a rare consumer, against
-      silent data loss in a common one.
+      Both spellings mean the same thing to a CommonMark reader. The difference
+      is what survives handling: trailing whitespace is removed by editors that
+      strip it on save, by `git apply --whitespace=fix`, and by CI whitespace
+      checks -- and removing ONE of the two spaces is enough, so the break does
+      not degrade, it VANISHES, silently, in a file nobody edited. The cost is
+      pre-CommonMark processors, which show a literal backslash instead of a
+      break: a visible artifact in a rare consumer, against silent data loss in
+      a common one.
 
       This is a property of the MARKDOWN target only. The canonical writer spells
       a hard break the way the Carve grammar does (`hard_break`, PART 3), and
@@ -10134,14 +8362,6 @@ EOF = (* end of file *) ;
         1. outer
            1\. inner
 
-      The alternative -- leaving the line at an indent below the nesting
-      threshold so no escape is needed -- looks appealing because it removes an
-      escape the author did not write. It is rejected because its correctness
-      depends on the WIDTH of the marker above it. Two spaces sit below the
-      threshold under `1. ` and reach it under `- `, so the same rule produces
-      a continuation in one list and a nested list in the other, silently
-      changing what the document says (carve#352).
-
       This does not conflict with §2. §2 governs whether a character is escaped
       GIVEN the line the writer emits; §10 fixes the line. A writer may not
       manufacture a layout whose only merit is dodging an escape.
@@ -10152,54 +8372,26 @@ EOF = (* end of file *) ;
       it, because HTML has nowhere to put a definition nobody used; the other
       three do not get to drop content the author wrote.
 
-      A LINK REFERENCE DEFINITION IS NOW COVERED TOO. It was excluded while it
-      was the one definition kind with NO NODE IN THE TREE -- `[lbl]: /u` alone
-      parsed to a document with empty `children`, so a renderer walking blocks
-      had nothing to walk and requiring the output would have required an output
-      no engine could produce (carve#592). PART 12 §10 gives it a node, so the
-      exclusion has no cause left: all three kinds walk, and all three emit.
-
-      This clause first said "link, footnote or abbreviation" and was wrong to.
-      PART 12 §3a had already considered the missing node and declined it --
-      "a bigger change than this clause is worth ... a new node type, a new
-      hoisting rule, three engines to move" -- so one section was requiring
-      what another section's recorded decision made unreachable. Narrowed here
-      rather than left contradictory: a spec that demands the impossible is
-      worse than one that admits a gap.
+      A LINK REFERENCE DEFINITION IS COVERED TOO. It was excluded while it was
+      the one definition kind with NO NODE IN THE TREE; PART 12 §10 gives it a
+      node, so all three kinds walk and all three emit.
 
       THE GAP IS REAL AND IS NOT CLOSED BY NARROWING. An unused link reference
       definition currently survives nothing: not the tree, not a round trip
       through the AST, and now explicitly not the non-HTML targets. So
       `carve --markdown` on a document that is only `[lbl]: /u` emits nothing,
-      and the URL the author wrote is gone. That is the same content loss §10a
+      and the URL the author wrote is gone -- the same content loss §10a
       exists to prevent, reached by a different route.
-
-      SETTLED IN PART 12 §10. The node was open on two grounds here -- making a
-      resolved reference's destination recoverable (§3a), and making an unused
-      one survive at all (this clause) -- and a third decided it: without the
-      node a writer cannot reproduce the definition, so PART 11 §1's
-      `parse(fmt(x)) == parse(x)` failed for every resolved reference in all
-      three engines (carve#642).
 
           [^n]: %         ->  markdown  [^n]: %
                               plain     [^n]: %
                               html      (nothing)
 
-      This is PART 11 §6's objection applied one target out: a renderer that
-      silently discards an authored construct makes the round trip lossy, and
-      an unused definition is exactly the construct a person is most likely to
-      be in the middle of writing. Dropping it also makes the output depend on
-      whether a reference exists elsewhere in the document, so adding one
-      reference changes an unrelated line.
-
       THE MARKER IS EMITTED AS WRITTEN. `[^n]: %` is a footnote definition, so
       it renders with its caret. `[n]: %` is not that construct -- it is a LINK
       reference definition, and emitting one where the author wrote the other
       turns a definition into something that parses back as a different
-      construct. Every engine drops the caret on the plain and terminal
-      targets, which is a defect independent of this rule: whichever way the
-      rule had gone, that output was neither the source nor the same
-      definition.
+      construct.
 
   10b. A TABLE ROW KEEPS ITS OWN CELL COUNT -- NORMATIVE. The canonical
       writer emits exactly the cells the row carries. It MAY align the padding
@@ -10247,27 +8439,14 @@ EOF = (* end of file *) ;
       every non-interactive target: a renderer MUST preserve the construct's
       CONTENT and may drop only its INTERACTION, and authored text -- a label
       or a title that distinguishes one block from another -- MUST NOT be
-      silently discarded. Three authored tokens were discarded anyway, by all
-      three engines:
+      silently discarded.
 
-      WHAT THIS CLAUSE DECIDES is where those three tokens go on the targets
-      named below, and nothing else. It neither restates the floor nor
-      narrows it: a loss this clause does not name is still a loss, and the
-      floor still forbids it. Reading a construct/target pair as CONFORMING
-      because no rendering for it is written here inverts the clause -- the
-      pairs it leaves open are open, not allowed.
-
-          |= H |             ->  markdown  | H |
-          | a |                            | --- |
-          ^ Table caption                  | a |
-
-          ```js "src/app.js"   ->  plain     const a = 1
-          const a = 1              terminal  ┌── js
-          ```                                  const a = 1
-
-          ```js [Node]         ->  plain     const a = 1
-          const a = 1              terminal  ┌── js
-          ```                                  const a = 1
+      WHAT THIS CLAUSE DECIDES is where a table caption, a fence title and a
+      fence label go on the targets named below, and nothing else. It neither
+      restates the floor nor narrows it: a loss this clause does not name is
+      still a loss, and the floor still forbids it. Reading a construct/target
+      pair as CONFORMING because no rendering for it is written here inverts
+      the clause -- the pairs it leaves open are open, not allowed.
 
       T1 A FENCE'S TITLE AND LABEL RENDER THE WAY A DIV'S ALREADY DO. This
          clause writes down an existing rule rather than a new one. A fenced
@@ -10286,15 +8465,6 @@ EOF = (* end of file *) ;
                                                     (blank)
                                                     composer require x
 
-         The language tag is untouched: it keeps whatever slot the target
-         already gives it, which on the terminal is the `┌── ` header line
-         and in plain text is nothing. Folding the title into that header
-         instead was considered and rejected -- the header exists only when
-         the fence has a language, so a titled fence with no language would
-         have needed a header invented for it, and a fence carrying both a
-         title and a label would have needed a separator invented too. The
-         div's shape needs neither and already ships.
-
       T2 A TABLE CAPTION SURVIVES THE MARKDOWN TARGET as body text AFTER the
          table, separated by one blank line. The position is what this target
          already does for the other two captioned hosts -- an image caption
@@ -10311,35 +8481,17 @@ EOF = (* end of file *) ;
       ADJACENCY IS NOT AVAILABLE HERE, AND THAT IS THE GENERAL FORM.
       A plain-text target has no delimiter to put around a block, so what it
       has instead is ADJACENCY: dropping the blank line says that the line
-      below belongs to the block above. That move is unavailable to both
-      halves of this clause, and measuring why gives the rule its shape:
-      attachment by adjacency is only available on a target where adjacency
-      does not change what the adjacent block IS.
+      below belongs to the block above. Attachment by adjacency is only
+      available on a target where adjacency does not change what the adjacent
+      block IS. A caption written directly after the last row of a Markdown
+      table is read by a GFM reader as ANOTHER ROW, and a line written
+      directly above a code block in plain text reads as the FIRST LINE OF THE
+      CODE.
 
-      A caption written directly after the last row of a Markdown table is
-      read by a GFM reader as ANOTHER ROW -- `| a |` then `Table caption`
-      yields `<td>a</td>` and `<td>Table caption</td>`. The words survive as
-      a fabricated data cell, which is worse than losing them, because a
-      reader cannot tell an authored cell from a caption and neither can a
-      parser. A line written directly above a code block in plain text reads
-      as the FIRST LINE OF THE CODE, for the same reason: that target draws
-      no delimiter around a code block at all.
-
-      So both halves take the separation their target forces and accept that
-      the ATTACHMENT is weaker than adjacency would have given. That is a
-      floor being met, not a relationship being preserved: this clause is
-      about the words surviving. Modeling a caption as something a round trip
-      can recover on the Markdown target is carve#1121's business, not this
-      clause's. Writing the relationship as an ELEMENT is not open here
-      either, though that target does admit HTML -- a `<caption>` is only
-      valid as the first child of a `<table>`, and the `<table>` a pipe table
-      produces is built by the READER, so there is nowhere to put one.
-
-      TWO MORE LOSSES OF THE SAME TOKENS ARE RECORDED HERE AND LEFT OPEN,
-      both measured on the same build that produced the rows above. Each
-      breaks the floor exactly as the three rows above did; what is missing
-      is a decided rendering, not a rule. Neither is settled by this clause
-      and neither is thereby permitted:
+      TWO MORE LOSSES OF THE SAME TOKENS ARE RECORDED HERE AND LEFT OPEN. Each
+      breaks the floor exactly as this clause's three tokens did; what is
+      missing is a decided rendering, not a rule. Neither is settled by this
+      clause and neither is thereby permitted:
 
         - A fence title on a fence with NO LANGUAGE is dropped by the
           MARKDOWN writer too: ```"src/app.js" emits a bare ``` and the
@@ -10357,23 +8509,7 @@ EOF = (* end of file *) ;
       §10a rules the definition NOTHING references: the Markdown, plain-text
       and terminal renderers all emit it, because those targets do not get to
       drop content the author wrote. It says nothing about the definition that
-      IS referenced, and each of the three got that one wrong in its own way:
-
-          *[HTML]: Hyper Text  ->  markdown  *[HTML]: Hyper Text
-                                             (blank)
-          HTML                               <abbr title="Hyper Text">HTML</abbr>
-
-                                   plain     *[HTML]: Hyper Text
-                                             (blank)
-                                             HTML
-
-                                   terminal  *[HTML]: Hyper Text   (dim)
-                                             (blank)
-                                             HTML (Hyper Text)
-
-      On two of them the same words are emitted twice. On the third a line of
-      CARVE SOURCE sits in a plain-text document AND the expansion the author
-      defined never appears anywhere, so that target is wrong on both halves.
+      IS referenced.
 
       WHAT THIS CLAUSE DECIDES is where the definition LINE goes on those
       three targets when the definition is consumed, and what the plain target
@@ -10395,25 +8531,12 @@ EOF = (* end of file *) ;
              (blank)                  terminal  HTML (Hyper Text)
              HTML
 
-         Neither half is invented. The terminal already writes
-         `TERM (expansion)` for an automatic expansion; PART 9 §9's
-         authored-`abbr` rule already writes the same shape on the PLAIN
-         target for an authored value (carve#1178). Plain lacked the automatic
-         case for a reason this clause removes -- carve#1178 left it out on
-         the ground that the definition line carried the mapping instead -- so
-         the expansion is not an addition to this ruling but the other half of
-         it. Emitting neither, which is what plain does today, loses the
-         author's expansion outright.
-
       THE TEST IS WHETHER THIS DEFINITION'S EXPANSION IS EMITTED, not whether
       its term appears. The line is dropped on plain and the terminal exactly
       where the same output carries the expansion that definition supplies,
-      and kept otherwise. That is not a refinement for its own sake: the line
-      goes because the content is emitted TWICE, and it is emitted twice only
-      where the expansion is emitted. Three shapes already in the corpus fail
-      the test, and in each the definition's text is carried by its own line
-      and by nothing else, so dropping it would be the content loss §10a
-      exists to prevent:
+      and kept otherwise. Three shapes fail the test, and in each the
+      definition's text is carried by its own line and by nothing else, so
+      dropping it would be the content loss §10a exists to prevent:
 
         - THE TERM NEVER APPEARS. That is §10a, which this clause leaves
           exactly as it stands.
@@ -10423,8 +8546,7 @@ EOF = (* end of file *) ;
           child contributes only its visible text there, so the definition's
           own expansion reaches no target. `45-inline-extensions-11` pins
           `HTML (Custom)` on plain and on the terminal with the definition
-          line above it, and this clause leaves that case as carve#1178 left
-          it.
+          line above it, and this clause leaves that case unchanged.
 
         - A LATER DEFINITION OF THE SAME TERM WON. PART 9R R3 is last-wins, so
           in
@@ -10436,10 +8558,8 @@ EOF = (* end of file *) ;
 
           only `b` is ever emitted. `*[A]: b` goes and `*[A]: a` stays, on
           plain and on the terminal alike. Dropping every definition of a term
-          that expanded anywhere was considered and rejected: it deletes the
-          string `a` from the document outright, and the reason this clause
-          moves anything at all is that the plain target should not be losing
-          text.
+          that expanded anywhere would delete the string `a` from the document
+          outright, which is the loss this clause moves to prevent.
 
       THE MARKDOWN TARGET NEEDS NONE OF THAT TEST -- it keeps every definition
       line whatever became of it. So does the canonical writer, where PART 11
@@ -10523,11 +8643,6 @@ EOF = (* end of file *) ;
       separate as well, so they come back as one. What earns the three is the
       boundary's job, not the run's length.
 
-      Pinned by corpus
-      395-a-longer-run-at-a-list-boundary-is-written-as-exactly-three-blank-lines,
-      whose source has SIX blank lines and whose `.fmt` sidecar has three
-      (carve#1505).
-
   10j. AN UNSPELLABLE BLOCK DOES NOT CANCEL THE ADJACENCY IT CANNOT SPELL --
       NORMATIVE (carve#1621). Where EVERY block between two sibling lists is
       UNSPELLABLE -- it reaches the writer from the AST and leaves no character
@@ -10539,22 +8654,9 @@ EOF = (* end of file *) ;
       block that separates the two lists and never writes PART 9 §11 N1a's
       boundary; and it has no Carve spelling, so nothing of it reaches the
       output. The lists come back with ONE blank line between them, which is
-      the loose separator, so they MERGE:
-
-        list, paragraph, list       is written as:   - a
-        -- the paragraph holding                     [blank line]
-        one ASCII SPACE                              - b
-
-      That source re-reads as ONE loose list, so two lists became one and the
-      items changed shape with them. What is lost is a document boundary rather
-      than a blank line, and §1's `to_html(fmt(x)) == to_html(x)` forbids it.
-
-      THE RULE IS ALREADY FOLLOWED ON THE SIBLING SHAPE, which is what settles
-      it without a cross-engine tally. The pinned build writes the boundary
-      across an EMPTY paragraph and not across a whitespace-only one, and those
-      two trees differ in nothing the writer can put on the page. That is one
-      engine reading its own rule two ways, and the reading that keeps §1 is
-      the one that survives.
+      the loose separator, so they MERGE into one loose list. What is lost is a
+      document boundary rather than a blank line, and §1's
+      `to_html(fmt(x)) == to_html(x)` forbids it.
 
       IT IS NOT A PARAGRAPH RULE. Any INTERCHANGE-ONLY block has this shape: a
       `figure` wrapping a `table` (PART 12 §17) is unspellable in the same
@@ -10564,13 +8666,6 @@ EOF = (* end of file *) ;
       ANYTHING -- a thematic break, or a paragraph holding a NO-BREAK SPACE
       (§7) -- separates the two lists as it always did, and no boundary is
       written.
-
-      THE BLOCK IS STILL LOST, and this clause does not pretend otherwise. It
-      bounds the loss TO the block, which is what §1 can be held to, instead
-      of letting it take a document boundary with it. Refusing the tree was the
-      alternative and is worse: it fails an editor's round trip on a tree the
-      renderer accepts, trading a silent loss for a loud one on the path that
-      can least afford it.
 
       NO CARVE SOURCE REACHES THIS, so nothing in the parse-driven corpus can
       pin it and the fixture is a hand-built payload entering through the AST
@@ -10611,16 +8706,13 @@ EOF = (* end of file *) ;
 
    A parsed document is exchangeable: an implementation MAY serialize its AST
    to JSON, and a consumer written against one implementation MUST be able to
-   read another's output. Nothing specified this before, and the engines'
-   INTERNAL field names already differ for the same node - one calls a link's
-   destination `href`, another `destination` - so three dialects were the
-   default outcome rather than a risk.
+   read another's output. The engines' INTERNAL field names already differ for
+   the same node - one calls a link's destination `href`, another `destination`
+   - so three dialects were the default outcome rather than a risk.
 
-   1. THE SHAPE IS carve-js's. It is the reference implementation, its AST is
-      already plain data, and the one serializer in the wild (carve-rb, over
-      carve-rs's tree) independently arrived at the same field names. An
-      implementation whose internals differ MAPS on the way out; it does not
-      export its internals.
+   1. THE SHAPE IS carve-js's. It is the reference implementation and its AST
+      is already plain data. An implementation whose internals differ MAPS on
+      the way out; it does not export its internals.
 
       THE TYPE NAME COMES FROM profiles.md, NOT FROM carve-js -- NORMATIVE.
       This clause is about the SHAPE of a node: which fields it carries and
@@ -10639,8 +8731,7 @@ EOF = (* end of file *) ;
       the document.
 
       It also makes node-for-node comparison meaningful, which is the only way
-      an engine's divergence from the reference can be MEASURED rather than
-      argued about (the shape check in scripts/ast-conformance.mjs).
+      an engine's divergence from the reference can be MEASURED.
 
       SCOPE. The rule is about `text` nodes only, and only about ADJACENCY
       within one parent's child list. It does not merge across an intervening
@@ -10654,9 +8745,8 @@ EOF = (* end of file *) ;
       An implementation that leaves the run split in the parsed tree and joins
       it in the encoder satisfies §1a and BREAKS §6 on the same document: what
       comes back holds one node where the tree held three, so the round trip is
-      not an identity. carve-rs was written that way first and its corpus
-      round-trip test failed on `03-links-12` (carve-rs#441). The tree
-      `parse(x)` returns is therefore already coalesced.
+      not an identity (carve-rs#441). The tree `parse(x)` returns is
+      therefore already coalesced.
 
       POSITIONS. A merged run keeps a span only where its pieces are CONTIGUOUS
       in the source. Where they are not -- the `<` and `>` of an autolink
@@ -10664,13 +8754,6 @@ EOF = (* end of file *) ;
       halves of a wrapped table cell -- the merged value is not a slice of the
       source at any offset, and §4 rates a span that selects the wrong text
       worse than no span at all. So such a run publishes NONE.
-
-      That is a real cost and is stated rather than glossed: per-piece spans
-      that existed before the merge are gone in exactly those cases. It only
-      happens where the value was never a source slice to begin with (a
-      manufactured joiner, a dropped delimiter), so nothing that WAS placeable
-      becomes unplaceable -- but a consumer wanting to locate the pieces of such
-      a run works from the source, not from the tree.
 
       `escaped_text` is NOT `text` and does not merge with it: PART 12 §5 keeps
       the two distinct on the wire because an escape is authored form, and
@@ -10789,44 +8872,29 @@ EOF = (* end of file *) ;
       every renderer unwraps it at the render seam exactly as it does today.
 
       Flattening it at the encoder is the fold this section exists to forbid,
-      and it is strictly lossier than the case the section opens with. An
-      unresolved reference at least keeps enough to be written back; a nested
-      link's destination does not survive at all. `[[x](y)](z)` published as a
-      link to `z` whose only child is the text `x` has lost `y` from the tree
-      entirely, so `fmt` on the parsed document writes `[[x](y)](z)` back and
-      `fmt` on the same document taken through the AST writes `[x](z)` -- two
-      spellings of the same source, which is the §6 round trip failing. An
-      autolink flattened the same way returns as a bare URL, and that is a
-      DIFFERENT document: a bare URL stays literal where an autolink is a link.
-
-      THE PRECEDENT IS INSIDE THIS RULE ALREADY. A `heading_ref` inside a link
-      is exempt from the flattening for exactly this reason -- it reaches the
-      serialized tree and the renderers suppress the nested anchor instead. A
-      link and an autolink are the same case and take the same treatment. An
-      image and a code span inside a label were never flattened at all, which
-      is what makes this an extension of an existing exemption rather than a
-      new rule about what a label may contain.
+      and it is strictly lossier than the case the section opens with.
+      `[[x](y)](z)` published as a link to `z` whose only child is the text `x`
+      has lost `y` from the tree entirely, so `fmt` on the parsed document and
+      `fmt` on the same document taken through the AST write two different
+      spellings -- the §6 round trip failing. An autolink flattened the same way
+      returns as a bare URL, and that is a DIFFERENT document: a bare URL stays
+      literal where an autolink is a link.
 
       THE NODE CARRIES NO NON-ANCHOR FLAG. Nothing on the wire marks the inner
-      link as unclickable; a consumer infers it from context. A field that
-      exactly one construct ever sets is a special case where the uniform rule
-      is available, and it would carry a RENDER fact -- "HTML cannot nest
-      anchors" -- back into the format that describes the SOURCE, which is the
-      layering this section rejects everywhere else. §3 already gives a link
-      `children`, and those children are inline nodes with `link` and
-      `autolink` among them, so keeping the node needs no new wire surface at
-      all: the flag would be the only reason to add one, on a surface §11 has
-      just made strict. The asymmetry is recorded rather than assumed -- adding
-      the flag later is a normal additive change, removing it later is a break,
-      and a worse one under strict ingest.
+      link as unclickable; a consumer infers it from context. Such a flag would
+      carry a RENDER fact -- "HTML cannot nest anchors" -- back into the format
+      that describes the SOURCE, which is the layering this section rejects
+      everywhere else. §3 already gives a link `children`, and those children
+      are inline nodes with `link` and `autolink` among them, so keeping the
+      node needs no new wire surface at all. The asymmetry is recorded rather
+      than assumed -- adding the flag later is a normal additive change,
+      removing it later is a break.
 
       RENDERED OUTPUT DOES NOT MOVE. Every target still unwraps, so this is a
       wire-format change with no HTML, Markdown, plain or ANSI consequence.
-      What moves is what a consumer of the TREE receives, which is why no
-      corpus golden pins it: a corpus pair here would pass before and after and
-      prove nothing. The pins that can fail are the §6 round trip on the two
-      shapes above and the AST-shape expectation that a `link` and an
-      `autolink` are admissible inside a link's children.
+      What moves is what a consumer of the TREE receives: the §6 round trip on
+      the two shapes above, and that a `link` and an `autolink` are admissible
+      inside a link's children.
 
       A DESTINATION IS THE AUTHOR'S TEXT, UNSANITIZED -- NORMATIVE. `href`,
       `src`, and every other destination field carry what the author wrote,
@@ -10846,35 +8914,15 @@ EOF = (* end of file *) ;
       renderer alone -- a scheme blanked in one target and passed through in
       another is not blocked, it is deferred by one step. Handing the tree to
       another tool is the whole purpose of this PART, so the argument applies
-      here with more force than it did to the Markdown target that prompted it:
-      a consumer that wires a serialized `href` into an anchor has published a
-      live `javascript:` URL.
-
-      Feeding the tree back through a conforming engine applies the denylist for
-      you, because the engine is a target. Walking the tree and building output
-      yourself does not.
+      here with more force: a consumer that wires a serialized `href` into an
+      anchor has published a live `javascript:` URL. Feeding the tree back
+      through a conforming engine applies the denylist for you, because the
+      engine is a target. Walking the tree and building output yourself does
+      not.
 
         See [getting started][] here.
 
         [getting started]: /start
-
-      serialized to a `link` with an empty `href`, a `ref`, a `rawRef`, and no
-      record anywhere of `/start`. A consumer that decoded and rendered got a
-      link to nothing, with no second stage available to it -- the input to that
-      stage had been dropped. §6's round trip still held, because both sides
-      carried the same empty `href`; what broke was rendering the tree at all,
-      which is worse and which §6 does not measure. (carve#524)
-
-      §10 HAS SINCE ANSWERED IT: a link reference definition IS a node, hoisted
-      to the document like the footnote definition, and it carries the
-      destination. Both documents above now publish one - measured across all
-      three engines, the definition-only document has a single
-      `link_reference_definition` child holding `/u`, and the resolved one a
-      `paragraph` and a `link_reference_definition` holding `/start`.
-
-      The paragraph above is kept as the REASON rather than deleted, because it
-      is the argument that produced §10 and the thing to re-read before anyone
-      proposes dropping the node again. It describes what was true, not what is.
 
       THE COLLAPSED FORM'S `ref` IS THE DERIVED LABEL. For `[getting started][]`
       the author wrote nothing between the second brackets, and `ref` carries
@@ -10882,17 +8930,15 @@ EOF = (* end of file *) ;
       only value a consumer can do anything with. An empty `ref` would say
       "there is a reference here and I will not tell you to what". `rawRef`
       holds the authored spelling, so the empty brackets are not lost by this.
-      The alternative was measured rather than argued: carve-php published
-      `ref: ""` for the collapsed form and carve-js published no `ref` at all
-      once resolved, so all three spellings were in the field at once.
+      A published `ref: ""`, and a `ref` dropped once resolved, are both
+      non-conforming.
 
       AN UNRESOLVED REFERENCE IS STILL A LINK NODE. Where nothing defines
       `[a]`, `see [a][] here` publishes `text`, `link`, `text` -- the link
       carrying `ref` and no `href` -- NOT one text node holding `see [a][]
       here`. Flattening it to text discards the fact that the author wrote a
       reference at all, and it makes the same document have two node counts
-      depending on which engine produced it, which is exactly what §1 and §1a
-      exist to prevent. (carve#486)
+      depending on which engine produced it. (carve#486)
 
       A CROSSREF IS A `heading_ref`, RESOLVED OR NOT -- NORMATIVE. `</#id>` is
       a reference like any other, so the same two halves apply: the authored
@@ -10927,37 +8973,21 @@ EOF = (* end of file *) ;
       in the same document, so a consumer reads it from there. This is the one
       place this clause departs from §5's added-alongside rule, and it does so
       because the alternative duplicates an arbitrary amount of inline content
-      per reference -- carve-js's resolved link clones the heading's children
-      into every crossref, which is why it also has to flatten nested crossrefs
-      and cache the clone to stay acyclic. `href` is a fixed-size result; the
-      display text is not.
+      per reference. `href` is a fixed-size result; the display text is not.
 
       SO THERE IS NO `raw_text`. An engine that reverts an unresolved reference
       to literal source needs a node type to carry text that must not be
       escaped again, and no such type is in the vocabulary. Under this clause
       the reversion does not happen, so the need does not arise: what the
-      author wrote is a link, and it stays one. §5 already excludes the
-      formatter-internal `raw_text` from the wire; this says why nothing on the
-      document side has to reach for it. (carve-php#624)
+      author wrote is a link, and it stays one.
 
-      WHY PRE-RESOLVE. Both stages are defensible and both validate against the
-      schema, which is how three engines came to disagree without any of them
-      being wrong (carve#481). The tie is broken by what each one COSTS.
-
-      Post-resolve makes `rawRef`'s stated purpose -- "so it can be restored as
-      literal text" -- unreachable, because the field it would be restored from
-      is gone by the time anyone could use it. It also means `[x][]` cannot
-      survive a format cycle in ANY implementation: the writer cannot reproduce
-      a construct the tree no longer carries, so PART 11's canonical writer
-      silently rewrites one construct into another. That is not a writer bug
-      and cannot be fixed in the writer.
-
-      Pre-resolve keeps both. It also keeps the distinction a linter, a
-      refactoring tool, or an editor round-tripping a file needs: `[a][]` and
-      `[a](#a)` are different things the author chose between, and a format
-      that preserves authored form one layer down (PART 11 §6: bullet
-      characters, delimiters, the bare marker) has no reason to discard this
-      one.
+      WHY PRE-RESOLVE. Post-resolve makes `rawRef`'s stated purpose -- "so it
+      can be restored as literal text" -- unreachable, and `[x][]` cannot
+      survive a format cycle: the writer cannot reproduce a construct the tree
+      no longer carries, so PART 11's canonical writer would silently rewrite
+      one construct into another. Pre-resolve also keeps the distinction a
+      linter, a refactoring tool, or an editor round-tripping a file needs:
+      `[a][]` and `[a](#a)` are different things the author chose between.
 
       WHAT IS STILL SERIALIZED. §5's rule is unchanged and is not in tension
       with this one: resolution RESULTS a consumer would otherwise have to
@@ -10969,16 +8999,6 @@ EOF = (* end of file *) ;
       which is the same shape: the authored construct is still there to be read,
       and the resolution result sits beside it.
 
-      WHAT WOULD MAKE `href: ""` DEFENSIBLE, and is not proposed here: a
-      `link_reference_definition` node in the vocabulary, hoisted to the
-      document like the footnote definition. Then the destination
-      survives serialization and a consumer can resolve for itself. It is a
-      bigger change than this clause is worth -- a new node type, a new hoisting
-      rule, three engines to move, and every consumer obliged to run a
-      resolution pass before it can render anything -- and the reason to prefer
-      it would be purity rather than a capability anyone is missing. Recorded so
-      the choice is visible as a choice.
-
    4. POSITIONS ARE REQUIRED. Every node EXCEPT the document root carries
       `pos`:
 
@@ -10988,39 +9008,21 @@ EOF = (* end of file *) ;
       Lines are 1-based. Columns are 1-based and offsets 0-based, both counted
       in UNICODE CODEPOINTS. `endColumn` and `endOffset` are exclusive.
 
-      The unit is stated because there is no convention to inherit: every
-      implementation otherwise reports whatever its own strings are indexed by,
-      and the differences are invisible on ASCII. Measured on `\u{1F600} *b*`,
-      where the delimiter sits at codepoint 2, UTF-16 unit 3 and byte 5:
-      djot.js and commonmark.js report 3, carve-js reported 3, and a byte-indexed
-      engine would report 5 -- three implementations, three answers, all
-      believing they were right.
-
       Codepoints rather than bytes or UTF-16 code units because a codepoint index
       always lands on a CHARACTER BOUNDARY. A byte offset can point inside a
       UTF-8 sequence and a UTF-16 offset inside a surrogate pair; either lets a
-      consumer slice a document into invalid text. This also follows djot's
-      reference implementation, which builds a byte-to-charpos table specifically
-      so it can report characters from a byte-indexed language -- the format's
-      author paid that conversion deliberately rather than exporting the host's
-      unit.
-
-      Every implementation therefore converts, and each pays it once per document
-      rather than per position: the mapping is a single pass, and it is the
-      identity for any document without an astral character.
+      consumer slice a document into invalid text. Every implementation
+      therefore converts, and each pays it once per document rather than per
+      position.
 
       The document root is exempt because it spans the whole source by
       definition, so a span on it carries no information a consumer does not
-      already have. The first draft of this section said "every node" without
-      that carve-out, which made the reference implementation non-conformant
-      with a rule written a day earlier - the conformance checker found it on
-      its first run.
+      already have.
 
       This is the field that makes a serialized AST worth exchanging: an
       editor, a language server or a tool grounding output back to source needs
-      to say WHERE, and a tree without positions can only be re-parsed rather
-      than navigated. Making it optional would mean every consumer has to
-      handle its absence, which in practice means not using it.
+      to say WHERE. Making it optional would mean every consumer has to handle
+      its absence, which in practice means not using it.
 
       A SPAN CONTAINS ITS CHILDREN'S SPANS -- NORMATIVE. A node's span
       covers every placed node inside it: a child's `startOffset` is not
@@ -11029,17 +9031,6 @@ EOF = (* end of file *) ;
       breaking the chain -- the comparison is against the nearest ANCESTOR
       that has one.
 
-      This is the one structural rule a checker can apply without knowing
-      what a node covers, which is why it matters: a span is compared against
-      the text it selects only for a `text` node, so every other node's span
-      was checked for being present, integral and in range, and never for
-      pointing at the right place. Adding this rule found 70 wrong spans the
-      day it was written -- 66 in carve-rs, 4 in carve-php, 5 more in
-      carve-js's serialized form -- in list items, a figure's quote target, a
-      table's caption, a footnote's body, and a crossref's cloned display
-      text. Every one was a span taken before the rest of the node had been
-      parsed, or copied from a node somewhere else.
-
       A CONSEQUENCE, worth stating because it settled a question of its own:
       a node whose content is not a contiguous slice of its own source MUST
       omit `pos` rather than publish a PARTIAL span. A `+` continuation cell
@@ -11047,16 +9038,12 @@ EOF = (* end of file *) ;
       and a span covering only the first fragment leaves the cell's own text
       children outside it -- which this rule reports. Omitting is already
       permitted below; this says the partial span is not an alternative to it.
-      (carve#541, carve#565.)
 
-      CHECKED ON ITS OWN, not as a consequence of the opening-markup clause
-      below. The two point the same way today -- a span covering the
-      construct's markup contains the children inside it -- and that is
-      precisely why containment is asserted separately: were the convention
-      ever revisited, a checker that derived containment from it would go quiet
-      with nothing failing. So the conformance run examines parent and child
-      spans in a pass of its own, and COUNTS the pairs it examined, so the pass
-      cannot come back clean by having compared nothing. (carve#913.)
+      CONTAINMENT IS CHECKED ON ITS OWN, not derived from the opening-markup
+      clause below. The two point the same way today, and that is precisely why
+      containment is asserted separately: were the convention ever revisited, a
+      check that derived containment from it would go quiet with nothing
+      failing.
 
       A SPAN COVERS THE MARKUP THE AUTHOR WROTE -- NORMATIVE. Where a node
       has markup of its own, its span covers that markup and not merely the
@@ -11077,15 +9064,6 @@ EOF = (* end of file *) ;
       the node begins and ends before the markup that gave it half its
       content.
 
-      This follows from the sentence above rather than adding to it -- an
-      attribute block is markup of the node's own by the same reading that
-      makes a break's backslash part of the break. carve-rs covers the block
-      and carve-js stops at the content, so carve-js moves (carve#521).
-
-      No corpus document has an attributed inline today, which is why two
-      answers coexisted. One case pins it; `*x*{#i}` is enough, and the
-      combined form `/*x*/{#i}` is worth a second because it is where the
-      derived inner span makes the difference observable.
 
       A break the parser SYNTHESIZED is a different case and keeps the bare
       newline: a line block's implied break and a hard-break fence's converted
@@ -11107,14 +9085,6 @@ EOF = (* end of file *) ;
       item's marker is placed by the whitespace before it, so a span that
       started at the marker would leave the characters deciding the item's
       column outside the item.
-
-      THE ALTERNATIVE WAS CONTENT-ONLY, and it is rejected for a structural
-      reason rather than a stylistic one: with it, a nested construct's span is
-      no longer contained by its parent's, so the span tree stops being a tree
-      and the clause above stops being enforceable. Its one advantage was that
-      fewer engines move. Recorded so it is not revisited: carve-js and
-      carve-php both move under this reading, and every consumer indexing on
-      content offsets moves with them.
 
       TWO EXCEPTIONS, both already stated elsewhere in this section and neither
       an opt-out from the rule:
@@ -11176,10 +9146,9 @@ EOF = (* end of file *) ;
 
       spans the emptied `block_quote` as `> ` and the hoisted
       `link_reference_definition` over the whole line, and offsets 0 to 2 sit in
-      two document-level siblings at once. Neither engine that publishes that is
-      wrong: §7, the emptied-container paragraph above and the sibling-overlap
-      rule cannot all three hold on this document, and the exception is where it
-      gives. (carve#1571, which leaves §7 and carve#1522 exactly as they are.)
+      two document-level siblings at once. §7, the emptied-container paragraph
+      above and the sibling-overlap rule cannot all three hold on this document,
+      and the exception is where it gives.
 
       THE EXCEPTION IS ABOUT THE PAIR, NOT ABOUT A DEFINITION. It does not say a
       hoisted definition overlaps nothing. Two definitions that claim the same
@@ -11200,13 +9169,6 @@ EOF = (* end of file *) ;
       paragraphs above rather than under this one. The exception excuses an
       overlap; it does not extend a container's span, and nothing here permits a
       host to cover source no child of it owns.
-
-      THE TRADE IS DELIBERATE. A list reports a shorter extent than the author
-      typed, which is worse for folding. An editor wanting the region the author
-      typed can recompute it from the item's content column; a consumer that
-      needs one unambiguous answer for one offset cannot recover it from two
-      overlapping spans, so the span carries the half that cannot be
-      reconstructed. (carve#1522.)
 
       An unattached attribute block is the same rule reached from the other
       clause above rather than a second one. `{.x}` written below an item
@@ -11253,13 +9215,10 @@ EOF = (* end of file *) ;
       next to the two above. The end rule asks where a container's CONTENT
       stops, so its last placed child is the right boundary; this one asks where
       the CONSTRUCT begins, and a construct begins at its own markup, which
-      exists whether or not any child was placed. An unplaced child says nothing
-      about where the construct was written. Read symmetrically, a line block
-      stanza whose first line holds a tab -- reassembled around expanded tabs,
-      so it carries no position by the clause below -- started its paragraph on
-      the line BELOW that one, which also put the break ending the tab-bearing
-      line outside the paragraph holding it and so contradicted the containment
-      clause above. (markup-carve/carve-rs#1247.)
+      exists whether or not any child was placed. Read symmetrically, a line
+      block stanza whose first line holds a tab -- reassembled around expanded
+      tabs, so it carries no position -- would start its paragraph on the line
+      BELOW that one, contradicting the containment clause above.
 
       A CONTAINER ENDS AT THE MARKUP THAT CLOSES IT EVEN WHERE ITS LAST CHILD
       IS UNPLACED -- NORMATIVE. A container whose last child omits `pos` ends
@@ -11272,11 +9231,8 @@ EOF = (* end of file *) ;
       container starts at the markup that opens it, and ends at the markup that
       closes it. "Ends at its last placed child" is the case for a container
       whose closer is IMPLICIT -- a list, an item, a definition list -- where
-      the last child's end is what the container has instead of a closer, and
-      where the source past it belongs to a hoisted sibling or to nothing. It
-      was the only rule written because it was the only case measured; it does
-      not narrow a container over source its own child covers.
-
+      the last child's end is what the container has instead of a closer. It
+      does not narrow a container over source its own child covers.
       A closerless container whose last child is unplaced therefore ends where
       its content ends, which is line geometry the block layer knows even where
       the text on that line cannot be sliced out of the source. A line block
@@ -11298,15 +9254,10 @@ EOF = (* end of file *) ;
       positions, not a parse without them.
 
       This is a concession to where the cost falls. Recording a span for every
-      node is not free -- carve-rs builds its line map only when the
-      source-line render option asks for it, precisely so an ordinary parse does
-      not pay -- and serialization is an operation most callers never perform.
-      Charging every parse in the fastest engine for a feature used by
-      exporters, editors and language servers would be the wrong trade, and a
-      spec that demanded it would be quietly ignored or quietly unimplemented.
-
-      The contract a consumer relies on is unchanged: JSON it is handed carries
-      positions. How the producer arranged that is the producer's business.
+      node is not free, and serialization is an operation most callers never
+      perform. The contract a consumer relies on is unchanged: JSON it is
+      handed carries positions. How the producer arranged that is the
+      producer's business.
 
       A REASSEMBLED NODE MUST OMIT `pos` -- NORMATIVE. A node whose value is not
       a contiguous slice of the source, because the producer joined it from
@@ -11328,14 +9279,9 @@ EOF = (* end of file *) ;
       rules left a producer no conformant answer at all: coalesce and carry a
       span over characters the value drops, or coalesce and omit the span the
       paragraph below appears to demand. §1a's own POSITIONS note already chose
-      the second; this is where §4 agrees to it. (carve#490)
-
-      Stated in the spec rather than left to each engine because §1a is
-      normative: any implementation following it faithfully arrives at the same
-      fork, so an answer chosen per engine would be three answers. That the
-      three engines' residues already converged -- same three documents, same
-      kind of content -- is the evidence that this is a property of the rules
-      and not of anyone's parser.
+      the second; this is where §4 agrees to it. It is stated here rather than
+      left to each engine because §1a is normative: any implementation
+      following it faithfully arrives at the same fork.
 
       A discontiguous node therefore has no span. A first-fragment span is not
       an alternative: it locates the beginning but falsely describes `pos` as
@@ -11356,10 +9302,6 @@ EOF = (* end of file *) ;
       a hoisted definition against the container it was authored in, per the
       clause of that name above.
 
-      The cost is an absent navigation target for that node; its contiguous
-      children may still be placed. This keeps `pos` meaning one thing:
-      the exact extent the node owns. (carve#541, carve#1060.)
-
       THE EXEMPTION IS NARROW. The test is whether a true span EXISTS, not
       whether one was computed. A node the producer has simply not placed yet
       is still a gap, and a text run lifted whole out of the source has a span
@@ -11371,9 +9313,7 @@ EOF = (* end of file *) ;
       The conformance checker still REPORTS an absent `pos`, because it cannot
       tell a reassembled node from an unplaced one from the tree alone. That is
       why the position half of that check is a report and the §1a half is a
-      gate. A report is the right instrument here: the distinction needs a human
-      reading the document, and the numbers below are what such a reading
-      produced.
+      gate.
 
       An implementation that cannot yet produce positions MUST NOT emit `pos`
       with invented values, and MUST NOT omit it silently: it does not yet
@@ -11398,13 +9338,9 @@ EOF = (* end of file *) ;
       of the heading. Dedup assigns the next free suffix in document order, so
       two `# Notes` headings yield `Notes` and then `Notes-2` (PART 9 §13; the
       slug and dedup rules are syntax.md §4.1, and PART 9 §13's namespace is
-      shared with every other generated id). Deriving the second one therefore
-      requires having seen every heading before it and replicating the dedup
-      spelling, in the same order. A consumer holding only the tree cannot do
-      that, and a table of contents, a go-to-definition jump and a
-      cross-document index each need the exact id, not a plausible one. This is
-      a stronger case than footnote numbering, where the missing state is a
-      counter the consumer could keep itself.
+      shared with every other generated id). A consumer holding only the tree
+      cannot replicate that, and a table of contents, a go-to-definition jump
+      and a cross-document index each need the exact id, not a plausible one.
 
       §3a IS NOT IN TENSION WITH THIS. §3a forbids folding a resolution result
       in place of the construct the author wrote; here nothing authored is
@@ -11430,9 +9366,9 @@ EOF = (* end of file *) ;
       An implementation MUST NOT emit parsed key/value pairs in its place:
       parsing YAML or TOML is not the markup parser's job, the raw text plus
       `format` lets any consumer do it, and a parsed map cannot represent a
-      document whose frontmatter is malformed. carve-rs holds a parsed map
-      internally; that is an internal choice, and §1 already requires mapping
-      on the way out rather than exporting internals.
+      document whose frontmatter is malformed. A parsed map held internally is
+      an internal choice, and §1 already requires mapping on the way out rather
+      than exporting internals.
 
       A FOOTNOTE DEFINITION IS A BLOCK NODE, `type: "footnote"`, carrying:
         label     the label as written, without the `[^` and `]:`
@@ -11452,9 +9388,7 @@ EOF = (* end of file *) ;
         abbr       the term as written, without the `*[` and `]:`
         expansion  the expansion text, without the separating space
       It renders nothing itself; it is what the inline `abbreviation` resolves
-      against. The node was named here in two clauses before it was described
-      in any, so its field names lived only in resources/ast-schema.json --
-      the shape a reader of this grammar could not see.
+      against.
 
       THE HOISTING CLAUSE ABOVE IS ABOUT FOOTNOTES. An `abbreviation_def` is
       never hoisted, because there is never one to hoist: the construct is
@@ -11480,43 +9414,20 @@ EOF = (* end of file *) ;
       line "is preserved as text" there too. The rule is reused, not invented.
 
       WHY ABBREVIATIONS AND NOT FOOTNOTES. An abbreviation is the only
-      definition kind with NO marker at the use site. A footnote needs `[^a]`
-      and a reference link needs `[text][ref]`, so their reach is bounded by
-      references the author wrote deliberately; an abbreviation rewrites EVERY
+      definition kind with NO marker at the use site: it rewrites EVERY
       occurrence of the term in the whole document, with nothing at the use
       site to point back at the definition. Hoisting is safe for a definition
-      that is inert until referenced and unsafe for one that acts on its own.
-      A container is exactly where quoted and foreign material lives, so
-      hoisting would let a quoted `*[X]: y` inject a document-wide rewrite into
-      the quoting document.
-
-      WHY NOT HOIST AN INERT NODE. The rejected alternative kept the hoist and
-      made a container-authored definition expand nothing: in the tree at
-      document level, but without effect. It loses information. Once hoisted,
-      an inert definition and a real one are the SAME wire shape, so a consumer
-      that decodes the tree expands what the parser did not -- §6's round trip
-      fails on a document the engine itself produced. The distinction has to be
-      recorded somewhere, and tree position records it for free; the
-      alternatives were a new wire field on every definition or an accepted
-      lossy round trip.
+      that is inert until referenced and unsafe for one that acts on its own,
+      and a container is exactly where quoted and foreign material lives.
 
       THE FORMATTER CONSEQUENCE IS ACCEPTED, NOT OVERLOOKED. Hoisting means
       PART 11's writer emits the definition after the container the author
       wrote it in, which reads like a violation of PART 11 §6 ("fmt does not
-      reorder ... those are the author's choices and the AST records them").
-      It is not, because §6 governs what the writer may do with what the tree
-      HOLDS, and this clause is what the tree holds. The consequence is already
-      shipping and corpus-pinned for footnotes:
-
-        See [^a].
-
-        > [^a]: note body
-
-      formats to the definition after an emptied `>`, and corpus
-      `115-footnote-definition-inside-a-container-is-collected` pins the
-      collection it follows from. It is accepted for footnotes because a
-      footnote definition renders as a footnote either way, so the move costs
-      the author placement and nothing else.
+      reorder ... those are the author's choices and the AST records them"). It
+      is not, because §6 governs what the writer may do with what the tree
+      HOLDS, and this clause is what the tree holds. It is accepted for
+      footnotes because a footnote definition renders as a footnote either way,
+      so the move costs the author placement and nothing else.
 
       Definitions appear in DOCUMENT ORDER by source position. Numbering is a
       resolution result and stays on the reference (§5).
@@ -11536,21 +9447,12 @@ EOF = (* end of file *) ;
       the rule the rendered list already shows -- so the grouping is derivable
       and is not published.
 
-      NOT publishing it is the decision, and it has three reasons.
-
-      A plain `{terms, definitions}` object CANNOT CARRY `pos`. §4 requires one
-      on every node but the root because a tree without positions can only be
-      re-parsed rather than navigated, and a term is exactly what an editor
-      jumps to and a language server renames. Under the object form a term was
-      the only content in a serialized document that could not be navigated to
-      -- the same argument §7 makes for frontmatter and footnote definitions,
-      which is why they are block nodes rather than root fields.
-
-      `definition_term` and `definition_description` are in the profiles.md
-      block vocabulary, so a profile can NAME them. Under the object form those
-      two entries named nothing: a host writing `denyBlock(['definition_term'])`
-      got silence, which profiles.md calls the specific failure a normative
-      vocabulary exists to prevent.
+      NOT publishing it is the decision. `definition_term` and
+      `definition_description` are in the profiles.md block vocabulary, so a
+      profile can NAME them; under an object form those two entries named
+      nothing, and a host writing `denyBlock(['definition_term'])` got silence,
+      which profiles.md calls the specific failure a normative vocabulary
+      exists to prevent.
 
       A SPELLED LOOSENESS IS A FIELD; A DERIVED ONE IS NOT. `definition_list`
       MAY carry `loose: true`, and it means what PART 9 §17 L7's consumed
@@ -11574,13 +9476,11 @@ EOF = (* end of file *) ;
       everything except the case the derivation cannot see.
 
       THE NAME IS `loose` AND NOT `tight`, and the divergence from `list` is
-      the point rather than an inconsistency. A `tight` field would be absent on
-      almost every definition list, and an absent boolean read as false says
-      LOOSE -- the opposite of the default, in the one place a consumer is most
-      likely to write `if (node.tight)`. `loose: true` has no such reading:
-      absent means derived, which is the truth. It also matches L7's own key,
-      and follows `list.bareMarker`, the other field here that records an
-      authored distinction the default spelling cannot express.
+      the point. An absent `tight` read as false would say LOOSE, the opposite
+      of the default; `loose: true` absent means derived, which is the truth.
+      It matches L7's own key, and follows `list.bareMarker`, the other field
+      here that records an authored distinction the default spelling cannot
+      express.
 
    9. HOW DEEP AN INGESTED AST MAY NEST -- NORMATIVE. Reading a serialized AST
       is a recursive descent over attacker-controlled structure, so it needs a
@@ -11605,22 +9505,17 @@ EOF = (* end of file *) ;
           because (a) and (b) are the whole of what a caller can rely on. An
           implementation MUST NOT publish its unit as a shared contract.
 
-      THE TRAP, stated once, because all three reference engines fell into a
-      different corner of it: an ingest bound is NOT measured in the same unit
+      THE TRAP, stated once: an ingest bound is NOT measured in the same unit
       as MAX_NESTING_DEPTH, and the conversion factor is NOT A CONSTANT. One
       AST level costs two JSON structural levels for a blockquote or div (the
       object plus its `children` array) and four for a list (list, items,
       item, children); in node terms a list level costs two nodes and a div
-      level one. At MAX_NESTING_DEPTH = 200 a blockquote chain therefore
-      encodes past 400 structural levels and a list ladder past 800 -- four
-      times the parser's own number, from the same document depth.
-
-      So neither MAX_NESTING_DEPTH nor "MAX_NESTING_DEPTH plus a small margin"
-      is a safe bound in either unit. An implementation MUST DERIVE its bound
-      from MAX_NESTING_DEPTH by the worst per-level cost of its own encoding,
-      and MUST NOT restate the parser's number as its ingest number -- a
-      second copy of a value is exactly how (a) gets violated. A bound written
-      down twice diverges; one derived from the other cannot.
+      level one. So neither MAX_NESTING_DEPTH nor "MAX_NESTING_DEPTH plus a
+      small margin" is a safe bound in either unit. An implementation MUST
+      DERIVE its bound from MAX_NESTING_DEPTH by the worst per-level cost of
+      its own encoding, and MUST NOT restate the parser's number as its ingest
+      number -- a bound written down twice diverges; one derived from the other
+      cannot.
 
       The root type is not a leniency point: §7 fixes it at `document`, and
       the schema pins it as a `const`. An ingest accepting some other root
@@ -11647,30 +9542,14 @@ EOF = (* end of file *) ;
       ABBREVIATION DEFINITION IS RECOGNIZED ONLY AT DOCUMENT LEVEL says the
       opposite for that one: inside a container the line is not a definition
       at all, it is paragraph text, and nothing is hoisted because nothing was
-      collected. Reading this section first, "the other two definition kinds"
-      said the reverse and made the abbreviation look like an unimplemented
-      hoist rather than a ruled-out one (carve#1267).
+      collected.
 
-      WHY A NODE AND NOT A ROOT MAP. §7 fixes the root at three fields, and its
-      reason is the one that decides this: §4 requires every node except the
-      root to carry `pos`, and a root FIELD cannot carry one. A definition is a
-      source construct occupying real bytes -- an editor jumps to it, a
-      formatter reproduces it, a language server renames its label. On the root
-      it would be the only content in the document that cannot be navigated to.
-      A node also answers "which definition wins" by document order rather than
-      by merge order, and holds its own attributes without a second rule.
-
-      WHAT THE NODE CLOSES. Three clauses wanted it and each named a different
-      loss:
-        §3a   a resolved reference published `href: ""` with the destination
-              recoverable from nothing
-        §10a  an unused definition survived neither the tree nor a round trip,
-              so `carve --markdown` on a document that is only `[lbl]: /u`
-              emitted nothing
-        §15 A2b  definition attributes had to be materialized onto every
-              resolved link, because there was nowhere to put them once
-      and the fourth is why it landed: a writer cannot reproduce a construct the
-      tree does not carry, so PART 11 §1's `parse(fmt(x)) == parse(x)` fails.
+      WHY A NODE AND NOT A ROOT MAP. §4 requires every node except the root to
+      carry `pos`, and a root FIELD cannot carry one, while a definition is a
+      source construct occupying real bytes that an editor jumps to and a
+      language server renames. A node also answers "which definition wins" by
+      document order rather than by merge order, and holds its own attributes
+      without a second rule.
 
       A DEFINITION IS STILL INVISIBLE IN HTML. The node renders nothing on that
       target; it feeds the links and images that resolve its label (PART 9R R1).
@@ -11685,30 +9564,18 @@ EOF = (* end of file *) ;
       offending property and the PATH it appeared at, so a caller can find it
       in a tree it did not write. Not a silent drop, and not a pass-through.
 
-      THE PASS-THROUGH IS THE ONE ANSWER THAT CANNOT BE RIGHT, and it is worth
-      saying why separately: an implementation that copies a wire record
-      wholesale re-emits the unknown property when it serializes again, so its
-      OWN OUTPUT no longer validates. A consumer that reads a tree here and
-      publishes it again then emits something the format rejects, having been
-      told nothing.
+      THE PASS-THROUGH IS THE ONE ANSWER THAT CANNOT BE RIGHT. An
+      implementation that copies a wire record wholesale re-emits the unknown
+      property when it serializes again, so its OWN OUTPUT no longer validates,
+      and a consumer that reads a tree here and publishes it again emits
+      something the format rejects, having been told nothing.
 
       REFUSE RATHER THAN DROP, for the reason §9(b) already gives about depth:
       "an ingest that accepts a tree and then silently renders only part of it
-      is the worst of the three, because the caller is told nothing". An
-      unknown property is the same shape of problem one field down. If a later
+      is the worst of the three, because the caller is told nothing". If a later
       version of this format gives that property a meaning, an engine that
       dropped it rendered a document that says something else and reported
       success; an engine that refused sent the caller to a version mismatch.
-      The root-type note under §9 settles the same question for the root and
-      points the same way: half-reading a foreign format is worse than
-      declining it.
-
-      FORWARD COMPATIBILITY IS NOT AN ARGUMENT FOR LENIENCY HERE. `parse` and
-      the schema ship together in one build, so an unknown property means the
-      payload came from a DIFFERENT version, and no engine can render a field
-      it does not implement whatever it does with it. Refusing makes the
-      version mismatch visible at the boundary where it can still be handled;
-      dropping defers it to whatever the missing field was load-bearing for.
 
       A DOCUMENTED LEGACY ALIAS IS THE ONE NARROW EXCEPTION. An implementation
       MAY accept a property it once published itself, PROVIDED it decodes that
@@ -11795,15 +9662,9 @@ EOF = (* end of file *) ;
           (carve#881). Types and required fields together, at DECODE, refused
           with the same typed error (a), (b) and (c) already require. Not a
           fourth list of leniency points -- the schema is the list, it already
-          describes every one of them, and the rows below were only ever
-          divergent because nothing consulted it.
-
-          One clause rather than a row per field: the schema already defines
-          the complete payload contract.
-
-          The rows already fixed are NOT reopened: an unnamed property under
-          §11 and a missing or non-string `type` under (c) landed separately
-          and keep their own clauses.
+          describes every one of them. An unnamed property under §11 and a
+          missing or non-string `type` under (c) keep their own clauses and are
+          not reopened.
 
       A `srcByteLength` THAT IS PRESENT BUT WRONG IS NOT THIS CLAUSE'S
       BUSINESS. It is derivable from the payload and nothing in the tree
@@ -12054,17 +9915,14 @@ EOF = (* end of file *) ;
       output would carry the caption text as literal body prose instead of
       losing it cleanly, and the loss would stop being observable as a loss.
 
-      A FIGURE GROUP'S TABLE PANEL IS NOT THIS WRAPPER. PART 9 §4c has since
-      made `:::` a captionable host (carve#1122), and a reader arriving here
-      will ask whether `::: figure` around a table now spells the shape. It
-      does not. §16 holds a `figure_group`'s panels in `children` as exactly
-      the nodes the inner caption rules built, so a table panel is a plain
-      `table` child of the group -- carrying its own `caption` if it has one --
-      and never a `figure` whose target is a table. The two say different
-      things: a group wraps a SEQUENCE of panels and captions the sequence,
-      while this wrapper wraps ONE table and captions that table. Carve 0.1
-      source still spells no `figure{target: table}`, which is what makes the
-      writer's loss unavoidable rather than a choice.
+      A FIGURE GROUP'S TABLE PANEL IS NOT THIS WRAPPER. §16 holds a
+      `figure_group`'s panels in `children` as exactly the nodes the inner
+      caption rules built, so a table panel is a plain `table` child of the
+      group -- carrying its own `caption` if it has one -- and never a `figure`
+      whose target is a table. A group wraps a SEQUENCE of panels and captions
+      the sequence, while this wrapper wraps ONE table and captions that table.
+      Carve 0.1 source still spells no `figure{target: table}`, which is what
+      makes the writer's loss unavoidable rather than a choice.
 
       THE TABLE IS THE ONLY HOST IN THIS POSITION. PART 9 §4b states what a
       caption makes of its host: every other captionable host -- an image, a
@@ -12093,20 +9951,6 @@ EOF = (* end of file *) ;
       at the use site, and §3 makes field names spec surface: one construct
       identified two ways in one document is the collision §1 exists to stop.
 
-      NEITHER CURRENT BEHAVIOR STANDS, and the two lose different halves of
-      what §10 keeps (carve#1276):
-
-        consuming the line at parse time    discards `pos` entirely, so the
-                                            line cannot be reproduced and an
-                                            AST round trip deletes it
-        leaving the line a paragraph        publishes the parser's failure to
-                                            recognize it: a `citation_group`
-                                            followed by the literal text
-                                            `: {author=` and the rest of the
-                                            entry, which a ProseMirror bridge
-                                            hands an editor as prose and round
-                                            trips as prose
-
       NO RENDERED OUTPUT MOVES ON ANY TARGET. The node renders nothing where it
       sits; the entry's text renders in the references list the extension
       builds, exactly as it did before. That is why the divergence survived so
@@ -12124,11 +9968,8 @@ EOF = (* end of file *) ;
       reference definition out of a container while §7 rules that an
       abbreviation definition inside one is not a definition at all, and this
       clause is about the node's SHAPE rather than about which lines produce
-      one. Measured on carve-js `620def4`, a `[@key]: entry` line inside a
-      block quote or a list item is paragraph text and defines nothing, which
-      is §7's answer rather than §10's; that is a measurement of one engine and
-      not a ruling. An implementation emitting the node for a definition it
-      recognizes satisfies this clause whichever way that question lands.
+      one. An implementation emitting the node for a definition it recognizes
+      satisfies this clause whichever way that question lands.
 
    18a. A CITATION ITEM IS A POSITIONED INLINE NODE -- NORMATIVE.
       Every item in `citation_group.items` carries `type: "citation"` and the
@@ -12240,34 +10081,20 @@ EOF = (* end of file *) ;
 
       THIS MIRRORS THE PARSE BOUNDARY, which is the whole of the rule: PART 0
       INPUT performs the same replacement on source, and PART 9 §29 carves
-      U+0000 out of the content class on that basis. A wire format that
-      admitted the character would put an authored NUL and an ingested one on
-      different footings - one replaced, one content - which is precisely the
-      divergence §29 exists to remove. An AST is a second door into the same
-      renderers; it takes the same doormat.
+      U+0000 out of the content class on that basis. An AST is a second door
+      into the same renderers; it takes the same doormat.
 
       A READER DOES NOT REFUSE THE VALUE, which is the choice worth stating.
       §11 and §12 refuse an unknown property and a deviant root, because those
-      are structure a producer got wrong and repairing them silently would
-      accept attacker-controlled shape. This is different: the replacement is
+      are structure a producer got wrong. This is different: the replacement is
       what the parse boundary already does to the identical string, so
-      performing it is not a repair, it is the documented reading. Refusing
-      instead would make an ingested document stricter than the same document
-      written as source, and a host that builds a tree programmatically would
-      have to implement CommonMark 2.3 itself before it could hand the tree
-      back.
-
-      Applying this rule at every ingest boundary gives parsers, renderers and
-      canonical writers the same guarantee and prevents U+0000 from colliding
-      with internal sentinels (carve-rs#1217, carve-js#1294).
+      performing it is the documented reading rather than a repair. Refusing
+      would make an ingested document stricter than the same document written
+      as source.
 
       AN IMPORTER IS THE SAME BOUNDARY BY THE SAME REASONING, and is stated
       here as a SHOULD rather than a MUST because the format being imported may
-      have its own rule. Carve's Markdown importer performs the replacement,
-      following CommonMark 2.3 (markup-carve/carve-js#1293); its BBCode
-      importer passes a raw NUL straight through into its Carve output, which
-      is not a substitution and BBCode has no clause to follow, but is the same
-      missing normalization arriving by a third door.
+      have its own rule.
 
    22. AN INGESTED VALUE THE SCHEMA CALLS ABSENT IS NORMALIZED AWAY --
       NORMATIVE (carve#1615). `resources/ast-schema.json` describes a list's
@@ -12285,19 +10112,14 @@ EOF = (* end of file *) ;
       value; §6 never promised to hand it back.
 
       THE DECIDING ASYMMETRY IS THAT NORMALIZING IS LOSSLESS. `start: 1` and no
-      `start` describe the same document -- the field is inert, and the renderer
-      emits no `start` attribute for either, `1` being the HTML default.
-      Nothing an author wrote is discarded. Preserving the value keeps a field
-      that makes the encoder's output depend on WHERE THE TREE CAME FROM, which
-      is the property §6's round trip exists to remove.
+      `start` describe the same document, so nothing an author wrote is
+      discarded, while preserving the value makes the encoder's output depend
+      on WHERE THE TREE CAME FROM.
 
       REFUSING THE PAYLOAD IS NOT THE ANSWER, though §11 refuses an unnamed
       property and §12 refuses a deviant root. `start` is a property the schema
       NAMES, and its value is in range; what is out of contract is only that the
-      value happens to be the default. Refusing would break editors that
-      round-trip a tree they did not author, and no engine does it today. This
-      clause is about a NAMED field carrying the value the schema describes as
-      absent, which is a narrower thing than either refusal clause covers.
+      value happens to be the default.
 
       WHAT THE RULE IS NOT. It is not "drop `start` always". `start: 0` and
       `start: 2` are carried through unchanged, and an implementation that
@@ -12323,12 +10145,10 @@ EOF = (* end of file *) ;
       runs rather than by one render target's limitation.
 
       NOT A DISTINCT NODE TYPE, deliberately. `block_image` is the honest shape
-      -- it IS a different construct, and the caption would have an obvious
-      home on it -- but it breaks every consumer that switches on node type and
-      it ripples through the engines, the importers, `fmt` and this schema at
-      once. A field is additive: a consumer that ignores it still works, and one
-      that reads it stops re-deriving. A type stays available later; going
-      field-first puts the phase and its call sites in place first.
+      -- it IS a different construct -- but it breaks every consumer that
+      switches on node type and it ripples through the engines, the importers,
+      `fmt` and this schema at once. A field is additive, and a type stays
+      available later.
 
       ON INGEST, TRUST THE PROPERTY -- NORMATIVE. A reader that receives
       `blockImage` USES it. It runs the promotion phase itself only for a tree
@@ -12348,24 +10168,12 @@ EOF = (* end of file *) ;
       reference is never defined still round-trips to itself (§6). The
       alternative makes the writer non-local: the same paragraph would be
       written differently depending on whether a definition appears somewhere
-      else in the document, possibly far away. PART 11 §1c already collapses on
-      the writer side, so teaching `fmt` about resolution buys nothing.
+      else in the document.
 
       AN IMPORTER READS THE FIELD RATHER THAN GUESSING. An HTML importer that
       escapes a following `^ ` line because the image above it "would capture
       it" is deriving R7 a third time, in a pipeline with no access to the
       phase (`docs/html-import.md`, the detached-caption case). It reads
       `blockImage` on the tree it built instead.
-
-      NO HTML MOVES. This is a wire-format clause: every render target already
-      produced the promoted output, so nothing in the corpus changes because of
-      the field. What the corpus pins is R7's OBSERVABLE half, and it was
-      already half-pinned: categories 201, 207, 209 and 412 hold the resolved
-      and unresolved reference image, each with and without a caption, and 209 -
-      the unresolved image whose caption line folds into the paragraph - is the
-      row a syntactic binding fails. Category 434 adds the two give-back paths
-      on which a LINE can be lost and that no CORPUS document held: a slot more
-      than one line wide, held only against the oracle by a unit test no engine
-      runs, and a slot inside a container, held by nothing at all.
 
    ============================================================================ *)

--- a/resources/spec/01-layout.ebnf
+++ b/resources/spec/01-layout.ebnf
@@ -15,21 +15,16 @@
            at the very start of the document is removed before the first line
            is read, so `<BOM># T` is a heading and not paragraph text. ONE, and
            only there: a U+FEFF anywhere else is an ordinary zero-width
-           character, which this file already says of a destination ("ZERO-WIDTH
-           characters (U+200B, U+FEFF) are NOT whitespace and ARE ordinary
-           destination characters").
+           character, and zero-width characters (U+200B, U+FEFF) are NOT
+           whitespace and ARE ordinary destination characters.
 
            A NULL IS REPLACED BEFORE THE FIRST LINE IS READ -- NORMATIVE.
            Every U+0000 in the source becomes U+FFFD REPLACEMENT CHARACTER,
            wherever it stands, before the first line is read. It is therefore
            not content, and it is the ONE C0 control PART 9 §29 does not make
-           content; §29 carries the carve-out and its reasons, and the
-           transform itself belongs here because it happens at this boundary
-           and for the same kind of reason as the mark above -- a document is
-           read over the OUTPUT of this layer, not over the bytes as authored.
-
-           EVERY occurrence is replaced. One U+0000 becomes one U+FFFD, so the
-           transform does not change source offsets (carve#1523).
+           content; §29 carries that carve-out. EVERY occurrence is replaced,
+           one U+0000 to one U+FFFD, so the transform does not change source
+           offsets (carve#1523).
 
            Column arithmetic is PART 9 §24 C1. A TAB IS SYNTAX ONLY IN THE
            LEADING RUN (PART 7).
@@ -221,10 +216,9 @@
         owner is selected before that leaf is continued.
 
         THE MARKER LINE'S CONTENT IS THE ITEM'S FIRST BLOCK -- NORMATIVE
-        (carve#1280). The clause above is spelled with an empty quote, which
-        reads as though EMPTINESS were the property doing the work. It is not,
-        any more than verbatimness is two clauses down. The parameter is the
-        one S4 names: does any container in the open stack hold an OPEN
+        (carve#1280). EMPTINESS is not the property doing the work. The
+        parameter is the one S4 names: does any container in the open stack
+        hold an OPEN
         PARAGRAPH. A block that leaves none leaves none wherever it was
         written, and `- # H` writes a HEADING as the item's first block exactly
         as `- ` plus an indented `# H` would. So each of
@@ -285,20 +279,6 @@
             tail             > > | b |          tail
                              tail
 
-        all end BOTH quotes and leave `tail` a top-level paragraph, for the
-        reason `> # H` / `tail` ends one. The reading that stopped at the outer
-        quote gave `tail` a paragraph in the outer quote CONTINUING NOTHING -
-        the outer quote's last block is the inner quote, and the inner quote's
-        is a heading, so there was no open paragraph anywhere in the stack for
-        S4's fold to carry out.
-
-        The one-level spelling already answered this way in every engine and
-        the two-level one did not in three of them, which makes it a
-        contradiction inside each of those readers rather than a gap in this
-        clause. `> > a` / `tail` still folds into the INNER quote, and
-        `> > # H` / `> > a` / `tail` folds too: those are the shapes with a
-        paragraph open, and depth was never the parameter.
-
         The rule reaches blocks written at an item's CONTENT COLUMN too. A
         heading there leaves no paragraph open, so a following below-column
         line cannot stay in that item. In a nested list the owner table is then
@@ -332,11 +312,10 @@
         same way and for the same reason (§10 I5 lists it too), so
         `: a` over `  %% c` over `tail` ends the `dd`.
 
-        AND THE DEFINITION REGISTERS, which is half of what I5 says and the
-        half an implementation can pass this rule without: "A link or footnote
-        definition belongs to an open list item only at that item's
+        AND THE DEFINITION REGISTERS, which is I5's other half: "A link or
+        footnote definition belongs to an open list item only at that item's
         `content_column`". Ending the container while DROPPING the definition
-        gets `tail` right by accident and fails the moment the column moves.
+        is not conforming.
         I5's other two columns are the controls and are UNCHANGED: at DOCUMENT
         column 0 the definition is a document-level interrupter, and at a
         nonzero column BELOW `content_column` it is lazy paragraph text that
@@ -347,8 +326,7 @@
         INVISIBLE LINE IS ONE CLASSIFICATION): recognized at document level
         only, so inside a container the line is not an invisible line at all --
         it is ordinary paragraph text and reopens the paragraph like any other
-        prose. Pinned in both bodies with a collector of their own by corpus
-        432-an-abbreviation-definition-outside-document-level-is-not-an-invisible-line.
+        prose.
 
         A QUOTE IS REACHED BY ITS MARKER, AND A COLUMN NEVER REACHES INTO ONE
         (carve#1384). I5's columns are read against the container a line is IN,
@@ -358,29 +336,9 @@
         so it is paragraph text: it renders where it was written and registers
         nothing.
 
-        The tell was that one line answered differently by what the quote HELD:
-
-            > x                > - x
-              [r]: /u            [r]: /u
-
-            See [r][].         See [r][].
-
-        Both second lines are identical and sit at the quote's content column,
-        and neither writes the marker. The left one folds into the quote's
-        paragraph as text in every reader. The right one was read as the INNER
-        ITEM's content column, where I5 makes a definition the item's, so this
-        implementation registered it and rendered it NOWHERE, and carve-js and
-        carve-php dropped it entirely -- render nothing and define nothing,
-        which is the one outcome carve#624 forbids. carve-rs folds both, and the
-        fold is what S4 already prescribes: the deepest open paragraph in the
-        stack is the inner item's, and the line continues it.
-
         WITH THE MARKER WRITTEN nothing about I5 changes: `> - x` over
-        `>   [r]: /u` registers at the inner item's content column in all four
-        readers, which is corpus
-        360-a-definition-behind-an-alternating-container-prefix-registers-at-the-innermost-content-column's
-        space. The marker is the parameter, and the quote's body is not.
-        Corpus 369.
+        `>   [r]: /u` registers at the inner item's content column. The marker
+        is the parameter, and the quote's body is not.
 
         PROSE REOPENS THE PARAGRAPH WHEREVER IT SITS AMONG THE ITEM'S BLOCKS,
         which is the general shape of that last sentence rather than a property
@@ -418,15 +376,8 @@
 
         end the item in the first two spellings and fold in the third, and the
         difference between them is the blank, never the missing closer. A
-        reader that made the closer decide answers one rule two ways inside a
-        single parse, which is what the executable spec did: it carried the
-        blank as container content and left the item's paragraph open across
-        it, so the flush-left line arrived at a div that should already have
-        been out of reach. carve-js, carve-php and carve-rs all end the item.
-        Corpus 362 pins it with two controls: the same input without the blank,
-        which still folds, and a following line at the item's content column,
-        which is the div's second block rather than the end of the item.
-        (carve#1379)
+        following line at the item's content column is the div's second block
+        rather than the end of the item. (carve#1379)
 
         THE COLUMN IS REACHED BY COMPOSING THE STRIPS, NOT BY WALKING THE
         PREFIX (carve#1368). Which container's `content_column` a line reaches
@@ -434,24 +385,21 @@
         own prefix and hands the residue down, so the question is asked of the
         INNERMOST container in the coordinates IT was handed. The shape of the
         prefix above it -- how many quotes and list items it alternates, in
-        what order, and how deep -- is not a parameter. Stated as a property
-        rather than as the list of prefixes that have been measured: two
-        container kinds already spell 62 of them by depth five, and the list
-        goes stale at depth six.
+        what order, and how deep -- is not a parameter.
 
         The DROP is the disappearance §24 C3 already forbids under AN INVISIBLE
-        LINE FOLDS LIKE ANY OTHER (carve-php#721): a definition may register, or
-        it may stay text, and half-folding it -- gone from the page, absent from
-        the tables -- is not an option the rule offers.
+        LINE FOLDS LIKE ANY OTHER: a definition may register, or it may stay
+        text, and half-folding it -- gone from the page, absent from the
+        tables -- is not an option the rule offers.
 
         AT A CONTAINER'S CONTENT COLUMN, A BLOCK ENDS THE PARAGRAPH IT SITS
-        UNDER -- NORMATIVE (carve#1350, carve#1357). The clause above names a
-        definition and a comment; this is the rule both are instances of, and
-        it is stated as a property because the instances are not enumerable.
+        UNDER -- NORMATIVE (carve#1350, carve#1357). The definition and the
+        comment above are instances; the rule is stated as a property because
+        the instances are not enumerable.
 
-        §24 C3 says the content column IS the container body's column 0: "a
-        block opener is recognized there exactly as a block opener is
-        recognized only at column 0 at the top level". So a line there is read
+        §24 C3 says the content column IS the container body's column 0: a
+        block opener is recognized there exactly as one is recognized only at
+        column 0 at the top level. So a line there is read
         as a BLOCK, and a block ends the paragraph above it. WHAT THE BLOCK
         RENDERS IS NOT A PARAMETER. A comment, a link or footnote definition
         and an attribute block all render nothing and all three end the
@@ -479,20 +427,11 @@
         marker line and a heading inside a quote. The line's position changes
         which container owns the heading, not whether the heading is a block.
 
-        THE §17 L1a OBJECTION DOES NOT REACH THIS. carve#621 and carve#625
-        ruled that an invisible line is NOT A PARAGRAPH for looseness. Whether
-        a line IS a paragraph and whether it ENDS one are different questions,
-        which is what the `dd` half of carve#1350 already turned on - and the
-        attribute block settles it by measurement rather than by argument,
-        since it is invisible, it ends the item, and every implementation
-        already agrees it does. An objection that would forbid that is an
-        objection to something nobody does.
-
         WHAT THIS DOES NOT REACH, and both are unchanged. BELOW the content
         column at a NONZERO column, the following line reaches the container
         only through S4's lazy fold, and §24 C3's comment exception keeps that
-        path open: `- a` / `  %% c` / ` b` keeps `b` in the item, and corpus
-        189 and 192 pin the nested spelling of it. A line at DOCUMENT column 0
+        path open: `- a` / `  %% c` / ` b` keeps `b` in the item. A line at
+        DOCUMENT column 0
         is not below a column - it is AT the enclosing context's own block
         position, the distinction C3 already draws for a definition. And a line
         AT the content column after the block is the container's own second
@@ -517,15 +456,9 @@
         THE LINK REFERENCE DEFINITION IS THE CONTROL, and it does not move. It
         has no body, so its block IS the one line: the blank after it falls
         OUTSIDE the block, the indented line below is the container's own
-        second paragraph, and the flush-left line folds into that. `- a` /
-        `  [r]: /u` / blank / `    more` / `tail` keeps both lines in the item,
-        which every implementation already does. So this turns on the block's
-        extent, the same thing the contiguous spelling turned on, and not on
-        indentation and not on blank lines.
-
-        The NESTED spelling (`- outer` / `  - inner` / `    [r]: /u` / `tail`)
-        is unanimous and belongs to the nested half this clause leaves open
-        above; it is not decided here.
+        second paragraph, and the flush-left line folds into that. So this
+        turns on the block's extent, not on indentation and not on blank
+        lines. The NESTED spelling is not decided here.
 
         A FENCED BODY IS NOT A PARAGRAPH -- NORMATIVE (carve#646). The same
         rule, with the unmatched container's last block a CODE FENCE opened on
@@ -544,39 +477,16 @@
         and `x` re-parses at document level -- where the trailing delimiter run
         is ordinary inline text.
 
-        AND THE FENCE KIND IS NOT A PARAMETER -- NORMATIVE (carve#980). The
-        clause above is named for a code fence, and reads as though
-        VERBATIMNESS were the property doing the work. It is not. The reach of a container
-        is not extended by what its innermost block happens to be, and the
-        parameter S4 actually consults is whether ANY container in the open
-        stack holds an OPEN PARAGRAPH -- explicitly regardless of how many
-        containers the line failed to match. The fence kind never enters.
-
-        Read that way the two fence kinds are ONE rule and the asymmetry
-        between them falls out of the paragraph:
-
-          - A CODE fence body cannot hold an open paragraph at all, so the
-            column-0 line always takes S4's otherwise and the container ends.
-            That is the clause above, with no exception to carry.
-          - A COLON fence body CAN hold one, so it takes the lazy branch when
-            it does and the same otherwise when it does not.
-
-        The second bullet is not a widening. An EMPTY colon fence already ends
-        the container today -- corpus 270's second document pins it and the
-        oracle produces it -- so the reach rule ALREADY reaches colon fences.
-        What it must not do is override an open paragraph, because S4's lazy
-        branch is what the reach rule is made of, not an exception to it.
-
-        S1 and S2 are why this needed saying. S1 MATCH PREFIXES stops the walk
-        at the ITEM and S2 FENCED BODY does not fire, in the colon spelling
-        exactly as in the code spelling. But stopping the walk only ROUTES the
-        line to S4; it does not decide it. Reading the stop as the decision
-        makes VERBATIMNESS look load-bearing when it only ever stood in for
-        "no paragraph is open", and that derivation reaches the opposite of
-        what corpus 270 and A REAL DIV IS A CONTAINER LIKE ANY OTHER already
-        require. Stated here because a clause that is silent about which
-        property governs leaves the wrong derivation available to the next
-        reader, which is how it was reached once already (carve#980).
+        AND THE FENCE KIND IS NOT A PARAMETER -- NORMATIVE.
+        VERBATIMNESS is not the property doing the work. The reach of a
+        container is not extended by what its innermost block happens to be,
+        and the parameter S4 consults is whether ANY container in the open
+        stack holds an OPEN PARAGRAPH. The fence kind never enters, so the two
+        fence kinds are ONE rule and the asymmetry between them falls out of
+        the paragraph: a CODE fence body cannot hold an open paragraph at all,
+        so the column-0 line always takes S4's otherwise and the container
+        ends, while a COLON fence body CAN hold one and takes the lazy branch
+        when it does.
 
         AND A FENCE THAT OPENED NO BODY IS NOT ONE EITHER (carve#1387). The
         first bullet presumes a code fence body EXISTS. §10 I4 decides that, and
@@ -596,16 +506,6 @@
               ```               > ```                 ```
             tail                tail                tail
 
-        all three fold `tail` into the paragraph that is still open, and no
-        container ends. The LIST spelling is the one that diverged: the
-        executable spec, carve-php and carve-rs ended the item while rendering
-        the same fence line as paragraph text, which is one line answered two
-        ways inside a single parse -- the shape PROSE REOPENS THE PARAGRAPH
-        already names. All three of them fold the quote spelling, and this
-        implementation folded the `dd` spelling too, so the contradiction was
-        inside each reader rather than between them. The fence CHARACTER is not
-        a parameter either: the tilde spelling is the same clause.
-
         THE CLOSER LOOKAHEAD DOES NOT STOP AT A BELOW-COLUMN LINE. §24 C3 folds
         such a line as lazy text while a paragraph is open, so a closer written
         below it is still written inside the container. Stopping there makes the
@@ -618,15 +518,13 @@
              y
               ```
 
-        differently from every engine, which ends the item at ` y` because this
-        fence does have its closer and a real body is open (corpus
-        276-a-fence-opened-on-a-list-marker-line-body-below-the-content-column).
+        wrongly: the item ends at ` y`, because this fence does have its closer
+        and a real body is open.
 
         A BLANK LINE and a TERMINATED fence are the controls, and both are
         unchanged: a blank closes the paragraph so S4's otherwise governs
         (carve#1379), and a fence with a closer is a BLOCK whose body leaves no
         paragraph open, which is the first bullet with its premise intact.
-        Corpus 367.
 
         AND NOTHING CLOSES MEANS THE CONTAINER GOES ON COLLECTING -- NORMATIVE
         (carve#980). S4's lazy branch says NOTHING closes, and that binds the
@@ -641,16 +539,11 @@
               b
               :::
 
-        On the left `a`, `d` and `b` are one paragraph in one div. Folding `d`
-        and then ending the container -- so that `b` lands beside the div
-        rather than inside it -- is the reach over-extended in the other
-        direction, and it renders a document nothing in the stack ever closed.
-        The right-hand document is the same rule with the fold as the last
-        line, which is the only spelling corpus 270 carried, and it is why a
-        reader could fold correctly and still get the left one wrong. Corpus
-        category 280 pins both, and the CONTROL beside them: with nothing in
-        the stack open, the flush-left line still ENDS the container and the
-        line after it is outside too.
+        On the left `a`, `d` and `b` are one paragraph in one div; `b` MUST NOT
+        land beside the div. The right-hand document is the same rule with the
+        fold as the last line. The CONTROL: with nothing in the stack open, the
+        flush-left line still ENDS the container and the line after it is
+        outside too.
 
         A REAL DIV IS A CONTAINER LIKE ANY OTHER -- NORMATIVE (carve#909). An
         unterminated `::: ` div in a container decides the same way, on the same
@@ -692,18 +585,9 @@
         governs, its lazy branch asks for an open PARAGRAPH, and a verbatim
         body is not one. So the containers close, the `dd` holds an EMPTY code
         block, and `body` re-parses at document level -- where the trailing
-        delimiter run is ordinary inline text, byte for byte the answer corpus
-        276 already pins for the `- ``` ` spelling.
+        delimiter run is ordinary inline text, byte for byte the answer the
+        `- ``` ` spelling gets.
 
-        This said "the innermost MATCHED context holds an OPEN PARAGRAPH",
-        which describes something no implementation does. A lazy line carries
-        no markers, so it matches ZERO containers and the innermost matched
-        context is the document root, which holds no open paragraph -- under
-        that wording `> a` / `b` would close the quote at depth 1. Every engine
-        folds there, and corpus 82-blockquote-lazy-continuation pins it. What
-        the wording did produce was a split at depth 2: carve-rs closed both
-        quotes where carve-js and carve-php folded into the nested one
-        (carve#506, carve-rs#452). Depth is not a parameter of this rule.
      S5 OPENERS. When S3/S4 classify the residue as a container opener (a
         quote marker; a list marker at an admissible column; a `+`
         continuation marker at the marker column, PART 9 §17 L3/L4; a fence

--- a/resources/spec/03-blocks-core.ebnf
+++ b/resources/spec/03-blocks-core.ebnf
@@ -28,23 +28,13 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
    character that is not one BEGINS the heading. `##<SP><SP>h` is the heading
    `h`, not `<SP>h`.
 
-   TWO CLAUSES DECIDE IT, and neither of them counts engines. MARKER
-   SEPARATORS AND PADDING SLOTS (PART 2) defines a marker separator as what
-   stands between the marker and the content it introduces and rules that a
-   writer aligning in a column "is writing separator, not content"; the four
-   slots that clause narrows to exactly one space are PADDING slots, an
-   enumeration it closes, and the heading marker is not among them. And
-   PART 11 §1 names MARKER ALIGNMENT among the spellings `fmt` may normalize
-   while preserving what the document says -- which holds only if the run is
-   not content. All three writers already normalize `##<SP><SP>h` to
-   `##<SP>h`, so under the literal reading every one of them changed the
-   document on every pass.
-
-   NO GATE COULD REACH IT. No corpus document, no optional-corpus case and
-   none of the authored documents in the oracle comparison's population
-   spelled a heading with a second space after the marker.
-   `84-single-line-headings-5` is `#` and two spaces and NOTHING else, which
-   is a different rule and is answered below.
+   TWO CLAUSES DECIDE IT. MARKER SEPARATORS AND PADDING SLOTS (PART 2) makes
+   a marker separator what stands between the marker and the content it
+   introduces, and the four slots it narrows to exactly one space are PADDING
+   slots -- a closed enumeration the heading marker is not in. And PART 11 §1
+   names MARKER ALIGNMENT among the spellings `fmt` may normalize while
+   preserving what the document says, which holds only if the run is not
+   content: `fmt` writes `##<SP><SP>h` as `##<SP>h`.
 
    A TAB IS NOT SEPARATOR. `space = ' '`, so `#<SP><TAB>x` is a heading whose
    text BEGINS with the tab, and `#<TAB>x` is not a heading at all -- the
@@ -53,16 +43,12 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
 
    AND THE MARKER REQUIRES CONTENT after the run as well: hashes, the
    separator and nothing but whitespace open no heading, and the line is
-   ordinary paragraph text with its trailing run dropped. That half needs no
-   correction -- it is the one thing every reader including the executable
-   spec already had, which is why `84-single-line-headings-5` was never red.
+   ordinary paragraph text with its trailing run dropped.
 
    WHAT MOVES WITH THE TEXT, AND WHAT DOES NOT. The derived id does NOT
    change: slugging drops a leading run either way, so `##<SP><SP>a b` is
-   `a-b` under both readings, and a ticket predicting otherwise is predicting
-   from the text rather than from the slug. A CROSSREF's AUTO-TEXT does move,
-   because §19 takes the heading's own text -- `</#a-b>` rendered
-   `<SP>a b` under the literal reading and renders `a b` under this one. *)
+   `a-b`. A CROSSREF's AUTO-TEXT takes the heading's own text (§19), so
+   `</#a-b>` renders `a b`. *)
 
 (* SINGLE-LINE HEADINGS -- NORMATIVE (diverges from Djot). A heading ENDS AT
    THE NEWLINE. It has no continuation line, and nothing following it folds in:
@@ -75,18 +61,6 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
      ## A             -> two separate <h2> elements
      ## B
 
-   It also makes this grammar's own model true. A heading is described here as
-   "a bounded title, not an open paragraph"; with continuation lines it had
-   paragraph-style spill anyway. LAZY CONTINUATION now means exactly one thing
-   across the whole language: it continues an OPEN PARAGRAPH (in a blockquote,
-   list item or definition body). A heading is not a paragraph, so nothing
-   continues it.
-
-   WHAT IS LOST: source-wrapping a long heading. Headings are short by
-   construction, Markdown never offered it, and the rendered result was a raw
-   newline inside the `h1`. A Djot document that wraps a heading therefore
-   renders differently in Carve; `carve lint --from-djot` reports it.
-
    A `^ ` caption line is no exception: it does not fold in, and it does not
    attach either, because a heading is NOT one of §4's captionable hosts. It
    opens an ordinary paragraph of its own.
@@ -94,21 +68,12 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
      # H              -> <h1>H</h1> then <p>^ cap</p>
      ^ cap
 
-   This sentence used to read "a caption still attaches to a heading (§4)",
-   citing as its authority the very clause whose enumeration omits a heading,
-   and no engine attaches one. A false claim carrying a true citation is worse
-   than a bare one: a reader who checks the reference finds the opposite and has
-   no way to tell which of the two is the language (carve#991).
-
    NO TRAILING ATTRIBUTES (djot-strict). A heading line carries NO trailing
    `{...}` attribute block: a `{...}` at the end of a heading line is ordinary
    inline content (literal text unless it forms an inline construct), and the
    id derives from the full literal text. Attributes attach via a PRECEDING
    block-attribute line (PART 9 §15), the uniform block rule; an explicit
-   `#id` from that line lives on the `<section>` wrapper (PART 9 §13).
-   Pinned by corpus 02-headings (the preceding-line and literal-trailing
-   pairs) and 82-single-line-headings (the five cases that used to fold, kept
-   as the regression guard for the behavior that replaced them). *)
+   `#id` from that line lives on the `<section>` wrapper (PART 9 §13). *)
 
 (* HEADING IDENTIFIERS -- NORMATIVE. A heading without an explicit {#id} gets an
    automatic identifier from its TEXT CONTENT, GitHub/SSG-style. WHICH INLINES
@@ -118,11 +83,7 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
    assigned before a cross-reference resolves or a symbol is looked up. Code
    spans, MATH runs, an image's alt text, a link's label and a superscript
    contribute; footnote references, cross-references and symbols `:name:` do
-   not, and a line comment ends the line it sits on. "Folded plain text" was the
-   older spelling here and is what let one engine drop math while keeping the
-   code span beside it: a plain-text projection that omits math supports that
-   reading, and nothing said the projection was not the rule. Corpus 332 pins
-   one document per inline kind. Then, on that text:
+   not, and a line comment ends the line it sits on. Then, on that text:
      - reverse smart-typography output to its ASCII source first, so the id does
        not depend on presentation (`Don’t` -> `Don-t`, `Step 1 → 2` -> `Step-1-2`);
      - replace each maximal run of non-alphanumeric ASCII characters with a single
@@ -131,12 +92,7 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
      - PRESERVE CASE (Unicode-aware): NON-ASCII characters AND letter case pass
        through unchanged (`Café` -> `Café`, `日本語` unchanged). The text IS
        NFC-normalized before slugging (PART 9 §25), so a precomposed `é` and a
-       decomposed `e` + U+0301 give the SAME id. The clause used to deny this and
-       argue that the slug "needs no Unicode tables" - but §25 already required
-       the normalization for Trojan-Source reasons, the corpus fixture beside it
-       pins the composed id, and all three engines plus the oracle compose. The
-       tables are carried either way, so the rationale was inverted as well as the
-       rule (carve#705);
+       decomposed `e` + U+0301 give the SAME id (carve#705);
      - a leading-digit result is prefixed `s-` (a bare leading digit is a valid HTML
        id but an invalid CSS selector); an empty result becomes a generated `s-N`;
      - duplicates within a document get a numeric `-2`, `-3`, ... suffix.
@@ -151,9 +107,9 @@ heading_marker = '#' | "##" | "###" | "####" | "#####" | "######" ;
    so the id is guaranteed to match `[0-9A-Za-z-]`. carve-js spells them `'fold'`
    and `'strict'`, carve-rs `AsciiHeadingIds::Fold` and `::Strict`; carve-php's
    extension is the STRICT one. The table itself is not normative -- what is, is
-   that the three engines carry the SAME table, so a folded id is byte-identical
-   across them. NOTE: carve PRESERVES case, matching djot.js / djot-php per #393;
-   cross-references resolve case-insensitively against the case-preserved id table. *)
+   that the three engines carry the SAME table. Carve PRESERVES case, matching
+   djot.js / djot-php per #393; cross-references resolve case-insensitively
+   against the case-preserved id table. *)
 
 (* --- Thematic Breaks --- *)
 thematic_break = (('-', '-', '-', {'-'}) | ('*', '*', '*', {'*'}) | ('_', '_', '_', {'_'})), newline ;
@@ -170,27 +126,22 @@ fenced_code_block = code_fence_open, [space], [code_fence_info], newline,
 (* The space between the fence and the info string is OPTIONAL (lenient:
    both ```php and ``` php are accepted; Markdown writes no space, Djot writes
    the space). The no-space form (```php) is canonical and is what the X->Carve
-   converters emit. It is a PADDING SLOT, not a marker separator (PART 7) --
-   the fence run has already decided that this is a code block, and the info
-   string only names the language and carries metadata -- but both roles take
-   `space`: the slot sits after the fence run, and A TAB IS SYNTAX ONLY IN THE
-   LEADING RUN (PART 7). The same holds for the two slots inside
-   code_fence_info below. So ```` ```<TAB>php ```` is not a fence opener; the
-   backtick run is an ordinary inline verbatim run (carve#1285). A TAB WITH
-   NOTHING AFTER IT IS NOT THIS SLOT, by ruling (carve#1295): it is trailing
-   whitespace on a content line, PART 2 drops it, and ```` ```<TAB> ```` opens
-   an ordinary fence with no info string. Position decides which clause
-   governs, here and at `frontmatter_open`, and refusing both positions is the
-   separator rule applied twice. raw_block (PART 9 §20)
-   spells its otherwise identical slot the same way, for the additional reason
-   that the `=` after it SELECTS a raw block over a code block.
+   converters emit. It is a PADDING SLOT, not a marker separator (PART 7), but
+   both roles take `space`: the slot sits after the fence run, and A TAB IS
+   SYNTAX ONLY IN THE LEADING RUN (PART 7). The same holds for the two slots
+   inside code_fence_info below. So ```` ```<TAB>php ```` is not a fence opener;
+   the backtick run is an ordinary inline verbatim run. A TAB WITH NOTHING AFTER
+   IT IS NOT THIS SLOT: it is trailing whitespace on a content line, PART 2
+   drops it, and ```` ```<TAB> ```` opens an ordinary fence with no info string.
+   Position decides which clause governs, here and at `frontmatter_open`.
+   raw_block (PART 9 §20) spells its otherwise identical slot the same way, for
+   the additional reason that the `=` after it SELECTS a raw block over a code
+   block.
    CARDINALITY DIFFERS BETWEEN THIS SLOT AND THE TWO INSIDE code_fence_info,
    deliberately: this one is `[space]`, exactly one, and those are `space+`.
    So ``` ```<SP><SP>php ``` is not a fence opener at all -- the second space
    reaches `language_info`, whose class holds no space, and the INVALID-FENCE
-   FALLBACK applies. All three engines and the executable spec accepted a run
-   here until carve#912 held the production right; corpus 263 carries it with
-   its one-space control. *)
+   FALLBACK applies. *)
 (* CODE-FENCE INFO STRING -- NORMATIVE. After the optional language_info
    token the opener admits, in this fixed order, an optional "header" (a
    quoted_title -- the SAME token as the admonition header, PART 9 §12) and an
@@ -245,10 +196,8 @@ code_fence_close = (backtick_fence | tilde_fence):close
      - A closing run indented PAST its opener is not a delimiter but code
        content -- which is exactly what lets an indented ``` line appear as
        sample text inside a fence.
-   Earlier drafts accepted 0-3 columns of indentation on a delimiter (a Markdown
-   inheritance, to disambiguate against the 4-space indented code block); Carve
-   has no such construct, so that tolerance is removed. The X->Carve converters
-   re-base an indented Markdown fence to its container's content column. *)
+   The X->Carve converters re-base an indented Markdown fence to its
+   container's content column. *)
 
 backtick_fence = '`', '`', '`', {'`'} ;
 tilde_fence = '~', '~', '~', {'~'} ;
@@ -264,8 +213,7 @@ code_fence_info = ( language_info, [space+, quoted_title], [space+, label] )
    "title" and [label] slots carry: the fence has already decided the block --
    and padding takes `space`, by A TAB IS SYNTAX ONLY IN THE LEADING RUN
    (PART 7). The label slot appears in two alternatives and is one slot with
-   one role, so both spellings carry the same terminal -- otherwise ```js "T" [L] and ``` "T" [L]
-   would disagree about a tab for no reason a reader could state. *)
+   one role, so both spellings carry the same terminal. *)
 language_info = (letter | digit | '-' | '_' | '+' | '#' | '.' | '/')+ ;  (* a single token; the punctuation covers real language tags like c++, c#, f#, asp.net, text/html. May start with a digit. The `/` is normative across all impls (so `text/html`, `image/svg` are language tokens, not split). A token MUST NOT start with `=`: a leading `=` is the raw_block opener (above), not a language. *)
 label = '[', { character - ']' }, ']' ;  (* structured metadata, e.g. [Installation]; not part of the class *)
 code_content = (* any text until matching fence, preserved literally *) ;
@@ -274,7 +222,7 @@ code_content = (* any text until matching fence, preserved literally *) ;
    are not interchangeable. Tab display width is a presentation concern (CSS
    `tab-size`). Tab-to-space expansion is NOT a default behavior -- it is opt-in
    via a tab-normalize extension (flat replacement, default 2 spaces, content
-   only). Matches djot / CommonMark. Pinned by corpus tabs-in-code-preserved. *)
+   only). Matches djot / CommonMark. *)
 
 (* --- Blockquotes --- *)
 blockquote = blockquote_line, {blockquote_line | lazy_continuation_line | continuation_marker_block}, [caption_slot] ;
@@ -325,25 +273,12 @@ bullet_marker = '-' | '*' ;  (* `+` is NOT a bullet in Carve -- it is the list
    opens its block only when followed by that space AND non-empty content. A
    content-less marker line -- bare (`-`) or with trailing whitespace only
    (`- `, `-   `) -- is NOT a list: it is paragraph text. The rule ignores
-   trailing whitespace, so `-` and `- ` behave identically (an editor stripping
-   the trailing space cannot change the meaning). Carve is stricter than
-   CommonMark, which treats a bare `-` as an empty item; requiring content keeps
-   a lone dash (a prose dash / placeholder) from silently becoming a list.
-   Pinned by corpus content-less-marker-is-not-a-list.
+   trailing whitespace, so `-` and `- ` behave identically. Stricter than
+   CommonMark, which treats a bare `-` as an empty item.
 
-   EVERY SUCH MARKER, not only the two named here. The rule is stated in terms
-   of bullets and ordered markers because those are where it was first needed,
-   but the rationale is a property of the separator space and applies wherever
-   one appears -- including the definition-term marker `::` and the description
-   marker `:`.
-
-   That omission was not theoretical: with the rule read narrowly, `:: ` was a
-   paragraph and `::` followed by TWO spaces was a definition list, so stripping
-   one trailing space changed the document's structure -- the exact thing the
-   sentence above exists to prevent. Three engines carried three answers
-   (paragraph, `<dt></dt>`, and `<dt> </dt>`) with every gate green, because the
-   corpus case pinned bullets only. Pinned now by corpus
-   content-less-marker-is-not-a-list-2 (carve#512).
+   EVERY SUCH MARKER, not only bullets and ordered markers: the rule is a
+   property of the separator space and applies wherever one appears --
+   including the definition-term marker `::` and the description marker `:`.
 
    THE DESCRIPTION MARKER -- NORMATIVE (carve#1830). `definition_separator` is a
    separator space, so a `:` line carrying only whitespace opens no description.
@@ -352,23 +287,17 @@ bullet_marker = '-' | '*' ;  (* `+` is NOT a bullet in Carve -- it is the list
    tab-separated `:` are one document, and the separator's width carries no
    meaning where it positions nothing. The tab is refused a step earlier, at the
    separator itself (PART 1, MARKER SEPARATORS AND PADDING SLOTS), and lands in
-   the same place. Pinned by corpus
-   a-colon-followed-by-only-whitespace-is-not-a-description.
+   the same place.
 
    A TAB AS THE FIRST CHARACTER OF CONTENT is a different question from the one
-   above -- NORMATIVE. There the separator space itself is present, so the
-   marker is satisfied and a term forms; the tab is not part of the separator
-   at all, it is the first character of the term's inline content. That tab is
-   ordinary leading whitespace, and is stripped like any other leading
-   whitespace in that position -- it does not appear in the rendered `<dt>`,
-   the same way a bullet's own extra separator whitespace never reaches the
-   item's content: content_column is where the item's content actually
-   STARTS (PART 9 §24 C3), so anything before it, space or tab alike, is
-   structural, not text. This is NOT the TABS IN CODE rule (PART 2, above):
-   that verbatim-preservation guarantee covers fenced code content and inline
-   code spans only, never a term's or a paragraph's inline content, so
-   nothing protects this tab. `::` + space + TAB + `x` therefore renders
-   `<dl><dt>x</dt></dl>` (carve#698). *)
+   above -- NORMATIVE.
+   There the separator space is present, so the marker is satisfied and a term
+   forms; the tab is the first character of the term's inline content. It is
+   ordinary leading whitespace and is stripped like any other in that position:
+   content_column is where the item's content actually STARTS (PART 9 §24 C3).
+   The TABS IN CODE rule (PART 2, above) does not apply -- it covers fenced code
+   content and inline code spans only. `::` + space + TAB + `x` therefore
+   renders `<dl><dt>x</dt></dl>`. *)
 
 ordered_list = ordered_item+ ;
 ordered_item = ordered_marker, [item_attributes], space, list_item_content ;
@@ -446,10 +375,8 @@ roman_numeral = ('i' | 'v' | 'x' | 'l' | 'c' | 'd' | 'm')+
    - Free slot: `-{` and `1.{` / `1){` are NOT list markers today (bullet and
      ordered both require the space), so no existing input changes meaning.
    - Diverges from djot (which has no li-attribute form); deliberate Carve
-     extension. The lazy-continuation accident -- a trailing `{…}` line folded
-     onto a tight item, which carve-php attached to the `<li>` and carve-js
-     dropped -- is REJECTED as the mechanism: it was position-dependent (broke
-     once a sub-list intervened) and is not normative. *)
+     extension. A trailing `{…}` line folded onto a tight item is NOT a
+     li-attribute mechanism. *)
 item_attributes = attributes ;
 
 list_item_content = first_block_content
@@ -466,10 +393,7 @@ indent = whitespace, {whitespace} ;
    one-off lone item: following markers at the sub-list's content column MERGE
    into the same nested list, and a post-blank block indented to that column is
    ABSORBED into the open nested item as a lazy continuation. This matches
-   reference djot.js (`@djot/djot`) and CommonMark. It CORRECTS a narrower
-   reading carve inherited from djot-php (which did not persist the nested list);
-   it is a bug fix, NOT a carve divergence. Pinned by corpus
-   marker-line-nested-lists. *)
+   reference djot.js (`@djot/djot`) and CommonMark. *)
 (* Continuation marker (Carve addition; see PART 9 §17): a lone `+` at the
    current container's marker column attaches the following flush-left block to
    that container -- a list item OR a block quote -- with no blank line, marker
@@ -497,28 +421,19 @@ task_state = ' ' | 'x' | 'X' | '-' | '_' | '>' | '?' ;
    indented line below it when it does not.
      `- [ ] a`        -> `<li><input ...> a</li>`
      `- [ ] > q`      -> `<li><input ...> ` newline `  <blockquote>...`
-   The executable spec emitted the checkbox only where the first block was a
-   PARAGRAPH, so a quote, a code fence, a `:::` div, a table row, a heading and
-   a thematic break each rendered a plain `<li>` and the state the author wrote
-   was gone from the output while the item parsed correctly. One serializer
-   branch built the opener without it, and it was the branch every
-   non-paragraph lead takes. carve-js and carve-php write it in all of them.
-   Corpus 363 pins three leads and both states. (carve#1381)
+   A quote, a code fence, a `:::` div, a table row, a heading and a thematic
+   break as the first block each still get the checkbox. (carve#1381)
 
-   THE TASK BOX CARRIES AN ACCESSIBLE NAME -- NORMATIVE (carve#1468). The box
-   is an <input type="checkbox"> and the word beside it is a SIBLING TEXT
-   NODE - not a <label>, not an aria-label - so the input carried a STATE and
-   no NAME, and a reader met an unlabeled disabled checkbox with ordinary prose
-   next to it. The box takes an `aria-label` naming it with the item's own
-   visible text: the DERIVED TEXT of the item's first block (PART 9R R4's
-   derivation, the same one a heading id and a crossref clone read). A
-   paragraph spans LINES -- a soft wrap, or a lazy continuation folded into it
-   -- and a name is ONE line, so each run of ASCII whitespace in the derived
-   text collapses to a single space and the result is trimmed. A NO-BREAK space
-   is content and survives; the collapse is ASCII-only for that reason.
-   Deriving rather than inventing is what keeps this string out of the `labels`
-   map (PART 9 SS16a) - it is the AUTHOR's text, already on the page, so a host
-   translating the document translates it exactly once.
+   THE TASK BOX CARRIES AN ACCESSIBLE NAME -- NORMATIVE. The box is an
+   <input type="checkbox"> and the word beside it is a SIBLING TEXT NODE - not
+   a <label>, not an aria-label - so without a name a reader meets an
+   unlabeled disabled checkbox. The box takes an `aria-label` naming it with
+   the item's own visible text: the DERIVED TEXT of the item's first block
+   (PART 9R R4's derivation). A name is ONE line, so each run of ASCII
+   whitespace in the derived text collapses to a single space and the result is
+   trimmed; a NO-BREAK space is content and survives. Deriving rather than
+   inventing is what keeps this string out of the `labels` map (PART 9 SS16a) -
+   it is the AUTHOR's text, already on the page.
      `- [ ] unchecked`   ->  `<input type="checkbox" disabled
                               aria-label="unchecked">`
      `- [x] done with `c``  ->  `... checked disabled aria-label="done with c"`
@@ -542,13 +457,7 @@ definition_term = "::", space, inline_content, newline, {term_continuation_line}
 term_continuation_line = inline_content, newline ;
 (* A term folds a following plain line as a soft break; a blank line, a new
    `::`/`: ` marker, or a block opener ends it. A term holds inline content
-   only -- no block body. (This used to read "like a heading", which was never
-   the right comparison: a term is the KEY half of a key-value entry, not a
-   title, and it is bound to the definition beneath it rather than to a section
-   of the document. It KEEPS its fold. What made the heading's fold a defect was
-   having TWO ways to spill onto the next line, one of them silent -- a term has
-   exactly one, so a long key stays wrappable at no cost. §434's follow-up
-   question is answered here rather than left open.) *)
+   only -- no block body. Unlike a heading, a term KEEPS its fold. *)
 definition_body = (':', definition_separator, first_block_content)
                 | (':', definition_separator, inline_content, newline,
                    { definition_continuation
@@ -568,54 +477,30 @@ definition_separator = space, {space} ;
    C1), so the spellings differ only in how far their continuations indent,
    never in what they mean.
 
-   This is the rule a BULLET already follows: `-   first` puts its content
-   column at 4 and a continuation at 2 does not reach it. The definition body
-   was the one construct that measured its separator against a fixed width
-   instead, and the one that demanded two spaces where every other marker in
-   the language takes one -- `- item`, `1. item`, `> quote`, `:: term`.
-
    ONE SPACE IS CANONICAL. A wider separator is accepted and the formatter
    narrows it, which is what a formatter is for; nothing about the document's
    meaning depends on the author having picked the canonical width. Narrowing
    the separator narrows the body's column, so a canonical rewrite carries every
    continuation inside that body down by the same amount. A formatter that
    trims the separator and leaves the body where it was changes what the
-   document says.
-
-   What changed for the one-space spelling is that it now HAS a meaning. It used
-   to have none, and the engines disagreed about what to do with a line that had
-   none -- carve-js folded `: x` after a term into the `<dt>`, the oracle left it
-   a stray paragraph. A colon line inside a definition context has exactly one
-   reading now. *)
+   document says. *)
 definition_continuation = (definition_indent, inline_content, newline)
                         | (backslash, newline, definition_indent, inline_content, newline) ;
 definition_indent = whitespace, {whitespace} ;
-(* INDENTATION IS COLUMNS, NOT CHARACTERS -- NORMATIVE (carve#692, carve#888).
-   This production used to read `space, space, space`, which made a definition
-   body's continuation a literal three-SPACE requirement. That contradicted
-   PART 9 §24 C1, which already gives a tab a column value (to the next
-   multiple of 4), and it made the definition body the ONE continuation in the
-   language that counted characters where its siblings count columns: a
-   footnote body honors C1 (`footnote_indent`, carve#692) and so does a list
-   item (`list_continuation`'s `indent`).
+(* INDENTATION IS COLUMNS, NOT CHARACTERS -- NORMATIVE. A tab has a column
+   value (PART 9 §24 C1, to the next multiple of 4), and a definition body's
+   continuation counts columns exactly as a footnote body (`footnote_indent`)
+   and a list item (`list_continuation`'s `indent`) do.
 
    `definition_indent` is any whitespace run REACHING THE BODY'S AUTHORED
    CONTENT COLUMN -- the column its separator width establishes. For canonical
    `: x`, two spaces reach column 2; for accepted `:  x`, three spaces reach
-   column 3. A bare tab reaches column 4 and qualifies for either. The floor is
-   column arithmetic, stated here rather than
-   encoded character-by-character, exactly as `footnote_indent` states its
-   own. This is INDENTATION, not a marker SEPARATOR: it does not change the
-   separator run after the `:` marker (PART 7's
-   MARKER SEPARATORS AND PADDING SLOTS clause, which is A TAB IS SYNTAX ONLY
-   IN THE LEADING RUN (PART 7) applied to a slot that sits inline).
+   column 3. A bare tab reaches column 4 and qualifies for either. This is
+   INDENTATION, not a marker SEPARATOR: it does not change the separator run
+   after the `:` marker (PART 7's MARKER SEPARATORS AND PADDING SLOTS clause).
 
-   The BACKSLASH branch spells the same indentation and is respelled with it,
-   for consistency of the file rather than for behavior: that branch resolves
-   through the hard break, where all four readers already fold the next line in
-   regardless of its indentation, so nothing observable turns on it and no
-   fixture below pins it. Recorded so the untouched-looking half is not read as
-   an oversight.
+   The BACKSLASH branch spells the same indentation: it resolves through the
+   hard break, which folds the next line in regardless of its indentation.
 
    BELOW THE BODY'S COLUMN THE BODY ENDS -- NORMATIVE (carve#932). The three
    bands, in column order, so the rule can be read off once:
@@ -634,9 +519,8 @@ definition_indent = whitespace, {whitespace} ;
        column (§10, A COMMENT IS THE ONE EXCEPTION), and a definition or
        attribute line at a nonzero column below the column is lazy paragraph
        text of THIS body (§10 I5, AN INVISIBLE LINE FOLDS LIKE ANY OTHER). At
-       DOCUMENT column 0 they are interrupters and the body does end. Reading
-       this bullet alone gave the band four different answers across the five
-       kinds, none of them the plain-line control's (carve#1800, carve#1801).
+       DOCUMENT column 0 they are interrupters and the body does end.
+       (carve#1800, carve#1801)
      - AT the column, the line is the body's own block content, so a block
        opener opens inside the `dd`.
      - PAST the column, a recognized block opener establishes its authored
@@ -644,24 +528,7 @@ definition_indent = whitespace, {whitespace} ;
        paragraph-continuation behavior.
 
    `definition_indent` states the floor as column arithmetic; this states what
-   happens on the other side of it. Nothing else in the language gives a
-   sub-column indent a third meaning, and a rule that did would make
-   indentation depth mean two different things one column apart.
-
-   THE RULE IS UNCHANGED AND THE NAMING IS THE CHANGE. The bands were already
-   stated here in passing -- "AT the column the line is the body's own block
-   content and the quote opens; below it the body ends", in the clause below --
-   and being unnamed they were inventoried nowhere and pinned by nothing. An
-   engine that follows this clause is not being asked to follow new prose.
-
-   THE LADDER IS PINNED (carve#1772). The documents this clause deferred to
-   their own pass are corpus 425: column 0 and the two columns above it in the
-   BELOW band, the column itself, one column past it, a second opener kind, and
-   the plain line that is not an opener at all and folds from any column. Until
-   they landed, lowering a reader's floor changed nothing any corpus document
-   could see -- a line below the column fell through to the flush-left branch
-   and nested anyway -- so a corpus run reporting every golden reproduced was
-   true and said nothing about this band.
+   happens on the other side of it.
 
    THE SURVIVING CONTEXT IS WHATEVER HOLDS THE LIST. At the top level an opener
    must be written at column 0, so a `>` one or two columns in opens nothing and
@@ -684,13 +551,12 @@ definition_indent = whitespace, {whitespace} ;
 
    opens a block quote. The same rule covers headings, lists, tables, code/raw/
    colon fences, definitions, attributes followed by their target and comments,
-   with or without a preceding blank. Tabs participate by visual column.
-
-   An ordinary over-indented line which is not a recognized opener remains
-   paragraph text. A line below the minimum column keeps the existing ownership
-   result. The leading run is measured once; implementations MUST NOT probe
-   every possible dedent. Opaque payload indentation beyond `block_base` is
-   authored data, and a closer belongs to the base established by its opener.
+   with or without a preceding blank. Tabs participate by visual column. An
+   ordinary over-indented line which is not a recognized opener remains
+   paragraph text, and the leading run is measured once: implementations MUST
+   NOT probe every possible dedent. Opaque payload indentation beyond
+   `block_base` is authored data, and a closer belongs to the base established
+   by its opener.
 
    MIGRATION. This changes released 0.1.3 documents whose over-indented literal
    text begins with a block opener. A diagnostic SHOULD offer two safe fixes:

--- a/resources/spec/04-blocks-tables-containers.ebnf
+++ b/resources/spec/04-blocks-tables-containers.ebnf
@@ -23,27 +23,20 @@ continuation_row = '+', table_cell, {'|', table_cell}, '|', newline ;
    2. A `+` CONTINUATION EXTENDS THE CELL, so a run left open by the row above
       is still open when the continuation is cut into cells: the pipes it spans
       there are its content too, and the block it reaches the end of is the
-      whole cell. Splitting a continuation row with a fresh scanner cuts inside
-      the run and drops what follows for want of a column to join it to, which
-      is content loss rather than a second answer.
+      whole cell.
 
    3. AN ESCAPED CLOSING PIPE IS STILL AN ESCAPE. `| a b \|` ends in a pipe, so
       the row closes there; the escape decides what the CELL holds, which is a
-      literal pipe rather than an orphaned backslash. Every reader already
-      honors `\|` in every other position of the same row, so reading it
-      everywhere EXCEPT the last position is a position exception with nothing
-      behind it -- and `\|` is the only way to write a literal pipe in a cell.
-      This does not widen what a row is: `| a | b`, with content dangling after
-      the last pipe, is prose exactly as before.
-
-   Pinned by corpus 328 and 332. *)
+      literal pipe rather than an orphaned backslash -- `\|` is the only way to
+      write a literal pipe in a cell, in every position of the row. This does
+      not widen what a row is: `| a | b`, with content dangling after the last
+      pipe, is prose exactly as before. *)
 
 (* Row-level attributes: a `{…}` attribute block GLUED to the row's closing `|`
    (no intervening space) sets the row's `<tr>` attributes -- the row-level twin
    of a cell's attribute block (cell_attributes). The two are NOT in the same
    position: a row's block follows the row's LAST `|`, a cell's follows the
-   cell's marker run (CELL ATTRIBUTES below). Row attributes are unaffected by
-   that rule and are stated here so the pair is not read as one. The whole
+   cell's marker run (CELL ATTRIBUTES below). The whole
    payload must be valid attribute syntax (§15); otherwise the `{` is ordinary
    content and the line is not a row attribute (see PART 9 §5, ROW
    ATTRIBUTES). *)
@@ -90,22 +83,13 @@ data_cell   =      [alignment_run], [cell_attributes], cell_padding, cell_conten
    text would leave this sentence with nothing to act on; `|{.x} < |` is
    `<td class="x">&lt;</td>`, never `<td>{.x} &lt;</td>`. The only stated route
    from a brace run to literal text is an INVALID payload, two sentences up.
-   This repo's own executable spec read it the other way for a while - it
-   cleared the attributes and re-read the whole segment - which is what
-   carve#1463 records and corpus 392 now pins. A computed rowspan/colspan/alignment is
-   authoritative, so an author copy of those keys is dropped. (corpus
-   99-table-cell-attributes, 319-cell-attributes-bind-after-the-kind-and-alignment-markers.)
+   A computed rowspan/colspan/alignment is authoritative, so an author copy of
+   those keys is dropped.
 
-   WHY LAST, AND NOT BEFORE THE MARKERS. Binding attributes to the opening `|`
-   ahead of the kind marker leaves an attributed header cell UNSPELLABLE: the
-   only shape available is `|{#x}=R|`, and that is ambiguous by construction --
-   readable either as an attributed header cell, or as a data cell whose
-   content begins with `=`. This grammar reads it the second way, so the shape
-   a canonical writer produced for an attributed header cell came back as
-   `<td id="x">=R</td>` and the PART 11 round-trip invariant failed on it.
-   Once `=` has committed the cell to header, everything after it is
-   unambiguous. Stating one order for both productions is what removes the
-   ambiguity, rather than giving header_cell a second, opposite one. *)
+   WHY LAST, AND NOT BEFORE THE MARKERS. `|{#x}=R|` is a DATA cell whose
+   content begins with `=`, not an attributed header cell: once `=` has
+   committed the cell to header, everything after it is unambiguous, and one
+   order for both productions is what removes the ambiguity. *)
 cell_attributes = attributes ;
 span_cell = rowspan_marker | colspan_marker ;
 
@@ -155,30 +139,20 @@ caption_continuation_line = inline_content, newline ;  (* a PLAIN line only *)
    that is not one BEGINS the caption. `^<SP><SP><SP>cap` is the caption `cap`,
    not `<SP><SP>cap`.
 
-   TWO CLAUSES DECIDE IT, neither of them a nose count. MARKER SEPARATORS AND
-   PADDING SLOTS (PART 2) defines a marker separator as what stands between the
-   marker and the content it introduces and rules that a writer aligning in a
-   column "is writing separator, not content"; the four slots that clause
-   narrows to exactly one space are PADDING slots, an enumeration it closes, and
-   the caret is not among them. And PART 11 §1 names MARKER ALIGNMENT among the
-   spellings `fmt` may normalize while preserving what the document says -- which
-   holds only if the run is not content. All three writers already normalize
-   `^<SP><SP><SP>cap` to `^<SP>cap`, so under the literal reading every one of
-   them changed the document on every pass.
+   TWO CLAUSES DECIDE IT. MARKER SEPARATORS AND PADDING SLOTS (PART 2) makes a
+   marker separator what stands between the marker and the content it
+   introduces, and the four slots it narrows to exactly one space are PADDING
+   slots -- a closed enumeration the caret is not in. And PART 11 §1 names
+   MARKER ALIGNMENT among the spellings `fmt` may normalize, which holds only
+   if the run is not content.
 
    A TAB IS NOT SEPARATOR. `space = ' '`, so `^<SP><TAB>cap` keeps the tab as
-   the caption's first character, exactly as a heading does at the same
-   position. MARKER REQUIRES CONTENT (PART 2) applies after the run as well:
-   a caret, the separator and nothing but whitespace opens no caption, and the
-   line is ordinary paragraph text.
+   the caption's first character. MARKER REQUIRES CONTENT (PART 2) applies
+   after the run as well: a caret, the separator and nothing but whitespace
+   opens no caption, and the line is ordinary paragraph text.
 
-   THE CONTINUATION LINE IS NOT TOUCHED BY THIS, and the two are different
-   positions rather than one rule read twice. A continuation line carries no
-   marker, so its leading run is INDENTATION and it is kept as written -- ruled
-   at carve#1561 on the ground that MULTI-LINE CAPTIONS enumerates only where a
-   caption ENDS and nothing in it, or in `caption_continuation_line`, dedents.
-   This clause is about the run that follows the CARET, which is the one
-   position on a caption where a separator exists at all. *)
+   THE CONTINUATION LINE IS NOT TOUCHED BY THIS. A continuation line carries no
+   marker, so its leading run is INDENTATION and it is kept as written. *)
 (* MULTI-LINE CAPTIONS -- NORMATIVE. A caption is multi-line inline CONTENT, so
    its text spills onto following lines exactly like a PARAGRAPH (§10), NOT like
    a heading. It ends the same way an open paragraph does:
@@ -240,11 +214,7 @@ colon_fence = ":::", {":"} ;
    makes the slot OPTIONAL because a bare `[label]` may sit flush against the
    fence (`:::[First]`); optional is a different property from a different
    role, and the slot answers the same way in all four openers whichever type
-   token follows it. Corpus 254 pins the slot PER OPENER, with a mixed-run case
-   beside each tab-first one, because implementations decide the one rule in
-   four separate places (carve#887, carve#900). Every implementation accepted a
-   tab here when carve#878 ruled on it; all three have since corrected it
-   (carve-js#794, carve-php#947, carve-rs#720). *)
+   token follows it. (carve#887, carve#900) *)
 colon_fence_close = colon_fence:close
                     where len(close) = len(open) ;
 (* FORMAL (PART 9 §12, now a guard): `open` is the colon_fence captured by
@@ -260,10 +230,6 @@ colon_fence_close = colon_fence:close
        documents and longer-inner ones both parse. `carve fmt` emits the
        inward-widening form (PART 11).
 
-   Earlier drafts used len(close) >= len(open), which made a container's
-   fence a quoting relation borrowed from the code fence. It forced a
-   canonical writer to know the maximum container depth of its whole
-   subtree, and it made equal-length nesting silently produce literal text.
    Code fences keep >= (PART 9 §2) because their length axis really is
    quoting: opaque content that never nests, which must be able to hold a
    shorter fence. *)
@@ -277,15 +243,9 @@ admonition = admonition_open, newline,
    a block still open when its HOST ends closes there, innermost first. The
    host is the ENCLOSING CONTAINER where there is one and the DOCUMENT
    otherwise, so "closes at end of input" is the top-level case rather than
-   the whole rule: corpus
-   271-the-flush-left-line-after-a-container-a-quoted-line-opened opens a
-   `::: note` inside a block quote, never closes it, and the container ends
-   WITH THE QUOTE -- the flush-left line below is a sibling paragraph outside
-   both, not content the div swallowed to the end of the file. This is
-   djot's behavior and it is the counterweight to the exact-length closer --
-   a mistyped closer leaves a container open, and the earlier rule (the
-   opener and everything after it degrade to literal text) turned one wrong
-   character into a corrupted document. An unclosed opener SHOULD be
+   the whole rule: a `::: note` opened inside a block quote and never closed
+   ends WITH THE QUOTE, and a flush-left line below is a sibling paragraph
+   outside both. This is djot's behavior. An unclosed opener SHOULD be
    diagnosed by lint and by the language server; it is not an error for the
    parser. Note this is NOT the `%%%` comment-block rule (§28), where an
    opener with no exact closer ahead opens nothing: a comment block is
@@ -302,18 +262,6 @@ admonition = admonition_open, newline,
        tail
                         tail
 
-   is literal item text on the left and an EMPTY div on the right. A blank
-   line is the container's own content, not a folded line, so an opener a
-   blank follows has opened an empty container exactly as one at end of input
-   has. The executable spec asked only whether the body was non-empty, which a
-   lone blank satisfies, and demoted the right-hand spelling to literal text
-   while answering the same opener correctly at end of input, with its closer,
-   with a body line, and inside a quote. That reads one blank line as content
-   in the collector and as absence of content in the block parser. carve-js,
-   carve-php and carve-rs open the div. Corpus 364 pins both sides, the second
-   as the control a fix that stopped asking about folding would flip.
-   (carve#1382)
-
    OPAQUE SPANS (PART 9 §12). `{block - admonition_close}` is a BLOCK
    sequence, so a fenced code block, a raw block and a comment block inside
    the body are single blocks and their lines are never examined for a
@@ -323,38 +271,29 @@ admonition = admonition_open, newline,
    span's opener BEFORE testing for its closer -- an opener with no info
    string (a bare code fence, a `%%%`) is closer-shaped itself, so testing it
    first ends the span on its own line and hands the span's contents back to
-   the block parser (carve#450). Under exact-length closers a miscount there
-   shifts the whole subtree, and a code fence is the only structural way to
-   quote a container fence, so this is the path every document that describes
-   Carve in Carve takes.
+   the block parser (carve#450).
 
    TOOLING FOR NEAR MATCHES (PART 9 §12). Exact length remains a parse rule,
    not a recoverable syntax error. A processor with diagnostics SHOULD report
    `colon-fence-length-mismatch` when a bare colon run does not close the
    innermost open container, would close it after resizing, and plausibly
    expresses closing intent. The finding names the authored and expected
-   widths, the opener position, and the line's actual parse outcome (a nested
-   container or literal text). It MUST NOT fire for typed openers, escaped
-   colons, opaque code/raw/comment payloads, or a different-width child fence
-   that has its own exact closer.
+   widths, the opener position, and the line's actual parse outcome. It MUST
+   NOT fire for typed openers, escaped colons, opaque code/raw/comment
+   payloads, or a different-width child fence that has its own exact closer.
 
    A tool MAY offer separate fixes to resize the run or preserve it as literal
    content. Neither is a canonical-formatting decision: `carve fmt` MUST NOT
    choose an intention. Editors SHOULD pair and highlight exact opener/closer
-   ranges from parser structure. Automatic paired edits stop after either side
-   is independently changed; proximity alone never licenses resizing a nested
-   fence. (carve#1727)
+   ranges from parser structure; proximity alone never licenses resizing a
+   nested fence.
 
    A CLOSER IS REQUIRED. Only a fence that closes is opaque. A ``` or ~~~
    opener with no closer ahead opens NO span: the container's own closer
    stays structural, and the lines after it are parsed normally. This is the
    same test PART 9 §10 I4 applies one level up -- an opener with no closer
    is not a fence -- and the same test the `%%%` rule above already states
-   ("an opener with no exact closer ahead opens nothing"). It was written
-   for the comment block and not for the code fence, and all three engines
-   implemented exactly what was written: `%%%` guarded, ``` not (carve#515).
-
-   Without it, one unclosed fence consumes the rest of the document. In
+   ("an opener with no exact closer ahead opens nothing") (carve#515). In
 
        ::: note
        ```
@@ -362,10 +301,8 @@ admonition = admonition_open, newline,
        :::
        after
 
-   the fence would take `x`, the `:::` AND `after`, closing the admonition
-   at end of input -- so a line written outside the container renders
-   inside it. With the guard the fence is not a span, the `:::` closes the
-   admonition, and `after` is a top-level paragraph.
+   the fence is not a span, the `:::` closes the admonition, and `after` is a
+   top-level paragraph.
 
    This does NOT change a fence with nothing to interrupt: `` ``` `` alone,
    or as the whole content of a blockquote, still opens a code block that
@@ -431,7 +368,7 @@ quoted_title = '"', {character - '"'}, '"' ;
    `table` end in, with the same one-optional-blank-line allowance. Two
    container kinds take it -- this one and `quote_block`, which captions like
    the block quote it is (§4) -- and a `^ ` line after any OTHER `:::` closer
-   is ordinary paragraph content (corpus 318-composite-figures-7). A group left
+   is ordinary paragraph content. A group left
    open at END OF INPUT closes there like any container (PART 9 §12) and, its
    closer line never having been written, has no caption position.
 
@@ -587,9 +524,7 @@ raw_block = code_fence_open, [space], "=", format_name, newline,
    raw). The closer follows the PART 9 §2 rule: same fence character, length
    >= opener. Content is verbatim; it is emitted UNESCAPED when the format
    matches the output format (html) and DROPPED otherwise -- the block parallel
-   of raw inline (PART 9 §20). This adopts djot's raw-block syntax; the earlier
-   ```raw FORMAT keyword form was removed (no English keyword; symbol-based and
-   symmetric with inline `{=format}`).
+   of raw inline (PART 9 §20). Adopts djot's raw-block syntax.
 
    THE INTERIOR IS VERBATIM, THE OPENING IS PLACED -- NORMATIVE. Inside a
    container, a renderer that indents its output indents the raw block's
@@ -597,68 +532,20 @@ raw_block = code_fence_open, [space], "=", format_name, newline,
    the raw content's own line structure. Every line after the first reaches the
    target with the columns the author gave it.
 
-   Both halves matter and neither is a formatting preference. Re-indenting an
-   interior line changes bytes the author wrote, and inside a `<pre>` those
-   columns are CONTENT -- the rendered code block then says something the
-   source did not. Leaving the block flush at column 0 instead would make
-   `raw_block` the one block kind whose placement ignores its container, which
-   is a second rule applying to one kind with nothing behind it.
-
-   THE `<pre>` HAZARD IS WHAT THIS RULE FORECLOSES, NOT WHAT IT REPAIRED, and
-   the difference matters to anyone arguing the clause later. Taken literally,
-   "indent every line" does corrupt a `<pre>`, and the oracle did exactly that.
-   No ENGINE did: every one of them already suspended re-indentation inside an
-   open `<pre>`, so all three agreed on every `<pre>` shape both before and
-   after this rule landed. What actually had to be settled was the ordinary
-   interior line, where the cost is changed bytes rather than changed rendered
-   content. Argue this clause from the rule; the `<pre>` example illustrates
-   it, and never distinguished the engines.
-
-   A FIXTURE FOR THIS RULE MUST BE AT LEAST TWO LINES WITH AT LEAST ONE OF THEM
-   OUTSIDE A `<pre>`. The corpus could not tell the readings apart because it
-   pinned only a SINGLE-LINE raw block -- a shape on which "indent the block"
-   and "indent every line" agree. The `<pre>` pair pins the placement half, but
-   an engine that re-indents only its non-`<pre>` interior lines passes that
-   pair, so it cannot stand in for the other. Three engines gave three answers
-   when carve#800 was filed; by the time the rule landed carve-js had moved and
-   it was one engine against two.
-
    THE PAYLOAD IS EVERY LINE BETWEEN THE DELIMITERS, blank lines included. A
    blank line is a line, and the last one is payload exactly as an interior one
-   is. This is the property corpus 291 already states for a fence -- a blank
-   line inside a fence is content, and the last one is content too, wherever
-   the fence ends -- and a raw block's verbatim body follows it for the same
-   reason a code block's does. Neither the container the block sits in nor
-   whether the closer was written is a parameter: an unterminated raw block
-   runs to the end of whatever encloses it, and its payload still ends on the
-   line before that end.
-
-   A RAW BLOCK WRITTEN LAST IN THE DOCUMENT CANNOT SHOW THIS, and that is a
-   property of the output's end rather than of the block. The payload's
-   trailing newlines land where the trailing-whitespace trim removes them, so
-   every reader prints the same bytes there whatever it does with the payload.
-   A fixture for this rule therefore needs a block AFTER the raw block, or a
-   container closing around it.
-
-   That shape is why the case looked unsettled. carve#1389 measured the
-   document-final spelling, read four readers agreeing there against three of
-   four inside a list item, and concluded the odd reader was the consistent
-   one. Measured with a paragraph after the block instead, the split is not
-   between the two contexts at all: the reader that drops the blank inside an
-   item drops it at document level too, and the other three keep it in both.
-   What decides it is not the count either way but a contradiction inside that
-   reader, which keeps the same trailing blank as content in a CODE fence --
-   corpus 291's four documents, which it reproduces -- and drops it from a raw
-   block. Corpus 366 pins the document-level and in-item shapes plus a
-   no-blank control.
+   is. Neither the container the block sits in nor whether the closer was
+   written is a parameter: an unterminated raw block runs to the end of
+   whatever encloses it, and its payload still ends on the line before that
+   end. At the END of the document the payload's trailing newlines land where
+   the trailing-whitespace trim removes them.
 
    AN ALL-BLANK PAYLOAD IS NOT AN ABSENT BLOCK. If the sole line between the
    delimiters is blank, that line is still the payload and contributes its
    newline when the raw format matches the output format. Zero payload lines
    contribute nothing; one blank payload line contributes one newline. An
-   implementation MUST NOT encode those two source shapes identically. Corpus
-   372 pins the distinction with a following paragraph so end trimming cannot
-   hide the newline (carve#1401).
+   implementation MUST NOT encode those two source shapes identically.
+   (carve#1401)
 
    RENDER-LOSS REPORTING -- NORMATIVE. Target routing may intentionally omit a
    raw node, but a checked renderer MUST make that omission observable. Its

--- a/resources/spec/06-inline-links-images.ebnf
+++ b/resources/spec/06-inline-links-images.ebnf
@@ -77,16 +77,12 @@ code_span_content = (* any chars except a closing backtick_run of equal count *)
    trailing whitespace is stripped; no surrounding single-space strip, which
    applies only to a closed span). Such an unclosed run is OPAQUE -- an
    emphasis delimiter or link tail after it is verbatim content, so the
-   surrounding construct never closes. Matches djot upstream and carve-php.
-   (Pinned as the "Inline verbatim ..." corpus pair; was a carve-js
-   divergence, resolved.) *)
+   surrounding construct never closes. Matches djot upstream. *)
 (* A trailing `{…}` on a code span is the generic inline-attribute
    block, NOT a language tag -- EXCEPT the exact form `{=format}`, which is
-   raw inline passthrough (raw_inline below, PART 9 §20). For any OTHER
-   `{…}`: both impls consume AND apply it -- `\`c\`{.x}` ->
-   `<code class="x">c</code>`, and `#id`/`key=value` likewise. (Was an impl
-   divergence where carve-js dropped the attributes; RESOLVED -- both now
-   apply them identically.) The STRICT attribute rule (§14) applies here and
+   raw inline passthrough (raw_inline below, PART 9 §20). Any OTHER `{…}` is
+   consumed AND applied -- `\`c\`{.x}` -> `<code class="x">c</code>`, and
+   `#id`/`key=value` likewise. The STRICT attribute rule (§14) applies here and
    to IMAGE trailing attrs exactly as to any other inline attribute. Explicit
    ids and classes admit a leading ASCII digit; a digit-leading key or any
    otherwise invalid payload makes the block literal. *)
@@ -153,11 +149,7 @@ link_text = inline_content ;
 
    This is a property of the DOCUMENT, and therefore binds EVERY target that
    can express a link -- HTML, Markdown and ANSI alike, exactly as the
-   smart-typography switch above applies to every target. Nested output is
-   not merely redundant: `[see [H](#H)](/outer)` is not valid Markdown, so a
-   consumer reparsing it gets something other than what the document says,
-   and a nested ANSI link sequence ends with its own reset, which closes the
-   outer link's styling early.
+   smart-typography switch above applies to every target.
 
    An implementation that resolves a construct into a link AFTER the pass
    that enforces this -- a cross-reference is the usual case, since `</#id>`
@@ -196,9 +188,7 @@ unicode_url_char = (* any non-whitespace, non-ASCII Unicode character *) ;
    `unicode_url_char` says "non-whitespace" without qualifying it to ASCII.
    So a NARROW NO-BREAK SPACE, an IDEOGRAPHIC SPACE and a THIN SPACE end an
    inline destination exactly as a plain space does, and an unbracketed
-   destination cannot contain one. Stated explicitly because two engines read
-   it as ASCII-only and produced a link whose href carried an invisible
-   character (carve#404).
+   destination cannot contain one -- an href MUST NOT carry one (carve#404).
 
    ZERO-WIDTH characters (U+200B, U+FEFF) are NOT whitespace and ARE ordinary
    destination characters. The test is the Unicode White_Space property, not
@@ -213,16 +203,13 @@ unicode_url_char = (* any non-whitespace, non-ASCII Unicode character *) ;
    ends the destination at `https://e.com`, and `/path` is then left over. It
    is NOT ignored: the definition is anchored at end of line (carve#911), so a
    leftover makes the production fail and the whole line is an ordinary
-   paragraph -- exactly as `[r]: https://e.com /path` behaves. That sentence
-   used to read "ignored", which is what all four artifacts did and what the
-   production never said. Whitespace between the mandatory separator space and
-   the destination is leading whitespace and is skipped. A definition whose
-   destination is EMPTY once that is done is NOT a definition: the line stays
-   literal, as `[r]:` already does.
+   paragraph -- exactly as `[r]: https://e.com /path` behaves. Whitespace
+   between the mandatory separator space and the destination is leading
+   whitespace and is skipped. A definition whose destination is EMPTY once that
+   is done is NOT a definition: the line stays literal, as `[r]:` already does.
 
-   There is deliberately no "trim the ends, keep the interior" variant. It
-   reads as the friendlier rule and it contradicts `link_destination`, which
-   admits no whitespace at all -- leaving `[r]: a b` specified two ways. *)
+   There is no "trim the ends, keep the interior" variant: `link_destination`
+   admits no whitespace at all. *)
 (* Titles accept double OR single quotes -- a deliberate enhancement
    over djot (which has no single-quote titles; it would fold `'...'`
    into the URL). The non-delimiting quote may appear inside the title. *)
@@ -235,14 +222,10 @@ unicode_url_char = (* any non-whitespace, non-ASCII Unicode character *) ;
    (PART 7): a link is already a link once its destination has been read, and a
    reference definition is already a definition, so the title is optional
    trailing metadata in both. It is spelled `space` all the same, because A
-   TAB IS SYNTAX ONLY IN THE LEADING RUN (PART 7). The three engines accept a
-   tab here today and diverge from this production (carve#901). Cardinality is
-   exactly one character, at both sites, and that is a RULING rather than an
-   oversight: all three engines and the executable spec accepted a run here
-   until carve#912 held the production right and narrowed them. So
-   `[t](/u<SP><SP>"T")` is not a titled link, the quoted run is left
-   unconsumed, and the bracket run stays literal text. Corpus 262 carries it,
-   with the one-space form as its control. *)
+   TAB IS SYNTAX ONLY IN THE LEADING RUN (PART 7, carve#901). Cardinality is
+   exactly one character, at both sites (carve#912). So `[t](/u<SP><SP>"T")` is
+   not a titled link, the quoted run is left unconsumed, and the bracket run
+   stays literal text. *)
 link_title = space, ('"', {('\', '"') | (character - '"')}, '"')
            | space, ("'", {('\', "'") | (character - "'")}, "'") ;
 
@@ -261,97 +244,32 @@ reference_label = (character - ']' - '@'), {character - ']'} ;
        [t][@a]
        ![t][@a]
 
-   both render as the text the author typed. The image spelling is stated here
-   rather than beside `reference_image` because it is the same slot reading the
-   same production, not a parallel rule. Nothing in this is special to `@`; it
-   is the existing fallback reaching one more shape, which is why the ruling
-   needed no new mechanism (carve#1302).
-
    THE FALLBACK IS THE VERBATIM SOURCE RUN, NOT A RESCAN -- NORMATIVE. Which
    one it is decides the rendering, so it cannot be left to inference. The
    declining run is emitted as the characters the author typed; the parser does
    NOT hand the interior back to the inline scanner. That is already the rule
    for every other declining reference: `[t][*a*]` keeps its asterisks rather
-   than emphasizing `a`, and TRAILING ATTRIBUTES ON A DEFINITION's neighbor
-   case -- `[text][missing]{.wide}` -- keeps its braces as text rather than
-   parsing them as `attributes`, which is what carve#679 fixed by carrying the
-   SOURCE STRING through the reference sentinel instead of re-printing a parsed
-   list.
-
-   The distinction bites hardest here, because the interior is `@`-initial by
-   construction and `@a` is exactly what a rescan would claim. A rescan would
-   read `[t][@a]` as a `[t][` run, a MENTION, and a `]` -- and with the Tier-2
-   extension on it would read the now tail-less `[@a]` as a CITATION, since a
-   citation is a `[...]` holding a `@key` with no link/ref/span tail. Both
-   readings are wrong: the bracket run declined as ONE construct and is
-   restored as one, so the `@a` inside it is text and nothing else. That is
-   what the corpus rows and the optional control pin, on both sides of the
-   extension switch.
+   than emphasizing `a`, and `[text][missing]{.wide}` keeps its braces as text
+   rather than parsing them as `attributes`. So the `@a` inside a declining
+   `[t][@a]` is text and nothing else: it is NOT re-read as a mention, and NOT
+   as a citation with the Tier-2 extension on.
 
    THE CONTROL CARRIES THE RULE. `[@a]` on its own IS a citation with the
-   extension on, and that is the REASON the label slot rejects it rather than a
-   side effect of rejecting it: `@` at the first position already means
-   citation, so it cannot also mean label, and an implementation that made the
-   slot accept `@` would be taking the spelling away from citations to do it.
-   Corpus 334-a-label-beginning-with-an-at-sign-is-not-a-reference-label
-   carries both spellings; the citation half is Tier-2, so it is pinned in
-   tests/corpus-optional (`43-citations-at-label-in-reference-position`), where
-   the same two lines are still literal text with citations enabled.
+   extension on, and that is the REASON the label slot rejects it.
 
-   WHAT THE CORPUS PINS, AND WHAT IT CANNOT. The rows are HTML, and at that
-   layer this rule is INDISTINGUISHABLE from "the label is undefined": `@` at
-   the first position is the one spelling `reference_label` rejects, and
-   `[@a]: /u` is reserved for the citation definition, so a `@`-first label can
-   never be defined, and a declining reference renders as its verbatim source
-   either way. The rows state the outcome, which is what a corpus is for; they
-   do not separate the two readings, and nothing else does.
-
-   THE TREE SHAPE IS THE ONE PLACE THEY WOULD SEPARATE, and it is left open
-   here rather than settled in passing. Measured on fresh main builds --
-   carve-js 99af44b, carve-php 035dfcd, carve-rs 564a3b8 -- all three publish
-   an UNRESOLVED REFERENCE node for both spellings:
-
-       {"type":"link","href":"","ref":"@a","rawRef":"[t][@a]"}
-
-   and its `image` counterpart. PART 12 §3a admits `ref` "because the author
-   wrote a reference link", and under this clause no reference link was
-   written, which points at a `text` node carrying the run. Against that, an
-   `href`-less node plus `rawRef` is the vehicle §3a already gives a declining
-   reference for restoring its source, so an engine reaching for it here is not
-   obviously wrong either. Both readings render the corpus rows correctly, no
-   HTML fixture can fail on the difference, and the ruling this clause states
-   did not reach it -- so it is recorded, not decided (carve#1302).
-
-   THE READING NOT TAKEN. "Link text `t` pointing at citation `a`" is coherent
-   authoring intent and has no spelling today, but adopting it here would
-   INVENT A CONSTRUCT on the strength of one bracket pair -- its own AST node
-   or field, renderer behavior on every target, a canonical writer spelling --
-   and nothing else in the language pairs link text with a citation target.
-   That is a feature proposal against a later roadmap, not a reading of this
-   production.
-
-   The EMPTY-TEXT spelling `[][@a]` was settled separately and narrowly in
-   markup-carve/carve-js#1119, deliberately scoped so that `[t][@a]` was not
-   decided as a side effect of an unrelated fix. This clause is what that
-   scoping was waiting on, and it leaves it standing. *)
+   THE TREE SHAPE for a declining `[t][@a]` is left open here; the rendering is
+   the verbatim source run either way. *)
 (* Both roles appear on this one line (PART 7), and both take `space`. The
-   `']' ':'` separator is a MARKER SEPARATOR -- settled in the note below and
-   rejected by all four implementations for a tab -- while the slot before the
-   trailing `attributes` is PADDING: the definition is already complete at
-   `[a]: /url` and the attribute block is optional trailing metadata. The role
-   differs, the terminal does not, because A TAB IS SYNTAX ONLY IN THE LEADING
-   RUN (PART 7). What `attributes` admits INTERNALLY is a separate production
-   (PART 4).
-   Cardinality is exactly one space at BOTH, and at the padding slot that is
-   carve#912's ruling rather than an oversight. Where the rejected block goes
-   differs by run, and the two cases are NOT the same: a ZERO-space run glues
-   the braces to the destination (`[a]: /u{.c}` gives href `/u{.c}`, because
-   `link_destination` reads them), while a TWO-space run cannot -- whitespace
-   ends the destination -- so `{.c}` is DROPPED. That is the outcome this
-   clause names as the one to avoid, and it happened only because
-   `reference_definition` was not anchored at end of line. carve#911 anchored
-   it and the line now falls back to prose instead. Corpus 265 carries it with
-   its one-space control. *)
+   `']' ':'` separator is a MARKER SEPARATOR -- settled in the note below --
+   while the slot before the trailing `attributes` is PADDING: the definition
+   is already complete at `[a]: /url` and the attribute block is optional
+   trailing metadata. The role differs, the terminal does not, because A TAB IS
+   SYNTAX ONLY IN THE LEADING RUN (PART 7).
+   Cardinality is exactly one space at BOTH. The two rejected runs are NOT the
+   same: a ZERO-space run glues the braces to the destination (`[a]: /u{.c}`
+   gives href `/u{.c}`), while a TWO-space run cannot -- whitespace ends the
+   destination -- so the line is left over at the end-of-line anchor and falls
+   back to prose. *)
 reference_definition = '[', reference_label, ']', ':', space, link_destination,
                        [link_title], [space, attributes], newline ;
 (* ANCHORED AT END OF LINE -- NORMATIVE. The production ends in `newline`, and
@@ -361,39 +279,26 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
 
        [a]: /u zzz
 
-   is NOT a definition, and a `[a][]` below it does not resolve. All three
-   engines and the executable spec read it as a definition with trailing junk
-   until carve#911, and nothing in this grammar authorized that reading.
+   is NOT a definition, and a `[a][]` below it does not resolve (carve#911).
 
    THE LINE ENDING is `whitespace` -- `' ' | '\t'` -- the same terminal
-   `blank_line = {whitespace}` takes (PART 1; carve#890). So `[a]: /u<SP>` and
+   `blank_line = {whitespace}` takes (PART 1). So `[a]: /u<SP>` and
    `[a]: /u<TAB>` are still definitions, while `[a]: /u<NBSP>`,
-   `[a]: /u<U+2000>` and `[a]: /u<FF>` are not: every one of those is CONTENT
-   under that ruling, and content after the production is exactly what the
-   anchor rejects. An implementation spelling the ending as a Unicode
-   whitespace PROPERTY reads all five as a line ending, and a tab fixture
-   cannot see the difference, because a tab is inside the property too
-   (carve#888).
+   `[a]: /u<U+2000>` and `[a]: /u<FF>` are not: every one of those is CONTENT,
+   and content after the production is exactly what the anchor rejects. An
+   implementation spelling the ending as a Unicode whitespace PROPERTY reads
+   all five as a line ending, and a tab fixture cannot see the difference.
 
-   A TRAILING ZERO-WIDTH CHARACTER IS NOT ON THAT LIST, and listing it there
-   was an error carried from carve#911's ruling prose into this clause
-   (carve#953). `[a]: /u<U+FEFF>` and `[a]: /u<U+200B>` ARE definitions. The
-   anchor only ever sees what is left over after the production, and here
-   nothing is: U+FEFF and U+200B are not `White_Space`, so they do not END the
-   destination -- `link_destination` absorbs them as ordinary
-   `unicode_url_char`s, exactly as the note beside that production states, and
-   the character is in the href. The anchor is therefore never reached, and it
-   is `url_char` -- the AUTOLINK body, a different production -- that excludes
-   format characters, not `link_destination` (corpus 240). The row is the
-   reason a mutant widening the line ending to "any invisible character"
-   survived: it asserted a differing render, which was true because the HREF
-   carried the character rather than because the line was rejected.
+   A TRAILING ZERO-WIDTH CHARACTER IS NOT ON THAT LIST. `[a]: /u<U+FEFF>` and
+   `[a]: /u<U+200B>` ARE definitions: U+FEFF and U+200B are not `White_Space`,
+   so they do not END the destination -- `link_destination` absorbs them as
+   ordinary `unicode_url_char`s -- and the anchor is never reached. It is
+   `url_char`, the AUTOLINK body, that excludes format characters.
 
    WHAT THE ANCHOR DOES NOT REJECT. `[a]: /u{.c}` is still a definition, with
    destination `/u{.c}`: nothing is left over, because `link_destination`
    simply reads the braces. It is a different shape from `[a]: /u  {.c}`, not
-   another spelling of it. Corpus 266 carries every legal form as a control,
-   since the failure mode of an over-eager anchor is rejecting them.
+   another spelling of it.
 
    AN INVALID BLOCK IS NOT `attributes`, SO THE LINE IS NOT A DEFINITION --
    NORMATIVE (carve#933). `[space, attributes]` names the `attributes`
@@ -406,21 +311,12 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
    is NOT a definition. `{#}` is not `attributes` -- there is no identifier
    after the `#` -- so the line renders as the paragraph `[a]: /u {#}` and a
    `[a][]` below it does not resolve. The same holds for `[a]: /u { }` and
-   `[a]: /u {=}`.
-
-   THE DECIDING ARGUMENT IS THAT THE SAME CHARACTERS ALREADY READ THIS WAY
-   ELSEWHERE. `x {#}` in a paragraph keeps the braces as text, because
-   `attributes` rejects that block there too and inline content keeps what it
-   cannot parse. Two readings of `{#}` one construct apart is the thing being
-   removed, and the reading kept is the one the rest of the language already
-   has.
+   `[a]: /u {=}`. `x {#}` in a paragraph keeps its braces as text for the same
+   reason.
 
    THE COMPATIBILITY BREAK THIS ADDS, recorded: a definition line carrying an
-   unparseable attribute block stops defining, and a document relying on it
-   resolves one fewer reference. Accepted (carve#933 signoff). Corpus rows --
-   including the control that a VALID block still defines and still transfers
-   its attributes, which is the row an over-eager fix breaks -- belong with
-   corpus 266 and are deferred to their own pass. *)
+   unparseable attribute block stops defining. A VALID block still defines and
+   still transfers its attributes. *)
 (* TRAILING ATTRIBUTES ON A DEFINITION -- NORMATIVE. A `{...}` block at the end
    of the definition line attaches to the DEFINITION, and PART 9R R1 already
    says what that means: the attributes transfer to every link OR IMAGE that
@@ -436,25 +332,11 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
    the label up in the same `linkDefs` table and takes the same three fields, so
    `[ex]: /i.png {.wide}` gives `<img src="/i.png" alt="alt" class="wide">`.
 
-   Stated because leaving it implicit produced a rule nobody could say out loud.
-   The table is `label -> (url, title?, attrs?)`; an image reference already took
-   `url` and `title` from it in every engine, and `attrs` crossed in carve-php
-   and not in carve-js or carve-rs (carve#604's follow-up). Two of three fields
-   transferring is not a rule, it is where an implementation stopped. The
-   ergonomics point the same way: a class repeated at every use site is more
-   common for images -- sizing, floating, lazy-loading -- than for links, which
-   is the case the definition form exists to serve.
-
    THE MERGE IS §15 A3's, the one stacked attribute lists already use: the
    definition's list first, the link's second, so a repeated `id` or key takes
    the LAST value (the link's) and CLASSES ACCUMULATE in source order. So
    `[ex]: /u {.external #a}` with `[Example][ex]{.internal #b}` renders
    `class="external internal" id="b"`.
-
-   Reusing A3 rather than writing a second merge is the point: "link attributes
-   override per key" in R1 is exact only once "per key" names a merge, and the
-   language has one. A rule where the link's `class` REPLACED the definition's
-   would make this the only place in Carve where stacking classes drops one.
 
    NOT THE SAME AS THE LINE ABOVE. The two forms are different constructs and
    both are now well-defined:
@@ -469,10 +351,9 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
 
    THE DEFINITION IS A NODE, so these attributes are serialized ONCE on it
    rather than materialized onto every resolved link. PART 12 §10 adds
-   `link_reference_definition` to the vocabulary; three clauses wanted it (§3a,
-   §10a and this one) and the fourth reason was decisive: without the node, a
-   writer cannot reproduce the definition, so `parse(fmt(x)) == parse(x)` fails
-   for every resolved reference (carve#642). *)
+   `link_reference_definition` to the vocabulary: without the node, a writer
+   cannot reproduce the definition, so `parse(fmt(x)) == parse(x)` fails for
+   every resolved reference (carve#642). *)
 (* THE DEFINITION MARKER SEPARATOR -- NORMATIVE. The marker-to-content
    separator is the `space` terminal (U+0020) ONLY, in all three definition
    markers: `reference_definition`, `footnote_definition` and
@@ -480,30 +361,16 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
    so `[^a]:<TAB>x`, `[a]:<TAB>/url` and `*[HTML]:<TAB>x` are ordinary
    paragraphs, not definitions -- the marker line is preserved as text. This
    mirrors the heading, list and task markers, which likewise require a
-   literal space after the marker. carve-rs is the reference here.
+   literal space after the marker.
 
    AND THE SEPARATOR IS A RUN (carve#892). `footnote_definition` and
    `abbreviation_definition` spell it `space+`: one or more ASCII spaces, all
-   of them separator. This is a correction, not a widening -- both productions
-   said `space` while all four readers consumed a run, so the grammar forbade
-   a shape nothing rejected.
-
-   CARDINALITY HERE IS THE OPPOSITE ANSWER FROM carve#912's, and the two are
-   not in conflict because they govern different POSITIONS. A PADDING SLOT
-   sits between two tokens on a line whose construct is already fixed, and its
-   width means nothing, so the four slots spelled `space` mean exactly one. A
-   MARKER SEPARATOR is what stands between the marker and the content it
-   introduces, and a writer aligning definitions in a column is writing
-   separator, not content. Stated here so the two rulings are not read as
-   contradicting each other.
+   of them separator.
 
    WHAT THE RUN DOES NOT INCLUDE. It is ASCII spaces, so the first character
    that is not one ends the separator and BEGINS the content. A no-break space
    is content: `*[HTML]:<SP><NBSP>Hyper` expands to `<NBSP>Hyper`, and
    `[^f]:<SP><NBSP>note` is a footnote whose body starts with the character.
-   This is where all three engines disagreed, each in a different place, and
-   where the executable spec gave a fourth answer no engine gave -- it refused
-   `[^f]:` plus any non-ASCII whitespace as a definition at all (carve#892).
 
    A TAB AFTER THE RUN is content too, by the same rule, and the two markers
    then answer differently for a reason that is downstream of this clause
@@ -522,9 +389,7 @@ reference_definition = '[', reference_label, ']', ':', space, link_destination,
    backslash-escape rule above: a `\"` inside the quoted run is a literal
    quote and does not end the title (`[y]: /u "a\"b\"c"` -> title
    `a"b"c`, emitted as `title="a&quot;b&quot;c"`). This matches the
-   inline-link title; the earlier carve-js divergence (ref-def title
-   stopping at the first raw quote) was fixed in the canonical oracle, and
-   the examples corpus now pins the ref-def escaped-quote form too. *)
+   inline-link title. *)
 (* A reference definition requires a NON-EMPTY `link_destination` (one or
    more `url_char`s after the `':' space`). A bare `[r]:` -- with nothing
    after the colon, or only trailing whitespace -- does NOT form a
@@ -590,41 +455,23 @@ control_char = (* any character in Unicode General_Category Cc *) ;
    internationalized domain written in its own script is an autolink, and
    so is a non-ASCII PATH.
 
-   The CONTROL half is not redundant with the ASCII enumeration, which is
-   the trap it was written around: `unicode_url_char` is "non-whitespace,
-   non-ASCII", so the C1 block U+0080-U+009F satisfies it. Those characters
-   are Cc, are not Cf, and only U+0085 is whitespace - so without this term
-   fourteen control characters would be `url_char`s while every C0 control
-   is excluded, which is not a rule anyone would state on purpose. The
-   executable spec admitted them until its own class test said so.
+   The CONTROL half is not redundant with the ASCII enumeration:
+   `unicode_url_char` is "non-whitespace, non-ASCII", so the C1 block
+   U+0080-U+009F satisfies it. Those characters are Cc, are not Cf, and only
+   U+0085 is whitespace -- so without this term fourteen control characters
+   would be `url_char`s while every C0 control is excluded.
 
-   WHY, since the ASCII enumeration was explicit. The same destination
-   written `[t](https://<IDN>/)` links in all three engines today, because
-   `link_destination` admits `unicode_url_char`. Two spellings of one
-   destination cannot answer differently on the character set, and the
-   inline form is the one with the corpus behind it, so the autolink
-   follows it. The exclusion also looks incidental rather than chosen: the
-   note above enumerates the punctuation `url_char` excludes and never
-   mentions non-ASCII, which is not what a decided exclusion reads like.
-
-   THE FORMAT-CHARACTER EXCLUSION IS THE PART THAT IS NEW RATHER THAN
-   PERMISSIVE. A format character (General_Category Cf: the byte order
-   mark, the zero-width space, the word joiner, the bidi marks) is
-   invisible by definition, so a host carrying one renders as the host
-   without it and links somewhere else. That is a spoofing surface, not an
-   authoring convenience, and no author types one on purpose. Stating it as
-   a PROPERTY rather than as a list of codepoints also makes the byte-order
-   -mark answer fall out of the rule: a host language whose own whitespace
-   class happens to hold U+FEFF gets the right answer for the wrong reason
-   and the wrong answer for U+200B, which is exactly the split carve#860
-   measured.
+   THE FORMAT-CHARACTER EXCLUSION. A format character (General_Category Cf:
+   the byte order mark, the zero-width space, the word joiner, the bidi
+   marks) is invisible by definition, so a host carrying one renders as the
+   host without it and links somewhere else -- a spoofing surface. It is
+   stated as a PROPERTY rather than as a list of codepoints, so U+FEFF and
+   U+200B answer the same way.
 
    THE ASCII HALF DOES NOT MOVE. The nine characters the note above
-   enumerates are still not `url_char`s: they are exclusions with a stated
-   reason, and all four artifacts agree on them today. The rule reads
-   `unicode_url_char - format_char` for that reason -- spelling it "any
-   non-whitespace, non-control character" would additionally re-admit those
-   nine and move every implementation on a question nobody asked.
+   enumerates are still not `url_char`s, which is why the rule reads
+   `unicode_url_char - format_char` rather than "any non-whitespace,
+   non-control character".
 
    `link_destination` IS UNCHANGED. It admits `unicode_url_char` in its own
    right, so a format character in an inline destination or a reference
@@ -635,16 +482,7 @@ control_char = (* any character in Unicode General_Category Cc *) ;
 
    `scheme` IS UNCHANGED AND IS ASCII. Only the BODY admits non-ASCII; a
    scheme is `letter, {letter | digit | '+' | '-' | '.'}` and `letter` is
-   the enumerated ASCII alphabet. The executable spec accepted a non-ASCII
-   scheme because ohm's built-in `letter` is Unicode-aware, and is corrected
-   under this clause rather than beside it.
-
-   Engine state when this landed, measured on fresh mains: carve-rs makes
-   EVERY non-ASCII autolink literal and moves on the first half
-   (markup-carve/carve-rs#755); carve-js and carve-php link format
-   characters and control characters and move on the second
-   (markup-carve/carve-js#834, markup-carve/carve-php#983). No
-   implementation had both halves. *)
+   the enumerated ASCII alphabet. *)
 
 (* --- Images --- *)
 (* An image has the same three forms as a link (inline / reference / collapsed
@@ -655,12 +493,9 @@ reference_image = '!', '[', alt_text, ']', '[', reference_label, ']', [attribute
 collapsed_reference_image = '!', '[', alt_text, ']', '[', ']', [attributes] ;
 alt_text = {character} ;
 (* SEMANTIC CONSTRAINT: the alt text ends at the matching `]` -- THE SAME
-   close as `link_text`, balanced-bracket, escape- and LITERAL-SPAN-aware, and
-   for the same reason: the sentence above this block says an image has the
-   same three forms as a link and that only the leading `!` and the `<img src>`
-   output differ. The bracketed run is not one of the things that differ. Not
+   close as `link_text`, balanced-bracket, escape- and LITERAL-SPAN-aware. Not
    expressible context-free, which is why this production reads `{character}`
-   and defers to the constraint rather than pretending to enumerate it.
+   and defers to the constraint.
 
    The VALUE is not `inline_content`. `alt` is an HTML attribute, so nothing
    inside the run is inline-parsed and no smart typography applies:

--- a/resources/spec/07-inline-rich-text.ebnf
+++ b/resources/spec/07-inline-rich-text.ebnf
@@ -116,28 +116,13 @@ forced_content    = (inline_element | text_run | literal_special)+ ;
 
      {//}  {**}  {__}  {~~}  {^^}  {,,}  {==}  {++}  {##}
 
-   all render literally. This is not a new rule -- it is the one already
-   written here and in docs/parsing-ambiguities.md §16 ("`{^^}` # Not
-   superscript (no content)"), and the two engines that read it that way,
-   carve-js and carve-rs, were the ones in conformance. The oracle and
-   carve-php emitted empty elements: `<em></em>`, `<sup></sup>`, `<mark></mark>`.
-
-   IT APPLIES TO THE EDITORIAL FAMILY TOO, whose content slots are the same
-   `+` repetition. `{++}` was an `<ins>` inserting nothing and `{##}` a comment
-   saying nothing to anybody; `{--}` was a `<del>` deleting nothing, and the
-   string it freed is the braced en dash (PART 9 §8).
-
-   AN EMPTY ELEMENT IS NOT THE HARM -- the harm is that the braces vanish. An
-   author who wrote `{^^}` sees their four characters replaced by nothing
-   visible, in the output only, which is the same silent-loss shape the hyphen
-   flanking rule refuses. Reading them back as text loses nothing.
+   all render literally. IT APPLIES TO THE EDITORIAL FAMILY TOO, whose content
+   slots are the same `+` repetition; the string `{--}` this frees is the
+   braced en dash (PART 9 §8).
 
    THE ONE FORM LEFT ALONE is a fully empty SUBSTITUTION, `{~~>~}`, which still
-   renders an empty del followed by an empty ins. Substitution is an open
-   divergence (see Editorial Markup below), and the same `+` on both of its
-   halves would also refuse `{~a~>~}` and `{~~>b~}` -- a deletion with no
-   replacement and an insertion replacing nothing, which are ordinary edits.
-   It needs its own decision rather than this one. *)
+   renders an empty del followed by an empty ins: substitution is an open
+   divergence (see Editorial Markup below) and needs its own decision. *)
 
 (* TRAILING ATTRIBUTES -- each emphasis-family span MAY carry a trailing
    `[attributes]` block: the generic inline-attribute carrier that attaches
@@ -146,24 +131,18 @@ forced_content    = (inline_element | text_run | literal_special)+ ;
    `<strong class="real">x</strong>`. It is the SAME `[attributes]` slot
    every other inline carrier uses (code_span, link, image, inline_span,
    extension_inline, autolink). Pinned by corpus
-   80-trailing-attribute-block-edge-cases; both reference impls agree. *)
+   80-trailing-attribute-block-edge-cases. *)
 
 (* Content MAY contain the delimiter character: a delimiter that does not
    satisfy the close condition (PART 9 §1) is literal content, not the span
-   boundary. The span ends at the matched closer only. Subtracting the
-   delimiter here would make e.g. "/usr/local/" -> <em>usr/local</em>
-   ungrammatical, contradicting edge-cases.md §1. The boundary is a semantic
-   constraint (PART 9 §1, §9), not a context-free one. *)
+   boundary. The span ends at the matched closer only. The boundary is a
+   semantic constraint (PART 9 §1, §9), not a context-free one. *)
 emphasis_content = (inline_element | text_run | literal_special)+ ;
 strong_content = (inline_element | text_run | literal_special)+ ;
 bi_content = (inline_element | text_run | literal_special)+ ;
 underline_content = (inline_element | text_run | literal_special)+ ;
 strike_content = (inline_element | text_run | literal_special)+ ;
 highlight_content = (inline_element | text_run | literal_special)+ ;
-
-(* The former prose pseudo-productions emphasis_open_condition /
-   emphasis_close_condition are SUPERSEDED by the formal bare_opener(d) /
-   bare_closer(d) templates above. *)
 
 (* --- Footnotes (PART 9 §16) --- *)
 (* Both implemented forms: the REFERENCE form `[^label]` resolving against a
@@ -185,9 +164,7 @@ footnote_label = {character - ']' - newline}+ ;
 inline_footnote = "^[", inline_content, ']' ;
 (* the closing `]` is the balanced, escape- and LITERAL-SPAN-aware close
    (PART 9 §16) -- the same scan `link_text` states, and the same three spans
-   it skips. This read "code-span-aware", naming only the first of the three,
-   which is the spelling carve#403 replaced at `link_text` and did not replace
-   here; footnote recognition is DISABLED inside the content *)
+   it skips; footnote recognition is DISABLED inside the content *)
 
 footnote_definition = "[^", footnote_label, "]:", space+, inline_content, newline,
                       {footnote_continuation | continuation_marker_block} ;
@@ -198,78 +175,44 @@ footnote_indent = whitespace, {whitespace} ;
    PART 9 §17), the same continuation marker lists, block quotes and definition
    bodies use.
 
-   INDENTATION IS COLUMNS, NOT CHARACTERS -- NORMATIVE (carve#692). The prior
-   spelling of `footnote_indent` as `space, space` made this production a
-   literal two-SPACE requirement, contradicting its own adjacent comment
-   ("indented by >= 2 spaces", a column claim) and PART 9 §24 C1, which
-   already gives a tab a column value (to the next multiple of 4). This
-   production widens to any whitespace run reaching column 2: a bare tab
-   (column 0 -> 4) or a space then a tab (column 1 -> 4) both qualify, exactly
-   as two literal spaces do; a single space (column 1) does not. This is
-   INDENTATION, not a marker SEPARATOR -- it does not touch the literal
-   `space` the def line's own `]:` separator requires (unchanged, PART 9 §24
-   C2's sibling rule for markers). `footnote_indent` above is therefore
-   deliberately loose (any run of `whitespace`, PART 2's own idiom for
-   `list_continuation`'s `indent`) -- the actual column-2 floor is column
-   arithmetic, stated here rather than encoded character-by-character.
+   INDENTATION IS COLUMNS, NOT CHARACTERS -- NORMATIVE (carve#692). Any
+   whitespace run REACHING COLUMN 2 indents the body: a bare tab (column 0 ->
+   4) or a space then a tab (column 1 -> 4) qualify exactly as two literal
+   spaces do; a single space (column 1) does not. PART 9 §24 C1 gives a tab its
+   column value (to the next multiple of 4). This is INDENTATION, not a marker
+   SEPARATOR -- it does not touch the literal `space` the def line's own `]:`
+   separator requires (unchanged, PART 9 §24 C2's sibling rule for markers).
+   `footnote_indent` above is therefore deliberately loose; the column-2 floor
+   is column arithmetic, not a character-by-character encoding.
 
    `inline_content` above describes THE SHAPE OF A LINE that belongs to the
    body, not how the collected body is parsed. The body is parsed AS BLOCKS
    (PART 9 §16: "parsed as blocks"), so a note may hold a table, a list, a code
    block or a quote, and the indentation beyond the body's own is theirs to
-   read. Taking the production literally reads as an inline-only body, which is
-   the opposite of what every implementation does and of what the corpus pins
-   ("A footnote body holds blocks", carve#691) -- and an engine written from
-   this line alone would flatten exactly the structure the indent carries
-   (carve-rs#611).
+   read.
 
    THE BODY'S OWN COLUMN IS TWO -- NOT the first continuation line's actual
    indent. A reader first consumes that minimum and then applies PART 0's ONE
    AUTHORED BLOCK BASE. Two is a floor for the body, not a ceiling for its
    blocks; this construct adds no second rebase rule. *)
 
-(* DISMISSED (not reserved, no production): a sidenote form
-     sidenote = "[>", inline_content, ']' ;
-   was proposed and declined -- margin placement is CSS over the existing
-   footnote/endnote output, so it does not warrant core syntax. The `[>`
+(* DISMISSED (not reserved, no production): a sidenote form `[>content]` --
+   margin placement is CSS over the existing footnote/endnote output. The `[>`
    opener is therefore UNCLAIMED and `[>foo]` is literal text (pinned by the
    corpus). Rationale: docs/dismissed-syntax.md. *)
 
 (* --- Citations (PART 9 §22, Tier-2 extension; issue #90) --- *)
 (* TIER-2, OFF BY DEFAULT. A `[...]` whose content contains a `@key` and which
-   has NO link/ref/span tail (`(url)` / `[ref]` / `{attrs}`) is a citation.
-   Bare `@key` stays a mention (PART 19); `\@` is literal. Items are
-   `;`-separated; each is `[prefix] [-] @key [, locator]` (`-` suppresses the
-   author in author-date mode). Bibliography entries are defined in-document:
-   `[@key]: {author= year=}? entry` (the `{…}` is optional, feeds author-date;
-   a leading `@` label is reserved here, never a link definition - see
-   reference_definition). Numbered output (default) emits `[1]` + an ordered
-   references list; author-date (configuration) emits `(Author Year)` + an
-   alphabetical list. The references list is appended at document end or
-   injected into a `::: references` block.
-
-   INTEGRAL MARKER (issue #226): a single leading `+` immediately after `[`
-   marks the whole citation cluster as integral (author-in-text). The `+` is
-   a group-level flag - there is no per-item integral mode. An integral cluster
-   is wrapped in `<span class="citation" data-cite-mode="integral">…</span>`.
-   The vocabulary (`integral` / `non-integral`) matches CSL / Citum `CitationMode`.
-   Example: `[+@smith2020]`, `[+see @smith2020, p. 12]`.
-
-   TYPED LOCATORS (issue #226): the locator text after the first `,` in an item
-   is parsed into a citeproc `{label, value}` structure plus a trailing suffix.
-   Longest-match, boundary rule: a term matches only when followed by end-of-locator,
-   whitespace, a digit, `§`, or `¶`. On a leading digit with no preceding term,
-   the default label is `page`. Trailing `,`, `&`, `-`, `.` are trimmed from the
-   value; the remainder is the suffix. Canonical labels with recognized abbreviations:
-     book (bk.) | chapter (chap., chaps.) | column | figure | folio |
-     issue (no.) | line (l., ll.) | note (n., nn.) | opus | page (p., pp.) |
-     paragraph (para., ¶) | part | section (sec., §) | sub verbo (s.v.) |
-     verse (v., vv.) | volume (vol.)
-
-   DATA-* HTML CONTRACT (issue #226): each citation anchor carries, in order,
-   only the attributes that apply: `data-cite-key`, `data-suppress-author`,
-   `data-cite-prefix`, `data-locator-label`, `data-locator`, `data-suffix`.
-   Prefix and suffix are flattened plain text.
+   has NO link/ref/span tail (`(url)` / `[ref]` / `{attrs}`) is a citation; a
+   bare `@key` stays a mention (PART 19) and `\@` is literal. Items are
+   `;`-separated; each is `[prefix] [-] @key [, locator]`. Bibliography entries
+   are defined in-document: `[@key]: {author= year=}? entry` -- the `{…}` is
+   optional and feeds author-date, and a leading `@` label is RESERVED here,
+   never a link definition (see reference_definition). NUMBERED output is the
+   DEFAULT: `[1]` plus an ordered references list. AUTHOR-DATE output
+   (configuration) emits `(Author Year)` plus an alphabetical list. The
+   references list is appended at document end, or injected into a
+   `::: references` block.
 
    Undefined behavior (impls MAY differ, NOT corpus-pinned): same-author-year
    disambiguation letters (e.g. `2020a` / `2020b`) are out of scope for v1 -
@@ -277,33 +220,35 @@ footnote_indent = whitespace, {whitespace} ;
    items); such a bracket falls back to literal text.
    Failure-mode handling IS pinned (tests/corpus-optional): a group with any
    undefined key renders the verbatim source; a `[@k]{...}` is a span, not a
-   citation; a `[@k, a; b]` with a `;` in the locator is literal text.
-   Pinned in tests/corpus-optional (features citations-numbered /
-   citations-author-date and the failure-mode cases, plus typed-locator,
-   integral, and suppress-author enrichment cases 13-24). *)
+   citation; a `[@k, a; b]` with a `;` in the locator is literal text. *)
 citation_group = '[', ['+'], citation_item, {';', citation_item}, ']' ;
 citation_item = [inline_content], ['-'], '@', citation_key, [',', space, inline_content] ;
 (* A single leading `+` immediately after `[` sets the whole citation cluster to
    integral mode (CSL/Citum CitationMode: integral = author-in-text; absent =
-   non-integral/parenthetical). This is the Djot draft `[+@foo, p. 15]` form.
-   Mode is a GROUP property; there is no per-item `+`. A bare `+` before `@key`
-   inside a multi-item bracket (e.g. `[@a; +@b]`) is parsed as prefix text on
-   that item, not as an integral marker.
+   non-integral/parenthetical), the Djot draft `[+@foo, p. 15]` form. Mode is a
+   GROUP property; there is no per-item `+`. A bare `+` before `@key` inside a
+   multi-item bracket (e.g. `[@a; +@b]`) is parsed as prefix text on that item,
+   not as an integral marker. An integral cluster wraps the ENTIRE citation
+   group output in `<span class="citation" data-cite-mode="integral">`.
    `-` before `@key` suppresses the author for that item (per-item; applies in
    both numbered and author-date modes via `data-suppress-author="true"`).
-   The locator (text after the first `,` in an item) is parsed into a typed
-   citeproc label + value + trailing suffix: longest-match label from the fixed
-   vocabulary (book/chapter/column/figure/folio/issue/line/note/opus/page/
-   paragraph/part/section/sub verbo/verse/volume, with abbreviations), matching
-   only at a boundary (end of string, whitespace, ASCII digit, `§`, or `¶`); no
-   label but a leading ASCII digit defaults to `page`; value is the leading run
-   of digits/roman/`.,&-` with trailing separators trimmed; the remainder is the
-   suffix. A roman numeral locator with no label produces no data-locator-label.
+   TYPED LOCATOR: the locator (text after the first `,` in an item) is parsed
+   into a citeproc label + value + trailing suffix. The label is the LONGEST
+   match from the fixed vocabulary below, and matches ONLY at a boundary --
+   end of locator, whitespace, an ASCII digit, `§`, or `¶`. Canonical labels,
+   with their recognized abbreviations:
+     book (bk.) | chapter (chap., chaps.) | column | figure | folio |
+     issue (no.) | line (l., ll.) | note (n., nn.) | opus | page (p., pp.) |
+     paragraph (para., ¶) | part | section (sec., §) | sub verbo (s.v.) |
+     verse (v., vv.) | volume (vol.)
+   No label but a leading ASCII digit defaults to `page`; a roman-numeral
+   locator with no label produces NO `data-locator-label`. The value is the
+   leading run of digits/roman/`.,&-`, with trailing `,`, `&`, `-`, `.` trimmed
+   off it; the remainder is the suffix.
    The structure is surfaced as `data-*` attributes on the rendered citation
-   anchors (`data-cite-key`, `data-suppress-author`, `data-cite-prefix`,
-   `data-locator-label`, `data-locator`, `data-suffix`) and, for an integral
-   cluster, a `<span class="citation" data-cite-mode="integral">` wrapper around
-   the entire citation group output. *)
+   anchor, IN THIS ORDER and only where each applies: `data-cite-key`,
+   `data-suppress-author`, `data-cite-prefix`, `data-locator-label`,
+   `data-locator`, `data-suffix`. Prefix and suffix are flattened plain text. *)
 citation_key = (letter | digit | '_'), {citation_key_char} ;
 (* Pandoc-compatible key charset (carve-js `KEY`): after the first char, any of
    these internal punctuation marks are allowed. *)
@@ -312,10 +257,7 @@ citation_key_char = letter | digit | '_' | ':' | '.' | '#' | '$' | '%' | '&'
 citation_definition = '[@', citation_key, "]:", space, [attributes], inline_content, newline ;
 (* The line is a NODE in the serialized tree -- `citation_definition`, carrying
    the key, the entry's inline content and the metadata block (PART 12 §18).
-   Like the other definition kinds it renders nothing where it sits, which is
-   exactly why it is a node: it was written somewhere, and neither consuming it
-   at parse time nor leaving it a paragraph of citation-shaped literal text can
-   put it back (carve#1276). *)
+   Like the other definition kinds it renders nothing where it sits. *)
 
 (* --- Extensions --- *)
 extension_inline = ':', extension_name, '[', extension_content, ']', [attributes] ;
@@ -347,45 +289,28 @@ comment_content = (* any text until the matching `#}`, preserved literally;
                      Forced Intraword Emphasis *) ;
 (* CONTENT IS LITERAL -- NORMATIVE. Nothing inside is parsed as markup, spaces
    are preserved, and no escape is resolved: `{# a *b* c #}` holds the eight
-   characters ` a *b* c ` and renders them, asterisks included. This says what
-   all three implementations already do; the production read `inline_content`,
-   which none of them implemented.
-
-   It follows from what the construct is. An editorial comment is the author's
-   aside about the text, not more text -- emphasis inside it would be markup
-   the reader never sees rendered, and a formatter could not tell it from
-   emphasis the author wrote outside. It is also what lets `link_text`'s scan
-   skip the span: with no escape available, a `]` inside is uncloseable any
-   other way.
+   characters ` a *b* c ` and renders them, asterisks included. It is also what
+   lets `link_text`'s scan skip the span: with no escape available, a `]`
+   inside is uncloseable any other way.
 
    `addition` and `deletion` are NOT literal: they take `inline_content`, and
    `{+a *b* c+}` really does emphasize `b`.
 
-   AN ADDITION'S AND A DELETION'S CONTENT IS NON-EMPTY, and the productions
-   ALREADY SAID SO: `inline_content` is a `+` repetition. `comment_content` now
-   says it too. `{++}`, `{--}` and `{##}` are therefore text, under the same
-   empty-brace clause the forced spans carry (carve#1447); `{---}` is still
-   `<del>-</del>` and `{-x-}` is still `<del>x</del>`. The string `{--}` freed
-   is the braced en dash (PART 9 §8).
+   AN ADDITION'S AND A DELETION'S CONTENT IS NON-EMPTY -- `inline_content` is a
+   `+` repetition, and `comment_content` says it too. `{++}`, `{--}` and `{##}`
+   are therefore text, under the same empty-brace clause the forced spans carry
+   (carve#1447); `{---}` is still `<del>-</del>` and `{-x-}` is still
+   `<del>x</del>`. The string `{--}` freed is the braced en dash (PART 9 §8).
 
-   `substitution` is NOT widened. Both of its halves are spelled
-   `inline_content`, but a half-empty substitution is a real edit -- `{~a~>~}`
-   deletes and `{~~>b~}` inserts -- so requiring content on each half would
-   refuse them, and requiring it across the pair is a different production.
-   The fully empty `{~~>~}` therefore still renders two empty elements, and
-   that sits with substitution's open divergence rather than with this
-   clause.
-
-   `substitution` is an OPEN divergence, deliberately left alone here. Its
+   `substitution` is NOT widened: a half-empty substitution is a real edit --
+   `{~a~>~}` deletes and `{~~>b~}` inserts -- so the fully empty `{~~>~}` still
+   renders two empty elements. `substitution` is an OPEN divergence: its
    production says `inline_content`, and all three implementations render
-   `{~*b*~>*e*~}` with the asterisks literal - so either the production or
-   every engine is wrong, and which one is a behavior question rather than a
-   transcription error. Not folded into this clause. *)
+   `{~*b*~>*e*~}` with the asterisks literal. *)
 (* ATTRIBUTES -- NORMATIVE: an addition / deletion is an ordinary inline node,
    so a trailing `{...}` attribute block attaches to its `<ins>` / `<del>`,
    exactly like a span, code span, link, or emphasis: `{+a+}{.a}` ->
-   `<ins class="a">…</ins>`. (All three impls agreed only after this was
-   pinned; carve-js dropped the block, carve-rs kept it literal.) *)
+   `<ins class="a">…</ins>`. *)
 (* DISAMBIGUATION (PART 9 §22). `{~ … ~}` is editorial SUBSTITUTION when it
    contains a top-level `~>`, and forced STRIKETHROUGH otherwise. `{# … #}`
    stays editorial comment (`#` is not an emphasis delimiter, no collision). *)
@@ -429,15 +354,7 @@ name_word = (letter | digit | '_' | '-')+ ;
    block after a mention stays literal (corpus
    153-attribute-block-after-a-mention-stays-literal), so `@alice{.x}` never
    produces an attributed mention. The slot is filled by a decoded wire
-   payload, the ProseMirror bridge (a stock Tiptap mention carries an id), or
-   an application building the node. Each implementation pins this in its own
-   suite; the corpus cannot, because the corpus renders source.
-
-   The rule exists because the alternative loses on round-trip: a writer that
-   spells an attributed mention as `[*\@alice*]{.mention #keepme}` only
-   satisfies toHtml(fmt(x)) == toHtml(x) if those attributes render, and a
-   writer that drops them instead satisfies it by deleting the data from both
-   sides. Resolved in carve-php#575. *)
+   payload, the ProseMirror bridge, or an application building the node. *)
 
 (* Boundary rules (PSEUDO-PRODUCTIONS -- prose conditions on `mention` /
    `tag` / `symbol`, normative in PART 9 §7, not reachable grammar symbols):
@@ -496,86 +413,46 @@ braced_en_dash = "{--}" ;   (* → – *)
 ellipsis = "..." ;    (* → … *)
 (* A BRACED HYPHEN PAIR IS AN EN DASH, NOT AN EMPTY DELETION -- NORMATIVE
    (carve#1447). `{--}` renders a single EN DASH and the braces are consumed.
-
    It exists because the flanking rule below leaves a position an author cannot
-   spell. A run with whitespace before it and a non-whitespace character after
-   it is flag-shaped and stays literal, which is right for `git log --oneline`
-   and wrong for the author who meant a dash there -- `x ---That`, `x ---(p)`
-   and `x ---, y` are all refused by that rule, and only the first of them is
-   plausibly a flag. `{--}` is the way to say "a dash, here, whatever stands
-   next to it", and it follows the braced precedent that forced spans already
-   set: a collision-prone bare form keeps a braced spelling that never
-   collides.
+   spell: a run with whitespace before it and a non-whitespace character after
+   it is flag-shaped and stays literal, so `x ---That`, `x ---(p)` and
+   `x ---, y` are all refused by that rule.
 
-   THE SPELLING WAS TAKEN, AND WHAT IT COST IS NOTHING. `{--}` rendered
-   `<del></del>`: the `{-` opener meeting its `-}` closer with no content, a
-   deletion that deletes nothing. `deletion` never permitted that -- its
-   content slot is `inline_content`, a `+` repetition -- so no conforming
-   document loses anything, and exactly one string moves: `{---}` is still
-   `<del>-</del>`, `{-x-}` is still `<del>x</del>`.
-
-   Every other empty brace pair reads back as TEXT rather than as a dash: see
-   the empty-brace clause under Forced Intraword Emphasis. `{--}` is the one
-   that becomes something, because a dash wanted the spelling and nothing
-   wants `{++}`.
-
-   There is NO braced EM dash. `{---}` is a deletion of a hyphen, which is a
-   thing an author writes, and taking it would cost what taking `{--}` did not.
-   So a tight em dash -- the Spanish, French and Russian dialogue convention,
-   `---That is mine.` -- still has no shorthand and is written as the literal
+   Exactly one string moves: `{---}` is still `<del>-</del>` and `{-x-}` is
+   still `<del>x</del>`. Every other empty brace pair reads back as TEXT rather
+   than as a dash (see the empty-brace clause under Forced Intraword Emphasis).
+   There is NO braced EM dash -- `{---}` is a deletion of a hyphen -- so a
+   tight em dash still has no shorthand and is written as the literal
    character. *)
 (* A HYPHEN RUN OPENING A WORD AFTER WHITESPACE IS A FLAG, NOT A DASH --
    NORMATIVE (carve#1443). A run of hyphens PRECEDED by whitespace (or the
    start of the inline content) and FOLLOWED by a non-whitespace character
    does not convert. It is literal text. Every other position converts as
-   before.
+   before. The case is a long CLI flag: `git log --oneline` rendered
+   `git log –oneline`, silently and in the output only.
 
-   The case is a long CLI flag, which is ordinary technical prose.
-   `git log --oneline` rendered `git log –oneline`, silently and in the output
-   only: the author saw their flag, the reader got a command that does not run,
-   and nothing warned. `--force-with-lease` failed the same way.
-
-   THE RULE IS DELIBERATELY NARROW, and the two obvious wider ones are both
-   wrong:
-
-   Requiring whitespace on BOTH sides removes the damage and the feature
-   together, because every canonical dash use is unspaced -- `pages 1--10`,
-   `the Mon--Fri window`, a tight `thought---interrupted---resumes`. A numeric
-   range is the reason en dashes exist.
-
-   Requiring the two SIDES TO MATCH in kind also fails, on a case the corpus
-   already pins: `a---- b----- c------` (19-smart-typography-dashes-and-quotes-7)
-   is alphanumeric on the left and whitespace on the right, and it converts. So
-   is a trailing dash on an interrupted clause. Only the LEFT-FLANKING-ONLY
-   shape -- whitespace before, word after -- is the one no dash wants and every
-   flag has.
+   THE RULE IS DELIBERATELY NARROW. Requiring whitespace on BOTH sides removes
+   every canonical dash use, which is unspaced -- `pages 1--10`, `the Mon--Fri
+   window`, a tight `thought---interrupted---resumes`. Requiring the two SIDES
+   TO MATCH in kind fails on `a---- b----- c------`, which is alphanumeric on
+   the left and whitespace on the right and converts. Only the
+   LEFT-FLANKING-ONLY shape -- whitespace before, word after -- is the one no
+   dash wants and every flag has.
 
    THE SPACE CLASS IS PART 7'S, and that is not the host language's `\s`. A
    VERTICAL TAB and a FORM FEED are CONTENT in Carve, so `---<VT>` converts or
-   stays literal exactly as `---!` does; a rule spelled with `\s` answered the
-   two differently, which is the divergence carve-php's whitespace-definition
-   sweep exists to catch. A NO-BREAK SPACE counts as a space here, because the
-   question asked is "does a space stand before this run" - the same question
-   quote flanking asks, and a nbsp is a space to the reader.
+   stays literal exactly as `---!` does. A NO-BREAK SPACE counts as a space
+   here, the same question quote flanking asks.
 
    ELLIPSIS IS NOT COVERED. `wait... really` is the ordinary use and it is
    word-then-whitespace; an ellipsis terminates a clause where a dash joins two
-   things, so their natural positions differ and the rule follows the construct.
+   things, so the rule follows the construct.
 
-   NOT FIXED BY THIS, and stated so it is a known limit rather than a
-   discovery: an HTML comment survives NEITHER half, and each half is lost to a
-   different rule. `<!-- c -->` renders `&lt;!– c →`. The OPENING run is
-   preceded by `!` rather than whitespace, so this clause does not reach it and
-   it converts to a dash. The CLOSING run was flag-shaped and literal under this
-   clause until the arrow set took the doubled run (§8 ARROWS, carve#1442), and
-   an arrow is matched before a hyphen run is decomposed.
-
-   That order is deliberate. Guarding `-->` for this one context would put a
-   context-sensitive exception into a set whose whole argument is that it has
-   none, and Carve escapes raw HTML by default: a literal HTML comment in prose
-   is a document ABOUT HTML rather than HTML, where an author who wants the
-   characters can escape one of them. Recognising the whole construct is what
-   the opening half wants; a wider dash rule would cost the numeric range.
+   NOT FIXED BY THIS: an HTML comment survives NEITHER half. `<!-- c -->`
+   renders `&lt;!– c →`. The OPENING run is preceded by `!` rather than
+   whitespace, so this clause does not reach it and it converts to a dash; the
+   CLOSING run is taken by the arrow set (§8 ARROWS, carve#1442), and an arrow
+   is matched before a hyphen run is decomposed.
 
    Composes with the run decomposition below rather than replacing it: this
    decides WHETHER a run converts, the length decides INTO WHAT. *)
@@ -605,32 +482,19 @@ smart_quote = '"' | "'" ;
 arrow = "<--" | "-->" | "<-->"      (* → ← → ↔, canonical *)
       | "<==" | "==>" | "<=>"       (* → ⇐ ⇒ ⇔ *)
       | "<-" | "->" | "<->" ;       (* deprecated, still rendered *)
-(* THE DOUBLED RUN IS THE CANONICAL ARROW, IN BOTH FAMILIES -- NORMATIVE
-   (carve#1442). Matched longest-first, as `<->` already beats `<-`, so `<==`
-   beats `<=` and `-->` beats the hyphen run.
+(* THE DOUBLED RUN IS THE CANONICAL ARROW, IN BOTH FAMILIES -- NORMATIVE.
+   Matched longest-first, as `<->` already beats `<-`, so `<==` beats `<=` and
+   `-->` beats the hyphen run.
 
-   The single-line family was complete and the double-line family was not:
-   `->`, `<-` and `<->` all existed, `=>` existed, and there was no `<=` arrow
-   because `<=` is the comparison. `<=>` -- the common spelling of "if and only
-   if", and the one a writer who has just met `=>` reaches for -- rendered
-   `≤>`.
-
-   `<=` KEEPS ≤, and that is what forces the answer. In technical prose `<=` is
-   far more often a comparison than a leftward implication, so the left double
-   arrow has to grow a character. Once it does, the family is spelled at one
-   width throughout rather than two, which is why the doubled run is canonical
-   everywhere rather than only where it had to be.
+   `<=` KEEPS ≤: in technical prose it is far more often a comparison than a
+   leftward implication, so the left double arrow grows a character.
 
    `->`, `<-` AND `<->` ARE DEPRECATED, NOT REMOVED. They keep rendering and
-   the canonical spelling is the doubled form; a document written before this
-   goes on working.
+   the canonical spelling is the doubled form.
 
-   `=>` IS REMOVED, and that is a behavior change rather than a deprecation.
-   It is the one form that was actively harmful instead of merely
-   non-canonical: `key => value`, `x => x + 1` and `Some(x) => x` are ordinary
-   prose about code, and every one of them silently became ⇒. So the two
-   families are treated differently on purpose, and each exception has a reason
-   that fits in a line -- `<=` is a comparison, and `=>` is code. *)
+   `=>` IS REMOVED, and that is a behavior change rather than a deprecation:
+   `key => value`, `x => x + 1` and `Some(x) => x` are ordinary prose about
+   code, and every one of them silently became ⇒. *)
 comparison = "!=" | "<=" | ">=" ;
 (* NOT the `:name:` symbol above -- these are the fixed typographic
    replacements (© ® ™ ±). Named `typographic_symbol` so the two do not

--- a/resources/spec/08-attributes.ebnf
+++ b/resources/spec/08-attributes.ebnf
@@ -24,12 +24,6 @@ attribute_list = attribute, {space+, attribute} ;
    padding is space-only everywhere, and a continuation line's leading run
    is indentation like any other leading run.
 
-   `opt_ws` was ONE name for both roles, used at five sites, and the two
-   are split rather than substituted so no site can keep the old meaning by
-   accident: `attr_pad` is the inline one, `opt_ws` now serves only
-   `opt_pad`, `attr_separator` and `continuation`, all three of which are
-   block-level.
-
    Two neighbouring questions are explicitly NOT decided here and have
    their own tickets: a NEWLINE inside a quoted value, where this file and
    carve-core.ohm split and the engines are 2-1 (carve#888), and
@@ -180,16 +174,6 @@ quoted_value = '"', { escaped_char | (character - '"' - '\' - newline) }, '"'
    inside the quotes while `resources/carve-core.ohm` excluded one at the
    same slot: ONE production, two normative answers, which is this ticket's
    subject rather than a consequence of any other clause.
-
-   It is settled the ohm file's way because the alternative falsifies a
-   sentence this grammar already states. `attributes` cannot span lines --
-   carve#897 ruled that an inline block stops at the newline, and since
-   carve#906 its padding is `attr_pad = {space}` and its separator `space+`,
-   neither of which admits one. The quoted VALUE was the last way through,
-   so `*x*{k="a` + newline + `b"}` was an attribute block under the EBNF
-   and literal text under the ohm. Narrowing here is what makes the note at
-   `block_attributes` -- "an inline block does not span lines in any
-   engine" -- true of the productions as well as of the engines.
 
    THE BLOCK-ATTRIBUTE LINE FOLLOWS, and that is the part with a cost.
    `block_attributes` reads the same `quoted_value`, so a line break inside

--- a/resources/spec/11-lexical.ebnf
+++ b/resources/spec/11-lexical.ebnf
@@ -43,31 +43,9 @@ digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' ;
    PART 2. MARKER SEPARATORS AND PADDING SLOTS below is 3 applied to every
    whitespace slot in this grammar that sits inline.
 
-   CONSOLIDATING THE STATEMENT DOES NOT REMOVE THE MEASUREMENT. A tab advances
-   to a stop rather than by a fixed amount, so computing a line's content
-   column still needs the per-line indentation walk. Nor does it make a
-   tab-indented source and a space-indented source the same document: the
-   source records what the author wrote (carve#817, carve#966). A
-   whole-document tab-expanding pre-pass could not be written in any case,
-   because 4 preserves tabs inside verbatim content, so the leading run still
-   has to be identified line by line. NO SEMANTIC CHANGE IS INTENDED and no
-   corpus document moves: the four sentences are what the twelve restatements
-   said between them, and not one production changes spelling. That is a claim
-   about this file, NOT a claim that every engine conforms -- the divergences
-   this file already records against these slots (carve#901 at the frontmatter
-   token, the fence info string and `link_title`) are unaffected, neither
-   settled nor widened by saying the rule once.
-
-   WHY ONCE. This was written twelve times, once per construct. A rule spelled
-   per construct is a rule that can drift per construct, and a construct added
-   later inherits eleven precedents for spelling it a twelfth way. That is the
-   hazard ONE WHITESPACE DEFINITION, IN EVERY CONSTRUCT below was written
-   against (carve#963), one layer up: forty-two productions each spelling a
-   whitespace run for themselves is what let three engines reach into three
-   host languages for three different answers, and a carve-php sweep then
-   found fourteen spellings where its ticket named three. The count behaved
-   the same way here -- the ticket named five sites and the sweep found
-   twelve. (carve#984) *)
+   Computing indentation still requires a per-line tab-stop walk. Source
+   spelling remains preserved, and tabs inside verbatim content are never
+   expanded. *)
 
 (* MARKER SEPARATORS AND PADDING SLOTS -- NORMATIVE. A TAB IS SYNTAX ONLY IN
    THE LEADING RUN, the clause directly above. Two consequences settle every

--- a/resources/spec/13-semantics-foundations.ebnf
+++ b/resources/spec/13-semantics-foundations.ebnf
@@ -49,42 +49,25 @@
 
       THE SEVENTH IS THE SECOND SPELLING OF THE SECOND. A `quote_block` IS a
       block quote (PART 2), so it captions like one and a captioned quote is a
-      FIGURE either way -- the two spellings cannot differ here without the
-      fenced form being a worse quote than the prefixed one, which is the whole
-      premise of admitting it. The slot hangs on the CLOSING fence, as
-      `figure_group`'s does, because that is where a fenced container's last
-      line is. So TWO `:::` kinds now take a closer caption, and a `^ ` line
-      after any OTHER `:::` closer is still ordinary paragraph content.
+      FIGURE either way. The slot hangs on the CLOSING fence, as
+      `figure_group`'s does. So TWO `:::` kinds now take a closer caption, and
+      a `^ ` line after any OTHER `:::` closer is still ordinary paragraph
+      content.
 
-      WHERE THAT ALLOWANCE IS WRITTEN DOWN differs, and saying so is the point
-      of this paragraph. For FIVE hosts it is STRUCTURAL -- `code_block`,
-      `blockquote`, `table`, `figure_group` and `quote_block` each end in
-      `[caption_slot]`
-      (PART 2; on `figure_group` the slot hangs on the closing fence), and
-      caption_slot's single optional blank_line IS the rule. For the IMAGE
-      PARAGRAPH and the STANDALONE DISPLAY-MATH BLOCK it is PROSE: this
-      clause is the rule, and PART 3 already says so beside `image` ("there
-      is no separate grammar production for the pair").
+      WHERE THAT ALLOWANCE IS WRITTEN DOWN differs. For FIVE hosts it is
+      STRUCTURAL -- `code_block`, `blockquote`, `table`, `figure_group` and
+      `quote_block` each end in `[caption_slot]` (PART 2; on `figure_group`
+      the slot hangs on the closing fence), and caption_slot's single optional
+      blank_line IS the rule. For the IMAGE PARAGRAPH and the STANDALONE
+      DISPLAY-MATH BLOCK it is PROSE: this clause is the rule, and PART 3
+      already says so beside `image` ("there is no separate grammar production
+      for the pair").
 
       NOT AN OVERSIGHT. Neither of those two has a production to hang the slot
-      on. Both ARE a `paragraph` (PART 2), and what distinguishes them -- a
-      paragraph whose whole content is one image, a paragraph that is solely
-      the display-math span -- is a condition on that paragraph's inline
-      content, the same not-context-free class as PART 7's cell_content ("may
-      not contain an unescaped `|`") and §15's block_attributes. Two ways to
-      formalize it fail on inspection: hanging `[caption_slot]` on `paragraph`
-      itself would make EVERY paragraph captionable, which this enumeration
-      denies and no engine does; and a separate image / math paragraph
-      production would duplicate `paragraph` ambiguously AND inherit its
-      trailing `[blank_line]`, so the one blank line the slot exists to
-      account for could be consumed by either optional -- structural in
-      spelling and undecided in fact.
-
-      One rule, two spellings, not two rules. An engine implements this
-      clause; it does not implement four productions and then guess at the
-      remaining two hosts. This paragraph used to end "structural now, not
-      prose", which was true of three hosts out of the five it then named and
-      read as true of all five (carve#991).
+      on. Both ARE a `paragraph` (PART 2), and what distinguishes them is a
+      condition on that paragraph's inline content, the same not-context-free
+      class as PART 7's cell_content and §15's block_attributes. `paragraph`
+      itself is NOT captionable: this enumeration is closed.
 
    4b. WHAT A CAPTION MAKES OF ITS HOST -- EXPLANATORY. The `figure` node is
       the GENERIC captioned wrapper, not the semantic notion "figure". A
@@ -96,25 +79,6 @@
       counter bucket key (PART 2, CAPTION NUMBER PLACEHOLDER) -- and never from
       the host's node type. `^ Listing #: …` on a code block yields "Listing 1"
       because the author wrote "Listing", not because a code block is a listing.
-
-      SO A QUOTE IS NOT A SPECIAL HOST. carve#1161 briefly made a caption on a
-      quote an `attribution` rendered as a `<footer>` INSIDE the `<blockquote>`,
-      on the argument that a figure is a numbered thing and `figure` was doing
-      two jobs. Both halves are wrong. `figure` does one job here, as the code
-      block above shows; and a caption with no bare `#` takes no number under
-      either model, so a quote captioned `^ William Shakespeare` never entered a
-      counter. That clause is withdrawn (carve#1213), and the PART 11 clause
-      that carried the attribution onto the other three targets goes with it.
-      Its number is retired, not reused, which is why PART 11 runs 10c, 10e.
-
-      HTML AGREES, AND IN THE OTHER DIRECTION. The HTML Standard's `blockquote`
-      section requires that "attribution for the quotation, if any, must be
-      placed outside the `blockquote` element", and gives a `<figure>` wrapping
-      the quote with a `<figcaption>` as the way "to clearly relate a quote to
-      its attribution (which is not part of the quote and therefore doesn't
-      belong inside the `blockquote` itself)". So the withdrawn clause was not
-      one valid spelling among two: it put the attribution in the one place the
-      HTML Standard names as wrong.
 
    4c. A COMPOSITE FIGURE GROUPS ITS PANELS UNDER ONE CAPTION -- NORMATIVE
       (governs `figure_group` in PART 2; carve#1122). A bare `::: figure`
@@ -136,10 +100,8 @@
       matches `admonition_open` instead and stays a generic Tier-2 container
       -- `<div class="figure">`, title and label preserved losslessly, the
       pre-§4c shape -- and `carve lint` reports
-      `figure-group-opener-metadata` (corpus 318-composite-figures-8). The
-      group has no title or label slot BY DESIGN: its one authored metadata
-      channel is the caption, and a second spelling for "the text above the
-      figure" would be claimed from carve#1121's design space.
+      `figure-group-opener-metadata`. The group has no title or label slot BY
+      DESIGN: its one authored metadata channel is the caption.
 
       PANELS ARE THE DIRECT CHILDREN THE INNER RULES ALREADY MAKE CAPTIONABLE
       THINGS OF. After the body parses under the UNCHANGED §4 rules, the
@@ -150,37 +112,26 @@
       source order. Everything else -- paragraphs, lists, uncaptioned
       quotes, nested containers -- is plain group content, PRESERVED IN
       PLACE between the panels; a strict profile lints it, and no renderer
-      may silently drop or re-attach it (318-composite-figures-5). Two
+      may silently drop or re-attach it. Two
       consequences worth naming:
 
         - AN UNCAPTIONED QUOTE inside the group is plain content, which is
           how a quotation carries a figure number without a caption of its
-          own: leave the quote bare and caption the GROUP
-          (318-composite-figures-10):
-
-            ::: figure
-            > To be
-            :::
-            ^ Figure #: A pull quote
-
-            <figure class="carve-figure-group">
-              <blockquote><p>To be</p></blockquote>
-              <figcaption>Figure 1: A pull quote</figcaption>
-            </figure>
-
-          A CAPTIONED quote is a `figure` whose target is the quote (§4b)
-          and panels like any other captionable host -- the quote is not a
-          special host inside the group either.
+          own: leave the quote bare and caption the GROUP, and the group's
+          `<figure class="carve-figure-group">` holds the `<blockquote>` and
+          the group `<figcaption>`. A CAPTIONED quote is a `figure` whose
+          target is the quote (§4b) and panels like any other captionable
+          host -- the quote is not a special host inside the group either.
         - A TABLE PANEL keeps its own caption as the table's `<caption>`;
           the panel wrapper adds nothing to it.
 
       THE GROUP CAPTION ATTACHES AT THE CLOSER, THIS KIND ONLY. A `^ ` line
       (or multiline caption block, the normal `caption` rules) adjacent to or
       exactly one blank line below the group's CLOSING fence is the group
-      caption; two blank lines detach it into an ordinary paragraph
-      (318-composite-figures-6). Every other `:::` kind keeps today's
-      behavior -- a `^ ` line after a `::: note` closer is ordinary paragraph
-      content (318-composite-figures-7). Captions INSIDE the fence attach
+      caption; two blank lines detach it into an ordinary paragraph. Every
+      other `:::` kind keeps today's behavior -- a `^ ` line after a
+      `::: note` closer is ordinary paragraph content. Captions INSIDE the
+      fence attach
       only to their local host, unchanged.
 
       THE GROUP IS ONE NUMBERING UNIT (PART 9R R5). A `#` placeholder in the
@@ -193,8 +144,8 @@
       entry. For CROSS-REFERENCES (PART 9R R4), a panel with an id resolves
       `</#id>` with the group's number plus a letter by panel order among the
       panels -- "Figure 2a", letters a..z then aa, ab, ... -- and the group's
-      own id resolves as the plain "Figure 2"
-      (318-composite-figures-2). The letters exist in crossref text only:
+      own id resolves as the plain "Figure 2". The letters exist in crossref
+      text only:
       this version generates no visible `(a)` label inside the panel (authors
       write panel letters in panel captions; the mechanism is reserved).
       Panel ids register only when the group itself drew a number -- an
@@ -209,22 +160,16 @@
       content -- a captioned figure inside an admonition inside the group,
       say -- which draws AFTER the group even though its caption line sits
       above the group's in the source: the inner figure is "Figure 2" and
-      the group "Figure 1" (corpus 318-composite-figures-11). That
-      construction is already the stray content a strict profile lints.
-      Caption-line order was considered and rejected: under it, editing a
-      group's INTERIOR could renumber the group itself, and a group's number
-      should be stable under edits to what it contains. All four
-      implementations of record -- the oracle, carve-js, carve-php and
-      carve-rs -- agree on the pre-order result, so this clause writes down
-      the answer they already share rather than choosing between them.
+      the group "Figure 1". That construction is already the stray content a
+      strict profile lints. Caption-line order is NOT the rule: a group's
+      number is stable under edits to what it contains.
 
       GROUPS DO NOT NEST. A bare `::: figure` opener anywhere inside an open
       group's body -- any depth -- is a generic Tier-2 container
       (`<div class="figure">`), not an inner group, and lints as
-      `figure-group-nested` (318-composite-figures-9). Rejected initially
-      rather than specified halfway: nested numbering ("Figure 2a.iii"?) is a
-      design question carve#1122 explicitly defers, and a generic container
-      is the lossless degradation.
+      `figure-group-nested` (318-composite-figures-9). Nested numbering is a
+      design question carve#1122 explicitly defers, and a generic container is
+      the lossless degradation.
 
       LINT, NOT PARSE. The five findings this clause names are diagnostics
       over a valid parse: `figure-group-opener-metadata` and
@@ -253,10 +198,7 @@
       what the element admits -- no intermediate `div` is needed to make the
       shape valid, and none is emitted. This is also the shape Pandoc's
       writers produce for its native subfigures, which keeps HTML
-      import/export symmetric with the Pandoc bridge. The initial draft of
-      this clause wrapped the panels in a `<div class="carve-figure-panels">`;
-      that form was revised to the flat one before any release, so no
-      shipped document ever carried the wrapper.
+      import/export symmetric with the Pandoc bridge.
 
       The class is FIRST on the group and on each panel, exactly the typed-
       container convention (`admonition note`): `carve-figure-group` leads,
@@ -267,7 +209,7 @@
       with `carve-figure-panel` leading its classes the same way. No group
       caption -> no trailing `<figcaption>`. Zero panels -> the group
       `<figure>` holds the preserved content directly; a consumer selects
-      panels by the `carve-figure-panel` class, never by position, so the
+      panels by the `carve-figure-panel` class, never by position.
       shape needs no branch on child count.
 
    5. TABLE MODEL -- OPERATIONAL SEMANTICS (cell split, row validity,
@@ -344,31 +286,24 @@
 
          - and the block above `+ b |` at the item's own column is a
          blockquote. T6 declines, the line is ordinary prose, and prose reopens
-         the item's paragraph (PART 1 S4's clause on that). No reader joins the
-         cell, so a reader that consults the quote's table anyway declines the
-         join and still ends the paragraph, which reads one line as prose and
-         as a table row in the same parse. Corpus 361 pins it, with the
-         same-column spelling `- | a |` / `  | b |` as its control: there the
-         row above IS the item's own, it joins, and no paragraph opens.
-         (carve#1370)
+         the item's paragraph (PART 1 S4's clause on that). The control is the
+         same-column spelling `- | a |` / `  | b |`: there the row above IS the
+         item's own, it joins, and no paragraph opens. (carve#1370)
 
-         HEADER-NESS IS NOT THE DISCRIMINATOR, and reading it as one gets 115
-         right for the wrong reason. The executable spec declined whenever the
-         row above was ALL-HEADER, which answers three neighbouring documents
-         wrongly and all three engines agree it does:
+         HEADER-NESS IS NOT THE DISCRIMINATOR. Declining whenever the row above
+         is ALL-HEADER answers three neighbouring documents wrongly:
 
              |=a |=b |          | a |            |=a |
              + cont |           |=b |            | - |
                                 + c |            + cont |
 
-         The first two JOIN in every reader - onto a native header row, and
-         onto an all-header row that is not the table's first - and the third
-         DECLINES in every reader, on a NATIVE header row, because a delimiter
-         row sits between the two lines. Header-ness answers all three
-         backwards; the delimiter row answers all three. T9 already says the
-         rest outright: a `^` rowspan MAY reach a header cell, so a header
-         cell is an ordinary cell in every other table mechanism, and nothing
-         here makes it less of a row.
+         The first two JOIN - onto a native header row, and onto an all-header
+         row that is not the table's first - and the third DECLINES, on a
+         NATIVE header row, because a delimiter row sits between the two lines.
+         Header-ness answers all three backwards; the delimiter row answers all
+         three. T9 already says the rest outright: a `^` rowspan MAY reach a
+         header cell, so a header cell is an ordinary cell in every other table
+         mechanism.
 
          AN ALL-EMPTY CONTINUATION ROW IS A CONTINUATION ROW. T2's "at least
          one cell lies between" is written of `valid_row`, the predicate that
@@ -383,8 +318,7 @@
              | a | b |          | a |
              + | |              + |
 
-         the first absorbed and the second published as a paragraph. All three
-         engines absorb both.
+         Both are absorbed.
 
          IT LEAVES NO PARAGRAPH OPEN, LIKE THE ROW IT APPENDS TO -- NORMATIVE.
          PART 1 S4 asks what a container's last BLOCK is, and the answer here
@@ -415,15 +349,12 @@
          ending on a continuation row is decided by the run inside the quote
          and not by the line that carries it. An implementation that peels the
          `>` off ONE line loses that run, and the same quote then answers
-         differently bare and wrapped in a definition body - which is the
-         defect carve-rs shows today, in the direction opposite to the other
-         two engines.
+         differently bare and wrapped in a definition body.
 
-         A QUOTE INSIDE A QUOTE IS ASKED THE SAME QUESTION, ruled at carve#1355
-         and stated in PART 1 S4 rather than here, since it is not about a
-         continuation row: an outer quote's last block may be an inner quote,
-         and then the INNER quote's own last block answers. `> > # H` over
-         `tail` ends both quotes for the reason `> # H` over `tail` ends one.
+         A QUOTE INSIDE A QUOTE IS ASKED THE SAME QUESTION, stated in PART 1
+         S4 rather than here since it is not about a continuation row: an
+         outer quote's last block may be an inner quote, and then the INNER
+         quote's own last block answers.
       T7 GFM DELIMITER ROW -- NORMATIVE. delimiter_row(R) := R is EXACTLY
          the SECOND row of the table AND every cell matches delimiter_cell
          (optional ws, optional `:`, one or more `-`, optional `:`,
@@ -465,23 +396,16 @@
          `<tbody>` (corpus 09-tables-7) -- so the attribute states an
          association the table already has rather than adding a concept.
 
-         IT IS NOT DECORATION. Without it a screen reader guesses the
-         association from position, and guesses wrong on any table with both
-         kinds of header; `scope` is the mechanism WCAG 1.3.1 names for
-         programmatically determined relationships. Carve emits real `<table>`
-         markup precisely so assistive technology can read it, and this was the
-         one part of that markup the language left to inference.
-
          AN AUTHORED `scope` REPLACES THE DEFAULT rather than joining it. A
          cell block naming `scope` suppresses the emitted one, so
          `|={scope="colgroup"} a |` -- a header cell carrying attributes,
          which is grammatical because of T10 and was not before it -- is
          `<th scope="colgroup">` and not
          `<th scope="col" scope="colgroup">`. That is how `colgroup` and
-         `rowgroup`, which have no marker spelling here, stay reachable. The
-         duplicate was the first thing this rule produced when the default was
-         emitted unconditionally: two attributes of one name, which is not
-         valid HTML and is not an override.
+         `<th scope="colgroup">` and not
+         `<th scope="col" scope="colgroup">`. That is how `colgroup` and
+         `rowgroup`, which have no marker spelling here, stay reachable: two
+         attributes of one name is not valid HTML and is not an override.
 
          THE TEST IS CASE-INSENSITIVE, which is the one place this rule departs
          from Carve's case-sensitive attribute names. `{Scope="colgroup"}` is a
@@ -509,45 +433,9 @@
          makes it ordinary content (T4's `{.x} <` is unchanged), and the
          validity rule is T8's.
 
-         WHAT THIS RULE EXISTS TO FIX. With the block bound to the opening
-         `|` instead, an attributed HEADER cell has no spelling at all. The
-         one shape available, `|{#x}=R|`, is ambiguous by construction: an
-         attributed header cell, or a data cell whose content starts with
-         `=`. §5 T1/T3 resolve it as the second, so a canonical writer that
-         emitted it for an attributed header cell round-tripped
-         `<th id="x">R</th>` into `<td id="x">=R</td>` -- a PART 11 §1
-         failure the corpus could not see, because the only document
-         pinning cell attributes (99-table-cell-attributes) carries no
-         marker, and every order agrees on a cell with no marker. Once `=`
-         has committed the cell to header, everything after it is
-         unambiguous, so binding last is the only placement under which the
-         shape is expressible.
-
-         THE COST, STATED. This CHANGES an already-released spelling on
-         `data_cell`: `|{#x}< content |` was documented as attributes then a
-         left-alignment marker, and under T10 the `<` is no longer in a
-         marker position, so it is literal content and the cell is not
-         aligned. (T11 moves that same spelling once more: with no space
-         after the closing brace there is no run, so the braces are content
-         too.) That source REINTERPRETS rather than erroring, which is
-         the outcome to be careful about. It is accepted here for the
-         uniform shape over the preserved special case, on a `0.x` line, and
-         it ships WITH its migration rather than a deprecation window: a
-         canonical writer rewrites the old spelling to the new one. Row
-         attributes (T8) do not move.
-
-         WHAT WAS ACTUALLY MEASURED, so the migration is not sized from the
-         prose. Against this repo's own oracle (scripts/spec) and the
-         `@markup-carve/carve` build package.json pins, `|{#x}< content |`
-         ALREADY renders `<td id="x">&lt; content</td>` -- neither reads the
-         `<` as alignment, so neither ever implemented the order this rule
-         replaces. The other half -- an attribute block after a marker --
-         is what was new, and both this repo's oracle and the pinned
-         `@markup-carve/carve` build read it. So the reinterpretation risk
-         falls on documents written to the retired PROSE, and the engine
-         work was to start reading the marker-run position, not to stop
-         reading the old one. Pinned by corpus
-         319-cell-attributes-bind-after-the-kind-and-alignment-markers.
+         The canonical writer uses this order. The retired
+         `|{#x}< content |` spelling is parsed as unaligned literal content;
+         row attributes (T8) are unaffected.
 
       T11 A MARKER RUN ENDS AT A SPACE -- NORMATIVE. A cell's marker run is
          the kind marker `=`, the alignment run and the attribute block, in
@@ -563,16 +451,6 @@
 
          A cell with NO run is unchanged -- `| a |`, `|a|` and `||` all mean
          what they meant.
-
-         THE RUN HAD NO TERMINATOR, SO IT TOOK CONTENT INSTEAD. `|=hot= |` is
-         a cell whose author wrote a highlight and got a header cell holding
-         `hot=`: the marker ate the opening `=` and nothing said so. Carve
-         resolves this class by making the failure VISIBLE -- `- {.notattr}
-         Milk` renders its braces rather than guessing -- and the table cell
-         was the outlier. The alignment run already required the space, and
-         a doubled marker (`|=<< Note |`) already fell back to content for
-         want of one; this states the rule ONCE, for the whole run, instead
-         of for one of its three parts.
 
          THE CLOSING PIPE IS NOT A TERMINATOR. `|=|` and `|{#x}|` carry no
          run; an empty marked cell is `|= |` and `|{#x} |` -- which is what
@@ -590,20 +468,16 @@
          line for one rule over three, and it ships WITH its migration: §6e's
          canonical writer already emits a space after every prefix, so a
          formatted document is already conformant, and the glued form is what
-         a linter can name. Pinned by corpus
-         390-a-table-cell-s-marker-run-ends-at-a-space.
+         a linter can name.
 
-         THE LINTER NAMES IT `table-marker-run-padding` -- NORMATIVE
-         (carve#1464). One id for the whole run, because T11 is one rule for
-         the whole run: it reports a glued kind marker, a glued alignment run
-         and a glued attribute block alike, and `fmt --migrate` repairs any of
-         them by inserting the space. It SUPERSEDES
-         `table-alignment-run-padding`, which named the middle part only -
-         which is how the one part of the run that reinterprets existing
-         documents, the kind marker, ended up the part with no diagnostic.
-         A lint id is spec surface (docs/validation.md carries the row), so it
-         is agreed here BEFORE an engine emits it, rather than two engines
-         picking different names for it.
+         THE LINTER NAMES IT `table-marker-run-padding` -- NORMATIVE. One id
+         for the whole run, because T11 is one rule for the whole run: it
+         reports a glued kind marker, a glued alignment run and a glued
+         attribute block alike, and `fmt --migrate` repairs any of them by
+         inserting the space. It SUPERSEDES `table-alignment-run-padding`,
+         which named the middle part only. A lint id is spec surface
+         (docs/validation.md carries the row), so it is agreed here BEFORE an
+         engine emits it.
 
    6. REFERENCE RESOLUTION -- FORMAL STATEMENT MOVED TO PART 9R (rules
       R1-R3; this §-anchor stays for existing references). Summary: link
@@ -641,9 +515,7 @@
         or glyph extension (a German / Swiss quote set, say) selects WHICH
         characters are emitted; it does NOT decide WHETHER the substitution
         runs, and removing such an extension does not disable the
-        transform. Stated explicitly because the existence of a
-        smart-quotes extension otherwise reads as "the transform is that
-        extension" -- it is not (carve#338).
+        transform.
       - OPTIONAL OFF SWITCH -- NORMATIVE WHERE OFFERED. A host MAY expose
         one document-global switch, `smartTypography`, defaulting to TRUE
         (idiomatic spellings: `smartTypography: false` in carve-js and
@@ -654,11 +526,7 @@
         document is configured when it is not, which is worse than the
         rejection an unimplemented option should produce. Omitting and
         implementing are both fine; the silent middle is the one state this
-        clause forbids. Measured on each engine's main: carve-php raises
-        `Unknown named parameter $smartTypography`, carve-rs has no such
-        method, and carve-js accepts the option and ignores it -- so the
-        reference is the only one currently non-conformant here, and it is
-        non-conformant in the direction a host cannot detect (carve#560).
+        clause forbids (carve#560).
 
         Where it IS offered and set to FALSE:
         * PARSING IS UNCHANGED. The nodes below are still produced, so the
@@ -720,11 +588,9 @@
             author typed as a typographic character is not a
             `smart_punctuation` node and is emitted unchanged either way.
           Rationale: Markdown is the target generated for machines to read,
-          and the glyph breaks exact-match search against the source - a
-          quote substituted around a code-ish value (`= 'verification-link-
-          sent'`) can no longer be found by searching for what the author
-          wrote, and the reader cannot undo it because the glyph is all that
-          survives. Pinned in tests/corpus-optional (feature
+          and the glyph breaks exact-match search against the source, which
+          the reader cannot undo because the glyph is all that survives.
+          Pinned in tests/corpus-optional (feature
           `markdown-typography-source`, target `markdown`).
         * KIND NAMES ARE SPEC SURFACE -- an implementation inventing its own
           spelling breaks every AST consumer. The fourteen table-resolved

--- a/resources/spec/14-semantics-blocks.ebnf
+++ b/resources/spec/14-semantics-blocks.ebnf
@@ -69,9 +69,7 @@
          "x = 5 \n * 3 + 17"; a blank line starts the list. (Deliberate
          change from the earlier bullet/ordered asymmetry: an ordered
          marker is too common in prose, and the symmetric rule removes the
-         hard-wrapped-bullet false positive. Pinned by corpus 05-lists-12/13,
-         76-paragraph-interruption, 77-blockquote-lazy-continuation,
-         82-single-line-headings.) TIGHT NESTED LISTS UNAFFECTED: an
+         hard-wrapped-bullet false positive.) TIGHT NESTED LISTS UNAFFECTED:
          indented marker inside an open list ITEM opens a sublist with no
          blank line -- that is §24 C3 (content column), not this relation.
       I3 IMAGE EXCLUDED. A line that is only a bare image ("![alt](url)")
@@ -87,10 +85,8 @@
          A `:::` OPENER IS NOT GUARDED. It interrupts whether or not a closer
          follows, and an unterminated one closes with its host -- the
          enclosing container's boundary, or end of input at the top level
-         (§12; the citation here read §25, which is the security section and
-         says nothing about it). Pinned by
-         corpus 81-paragraph-interruption-20: `Text` / `:::` / `stuff` is a
-         paragraph followed by a div holding `stuff`.
+         (§12). Pinned by corpus 81-paragraph-interruption-20: `Text` /
+         `:::` / `stuff` is a paragraph followed by a div holding `stuff`.
 
       I5 INVISIBLE CONSTRUCTS interrupt AND are consumed: a reference
          definition (link `[r]: url`, footnote `[^r]: …`, abbreviation
@@ -179,16 +175,11 @@
          in scope versus retain pending metadata -- and the column that selects
          the band does not.
 
-         WHICH CONTAINER, NOT ONLY THAT IT IS TEXT (carve#1800). "Lazy
-         paragraph text" names an operation on an OPEN PARAGRAPH, so the text
-         lands in the container that holds that paragraph, and a reader that
-         ends the container and then publishes the same characters one level out
-         has not carried the sentence out -- it has produced text in a place the
-         sentence does not name. The definition-description host is where the
-         two readings came apart: a link or footnote definition one or two
-         columns below the description's content column ended the `dd` and was
-         published as a DOCUMENT-level paragraph, one line after a plain line at
-         the identical column folded into the `dd`. Pinned per kind by corpus
+         WHICH CONTAINER, NOT ONLY THAT IT IS TEXT. "Lazy paragraph text" names
+         an operation on an OPEN PARAGRAPH, so the text lands in the container
+         that holds that paragraph; a reader that ends the container and then
+         publishes the same characters one level out has produced text in a
+         place the sentence does not name. Pinned per kind by corpus
          430-below-a-definition-body-s-column-an-invisible-line-folds-as-text.
 
          A DEFINITION COLLECTED AT content_column ENDS THE ITEM'S OPEN
@@ -225,14 +216,8 @@
          about a caption, stated separately from item 2's "a line that
          interrupts a paragraph" precisely because a caret line is not one of
          those. Item 4 would be redundant if it were.
-         WHY IT NEEDED WRITING DOWN. Only the INDENTED spelling was in the
-         corpus (158-indented-image-and-caption-stay-literal), where both
-         readings agree because an indented line opens no top-level block at
-         all. The executable spec ended the paragraph on EVERY caret line, all
-         three engines folded it in, and nothing failed until the canonical
-         writer stopped force-escaping a line-initial caret and `oracle(fmt(x))`
-         parted from `oracle(x)` (carve#1046). Pinned by corpus
-         286-a-caret-line-does-not-end-a-paragraph-it-cannot-caption.
+         An INDENTED caret line opens no top-level block at all, so both
+         readings agree there. (carve#1046)
 
    11. LIST MARKER CHANGE STARTS A NEW LIST -- OPERATIONAL (governs `list`
       in PART 2). §10 decides FIRST whether marker lines establish a list
@@ -264,24 +249,16 @@
            - oranges
          AT EVERY LEVEL. The boundary is not restricted to the top level: it
          applies wherever a list is, including a list nested in a list item
-         and a list inside a quote or a div. A rule that fired at the top
-         level and not inside an item would make one spelling mean two
-         things depending on where it sits, which Design Principle 1 exists
-         to prevent, and the marker's own container has nothing to do with
-         what the run separates.
+         and a list inside a quote or a div.
          THE RUN CLOSES NOTHING ON ITS OWN. It denies a FOLLOWING SIBLING
          MARKER the right to join; it does not end the item. A run followed
          by a continuation at the item's content column continues that item,
          at any run length -- which is SS17's content-column model unchanged,
          and is why three blank lines before indented text still leave one
          loose item.
-         WHY THREE AND NOT TWO. Two fires on decoration. Sampling 8000
-         Markdown files for the shape that would change -- a list open above
-         the run, a compatible sibling marker after it -- found 30 sites at
-         two blank lines and NONE at three, and every one of the 30 was
-         generator output or a changelog's spacing rather than an author
-         separating two lists. A released line needs a threshold that fires
-         on nothing already written.
+         WHY THREE AND NOT TWO. Two fires on decoration -- generator output
+         and changelog spacing routinely spell two blank lines between
+         compatible sibling markers.
       N2 ORDERED DIALECT. A list's dialect (decimal / lower- or upper-alpha
          / lower- or upper-roman) and delimiter are fixed by its FIRST
          item; a later marker outside the dialect, or with the other
@@ -303,9 +280,7 @@
       on the type identifier (below). A BARE `:::` opener with NO type
       word is a GENERIC DIV: a plain `<div>` (no class added), i.e. djot's
       generic container. An EMPTY one closes on the next line --
-      `<div>` newline `</div>`, the exception PART 10 §4 states -- not
-      `<div></div>`, which no engine emits and which this line claimed
-      until carve#531 measured it.
+      `<div>` newline `</div>`, the exception PART 10 §4 states.
 
       INLINE OPENER ATTRIBUTES -- STRICT (djot). The opener line carries NO
       inline attributes: it is the colon fence, an optional type word, and
@@ -332,26 +307,18 @@
       may hold `::: tip`, the inner line being an opener rather than a closer
       on account of its label. Only a bare equal-length line closes.
 
-      Compatibility history for the retired equal-or-greater closer and
-      literal-unclosed readings lives in docs/spec-history.md. The current rule
-      is fully stated above and pinned by carve#770 and carve#1717.
-
       THE CANONICAL WIDTH IS A FUNCTION OF DEPTH, AND THAT COSTS O(depth^2)
       BYTES (carve#1553). The exact-length guard leaves the DIRECTION free --
       longer-outer documents and longer-inner ones both parse -- and `carve
       fmt` writes the inward one: the outermost container is `:::` and each
       level inward adds one colon (PART 11; the `colon_fence` note in PART 2).
       So the writer sizes each fence from the depth it is ALREADY CARRYING. It
-      needs no lookahead and no scan of the subtree it has not written yet, and
-      the widths it emits cannot collide with one another, because along any
-      one chain they are STRICTLY INCREASING: a container's closer is wider
-      than every fence enclosing it and narrower than every fence it encloses.
-      (A fence-shaped line in TEXT is a different problem, answered by PART 11
-      §5's escaping rather than by this width.)
+      needs no lookahead, and the widths it emits cannot collide, because along
+      any one chain they are STRICTLY INCREASING. (A fence-shaped line in TEXT
+      is a different problem, answered by PART 11 §5's escaping.)
 
       A nest d containers deep spends d^2 + 5d bytes on opener and closer
-      markers. This accepted canonical-size trade is recorded in
-      docs/spec-history.md (carve#1553).
+      markers -- the accepted canonical-size trade (docs/spec-history.md).
 
       A COLON-FENCE LINE THAT FAILS THE OPENER TEST LEAVES THE PARAGRAPH
       EXPECTING A CLOSER -- NORMATIVE. A `:::` line that is not a valid opener
@@ -407,13 +374,8 @@
       that holds it (corpus
       270-a-real-div-in-a-container-and-the-flush-left-line-after-it), which is
       end of input only when the item runs that far.
-      The corpus pins these
-      (resources/examples/edge-cases.md "Fence opener with a nested-list body inside a list
-      item").
-
-      The retired missing-closer reading and its compatibility evidence live in
-      docs/spec-history.md. The current host-closing rule applies unchanged in
-      a list item and is pinned by carve#1722.
+      (resources/examples/edge-cases.md "Fence opener with a nested-list body
+      inside a list item" pins these.)
 
       The two tiers for a typed block:
 
@@ -456,12 +418,10 @@
            An explicitly empty `""` still counts as a supplied (empty)
            title. Applies to both tiers.
 
-      AN ADMONITION LANDMARK CARRIES AN ACCESSIBLE NAME -- NORMATIVE
-      (carve#1468). A Tier-1 block renders `<aside>`, which is a COMPLEMENTARY
-      LANDMARK, and a landmark with no name is an anonymous row in a reader's
-      landmark list -- the same defect as the unnamed backlink SS16 records, one
-      element up. Tier 2 renders `<div>`, is not a landmark, and takes nothing
-      here.
+      AN ADMONITION LANDMARK CARRIES AN ACCESSIBLE NAME -- NORMATIVE. A
+      Tier-1 block renders `<aside>`, which is a COMPLEMENTARY LANDMARK, and a
+      landmark with no name is an anonymous row in a reader's landmark list.
+      Tier 2 renders `<div>`, is not a landmark, and takes nothing here.
 
         TITLED: the name is the title the author already wrote. The
         `<p class="admonition-title">` takes an `id` and the aside points at it
@@ -537,8 +497,7 @@
         `jgm/djot.js#43` the other way (all attributes migrate to the
         section) and then implemented that resolution only when an
         explicit id is present, so djot's two id cases disagree with
-        each other (`jgm/djot.js#144`). Carve's two cases agree. See
-        divergence-from-djot.md.
+        each other. Carve's two cases agree. See divergence-from-djot.md.
       - HEADINGS INSIDE CONTAINERS DO NOT WRAP. The algorithm walks
         TOP-LEVEL blocks (and the sections it opens), so a heading
         inside a blockquote, div, admonition, list item, definition,
@@ -584,9 +543,7 @@
       - The two-pass id resolution (collect explicit ids first, then
         auto-slug headings with collision-dedup) is unaffected by this
         rule -- only the EMISSION site of the id moves from <h*> to
-        <section>. Existing crossref (`</#id>`) and implicit-heading
-        ref (`[Heading][]`) resolution continue to target the same
-        slug; the fragment URL `#{slug}` resolves to <section id> the
+        <section>. The fragment URL `#{slug}` resolves to <section id> the
         same way browsers resolve to <h* id>.
       - Carve does NOT add `<section>` wrappers around non-heading
         top-level blocks. Headings are the only trigger.
@@ -618,12 +575,11 @@
           attributes.
         - empty or SPACE-only (`[text]{}`, `[text]{ }`) -> a valid EMPTY
           block: a bare `<span>text</span>`. A TAB inside it is not padding
-          and the block is unrecognized (carve#906, the A7 position of THE
-          INLINE INTERIOR IS SPACE-ONLY in PART 4). Both reference impls
-          agree on the space form, even
-          though the bare `attribute_list` production nominally needs >= 1
-          attribute; the empty block is a blessed exception so a
-          default-attribute processor can target the span.
+          and the block is unrecognized (the A7 position of THE INLINE
+          INTERIOR IS SPACE-ONLY in PART 4). The empty block is a blessed
+          exception -- the bare `attribute_list` production nominally needs
+          >= 1 attribute -- so a default-attribute processor can target the
+          span.
         - unrecognized non-empty content (`[text]{???}`, `[text]{=y=}`) -> NOT
           an attribute block: the `]` and the `{...}` render literally. The
           inner bracket content is still inline-parsed, so `[*x*]{???}` ->
@@ -643,7 +599,7 @@
       with id/class/key=value in source order; multiple are allowed; a
       digit-first bare word is not a valid name (the block stays literal, as for
       any digit-first identifier). All impls support it (a carve extension
-      beyond canonical djot, matching djot-php; corpus 97-boolean-attributes).
+      beyond canonical djot, matching djot-php).
       THE THREE NAMES OF PART 9 §9 ARE THE EXCEPTION TO `name=""`: on an
       ordinary span, `abbr`, `time` and `kbd` are consumed into an HTML
       element instead of reaching the output as an attribute, so `[Tab]{kbd}`
@@ -651,20 +607,17 @@
       semantic names -- `samp`, `var`, `cite` and `dfn` -- are NOT core: a
       conformant core leaves them as ordinary boolean attributes
       (`<span samp="">x</span>`), and only the Tier-2 SemanticSpan extension
-      consumes them (§10; corpus 45-inline-extensions-10 pins the core render).
-      All seven are boolean attributes everywhere else,
+      consumes them (§10). All seven are boolean attributes everywhere else,
       including in the AST and in the canonical writer, which writes the span
       back as `[Tab]{kbd}` -- a value-less attribute is spelled bare there
-      (PART 11 §6c), so the consumed name comes back in the form the author
-      wrote it.
+      (PART 11 §6c).
       A COLON is not an `identifier` character, so a colon-bearing name is
       unrecognized in every form -- `{xml:lang="en"}`, `{.sm:hover}`, `{#a:b}`
-      and a bare `{a:b}` all leave the run literal, in every engine (corpus
-      248-an-attribute-name-admits-no-colon). It stays legal one position over,
-      inside an unquoted VALUE (`{k=a:b}`), which `unquoted_value` admits.
-      (A `{% ... %}` block is NOT a comment in Carve -- comments
-      are `%%` / `%%%` only, PART 9 -- and a `%`-bearing attribute block is an
-      invalid attribute that renders literally in ALL impls.)
+      and a bare `{a:b}` all leave the run literal. It stays legal one position
+      over, inside an unquoted VALUE (`{k=a:b}`), which `unquoted_value` admits.
+      (A `{% ... %}` block is NOT a comment in Carve -- comments are `%%` /
+      `%%%` only, PART 9 -- and a `%`-bearing attribute block is an invalid
+      attribute that renders literally in ALL impls.)
 
    15. BLOCK ATTRIBUTE LINES -- OPERATIONAL SEMANTICS (governs
       `block_attributes` in PART 2; matches djot). STATE: pending := the
@@ -689,15 +642,6 @@
              [^f]: note
 
              e
-
-         is `<p id="i">e</p>`. The attribute is the author's instruction about
-         a rendered element; attaching it to a construct that emits nothing
-         silently discards it, and A4 reserves discarding for the cases where
-         there is genuinely nothing left -- end of document, and end of the
-         container that holds the attribute (carve#1281). Neither is silent:
-         both are reported as `unattached-block-attribute`. This clause is about
-         floating PAST something invisible, which is a different question from
-         running out of blocks to float to.
 
       A3 MERGE (over all pending blocks, source order):
          * id -> last one wins;
@@ -731,10 +675,6 @@
          line onto a document-level paragraph; `- {.k}` / `# H` leaves the
          heading outside the item rather than pulling it in to be attributed.
 
-         The failure mode of the other reading is the argument against it. An
-         attribute reaching content the author did not write it next to is the
-         worst of the answers available, and it is the one carve-php shipped.
-
          DROPPING SILENTLY IS THE ONE THING THIS MAY NOT DO. Both dangling
          cases are a lint diagnostic, `unattached-block-attribute`
          (docs/validation.md), in the same family as the other constructs that
@@ -748,9 +688,8 @@
          has nothing left for the attribute.
 
          OUT OF SCOPE, and left open deliberately: what a container that ends up
-         EMPTY renders. carve-rs emits an empty `<blockquote>` for `> {.k}` /
-         `tail`; that is a rendering question about empty containers in general
-         and is not settled here.
+         EMPTY renders. That is a rendering question about empty containers in
+         general and is not settled here.
       A5 MULTI-LINE BLOCK. One block may wrap across lines ({#id\n .foo} is
          one block: id `id`, class `foo`). A BLANK line inside the braces
          ends the attempt -- the text is then literal, not a
@@ -782,10 +721,5 @@
          start after a marker, and A1/A2 apply to it exactly as they would
          at the top level -- a container does not get its own attribute
          rules.
-         Decided in carve#454. The two halves were each pinned (corpus
-         90-list-item-attributes-7 for the literal form, 84 for A1/A2) and
-         their boundary was not, so carve-rs read the marker line as
-         literal while carve-js, carve-php and the executable spec read it
-         as an attribute line. None of them could be shown wrong until the
-         boundary was stated.
+         Decided in carve#454.
    ============================================================================ *)

--- a/resources/spec/15-semantics-resolution-rendering.ebnf
+++ b/resources/spec/15-semantics-resolution-rendering.ebnf
@@ -39,31 +39,25 @@
         repeat uses `fnref{n}-{k}` and adds another backlink. The
         backlink glyph is the plain return arrow `↩` (Carve's choice;
         djot appends a variation selector).
-        THE BACKLINK CARRIES AN ACCESSIBLE NAME -- NORMATIVE (carve#1455).
-        The `role` alone was right and the NAME was the glyph, so a screen
-        reader announced the character's Unicode name ("leftwards arrow with
-        hook") or skipped the link outright: correct semantics, no way to know
-        where the link goes. `{name}` is the `footnoteBacklink` label (PART 9
-        §16a) followed by WHAT THE LINK VISIBLY SAYS -- the label alone for a
-        lone backlink (`↩`, so `aria-label="Back to reference"`), the label
-        plus k for the k-th of several (`↩<sup>k</sup>`, so
-        `aria-label="Back to reference 2"`). Matching the visible text is WCAG
-        2.5.3, and it is why the number here is the REFERENCE ORDINAL and not
-        the note number: the note number appears nowhere in this link's text.
-        The name is TEXT and is attribute-escaped.
-        THE ENDNOTES SECTION CARRIES AN ACCESSIBLE NAME -- NORMATIVE
-        (carve#1468). The rule above names the LINKS and left the REGION they
-        sit in anonymous: `<section role="doc-endnotes">` says what the region
-        is and nothing said what it is called, so a landmark list held an
-        unnamed entry for exactly the reason the backlink did. The section
-        takes `aria-label`, the string is the `endnotes` label (SS16a), and it
-        is escaped the same way:
+        THE BACKLINK CARRIES AN ACCESSIBLE NAME -- NORMATIVE. The `role` alone
+        was right and the NAME was the glyph, so a screen reader announced the
+        character's Unicode name or skipped the link outright. `{name}` is the
+        `footnoteBacklink` label (PART 9 §16a) followed by WHAT THE LINK VISIBLY
+        SAYS -- the label alone for a lone backlink (`↩`, so
+        `aria-label="Back to reference"`), the label plus k for the k-th of
+        several (`↩<sup>k</sup>`, so `aria-label="Back to reference 2"`).
+        Matching the visible text is WCAG 2.5.3, and it is why the number here
+        is the REFERENCE ORDINAL and not the note number. The name is TEXT and
+        is attribute-escaped.
+        THE ENDNOTES SECTION CARRIES AN ACCESSIBLE NAME -- NORMATIVE. The rule
+        above names the LINKS and left the REGION they sit in anonymous. The
+        section takes `aria-label`, the string is the `endnotes` label (SS16a),
+        and it is escaped the same way:
             <section role="doc-endnotes" aria-label="Footnotes">
         The default is "Footnotes" rather than "Endnotes" because that is the
-        word the rest of this grammar uses for the construct, and a reader
-        meeting the region should hear the name the document's own prose uses
-        for it. A host that renders them at the end and calls them endnotes
-        sets the label; that is what the map is for.
+        word the rest of this grammar uses for the construct. A host that
+        renders them at the end and calls them endnotes sets the label; that is
+        what the map is for.
       - BACKLINK PLACEMENT WHEN THE BODY DOES NOT END IN A PARAGRAPH. "The
         note's last paragraph" above presumes there is one. When the note
         body's LAST BLOCK is not a paragraph (a code block, a block quote, a
@@ -77,11 +71,8 @@
         (or otherwise contained) content, not to the note's own backlink, so
         appending there would misattribute the backlink to the quotation. A
         note body consisting ONLY of a non-paragraph block still gets the
-        synthesized trailing <p>. Decided in carve#688: appending to
-        whatever paragraph happens to be last is undefined when the last
-        block has no paragraph, and where a literal reading of the old rule
-        DOES find one (inside a block quote, or nowhere, leaving the anchor
-        a bare inline child of <li>) it is wrong for the reason just given.
+        synthesized trailing <p>. Appending to whatever paragraph happens to
+        be last is undefined when the last block has no paragraph.
       - INLINE FOOTNOTE `^[content]` (pandoc form; a deliberate carve
         extension -- canonical djot has no inline footnotes). A `^`
         IMMEDIATELY before `[` opens an anonymous note whose content is the
@@ -197,12 +188,6 @@
                ```
              - c
 
-         is tight in every reader. Reading the PAYLOAD instead of the position
-         was the alternative, and it fails on its own terms: it would make a
-         structural answer depend on a detail readers already spell
-         differently, since carve-php drops the trailing blank from a raw
-         block and keeps it in a code block.
-
       L2 COMPACT LIST BLOCKS -- Carve deviation from djot/CommonMark. A
          blank line before an item's sub-BLOCK (sub-list, block quote,
          fenced code, fenced div, heading, table) does NOT loosen: the item
@@ -259,9 +244,7 @@
          This is a BREAK against released carve-js 0.1.3, which attached to the
          boundary, and it is deliberate: the boundary reading is the same
          absorb-flush-left-blocks-until-something-stops-you behavior that PART 1
-         S4 refuses one clause over, and taking it here would reject that shape
-         in the layout section and reinstate it in this one. carve-rs already
-         attaches one.
+         S4 refuses one clause over.
          THE MARKER IS ONE OPERATION IN EVERY CONTAINER -- NORMATIVE
          (carve#1782). The clause above is the WHOLE definition of `+`:
          ownership of the next flush-left block passes to the container, and
@@ -272,14 +255,6 @@
          set above hold in EVERY container in L4, not only in the two that had
          them spelled out.
 
-         This is stated because the readers disagreed while the clause did
-         not. The executable spec measured the extent in FOUR places and
-         narrowed it to one block in three of them, so `+` / `para` / `> q`
-         attached one block in a list item and both blocks in a footnote body
-         and in a definition description; a fourth place tested for a quote
-         line, so a `+` inside a block quote attached NOTHING when a quote
-         followed it, which the same clause forbids one sentence up ("the
-         marker only ATTACHES").
       L4 CONTAINERS THAT TAKE THE MARKER:
          - LIST ITEM (pinned by corpus list-continuation-marker): `+` at
            the item's marker column attaches the block to the item (for
@@ -330,14 +305,8 @@
 
          That is a DIFFERENT ANSWER from "place the payload by its column", not
          a narrower one, which is why it is stated rather than left to the
-         reader of L3. The executable spec instead REFUSED the whole document,
-         `stray continuation marker`, at every payload column -- one reader of
-         four, while carve-js, carve-php and carve-rs rendered the text and
-         agreed byte for byte. The refusal was not a conservative version of the
-         shipped form either: it fired at COLUMN 0 too, the one column where the
-         first-block form attaches cleanly in the two containers that have it.
-         Extending the form to the other two was the alternative, and it is not
-         what this clause does. Corpus 437 pins all six documents.
+         reader of L3. Extending the first-block form to the other two
+         containers was the alternative, and it is not what this clause does.
       L5 NOT CONTINUATION CONTAINERS (a lone `+` keeps its plain meaning):
          - fenced containers (admonition / generic div / line block) --
            their bodies already hold flush-left blocks; a lone `+` inside
@@ -367,14 +336,8 @@
          covered by the same rule without a new clause here: enumerating
          "which containers collect" was considered and rejected, because an
          enumeration re-opens the question for every container invented
-         afterward and leaves a silent gap exactly where nobody has
-         measured yet -- which is how the `+`-attached position went
-         unmeasured until three engines gave three different answers, one
-         of them leaving a blank line inside the item where the attached
-         definition used to be (carve#665), and how the `dd` position went
-         unmeasured until two engines produced the combination this rule
-         forbids on ANY reading -- the line renders nowhere AND defines
-         nothing, so the author's text is simply gone (carve#666).
+         afterward and leaves a silent gap exactly where nobody has measured
+         yet.
 
          "No trace" is about OUTPUT, not about block structure -- it does
          not exempt a definition line from §10 I5, which already governs
@@ -392,12 +355,10 @@
          A footnote definition sitting on a list item's OWN line, followed
          by a plain continuation line, is this exact shape: the item holds
          TWO paragraph blocks with no blank between them and renders both
-         bare, `<li>first\n  second\n</li>` (carve#668). Treating the
-         definition as if it both interrupted AND merged -- attaching the
-         following line back onto the block it just ended -- would need a
-         rule found nowhere else in this grammar; treating it as loosening
-         the item on its own would contradict L2 directly. Three engines
-         each did one of those two things; neither is this rule.
+         bare, `<li>first\n  second\n</li>`. Treating the definition as if it
+         both interrupted AND merged would need a rule found nowhere else in
+         this grammar; treating it as loosening the item on its own would
+         contradict L2 directly.
 
       L7 ONE CONSUMED BOOLEAN SPELLS THE LOOSENESS NO BLANK LINE CAN --
          NORMATIVE (carve#1612). A container's preceding BLOCK-ATTRIBUTE LINE
@@ -418,24 +379,14 @@
              </ul>
 
          THE KEY IS NOT LIST-SPECIFIC, and writing it as if it were would have
-         been the first of at least two one-off keys. Measured over every
-         container that can suppress a paragraph wrapper:
-
-             list item, tight              no <p>    <li>x</li>
-             list item, loose              has <p>   <li><p>x</p></li>
-             definition description        no <p>    <dd>x</dd>
-             definition description, 2 blocks  has <p>  <dd><p>x</p><p>y</p></dd>
-             table cell                    no <p>    no wrapped alternative
-             caption                       no <p>    no wrapped alternative
-             block quote, div, line block, footnote body   always <p>
-
-         So the tight/loose axis exists in exactly TWO places, and this key
-         applies wherever it exists: a LIST (L1) and a DEFINITION LIST (PART 2,
-         definition lists) today, and any container a later clause gives the
-         axis to, with no second key to invent. On a container with no such axis
-         the name has no special meaning and renders `loose=""` like any other
-         boolean. This clause adds a meaning at the positions that have one and
-         reserves the name nowhere else.
+         been the first of at least two one-off keys. The tight/loose axis
+         exists in exactly TWO places, and this key applies wherever it exists:
+         a LIST (L1) and a DEFINITION LIST (PART 2, definition lists) today, and
+         any container a later clause gives the axis to, with no second key to
+         invent. A table cell and a caption suppress the paragraph wrapper with
+         no wrapped alternative at all; a block quote, div, line block and
+         footnote body always wrap. On a container with no such axis the name
+         has no special meaning and renders `loose=""` like any other boolean.
 
          WHAT IS UNSPELLABLE WITHOUT IT. Looseness is spelled with a blank line,
          and a blank line needs two things to stand between, so the shape with
@@ -448,39 +399,19 @@
              inside the description wraps it -- so `<dd><p>x</p></dd>` is
              unspellable at every entry count, not just at one.
 
-         The definition list is therefore worse off than the list, which is the
-         measurement that made the general key the cheaper answer: a list-only
-         key would have left the container with NO looseness mechanism at all
-         still without one.
-
-         THE SHAPE ARRIVES FROM ORDINARY HTML, which is why it earns syntax
-         rather than an interchange-only declaration. `<li><p>...</p></li>` is
-         what WordPress, TinyMCE and Google Docs export emit, so an importer
-         meets it on routine input (carve#1607). The alternative -- keep the
-         tree, report `structure-unspellable`, carry the shape through AST
-         encode/decode by PART 12 §6, exactly how multiple table bodies already
-         work -- costs no syntax and was rejected for that reason: the
-         diagnostic would fire on ordinary imports and tell the author only that
-         Carve cannot say what their document said.
 
          THERE IS NO `tight` TWIN, and its absence is a decision rather than an
          omission. TIGHT IS ALWAYS SPELLABLE: remove the blank lines. Only loose
          has an unspellable case, so a `tight` key would be surface with no
-         shape behind it -- and it would introduce the one genuinely ambiguous
-         document this asymmetric design does not have, where the blank lines
-         say loose and the attribute says tight. Symmetry is the instinct here
-         and it buys a contradiction.
+         shape behind it -- and it would introduce a genuinely ambiguous
+         document, where the blank lines say loose and the attribute says tight.
 
-         THE NAME IS THE TERM OF ART, on purpose. A name describing the tree --
-         `block-children` and its neighbours -- would name the wrong fact: the
-         children are already block nodes in both spellings, and what moves is
-         how they RENDER. A name describing the output -- `paragraphs`,
-         `wrapped` -- would be an HTML artifact, and this axis has to mean
-         something on the Markdown, plain and terminal targets too. `loose` is
-         what CommonMark, djot and Markdown Extra all call this distinction, in
-         lists and in definition lists alike, and L1 above already spells the
-         axis LOOSE. A second vocabulary for one axis inside one grammar costs
-         more than the imperfect fit of "a loose `<dd>`".
+         THE NAME IS THE TERM OF ART, on purpose. A name describing the tree
+         would name the wrong fact -- the children are already block nodes in
+         both spellings, and what moves is how they RENDER -- and a name
+         describing the output would be an HTML artifact, where this axis has to
+         mean something on the Markdown, plain and terminal targets too. `loose`
+         is what CommonMark, djot and Markdown Extra all call this distinction.
 
          REDUNDANT USE IS A NO-OP. `loose` on a list the blank lines already
          made loose is legal and changes nothing, and so is `loose` on a
@@ -493,55 +424,34 @@
          `footer-rows` when they are present" rather than deriving them onto
          every table, and PART 11 §2, which spends a mark only where omitting it
          would change the re-parsed document. On a multi-item loose list the
-         blank lines already say it, so the key would be an idle mark by exactly
-         that test. The alternative -- emit it on every loose container -- would
-         rewrite a large share of the corpus and of every document anyone has
-         written, for nothing gained.
+         blank lines already say it, so the key would be an idle mark.
 
-         THE TEST IS A RE-PARSE, AND IT IS OVER THE DOCUMENT (markup-carve/carve-rs#1305).
-         Write the container's body without the key, read it back, and emit the
-         key exactly where the container's own looseness field did not survive
-         that trip. The equality is PART 11 §1's, taken over the re-parsed
-         document; taking it over the RENDER instead answers a different
-         question and gets the definition list wrong, below.
+         THE TEST IS A RE-PARSE, AND IT IS OVER THE DOCUMENT. Write the
+         container's body without the key, read it back, and emit the key
+         exactly where the container's own looseness field did not survive that
+         trip. The equality is PART 11 §1's, taken over the re-parsed document;
+         taking it over the RENDER instead answers a different question.
 
-         THE ITEM COUNT IS NOT THE TEST. "Two or more items already say it" is
-         true, so the converse -- fewer than two items, therefore write the key
-         -- reads like the same rule backwards, and it is not: a ONE-ITEM list
-         is loose whenever the blank line sits INSIDE that item, and there the
-         blank-line spelling did express the looseness. Corpus document
-         `05-lists-11` is exactly that shape -- one ordered item holding two
-         paragraphs -- so a writer keyed on the item count rewrites it and fails
-         `parse(fmt(x)) == parse(x)` on a document that was never lossy. The
-         count is sound as a SHORTCUT IN ONE DIRECTION ONLY: two or more items
-         always re-parse loose, so the read may be skipped there, which keeps it
-         off almost every list in the corpus. Corpus
-         `408-the-writer-spells-looseness-only-where-a-blank-line-cannot` pins
-         the multi-item case and `-2` the one-item case, both through a `.fmt`
-         sidecar, because the HTML is identical under both spellings and no HTML
-         fixture can see the difference.
+         THE ITEM COUNT IS NOT THE TEST. A ONE-ITEM list is loose whenever the
+         blank line sits INSIDE that item, and there the blank-line spelling did
+         express the looseness, so a writer keyed on the item count rewrites
+         such a document and fails `parse(fmt(x)) == parse(x)`. The count is
+         sound as a SHORTCUT IN ONE DIRECTION ONLY: two or more items always
+         re-parse loose, so the read may be skipped there.
 
-         THE COUNT IS ALSO WRONG IN THE OTHER DIRECTION, which is why it is a
-         different rule rather than a shortcut to be repaired. A definition
-         list's entries count as two or more on any list worth writing, and a
-         blank line between two ENTRIES does not loosen a `<dl>` at any count -
-         so a writer keyed on the count OMITS the key from the container that
-         needs it most. Corpus
-         `407-one-consumed-boolean-spells-the-looseness-no-blank-line-can-2` is
-         that document: two entries, and unspellable without the key.
+         THE COUNT IS ALSO WRONG IN THE OTHER DIRECTION. A definition list's
+         entries count as two or more on any list worth writing, and a blank
+         line between two ENTRIES does not loosen a `<dl>` at any count - so a
+         writer keyed on the count OMITS the key from the container that needs
+         it most.
 
          ON A DEFINITION LIST THE ANSWER IS UNCONDITIONAL: the writer emits the
          key on every definition list carrying `loose`. PART 12 §8 publishes
          `definition_list.loose` ONLY where the looseness was SPELLED, so a body
          written without the key can never read back with the field set, and the
          re-parse test says "emit" every time. A description that already holds
-         two blocks does not change it. There the key is redundant in the RENDER
-         -- both spellings wrap the `<dd>`, which is why redundant use is a
-         no-op above -- and it is not redundant in the TREE, and the tree is what
-         the equality is taken over. That is the same asymmetry the two fields
-         have: `list.tight` is total and derived from the source, so the writer
-         has a real question to answer, while a definition list's field records
-         only what its own derivation misses.
+         two blocks does not change it: there the key is redundant in the RENDER
+         and not in the TREE, and the tree is what the equality is taken over.
 
          ORDERED AND NESTED CONTAINERS TAKE THE SAME KEY AT THE SAME PLACEMENT,
          at the nested container's own indent, so this needs no rediscovering:
@@ -580,24 +490,18 @@
       Author `{attrs}` after the span merge onto the <span> (the base
       `math …` class is kept; see PART 10 §1).
 
-      A MATH SPAN CARRIES ROLE MATH -- NORMATIVE (carve#1468). The delimiters
-      are written for a typesetter to find. Until one runs -- and if none ever
-      does, which is the default, since no engine ships one -- the span is a
-      plain `<span>` full of backslashes and carets, and a reader announces
-      them as prose: "backslash paren E equals m c caret 2". `role="math"` says
-      the run IS MATHEMATICS whether or not the script arrives, and a reader
-      that understands the role can hand the content to a math view instead of
-      spelling it.
+      A MATH SPAN CARRIES ROLE MATH -- NORMATIVE. The delimiters are written
+      for a typesetter to find. Until one runs -- and if none ever does, which
+      is the default -- the span is a plain `<span>` full of backslashes and
+      carets, and a reader announces them as prose. `role="math"` says the run
+      IS MATHEMATICS whether or not the script arrives.
 
       THE NAME STAYS THE AUTHOR'S, and no key is added to §16a for it. A
-      formula's spoken form is not a string the engine could know -- it is
-      per-formula content, not an engine word -- and the seam for it already
-      exists: `{attrs}` merge onto this same span, so a trailing
-      {aria-label="E equals m c squared"} on the formula needs nothing new. An
-      author who spells their own `role` keeps it -- under any ASCII casing,
-      for the reason SS12 states: the name is emitted verbatim, HTML attribute
-      names are case-insensitive, so a case-SENSITIVE test writes a duplicate of
-      the very attribute it is checking for.
+      formula's spoken form is per-formula content, not an engine word, and the
+      seam for it already exists: `{attrs}` merge onto this same span, so a
+      trailing {aria-label="E equals m c squared"} needs nothing new. An author
+      who spells their own `role` keeps it -- under any ASCII casing, for the
+      reason SS12 states.
 
       `role` is written LAST, after the merged author attributes, so adding it
       never moves an attribute the author placed (the ordering PART 10 §1
@@ -620,10 +524,8 @@
       THE ROUND-TRIP ARGUMENT IS REAL AND LOSES ANYWAY. A math-block extension
       WRITES that div, so the fence is an exact round trip of the document that
       produced the HTML. But an importer's job is to produce a document that
-      means what the HTML meant, not to reconstruct the document that happened
-      to generate it -- and it cannot know that an extension generated it at
-      all. HTML from anywhere else carrying those classes gets the same
-      treatment.
+      means what the HTML meant, and it cannot know that an extension generated
+      it at all.
 
       THE CONDITIONAL FORM IS REJECTED ON PURPOSE. Emitting the fence when the
       extension is registered and the core form otherwise makes the importer's
@@ -637,19 +539,7 @@
       its `alttext` is written `` $`E = mc^2` `` inline and ``` $$`E = mc^2` ```
       for `display="block"`, with no `$` or `$$` after the closing backtick. A
       trailing delimiter is literal text, and it renders as a stray dollar sign
-      beside the formula. carve-php carried that defect and removed it in
-      markup-carve/carve-php#1546; carve-js and carve-rs were measured and
-      never had it.
-
-      (Pinned twice, because the two halves need different readers. Converter
-      corpus 33-html-block-math-imports-as-the-core-form compares the RENDER of
-      the produced Carve, which is where the two spellings of the div are
-      distinguishable at all: the fence renders a `language-math` code block
-      where the core form renders the math span. The MathML half has no such
-      render difference -- a stray `$$` is only a stray dollar sign -- so it is
-      pinned on the BYTES, by the `tests/html-import/math-block-and-mathml`
-      fixture, which carries both halves and whose `expected.crv` is compared
-      exactly.)
+      beside the formula.
 
    19. CROSSREF AUTO-TEXT + DEFAULT-ON / PROCESSOR FEATURES -- NORMATIVE
       (resolution formalized as PART 9R rules R4/R5; behavior detail here).

--- a/resources/spec/16-semantics-comments-security.ebnf
+++ b/resources/spec/16-semantics-comments-security.ebnf
@@ -42,14 +42,10 @@
         node says which one produced it (`delimited: true` for this form, PART
         12). Without that field a writer reading the tree back has one spelling
         for two constructs, and `foo {% bar %} baz` formats to `foo %% bar` --
-        the trailing form swallowing `baz`. Silent loss through the formatter,
-        on the one construct whose output is invisible.
-      - THIS IS A BEHAVIOR CHANGE. `foo {% bar %} baz` used to render its braces
-        literally. `carve lint` reports a braced comment in a document that also
-        carries template tags (`{% raw %}`, `{% endif %}`), which is the one
-        shape where a Liquid or Nunjucks source reaches the parser as text.
-      (corpus: prose, inside emphasis, table cell, link text, multi-line,
-      unterminated, verbatim span, and an fmt round trip.)
+        the trailing form swallowing `baz`.
+      - `carve lint` reports a braced comment in a document that also carries
+        template tags (`{% raw %}`, `{% endif %}`), which is the one shape
+        where a Liquid or Nunjucks source reaches the parser as text.
 
    22. FORCED INTRAWORD EMPHASIS -- NORMATIVE (governs the forced_* productions
       in PART 3). The brace-pair family is the escape hatch for emphasis where a
@@ -102,11 +98,8 @@
         `<br>`, however the boundary is spelled. The additive reading would
         have to SYNTHESIZE a break node no production yields, and it would
         make the container ADD a line to the layout this block exists to
-        preserve. It also reaches the markdown, plain and ansi targets, where
-        nothing rules on a second break. Ruled at carve#1334, superseding a
-        note on carve-rs#1026 that counted engines rather than citing a clause
-        (PART 0, THE EXECUTABLE ARTIFACTS DECIDE NOTHING) and whose two
-        witnesses have since changed.
+        preserve. It holds on the markdown, plain and ansi targets too
+        (carve#1334).
 
         THE BACKSLASH STILL HAS A JOB HERE, so it is not redundant syntax the
         writer may drop. PART 7 makes the whitespace run before it INTERIOR,
@@ -124,35 +117,22 @@
         whether a `soft_break` NODE is there. Nothing conditions the rule on
         what ENCLOSES that node, and an emphasis run, a link label or a
         semantic span spanning a boundary encloses one: the newline is a node
-        BESIDE the construct's text, not part of it. So
-
-          ::: |
-          *a
-          b*
-          :::
-
-        holds `<strong>a<br>` over `b</strong>`, the same break the same two
-        lines get with no emphasis around them.
+        BESIDE the construct's text, not part of it. So a stanza holding `*a`
+        over `b*` gives `<strong>a<br>` over `b</strong>`, the same break the
+        same two lines get with no emphasis around them.
 
         THE CONVERSION IS IN THE TREE, NOT ONLY IN THE HTML. A stanza's bare
         newline is a `hard_break` NODE (PART 12), which is what lets PART 11
         §7c spell one as a bare newline at all - "re-reading that newline
-        yields the SAME TREE" is a statement about nodes. So the conversion
-        runs at every depth for the same reason the render does, and an
-        engine's own AST is where the other reading is easiest to see: all
-        three yield `hard_break` between two body lines and `soft_break`
-        between the same two lines inside a `strong`, one document answered
-        two ways by an enclosure no clause names.
+        yields the SAME TREE" is a statement about nodes.
 
-        THE TWO EXEMPTIONS ABOVE ARE DIFFERENT IN KIND, NOT IN DEPTH, which
-        is why neither ever needed a depth stated. A backslash is exempt
-        because `hard_break` consumes its own newline. A verbatim run is
-        exempt because it carries the newline as its own CONTENT (carve#1282;
-        BUT IT DOES NOT SURVIVE A RUN THAT ATE ITS LINE below draws the
-        consequence in these words: "there is no boundary left in the tree").
-        Both leave NO NODE. A run that closes on a LATER line is exempt for
-        that same reason and not for closing, the newline being inside its
-        value either way:
+        THE TWO EXEMPTIONS ABOVE ARE DIFFERENT IN KIND, NOT IN DEPTH. A
+        backslash is exempt because `hard_break` consumes its own newline. A
+        verbatim run is exempt because it carries the newline as its own
+        CONTENT (BUT IT DOES NOT SURVIVE A RUN THAT ATE ITS LINE below: "there
+        is no boundary left in the tree"). Both leave NO NODE. A run that
+        closes on a LATER line is exempt for that same reason and not for
+        closing, the newline being inside its value either way:
 
           ::: |
           a `b
@@ -162,19 +142,6 @@
         keeps the newline as content while the emphasis above hardens. The
         two documents differ only in WHICH CONSTRUCT spans the boundary, and
         that is the difference the rule turns on.
-
-        WHAT THE OTHER READING COST. It made the block answer by the SPELLING
-        of a boundary, which the clause above forbids outright: all three
-        engines emit the `<br>` inside the `<strong>` for `*a\` over `b*` and
-        nothing for `*a` over `b*` - one boundary, one container, two
-        answers. It made a single stanza harden one boundary and not the next,
-        `*a` over `b*` over `c` giving a bare newline and then a `<br>`. And
-        it let any emphasized couplet lose the per-line layout this block
-        exists to preserve. Ruled at carve#1351, superseding four rows pinned
-        on carve-js#1127 whose argument was that the reference engine is
-        unambiguous (PART 0, THE EXECUTABLE ARTIFACTS DECIDE NOTHING) and
-        whose premise - that an inline construct CONSUMED the newline - the
-        `soft_break` node that same parser emits contradicts.
       - STANZAS. A blank line ends a stanza; each stanza is its own `<p>` inside
         the single `<div class="line-block">`.
       - LEADING WHITESPACE. Each body line's leading whitespace is PRESERVED
@@ -210,24 +177,21 @@
         line block has.
 
         A COMMENT IS THE ONE EXCEPTION, and the exception is about TIMING
-        rather than about what a comment is. This clause used to say "a
-        comment is not a block construct", which is false: `comment_line` IS
-        a block, listed in PART 1 among the INVISIBLE blocks and ruled by §10
-        I5 to interrupt an open paragraph and be consumed. The real reason it
-        survives the suppression above is that it is the only construct on
-        that list whose recognition PRESERVES the verse instead of rewriting
-        it. A definition or a fence opener CLAIMS the line and changes what
-        renders; a comment-only body line leaves an EMPTY verse line - the
-        line was written, so the stanza keeps its shape.
+        rather than about what a comment is. `comment_line` IS a block, listed
+        in PART 1 among the INVISIBLE blocks and ruled by §10 I5 to interrupt
+        an open paragraph and be consumed. It survives the suppression above
+        because it is the only construct on that list whose recognition
+        PRESERVES the verse instead of rewriting it: a definition or a fence
+        opener CLAIMS the line and changes what renders, while a comment-only
+        body line leaves an EMPTY verse line.
 
         IT IS REMOVED AT THE BLOCK LAYER -- NORMATIVE. The line is decided
         with the other block-layer decisions, BEFORE any inline content
         exists. No inline run can reach it, so whether an EARLIER line left a
-        verbatim run open cannot change whether a line is a comment. Leaving
-        this unsaid let §21's verbatim exclusion claim the line and PUBLISH
-        the comment's own text, which is the one outcome a comment may never
-        have, on a document whose only defect is a stray backtick somewhere
-        above it (carve#1333):
+        verbatim run open cannot change whether a line is a comment. Otherwise
+        §21's verbatim exclusion claims the line and PUBLISHES the comment's
+        own text -- the one outcome a comment may never have -- on a document
+        whose only defect is a stray backtick above it (carve#1333):
 
           ::: |
           a `b
@@ -244,24 +208,19 @@
         emits it back UNCHANGED and at the SAME column. A writer that indents
         it by a space to stop the line re-reading as a comment publishes the
         very text the removal exists to hide, because in verse a leading run
-        is CONTENT (below) and an indented `%%` line is ordinary text. That is
-        a PART 11 §1 failure, and it is what the pinned build does today.
+        is CONTENT (below) and an indented `%%` line is ordinary text: a
+        PART 11 §1 failure.
 
         THE NODE'S SURVIVAL DOES NOT DEPEND ON HOW THE BOUNDARY ABOVE IT WAS
         SPELLED -- NORMATIVE. `a` over `%% c` and `a \` over `%% c` are the
         same document but for a backslash on the line above, and the comment
-        is a node in both. An engine that asks the question of the SOFT-break
-        conversion asks it where a `\` never arrives -- A BACKSLASH BREAK IS
-        NOT ADDITIVE consumed the newline before the conversion ran -- so the
-        note is kept under one spelling and dropped under the other. The
-        boundary that OPENS the comment's line is there either way, which is
-        the only thing the line needs to exist.
+        is a node in both. The boundary that OPENS the comment's line is there
+        either way, which is the only thing the line needs to exist.
 
         BUT IT DOES NOT SURVIVE A RUN THAT ATE ITS LINE. What an unclosed
-        verbatim run carries across an emptied line is the NEWLINE, the same
-        thing it carries across every boundary it swallows, so there is no
-        boundary left in the tree for a `comment` node to sit on and the run's
-        value holds an EMPTY LINE instead. Appending the node anyway puts its
+        verbatim run carries across an emptied line is the NEWLINE, so there
+        is no boundary left in the tree for a `comment` node to sit on and the
+        run's value holds an EMPTY LINE instead. Appending the node anyway puts its
         span before the run that contains it and after the node that follows
         it, which PART 12 containment refuses. The writer's answer for that
         empty line is PART 11 §7c.
@@ -270,11 +229,9 @@
         the last one. A tree records no closer for a verbatim run (PART 12 §3
         gives `code` a value and nothing else), so PART 11 §6's second half
         hands that spelling to the writer, which CLOSES what the author left
-        open -- in an ordinary paragraph too, where a lone opener comes back
-        with a closer beside the run's end. Inside verse the closer occupies a
-        LINE, so §7c's `%%` is written for every emptied line the run still
-        spans and not for the one the closer lands on. Written as source over
-        the form the writer emits for it:
+        open. Inside verse the closer occupies a LINE, so §7c's `%%` is
+        written for every emptied line the run still spans and not for the one
+        the closer lands on -- source over the form the writer emits for it:
 
           ::: |     ->     ::: |          the emptied line is INTERIOR: the
           `                `              run spans past it to `x`, so §7c
@@ -287,24 +244,15 @@
           %%               `              closer takes the emptied line and
           :::              :::            no empty line is left to spell
 
-        Both preserve the tree and the HTML. Corpus
-        380-a-terminal-comment-line-still-leaves-an-empty-verse-line and its
-        `.fmt` file pin the second form (carve#1472).
+        Both preserve the tree and the HTML.
 
         A TRAILING COMMENT IS A DIFFERENT CONSTRUCT and this clause does not
         reach it. `x %% secret` is `inline_comment` (PART 3, §21), not
         `comment_line`, and §21's third bullet governs it: inside a verbatim
         run there is no comment there at all, only two percent characters in
-        content -- exactly what PART 3's UNCLOSED RUN clause already rules for
-        an emphasis delimiter or a link tail after the same opener. That holds
-        in a line block for the same reason it holds in a paragraph, where
-        the one line
-
-          a `b %% secret
-
-        publishes the same text with no container involved.
-        The asymmetry is deliberate: an engine may leave a `%%` standing
-        inside a verbatim run, and may never delete author bytes out of one.
+        content. The asymmetry is deliberate: an engine may leave a `%%`
+        standing inside a verbatim run, and may never delete author bytes out
+        of one.
 
         LEADING WHITESPACE IS CONTENT HERE, so `comment_line`'s optional
         `[whitespace]` prefix has nothing to consume in verse: ONLY a body
@@ -318,12 +266,7 @@
         the break that already separates it from the line before: `a` over
         `%% c` is `a<br>` and a stanza that is nothing but a comment is an
         EMPTY paragraph. Anything else would put two breaks on one boundary,
-        which is what A BACKSLASH BREAK IS NOT ADDITIVE refuses above. Written
-        down because "leaves an EMPTY verse line" reads, at a stanza's end,
-        as though the line owed a break of its own.
-
-        A line block preserves authored layout: nothing inside it is claimed
-        and nothing is dropped unless it is a comment (carve#510, carve#573).
+        which is what A BACKSLASH BREAK IS NOT ADDITIVE refuses above.
 
       (corpus 41-line-blocks*.)
 
@@ -341,6 +284,7 @@
       - NO WHITESPACE PRESERVATION. Unlike `::: |`, leading whitespace has no
         special visual-preservation rule. Ordinary paragraph parsing trims or
         folds it as usual.
+
       (corpus 41-line-blocks*.)
 
    24. TABS AND INDENTATION -- FORMALIZED COLUMN ARITHMETIC (governs
@@ -407,28 +351,19 @@
                - after a BLANK LINE, the item is already ended by the clause
                  above, so the branch is never reached at all.
 
-             Two things are NOT settled by this sentence, and both are recorded
-             rather than decided (carve#682):
+            Two things are NOT settled by this sentence, and both are recorded
+            rather than decided:
 
                - the paragraph closed by a construct that leaves the ITEM's fate
-                 open. A closed CODE fence is the measured one: carve-js and
-                 carve-rs nest a sublist, carve-php and the executable spec open
-                 a sibling list at the top level. That row turns on whether the
-                 item survives the fence, which no clause here states.
+                 open, a closed CODE fence being the case in point: that turns
+                 on whether the item survives the fence, which no clause here
+                 states.
                - the comment's own COLUMN. The comment exception is written
                  without reference to a column, but the two spellings answer
                  differently: at the content column the marker opens a sublist,
                  while BELOW it the following line reaches the item only through
-                 the lazy fold, so ending the paragraph would take that path
-                 away. Corpus 189 and 192 pin the below-column answer (`- - a` /
-                 ` %% c` / ` b` keeps `b` in the INNER item, carve#618), so
-                 aligning the two means moving a pin, not tidying a clause.
-
-             The BLOCK QUOTE row is the control that shows this is the
-             mechanism and not a coincidence: a quote leaves ITS OWN paragraph
-             open, so the fold IS available and all readers agree the marker
-             folds into the quote. Every row where a paragraph is open is
-             unanimous; the disagreements are all rows where none is.
+                 the lazy fold. Corpus 189 and 192 pin the below-column answer,
+                 so aligning the two means moving a pin, not tidying a clause.
 
              AN INVISIBLE LINE FOLDS LIKE ANY OTHER -- NORMATIVE. "Every other
              line" includes the ones that are not block-SHAPED. This is the
@@ -440,57 +375,44 @@
              on the page, definition in the tables -- is not an option the
              rule offers.
 
-             A BLOCK-ATTRIBUTE LINE FOLDS THE SAME WAY, and for the same
-             reason: it is on I5's interrupter list with the definitions, and
-             below the column it reaches no opener column either. So it is text
-             -- the authored braces render as characters -- and it attaches
-             nothing. Half-folding an attribute is the same unavailable option
-             one construct over, and its failure mode is worse than a wrong
-             shape: an attribute recognized below the column has no visible
-             block left in the container to attach to, so §15 A4 discards it and
-             the author's characters reach neither the page nor any table. That
-             is what carve#1801 measured in a definition description, where the
-             identical line one host over folds as literal text.
+            A BLOCK-ATTRIBUTE LINE FOLDS THE SAME WAY, and for the same
+            reason: it is on I5's interrupter list with the definitions, and
+            below the column it reaches no opener column either. So it is text
+            -- the authored braces render as characters -- and it attaches
+            nothing. Half-folding an attribute is the same unavailable option
+            one construct over: an attribute recognized below the column has no
+            visible block left in the container to attach to, so §15 A4
+            discards it and the author's characters reach neither the page nor
+            any table (carve#1801).
 
-             THE FOLD IS INTO THE CONTAINER, in every host, which is the half
-             this clause used to leave to the reader. "Folds as TEXT" and
-             I5's "lazy paragraph text" name one operation on one open
-             paragraph, and that paragraph belongs to the container whose
-             content column the line fell below. Ending the container and
-             emitting the characters at document level satisfies neither
-             sentence (carve#1800).
+            THE FOLD IS INTO THE CONTAINER, in every host, which is the half
+            this clause used to leave to the reader. "Folds as TEXT" and
+            I5's "lazy paragraph text" name one operation on one open
+            paragraph, and that paragraph belongs to the container whose
+            content column the line fell below. Ending the container and
+            emitting the characters at document level satisfies neither
+            sentence (carve#1800).
 
-               - - a
-                [^f]: x
+              - - a
+               [^f]: x
 
-             renders `a` and the literal `[^f]: x` inside the inner item. The
-             failure this guards against is not a wrong shape but a
-             DISAPPEARANCE: a definition that fell past the fold branch was
-             pushed trimmed into the item stream, landed at the item's own
-             column 0, and was skipped there as already-extracted, so the
-             author's line rendered as nothing at all (carve-php#721).
+            renders `a` and the literal `[^f]: x` inside the inner item.
 
-             A COMMENT IS THE ONE EXCEPTION -- NORMATIVE. The first of the two
-             exceptions to §10 I5's classification, and it is a question of
-             MEMBERSHIP: it decides which lines are invisible below a column,
-             not how an invisible line behaves. A comment is recognized at ANY
-             column, above the content column, at it, or below it, and stays
-             invisible. BOTH SPELLINGS: the `%%` line form
-             and the `%%%` fence form, whose body and closer travel with its
-             opener. Leaving the fence out made the same rule answer twice one
-             delimiter apart -- the line form invisible, the fence form
-             VISIBLE text -- which is what carve#629 reported and carve#634
-             settled (corpus 186). Folding it would make the comment VISIBLE, which
-             is the one outcome a comment may never have, and an indented
-             comment at the top level is already invisible for the same
-             reason. It does not close the ITEM either: a following line still
-             belongs to the item rather than parsing at document level
-             (carve#618). It does end the open PARAGRAPH, though, so that line
-             begins the item's SECOND paragraph rather than continuing the
-             first. One sentence used to make both claims and only the first
-             was true; nothing pinned the difference, because it shows only in
-             a LOOSE list -- in a tight one both readings render the same
-             (carve#677).
+            A COMMENT IS THE ONE EXCEPTION -- NORMATIVE. The first of the two
+            exceptions to §10 I5's classification, and it is a question of
+            MEMBERSHIP: it decides which lines are invisible below a column,
+            not how an invisible line behaves. A comment is recognized at ANY
+            column, above the content column, at it, or below it, and stays
+            invisible. BOTH SPELLINGS: the `%%` line form
+            and the `%%%` fence form, whose body and closer travel with its
+            opener (corpus 186, carve#634). Folding it would make the comment
+            VISIBLE, which is the one outcome a comment may never have, and an
+            indented comment at the top level is already invisible for the same
+            reason. It does not close the ITEM either: a following line still
+            belongs to the item rather than parsing at document level
+            (carve#618). It does end the open PARAGRAPH, though, so that line
+            begins the item's SECOND paragraph rather than continuing the
+            first -- a difference visible only in a LOOSE list (carve#677).
            - AT OR ABOVE content_column: a block opener nests and a list marker
              opens a sublist. Recognized non-list blocks apply PART 0's ONE
              AUTHORED BLOCK BASE; this item clause defines only containment and
@@ -563,21 +485,13 @@
         SPACE before reading a scheme, and nothing else. A destination
         beginning with any other format character -- ZERO WIDTH SPACE
         (U+200B), LEFT-TO-RIGHT MARK (U+200E), WORD JOINER (U+2060), SOFT
-        HYPHEN (U+00AD) -- therefore FAILS to parse as a URL at all, and a
-        consumer resolving it against a base gets a relative path, never a
-        `javascript:` navigation. Measured against the WHATWG parser: each of
-        those prefixes yields a parse failure, while a TAB or SPACE prefix
-        yields `javascript:` -- which is exactly the set already stripped.
-
-        So the probe strips what an eventual URL parser would strip (plus the
-        Unicode spaces and the BOM, which some parsers historically tolerated),
-        and it deliberately does NOT strip the wider `Cf` category: a
-        `<U+200B>javascript:` destination stays in the document as written and
-        is inert where it lands. Widening the class to all of `Cf` would blank
-        destinations that were never dangerous, and would make the rendered
-        `href` differ from the author's bytes for no gain (carve#782). A `data:` exception for images, if offered, MUST be
-        opt-in. An attribute-block `href`/`src` override (PART 4) MUST NOT
-        reintroduce a rejected scheme.
+        HYPHEN (U+00AD) -- therefore FAILS to parse as a URL at all. So the
+        probe strips what an eventual URL parser would strip (plus the Unicode
+        spaces and the BOM), and it deliberately does NOT strip the wider `Cf`
+        category.
+        A `data:` exception for images, if offered, MUST be opt-in. An
+        attribute-block `href`/`src` override (PART 4) MUST NOT reintroduce a
+        rejected scheme.
 
         THIS APPLIES TO EVERY TARGET THAT EMITS A RESOLVABLE URL, not only to
         the HTML renderer. A Markdown target's link and image destinations are
@@ -588,21 +502,14 @@
 
         "EMITS A RESOLVABLE URL" IS ABOUT THE URL REACHING A READER THAT
         RESOLVES IT, not about the target emitting a hyperlink construct. The
-        TERMINAL target is bound: it prints a link's destination beside the text,
-        and every current terminal emulator autolinks a URL in its output and
-        hands the scheme to the OS handler when the reader clicks it -- the same
-        one step as Markdown, reached without any anchor or OSC 8 sequence being
-        written. This needed saying because the two text targets differ only by
-        accident of their formats: plain text drops the destination and so never
-        faces the question, while the terminal printed it, and all three engines
-        printed `javascript:` and the OS-handler class there while blanking both
-        in Markdown (carve#765).
+        TERMINAL target is bound: it prints a link's destination beside the
+        text, and every current terminal emulator autolinks a URL in its output
+        and hands the scheme to the OS handler when the reader clicks it.
 
         WHAT IS BLANKED IS THE DESTINATION, NOT THE TEXT. A denied autolink's
-        visible text IS its URL, and every target shows it: HTML inside
-        `<a href="">`, Markdown as the label of `[...]()`, plain text and the
-        terminal as the characters themselves. Blanking there would edit what the
-        author wrote rather than withhold a destination, and it is not required.
+        visible text IS its URL, and every target shows it. Blanking there
+        would edit what the author wrote rather than withhold a destination:
+        not required.
       - ATTRIBUTE NAME/VALUE HARDENING. On EVERY rendered element -- including
         elements emitted by extensions -- an HTML renderer MUST drop
         attributes whose name begins with `on` (case-insensitive) and the
@@ -619,8 +526,8 @@
         NORMATIVE. The probe above reads the value's LEADING scheme, which
         vouches for the whole value only where the whole value is ONE URL.
         Four attributes carry a LIST of URLs: `srcset`, `imagesrcset`, `ping`
-        and `attributionsrc`. So a dangerous scheme in any position but the
-        first went unread. The first two -- on `img`/`source` and on `link`
+        and `attributionsrc`, so a dangerous scheme in any position but the
+        first goes unread. The first two -- on `img`/`source` and on `link`
         -- are comma-separated image candidate strings, each a URL plus an
         optional `w`/`x` descriptor; `ping`, on `a` and `area`, is a
         space-separated set of URLs the user agent POSTs to on activation;
@@ -635,18 +542,12 @@
         THE TOKEN PASS IS IN ADDITION TO THE VALUE-WIDE PROBE, NOT INSTEAD OF
         IT. These four names keep the leading-scheme probe on the WHOLE value
         as well, and the value is blanked when EITHER the whole value probes
-        dangerous OR any token does. Reading the token pass as a replacement
-        would make these four names deny LESS than the leading rule already
-        denied, which is the opposite of what this paragraph is for: the
-        value-wide probe strips the ASCII whitespace the SPLIT breaks on, so
-        `ping="java script:alert(1)"` is two harmless tokens -- `java` carries
-        no scheme and `script` is not denylisted -- and one denied value. That
-        shape is pinned, in both separator sets (resources/examples/edge-cases.md
-        "URL-list attributes are probed token-wise").
+        dangerous OR any token does: the value-wide probe strips the ASCII
+        whitespace the SPLIT breaks on, so `ping="java script:alert(1)"` is
+        two harmless tokens and one denied value.
         THE NAME MATCH IS CASE-INSENSITIVE, like the `on` prefix above: an
-        attribute block may spell the name in any case and the element still
-        carries the author's spelling, so matching on the exact bytes would
-        leave `SRCSET` unprobed.
+        attribute block may spell the name in any case, so matching on the
+        exact bytes would leave `SRCSET` unprobed.
 
         THE SEPARATORS ARE THE ONES THE ATTRIBUTE'S OWN GRAMMAR USES, and the
         set splits in two on this. `ping` and `attributionsrc` split on ASCII
@@ -662,73 +563,47 @@
         THE COMMA SPLIT OVER-BLANKS ONE SHAPE AND THAT IS THE CHOSEN SIDE. A
         srcset URL may itself contain a comma, so
         `srcset="https://example.com/a,data:x 1x"` is ONE candidate to a
-        consumer and is blanked here anyway. Reading it exactly would mean
-        requiring the HTML candidate-list algorithm, descriptor scan and
-        paren-awareness included, from three engines that have to agree byte
-        for byte -- a large ask to buy back a URL that embeds a comma
-        immediately followed by a denylisted scheme. Erring toward blanking is
-        also the safe direction HERE specifically, because it can only reach a
-        URL-list attribute and never prose. Both shapes are pinned, so the
-        engines cannot each pick a different tokenization.
+        consumer and is blanked here anyway: erring toward blanking can only
+        reach a URL-list attribute and never prose.
 
-        THE STRIP IS PER TOKEN, NOT ONCE AT THE FRONT of the value, so the
-        preceding paragraphs' reasoning composes rather than being bypassed:
-        each token is control-stripped and Unicode-whitespace-stripped on its
-        own before its scheme is read, and a `<U+202F>javascript:` candidate
-        blanks wherever it sits. The `Cf` decision composes unchanged too --
-        a token beginning `<U+200B>javascript:` is left alone at EVERY
-        position, for the reason already given: it fails WHATWG URL parsing
-        and lands inert. Note that the whitespace the STRIP removes is wider
-        than the whitespace the SPLIT breaks on, and deliberately so:
+        THE STRIP IS PER TOKEN, NOT ONCE AT THE FRONT of the value: each token
+        is control-stripped and Unicode-whitespace-stripped on its own before
+        its scheme is read, and a `<U+202F>javascript:` candidate blanks
+        wherever it sits. The `Cf` decision composes unchanged -- a token
+        beginning `<U+200B>javascript:` is left alone at EVERY position, since
+        it fails WHATWG URL parsing and lands inert. The whitespace the STRIP
+        removes is wider than the whitespace the SPLIT breaks on, deliberately:
         `a<U+202F>javascript:x` is ONE token to a consumer, because both
         grammars put their boundaries at ASCII whitespace, and it resolves as
-        a relative URL rather than a navigation. Same measured basis as the
-        rest of this clause.
+        a relative URL rather than a navigation.
 
         WHAT IS BLANKED IS THE WHOLE VALUE, NOT THE OFFENDING CANDIDATE.
         Excising one candidate would make the rendered attribute differ from
         the author's bytes, which this clause already declined to do for the
-        `Cf` case (carve#782), and it would give one value a THIRD outcome --
-        kept, blanked, or silently rewritten -- when the defect being fixed
-        is that one value already had two. Measured before this was written,
-        on all three engines and identical byte for byte in each:
-        `srcset="javascript:alert(1) 1x, safe.png 2x"` blanked while
-        `srcset="safe.png 1x, javascript:alert(1) 2x"` rendered verbatim, and
-        `ping` split the same way (carve#1320). The point is that the SAME
-        VALUE got two answers depending on where the scheme sat. A browser
-        navigates neither -- it does not run `javascript:` in an image
-        context and it pings http(s) only -- so what this fixes is a defense
-        that was positionally inconsistent and a guarantee this clause states
-        but did not keep, for the consumers of Carve's HTML that are not
-        browsers and have no image-context protection of their own.
+        `Cf` case, and it would give one value a THIRD outcome -- kept,
+        blanked, or silently rewritten. A browser navigates neither, so what
+        this protects is the consumers of Carve's HTML that are not browsers.
 
         THE SET IS CLOSED BY A CRITERION rather than by taste: an attribute
         whose value grammar is a LIST of URLs that a consumer RESOLVES OR
         FETCHES. THE CRITERION GOVERNS, NOT THE DOCUMENT AN ATTRIBUTE HAPPENS
-        TO LIVE IN -- three of the four come from the HTML Standard's
-        attribute index, and `attributionsrc` from the Attribution Reporting
-        API, which browsers ship and which sends a request to every URL in
-        the list. An attribute admitted to the language and fetched by a
-        consumer is in scope wherever it was specified.
+        TO LIVE IN -- `attributionsrc` comes from the Attribution Reporting
+        API rather than the HTML Standard's attribute index, and is in scope
+        because a consumer fetches every URL in the list.
 
-        The exclusions are named so the set is not widened by
-        pattern-match. `itemtype` and `itemprop` are space-separated
-        absolute-URL token lists, but the standard forbids dereferencing
-        them, so they are identifiers and not sinks; `itemid` is a single URL
-        and the leading rule already reaches it; `archive` on `object` is
-        non-conforming and no longer carries a URL-list value type; `for` on
-        `output` and `headers` on `td`/`th` list IDs, not URLs. A single URL
-        embedded at a NON-LEADING position inside a structured value is a
-        neighboring class and not this one: `style` is that class and
-        already has its own named rule above, and a `meta` refresh `content`
-        is that class but no renderer emits `meta` from document content.
+        The exclusions are named so the set is not widened by pattern-match.
+        `itemtype` and `itemprop` are space-separated absolute-URL token lists,
+        but the standard forbids dereferencing them, so they are identifiers
+        and not sinks; `itemid` is a single URL and the leading rule already
+        reaches it; `archive` on `object` is non-conforming and no longer
+        carries a URL-list value type; `for` on `output` and `headers` on
+        `td`/`th` list IDs, not URLs. A single URL embedded at a NON-LEADING
+        position inside a structured value is a neighboring class and not this
+        one: `style` is that class and already has its own named rule above.
         PROSE ATTRIBUTES ARE NOT IN THE SET AND MUST NOT BE TOKENIZED --
         `title`, `alt` and `aria-label` legitimately contain colons, and a
         blanket "any token that looks like a scheme" test would refuse
-        ordinary text. The corpus pins BOTH directions: a dangerous scheme in
-        a non-leading candidate is blanked, and a prose value carrying a
-        colon is not (resources/examples/edge-cases.md "URL-list attributes are
-        probed token-wise").
+        ordinary text.
       - RAW PASSTHROUGH OPT-OUT. Raw blocks (```=FORMAT, PART 2) and raw
         inline (`{=format}`, §20) emit verbatim UNESCAPED content. An
         implementation MUST provide a mode in which raw passthrough is NOT
@@ -774,8 +649,7 @@
 
         "Degrades to literal text" is the whole rule; nothing about being
         past the cap makes a line group differently from the same characters
-        typed by an author, and a degrade path that invented its own block
-        structure would be a second paragraph rule to specify and to test.
+        typed by an author.
 
         Recursive RENDER / RESOLVE /
         FILTER passes over a programmatically constructed tree MUST be
@@ -796,15 +670,10 @@
         uses, container depth (one step per nesting level) or AST node
         levels among them, and the conversion factor between units is NOT 1:
         a list level costs ONE container-depth step but TWO AST node levels
-        (`list`, then `list_item`) before its body reads as a further level
-        down. A margin sized for one unit does not carry over to the other.
-        This repo's reference counts container depth, where MAX_NESTING_DEPTH
-        + 32 = 232 covers the blocks a container subtree adds; restating that
-        SAME NUMBER in an AST-node-counting implementation understates what
-        that unit actually needs by roughly half, and an ordinary 120-level
-        list ladder -- well inside the parse cap of 200 -- reached such a
-        ceiling and silently dropped the innermost content (carve#650). An
-        implementation MUST THEREFORE DERIVE its margin from the worst
+        (`list`, then `list_item`). A margin sized for one unit does not carry
+        over to the other. This repo's reference counts container depth, where
+        MAX_NESTING_DEPTH + 32 = 232 covers the blocks a container subtree
+        adds. An implementation MUST THEREFORE DERIVE its margin from the worst
         per-level cost of ITS OWN unit (as PART 12 §9(c) already requires for
         the ingest bound), and MUST NOT adopt another implementation's number
         without redoing that derivation.
@@ -812,14 +681,8 @@
         HOW THE MARGIN IS SPELLED IS NOT THE REQUIREMENT. A multiple of
         MAX_NESTING_DEPTH and an offset added to it are the same statement
         once the offset has been shown to cover the worst per-level cost of
-        the unit in question: `+ 32` DERIVED for container depth satisfies
-        this clause, and the identical `+ 32` COPIED into an
-        AST-node-counting implementation does not. This paragraph previously
-        required the multiple FORM, which the reference itself did not use --
-        so the clause stated a rule its own reference broke, and an
-        implementation could satisfy the letter of it by writing
-        MAX_NESTING_DEPTH * 1.16 without anyone having thought about the
-        unit. The unit is what went wrong in carve#650 (carve#754).
+        the unit in question. The FORM is not the requirement; the derivation
+        is.
 
         AT THE RENDER CEILING, A RENDERER REFUSES -- NORMATIVE. Reaching it
         MUST produce a typed, documented failure naming the depth bound. NOT
@@ -835,55 +698,21 @@
         travels. A ceiling derived per the margin rule above exceeds
         MAX_NESTING_DEPTH BY CONSTRUCTION IN ITS OWN UNIT, so no tree from
         `parse` can reach it, and §9(b) already refuses an ingested tree
-        deeper than the parser's own limit. "By construction" is a property
-        of the DERIVATION, not of any single borrowed number -- a ceiling
-        that copies another implementation's margin instead of deriving its
-        own is not exceeding anything by construction, it is a coincidence
-        that holds for one unit and fails for another. What is left is a
-        tree built through the API, where the caller is the one who built it
-        and is the one who can act on the error.
+        deeper than the parser's own limit. What is left is a tree built
+        through the API, where the caller is the one who built it and is the
+        one who can act on the error.
 
         Truncation is not the safe default it looks like. The parse path
         degrades VISIBLY -- an over-cap opener becomes literal text the reader
         can see -- while a renderer that stops emitting produces a document
-        that looks complete and is not. The failure mode a formatter must
-        never have is deleting content without saying so, which is what
-        carve#517 moved the ceiling out of reach to prevent; leaving
-        truncation as the answer at the ceiling reinstates it for every tree
-        that arrives over the wire or through a builder.
+        that looks complete and is not, the canonical writer included.
 
-          depth  renderMarkdown  renderCarve  renderPlainText  renderAnsi  renderHtml
-          231    content kept    kept         kept             kept        kept
-          232    DROPPED         DROPPED      DROPPED          empty       kept
-          1000   DROPPED         DROPPED      DROPPED          empty       kept
-
-        The ceiling itself is in the right place -- above MAX_NESTING_DEPTH,
-        as the paragraph above requires. What happens AT it is the problem.
-        Three of the five emit the nested markers and delete only the BODY, so
-        the output looks complete and is not; one returns an empty string; and
-        renderHtml has no ceiling at all, recursing until the host stack gives
-        out (`RangeError: Maximum call stack size exceeded` at depth 2000).
-        That last one is the "crashing" this section already forbids, and it
-        makes the reference engine's primary renderer the one that behaves
-        unlike every other renderer in the ecosystem, including its own
-        siblings.
-
-        Silent truncation is the worse half even though it looks tidier. One
-        of the three is renderCarve, the canonical writer: a tree built
-        through the API and formatted comes back as a document whose body is
-        gone, with nothing in the return value to say so. (carve#526)
-
-        The cost is real and is not hidden: this makes a renderer FALLIBLE in
-        implementations whose signature says it cannot fail, which is a
-        breaking change to those signatures rather than an internal one. It
-        was preferred anyway, because the alternative -- a diagnostic channel
-        alongside a still-infallible return -- needs a channel every renderer
-        signature can carry, which none of them have either, and leaves a
-        caller that ignores it exactly where it is today. It MUST bound abbreviation, reference,
-        footnote, and crossref expansion so total work stays O(n): in
-        particular an empty abbreviation term is rejected, a reference is not
-        resolved by rescanning the whole output per occurrence, and a crossref
-        target is not cloned without bound.
+        The cost is accepted knowingly: this makes a renderer FALLIBLE in
+        implementations whose signature says it cannot fail. An implementation
+        MUST bound abbreviation, reference, footnote, and crossref expansion so
+        total work stays O(n): in particular an empty abbreviation term is
+        rejected, a reference is not resolved by rescanning the whole output
+        per occurrence, and a crossref target is not cloned without bound.
       - NON-HTML TARGETS. The Markdown, plain-text, and terminal (ANSI)
         renderers MUST NOT become injection vectors either. The TERMINAL
         target MUST strip text, code, math AND URL values of every control

--- a/resources/spec/17-semantics-unicode-controls.ebnf
+++ b/resources/spec/17-semantics-unicode-controls.ebnf
@@ -105,12 +105,10 @@
    29. C0 CONTROLS ON THE RENDER TARGETS -- NORMATIVE (governs what each
       target may emit; the companion to PART 7's ONE WHITESPACE DEFINITION,
       IN EVERY CONSTRUCT, which governs what the LANGUAGE reads). The two
-      questions are different and were being answered as one: PART 7 makes a
-      character CONTENT, and a target then deleted it on the way out. Twice
-      in one day that strip was read as a PART 7 violation and nearly
-      "fixed" as one, by two agents independently, which is why it is
-      written down here rather than left as an implementation habit
-      (carve#963, carve#979).
+      questions are different: PART 7 makes a character CONTENT, and a target
+      then decides whether to emit it. Read as one, a target's strip looks
+      like a PART 7 violation, which is why it is written down here rather
+      than left as an implementation habit.
 
       THE SUBJECT IS A CLASS, NOT TWO CHARACTERS. After carve#963 the
       whitespace of this language is exactly U+0020, U+0009, U+000A and
@@ -135,27 +133,6 @@
       holding a NUL has skipped the parse boundary, not found an exception
       here.
 
-      WHY THE ONE CARVE-OUT, since a rule with an exception has to say why
-      the exception does not spread. Three reasons, none of which reaches
-      another C0 control:
-      - A NUL IS NOT VALID IN AN HTML DOCUMENT. T1's argument for emitting
-        the rest is that the consumer is a parser which treats a stray
-        control as inert character data. That is the argument that fails for
-        this one character, and it fails on the consumer's own terms rather
-        than on a general worry about control characters -- which is exactly
-        the shape T4 already uses to reach one target and no other.
-      - THE IMPORTER ALREADY REPLACES IT. CommonMark 2.3 mandates the
-        replacement and Carve's Markdown importer performs it
-        (markup-carve/carve-js#1293). A language that strips the character on
-        the way in and emits it on the way out is incoherent at its own
-        boundary, and the incoherence is not fixable in the importer: the
-        authored NUL would still reach the output.
-      - THE ENGINES ALREADY AGREED, DELIBERATELY. All three replace it and
-        none said so, while the executable spec kept it -- the same shape as
-        the byte order mark (carve#872), down to why it stayed invisible: no
-        corpus document carried the byte, so neither behavior was pinned.
-        This is not three independent accidents being ratified.
-
       T1 HTML EMITS THEM. The HTML target does not strip a non-whitespace C0
          control from rendered text. That is the status quo, and the
          asymmetry with T4 is DELIBERATE rather than an oversight: it is
@@ -168,21 +145,15 @@
          is not.
 
       T2 MARKDOWN EMITS THEM. The Markdown target does not strip them
-         either. A target that silently removes content is lossy in exactly
-         the way carve#817 rejected for the wire, and the reason first
-         offered for the strip -- that a Markdown reader would reclassify
-         these characters as whitespace, so emitting them changes meaning at
-         the boundary -- was measured and did not hold. FOUR READERS WERE
-         MEASURED: the CommonMark reference implementation, and markdown-it
-         in default, commonmark and typographer modes. All four KEEP U+000B
-         and U+000C inline, on a lone line between paragraphs, inside a code
-         span, after a list marker and after an ATX hash. The sharpest case
-         is that `-<VT>item` opens no list in any of them, which it would if
-         the character were whitespace to that reader. They are dropped in
-         exactly two positions, leading and trailing on a line, which is
-         where Carve drops whitespace too. So the downstream reader agrees
-         with carve#963, and stripping makes Carve the lossy party for no
-         reason the consumer requires.
+         either. A target that silently removes content is lossy, and the
+         reason first offered for the strip -- that a Markdown reader would
+         reclassify these characters as whitespace, so emitting them changes
+         meaning at the boundary -- does not hold. Downstream readers KEEP
+         U+000B and U+000C inline, on a lone line between paragraphs, inside a
+         code span, after a list marker and after an ATX hash; `-<VT>item`
+         opens no list, which it would if the character were whitespace to
+         that reader. They are dropped in exactly two positions, leading and
+         trailing on a line, which is where Carve drops whitespace too.
 
       T3 PLAIN TEXT EMITS THEM, FOLLOWING MARKDOWN. This row is a JUDGEMENT
          and is recorded as one rather than as a measurement: plain text is
@@ -208,38 +179,17 @@
 
       T5 WHAT THIS SECTION DOES NOT SETTLE, stated so its silence is not
          read as agreement:
-         - PANDOC HAS NOW BEEN MEASURED, and it agrees. pandoc 3.5 keeps
-           U+000B and U+000C in all five positions T2 names -- inline, on a
-           lone line between paragraphs, inside a code span, after a list
-           marker and after an ATX hash -- in its `commonmark`, `gfm` and
-           `markdown` readers alike, and `-<VT>item` opens no list in any of
-           them. T2's finding therefore rests on five readers rather than
-           four. What it still does NOT claim is that EVERY reader agrees: a
-           reader that reclassified these characters as whitespace would be a
-           reason to revisit T2, and none measured so far does.
-         - CARVE-RS HAS NOW BEEN MEASURED, and it conforms. Driving both
-           U+000B and U+000C through the five positions T2 names, on each
-           target: carve-rs keeps them on HTML, Markdown and plain text and
-           strips them on ANSI -- T1, T2, T3 and T4 respectively, ten of ten
-           on each row. carve-js and carve-php were measured the same way at
-           the same time and agree with it on all four. So the three engines
-           are uniform here and the row's worry -- that carve-rs might be
-           doing something else unseen -- did not hold. Assuming it was wrong
-           would have been the error this row was written to prevent.
          - DEL (U+007F) AND THE C1 CONTROLS are outside this section, which
-           is about C0. The sweep that prompted this note found them reaching
-           Markdown output in carve-js and carve-rs while carve-php refused
-           them; that has since been fixed, and re-measuring finds all three
-           engines identical -- DEL, CSI (U+009B), OSC (U+009D) and U+0080 are
-           stripped on Markdown, plain text and ANSI alike. §25's NON-HTML
-           TARGETS requirement is met on those three.
-           WHAT IS STILL OPEN is the CANONICAL WRITER: all three engines let
-           every one of those characters through on the `carve` target. That
-           may be right -- a writer that drops content is lossy, and the
-           round-trip invariant is what that target answers to -- but §25 says
-           "non-HTML targets" without saying whether the canonical writer is
-           one, and the same question is open for §26's bidi overrides
-           (carve#1076). Deciding it once would settle both.
+           is about C0. DEL, CSI (U+009B), OSC (U+009D) and U+0080 are
+           stripped on Markdown, plain text and ANSI alike, so §25's
+           NON-HTML TARGETS requirement is met on those three.
+           WHAT IS STILL OPEN is the CANONICAL WRITER: every one of those
+           characters passes through on the `carve` target. That may be right
+           -- a writer that drops content is lossy, and the round-trip
+           invariant is what that target answers to -- but §25 says "non-HTML
+           targets" without saying whether the canonical writer is one, and
+           the same question is open for §26's bidi overrides. Deciding it
+           once would settle both.
 *)
 
 
@@ -275,63 +225,30 @@
      admonitionExample  "Example"
      admonitionQuote    "Quote"
 
-   THE SET IS SMALL BECAUSE THE ENGINE WRITES LITTLE. Every key here names a
-   string a READER HEARS and no author can spell: an accessible name on an
-   element the author never wrote. That is the whole test for admission, and it
-   is why the set grew from one key to ten in a single sweep (carve#1468) and
-   is expected to stay near that size. The map exists rather than a
-   per-construct option because core has no extension to hang an option on, and
-   because a new such string needs a place to land that the three engines
-   already agree on.
+   WHAT DOES NOT BELONG HERE: a string the AUTHOR already wrote is never a key.
+   A task box is named by its item's own text and an admonition with a title is
+   named by that title (PART 2 `task_marker`, §12), both DERIVED rather than
+   written, so neither adds a key. Only where there is nothing on the page to
+   read does a label appear -- the untitled admonition's type word, and the two
+   footnote strings.
 
-   WHAT DOES NOT BELONG HERE, restated because the sweep tested it four times:
-   a string the AUTHOR already wrote is never a key. A task box is named by its
-   item's own text and an admonition with a title is named by that title
-   (PART 2 `task_marker`, §12), both DERIVED rather than written, so neither
-   adds a key. A host that translates the document translates those once, in
-   the document. Only where there is nothing on the page to read does a label
-   appear -- the untitled admonition's type word, and the two footnote
-   strings.
-
-   AN EXTENSION WRITES INTO THE SAME MAP -- NORMATIVE (carve#1508). The map is
-   the renderer's, not core's: Extensions §1.5 states which strings an
-   EXTENSION contributes to it, and those keys are part of the same map a host
-   passes once. So the list above is what CORE defines and not the whole map an
-   engine honors -- measured against the pinned build, `indexBackref`,
-   `tabsGroup` and `codeGroup` are honored beside the ten. A fourth,
-   `tocNav` (Extensions SS8b.1, carve#1509), is STATED and not yet honored by
+   AN EXTENSION WRITES INTO THE SAME MAP -- NORMATIVE. The map is the
+   renderer's, not core's: Extensions §1.5 states which strings an EXTENSION
+   contributes to it, and those keys are part of the same map a host passes
+   once. So the list above is what CORE defines and not the whole map an engine
+   honors -- `indexBackref`, `tabsGroup` and `codeGroup` are honored beside the
+   ten. A fourth, `tocNav` (Extensions SS8b.1), is STATED and not yet honored by
    any engine: the table-of-contents nav is a navigation landmark and carries an
-   accessible name, and until an engine ships it the key is declared ahead of
-   the pin rather than measured. A host translating a
-   document therefore sets ONE map, which is the whole reason the map exists
-   rather than a per-construct option.
-
-   THE EARLIER READING WAS THE OPPOSITE, and is recorded so a reader of the
-   history is not left with two rules. This clause said extension-written
-   strings STAY with their extension, because moving one into the map would
-   give it two spellings and no rule for which wins. §1.5 supplies exactly
-   that rule -- the author's attribute, then the extension's own option, then
-   the map, then the default -- so the objection no longer holds, and three
-   extension-written strings live under it with both a key and an option.
+   accessible name. A host translating a document therefore sets ONE map.
 
    AN EXTENSION MAY read the map for a string it shares with core; it MUST NOT
    require the host to configure the same text twice. Two extension-written
    strings have no key and are options only -- the heading-permalink label and
    the table-of-contents summary (which is the `<details>` disclosure's VISIBLE
-   text, and not the nav's name: that one is the `tocNav` key above, on a shape
-   the summary never shares) (carve-js `ariaLabel` / `summary`, carve-php
-   `$ariaLabel`, carve-rs `aria_label`). That is now the RULE and not merely the
-   state (carve#1510): a string the extension already exposes as an option is
-   configured there, and §1.5's admission sentence has been narrowed to say so
-   instead of reading on these two. Adding a key would give one string two
-   spellings where the extension already had one.
-
-   EVERY DOCUMENTED KEY REACHES THE OUTPUT, and that is checked rather than
-   asserted (carve#1508). No fixture in the spec repo renders with a non-default
-   map, so every key was verified at its English default only and an engine that
-   hard-coded all of them would have passed every check. The key names are read
-   off this list and off §1.5's table and each is rendered with a sentinel, so
-   a key documented in neither, or documented and inert, fails.
+   text, and not the nav's name: that one is the `tocNav` key above). That is
+   the RULE and not merely the state: a string the extension already exposes as
+   an option is configured there, and §1.5's admission sentence has been
+   narrowed to say so.
 
    WHAT THIS DOES NOT DO: it is not localization. There is no locale name and
    no built-in table beyond the English defaults, because a locale table is
@@ -351,30 +268,24 @@
    PROVENANCE IS NOT THE TEST, and cannot be. Nothing in the HTML says who
    wrote an attribute. But where the value EQUALS the generated one the output
    is identical whichever of them wrote it, so a value-matched drop is a no-op
-   for what a reader hears: the document rebuilds byte-identical at the default
-   labels. That is why the `scope` rule is phrased as "matches the value the
-   renderer derives" rather than as a test of who wrote it, and it is why this
-   rule cannot repeat the accessibility regression a blanket `aria-label` drop
-   caused. A name that DIFFERS from the derived one is kept, always.
+   for what a reader hears. That is why the `scope` rule is phrased as "matches
+   the value the renderer derives" rather than as a test of who wrote it. A
+   name that DIFFERS from the derived one is kept, always.
 
    WHAT THE DROP BUYS is the only thing keeping the `labels` map alive across a
    round trip. A kept `aria-label="Note"` is indistinguishable from an authored
-   one, and §12's author-wins rule then makes it WIN on the next render: the
-   same source re-rendered with `admonitionNote` set to `Hinweis` still emits
-   `aria-label="Note"`. Dropping it emits `Hinweis`. So an import that keeps a
-   derived name has permanently unlocalized the document while changing no
-   byte of today's output.
+   one, and §12's author-wins rule then makes it WIN on the next render, so an
+   import that keeps a derived name has permanently unlocalized the document
+   while changing no byte of today's output.
 
    NOTHING IS LOST, SO NOTHING IS DIAGNOSED. The renderer writes the value
    back, so a value-matched drop is not a lossy decision and emits no
-   `attribute-dropped` -- the same reason the `<figure>` and `<blockquote cite>`
-   imports report nothing. A drop of the OTHER kind, where the value could not
-   be represented, is diagnosed as it always was.
+   `attribute-dropped`. A drop of the OTHER kind, where the value could not be
+   represented, is diagnosed as it always was.
 
    BYTE-STABILITY IS THEREFORE NOT THE TEST EITHER. A round trip over that
-   admonition is byte-identical while the defect is present, so a round-trip
-   assertion passes and nothing is learned. The assertion has to be that a
-   DERIVED NAME IS ABSENT from the imported source.
+   admonition is byte-identical while the defect is present, so the assertion
+   has to be that a DERIVED NAME IS ABSENT from the imported source.
 
    TWO LIMITS, both accepted rather than closed:
 
@@ -430,14 +341,10 @@
    the element being READ, not of what the import goes on to do with it. Both
    halves of §16's endnotes section are covered: the REFERENCED form is consumed
    into footnote definitions and the renderer writes the section back, while the
-   REFERENCE-LESS form degrades to the `<hr>` and `<ol>` it is built from
-   (carve#1558) and the renderer writes no section for it at all. The second
-   still reports nothing, because the author still wrote none of it. An importer
-   that instead asks its own EMITTED document whether the value came back
-   answers no for the degraded form -- correctly, and about the wrong question,
-   which is the measurement carve#1502 records: a report built that way
-   contradicts the conversion beside it and calls every value an extension
-   derives a loss.
+   REFERENCE-LESS form degrades to the `<hr>` and `<ol>` it is built from and the
+   renderer writes no section for it at all. The second still reports nothing,
+   because the author still wrote none of it. An importer that instead asks its
+   own EMITTED document whether the value came back answers the wrong question.
 
    WHAT IS STILL REPORTED is everything the element carried that this property
    does not reach. An authored `class` on an endnotes section is reported when

--- a/resources/spec/18-resolution.ebnf
+++ b/resources/spec/18-resolution.ebnf
@@ -63,31 +63,17 @@
       linkDefs entry is unresolved and renders as literal source text; it
       does not fall through to the heading index at ANY spelling, folded
       or exact.
-      THE ASYMMETRY IS THE ONE THE PARAGRAPH ABOVE ALREADY GIVES. It is
-      the stated reason the two matchings differ in the first place: a
+      THE ASYMMETRY IS THE ONE THE PARAGRAPH ABOVE ALREADY GIVES: a
       collapsed label is the author quoting prose from elsewhere in the
       document, which is why its matching is loose, and an explicit label
       is an identifier the author wrote twice and can keep identical,
       which is why its matching is exact. An identifier that names nothing
-      names nothing; it is not retried as prose. Reading the fallback as
-      covering both forms deletes that distinction while leaving the
-      sentence that justifies it in place.
-      PROSE IS NORMATIVE AND A READER IS AN IMPLEMENTATION. Measured at
-      the time of this ruling, three of the four readers resolved a shape
-      this rule does not offer -- two of them on both the folded and the
-      exact spelling, one on the exact spelling only -- and one read the
-      rule as written. Which three is a measurement and belongs on the
-      implementation tickets, not here; that they were a majority is not
-      an argument (PART 0's THE EXECUTABLE ARTIFACTS DECIDE NOTHING). If
-      the explicit form SHOULD reach the index, that is a deliberate
+      names nothing; it is not retried as prose.
+      If the explicit form SHOULD reach the index, that is a deliberate
       widening with its own clause, not a retrofit to the engines.
       THE COMPATIBILITY BREAK, recorded: a document whose
       `[text][Some Heading]` resolves today renders the bracketed run
-      literally instead. Accepted (carve#742 signoff). Corpus rows -- with
-      the control that the collapsed form still reaches the index, and the
-      control that an explicit label matching a real linkDefs entry still
-      resolves, since a fix keyed on "unresolved" rather than on "collapsed"
-      breaks the second -- are deferred to their own pass.
+      literally instead.
       ON THIS PATH THE LABEL ENTERS AS ITS RENDERED PLAIN TEXT, the same
       string kind the heading side already enters as. The index is keyed
       by the heading's rendered plain text, so `# *bold* heading` is
@@ -119,18 +105,12 @@
       heading even though the heading is now reachable.
       NFC and NOT NFKC: canonical equivalence only, so `ﬁle` does not
       match `file` and `① one` does not match `1 one` -- compatibility
-      folding would change which text an author is quoting, not just how it
-      is spelled. NFC belongs in the list for two reasons. The id side is
-      ALREADY NFC (§25), so without it a document publishes `id="Café"`
-      and then declines `[Café][]` against the heading that produced it --
-      the same alphabet on one side of the resolution and not the other.
-      And NFC is a WEAKER fold than the case fold this list already
-      admits: case folding relates codepoints Unicode calls distinct,
-      while NFC relates sequences Unicode DEFINES as the same, so
-      admitting the stronger one and refusing the weaker one is backwards.
-      The two spellings are also indistinguishable on screen, so a
-      reference that misses has no visible cause (carve#725, where
-      carve-rs folded and the other three did not). The index holds
+      folding would change which text an author is quoting. NFC belongs in the
+      list for two reasons. The id side is ALREADY NFC (§25), so without it a
+      document publishes `id="Café"` and then declines `[Café][]` against the
+      heading that produced it. And NFC is a WEAKER fold than the case fold
+      this list already admits, so admitting the stronger one and refusing the
+      weaker one is backwards. The index holds
       headings at top level and
       inside divs, admonitions, list items, and definitions, but
       DECLINES any heading with a blockquote ancestor, in either
@@ -158,13 +138,6 @@
       invisible constructs interrupt), so it is never a lazy line there. No
       document distinguishes this clause's answer from section 7's for that kind.
       The link and footnote kinds are the ones this clause governs on its own.
-
-      This is a consequence of NO OPEN PARAGRAPH, NO LAZY LINE, stated here
-      because collection runs BEFORE block structure in every implementation and
-      three engines each got a different answer without it: one deleted the
-      definition's text and left the marker, one registered it while also
-      rendering it, and one half-collected a footnote into the paragraph it was
-      written in.
 
       HOW AN ENGINE MAY DECIDE IT. Collection is a pre-pass over lines, so the
       answer is not local to the line. An implementation MAY ask the block
@@ -204,15 +177,6 @@
       document. A matcher whose answer depends on where it sits in the whole
       document, or on lines the array does not contain, is NOT CONFORMING.
 
-      THIS IS NOT A PROPERTY OF THE PROBE. R1a's pre-pass parses the run back to
-      the last blank line, and that run is re-based -- but so is every container
-      body, with no definition anywhere in the document. Measured on all three
-      engines: a four-line document whose list item holds two lines invokes the
-      matcher with a TWO-LINE array at index 0, then with the whole document at
-      index 3; a block quote and a `:::` container do the same. Scoping the rule
-      to the probe would leave the identical hazard unstated for every container,
-      which is where an extension author meets it first.
-
    R2 FOOTNOTES (rendering in PART 9 §16). Footnote labels use the same
       ASCII-whitespace-normalized, case-sensitive key as R1. A [^label] use
       with a matching footnoteDefs entry is numbered by FIRST-REFERENCE order from
@@ -234,12 +198,9 @@
       section is written on its account.
       RESOLUTION ORDER IS NOT THE ANSWER. An implementation that numbers
       footnotes before it knows whether the reference resolved counts the
-      discarded use, and the numbering then says so out loud: the note a
-      reader can see is numbered fnref{n}-2, a repeat of a reference the
-      document does not contain, and a lone one leaves an endnote whose
-      backlink names an id no element carries. Which pass runs first is a
-      property of a pipeline rather than of the language, and ratifying it
-      would make an ordering artifact into a rule (carve#1198 signoff).
+      discarded use, and the numbering then says so out loud. Which pass runs
+      first is a property of a pipeline rather than of the language, and
+      ratifying it would make an ordering artifact into a rule.
       WHAT IS COUNTED IS WHAT THE OUTPUT HOLDS, which decides the cases
       either side of this one the same way. A note in a reference that DOES
       resolve is an ordinary reference, because the resolved link text is
@@ -258,42 +219,30 @@
       link text is then LABEL + NUMBER, e.g. "Figure 1", markup preserved).
       Resolution is ONE LEVEL: cloned heading text is not re-expanded, so
       self-references and cycles are safe. Unresolved -> literal.
-      WHAT IS CLONED IS THE HEADING'S INLINE NODES -- NORMATIVE (carve#915).
+      WHAT IS CLONED IS THE HEADING'S INLINE NODES -- NORMATIVE.
       "Cloned heading text" means the nodes, not a rendered string. A node
       carries its SOURCE RUN, and a string does not, so an implementation that
       flattens the heading to glyphs while building its id index has destroyed
-      the run before any renderer is invoked. Smart typography's SOURCE mode
-      (§8) then cannot recover it on ANY target, and no renderer change reaches
-      the loss -- the label was materialized in the wrong subsystem. The same
-      argument covers every other run a renderer may want back: a code span, an
-      escape, an inline literal. "markup preserved" already said this for the
-      caption side; it holds for the heading side too, and for the source
-      spelling as much as for the markup.
-      DERIVED DISPLAY TEXT CLONES THE SAME NODES -- NORMATIVE (carve#957).
-      The clause above binds every consumer that derives display text from
-      a heading, not the crossref alone. A render-stage transform may not
-      undo a core resolution rule, so wherever anything builds visible text
-      from a heading -- a numbered cross-reference label, an index term's
-      display, a table-of-contents entry -- it clones the same inline
-      NODES. Flattening to a string at the derivation site destroys the
-      source run exactly as flattening at the index site does, and no
-      renderer downstream can recover it. Stated once here rather than
-      per consumer, because the reach of R4 is what is at issue and the
-      next consumer that derives display text inherits the answer.
+      the run before any renderer is invoked, and no renderer change reaches
+      the loss. The same argument covers every other run a renderer may want
+      back: a code span, an escape, an inline literal.
+      DERIVED DISPLAY TEXT CLONES THE SAME NODES -- NORMATIVE. The clause
+      above binds every consumer that derives display text from a heading, not
+      the crossref alone: a numbered cross-reference label, an index term's
+      display, a table-of-contents entry. Flattening to a string at the
+      derivation site destroys the source run exactly as flattening at the
+      index site does. Stated once here rather than per consumer.
       THE LABEL IS TAKEN BEFORE ANY RENDER-STAGE INJECTION. A heading's
       cloned nodes are its AUTHORED inline content. Whatever a render-stage
       transform later adds to the heading -- a `section-number` span, a
       permalink anchor -- is not part of the label and never appears in
       derived text, so an implementation that resolves cross-references
       AFTER such a transform must clone from the PRISTINE heading and not
-      from the live one.
-      That sentence is normative rather than incidental because two
-      implementations may differ HERE BY CONSTRUCTION rather than by
-      defect: one resolves cross-references before the numbering transform
-      runs, the other after it. Both follow the same words and produce
-      different labels -- one numbered, one plain -- unless the words say
-      which side of the injection the label comes from. Naming the side is
-      therefore the whole content of this half of the clause.
+      from the live one. That is normative rather than incidental because two
+      implementations may differ HERE BY CONSTRUCTION: one resolves
+      cross-references before the numbering transform runs, the other after
+      it, and both follow the same words unless the words say which side of
+      the injection the label comes from.
       NUMBERING, PREFIXING AND JOINING REMAIN THE EXTENSION'S OWN
       BUSINESS. This governs what the TITLE part is made of, not the label
       word, not the number, and not the separator around them.
@@ -326,11 +275,9 @@
       does not merely leave a paragraph behind; it takes the caption line into
       it.
 
-      That binding is resolution-dependent BY DESIGN, and it is the half worth
-      stating outright, because the alternative reads cleaner and is wrong.
-      Binding on the SOURCE SHAPE would put a `<figure>` around a paragraph of
-      literal `![a][r]` -- output no engine writes and no clause asks for. So
-      the caption is a property of the same resolved tree the image is.
+      That binding is resolution-dependent BY DESIGN. Binding on the SOURCE
+      SHAPE would put a `<figure>` around a paragraph of literal `![a][r]` --
+      output no engine writes and no clause asks for.
 
       A DISPLAY-MATH HOST HAS NOTHING TO WAIT FOR. §4's other prose-spelled
       captionable host, a paragraph whose whole content is one display-math
@@ -340,15 +287,4 @@
       settles nothing else -- an unresolved reference image is
       captionable-SHAPED, and it is not a block image.
 
-      WHAT THIS REPLACES, so the shape is not rebuilt by accident. The answer
-      used to be reached four times: a syntactic pre-filter in the block layer,
-      a post-pass that took apart a figure the block layer had built
-      speculatively (carrying the undo data on the node to do it), a probe
-      render whose output was discarded, and the paragraph serializer's own
-      render-and-test. Resolution fed the structural decision from four
-      directions, and a fifth consumer -- an importer with no access to any of
-      them -- guessed the rule a third time. An implementation that attaches
-      the caption optimistically and detaches it later is passing this clause's
-      tests while keeping the defect it exists to remove.
    ============================================================================ *)
-

--- a/resources/spec/19-html-serialization.ebnf
+++ b/resources/spec/19-html-serialization.ebnf
@@ -31,18 +31,14 @@
       A structural CLASS instead merges into the class slot at its FRONT,
       which is the mandatory-base-class rule above said from the other
       side (`task-list`, math's `math inline|display`).
-      This matches reference djot (measured, 0.3.2) on every shape tried --
+      This matches reference djot on every shape tried --
       `<ol type="a" class="attr">`, `<ol start="5" class="attr">`,
       `<a href="…" class="c" id="i" k="v">`, `<img alt="a" src="…"
       class="c">`, `<ul class="task-list c">` -- and it is the same
       placement PART 10 §1 already states for a mention, where the
       structural `href` precedes the author's `data-role` and `id`.
       SO THE DISCRIMINATOR IS THREE-WAY, not two: structural leads,
-      authored follows in source order, engine-minted follows that. Reading
-      a structural attribute as "generated" put carve-rs alone against
-      carve-js, carve-php and djot on `{.attr}` / `a. alpha`
-      (markup-carve/carve#1090); nothing pinned it, which is why the two
-      readings survived side by side.
+      authored follows in source order, engine-minted follows that.
 
       A GENERATED ATTRIBUTE JOINS AT THE END. The two rules above cover
       an all-authored Attrs and an all-programmatic one; the MIXED case
@@ -68,12 +64,10 @@
         > ## Nested   -> <h2 id="Nested" data-source-line="1">
       This is a THIRD category, and stating it is what stops an engine
       from being conformant and divergent at once. An engine that
-      appends the stamp at RENDER time (carve-js) gets the order for
-      free, because the stamp is written outside the attribute walk. An
-      engine that attaches it at PARSE time (carve-rs) carries it inside
-      the authored run, where the "generated last" rule alone would put
-      the id behind it -- which is exactly what carve-rs did until it
-      was caught by a test rather than by this text.
+      appends the stamp at RENDER time gets the order for free, because the
+      stamp is written outside the attribute walk; an engine that attaches it
+      at PARSE time carries it inside the authored run, where the "generated
+      last" rule alone would put the id behind it.
 
       TEXT-BLOCK ALIGNMENT IS A SEMANTIC ATTRIBUTE. On `<p>`, `<div>` and
       `<h1>` through `<h6>`, an authored `align` key whose trimmed,

--- a/resources/spec/20-writer-invariants.ebnf
+++ b/resources/spec/20-writer-invariants.ebnf
@@ -24,31 +24,18 @@
       in what the author wrote to get there.
 
       Without that clause the first invariant would be unattainable by
-      construction, not merely unmet. §5 requires the writer to escape `"` and
-      `'` UNCONDITIONALLY: a bare quote reaching the writer as text would
-      otherwise re-derive as smart punctuation (PART 9 §8) and change the
-      document. So a text node holding a quote MUST come back carrying an
-      escape, which parses to `escaped_text`. Read strictly, §1 and §5 would
-      contradict each other for every document containing a quote.
-
-      This is also the comparison §4 already performs internally: the two
-      renders it weighs differ precisely in their escaping, so telling them
-      apart BY the escaping would escalate every document. The invariant and
-      the strategy therefore ask the same question -- does dropping the escapes
-      change anything ELSE?
+      construction. §5 requires the writer to escape `"` and `'`
+      UNCONDITIONALLY: a bare quote reaching the writer as text would otherwise
+      re-derive as smart punctuation (PART 9 §8) and change the document, so a
+      text node holding a quote MUST come back carrying an escape, which parses
+      to `escaped_text`. It is also the comparison §4 already performs
+      internally -- the two renders it weighs differ precisely in their
+      escaping, so telling them apart BY the escaping would escalate every
+      document.
 
       What escaping still MUST preserve is the rendered result: the escape is
       authoring syntax, so `to_html(fmt(x)) == to_html(x)` admits no such
       latitude, and neither does idempotence.
-
-      KNOWN GAP -- the first invariant is not met by every implementation on
-      every input. The four constructs first recorded here (a table carrying a
-      colspan, a doubled alignment marker, a list-item attribute form and a
-      line-block shape) are fixed; a corpus-wide sweep finds others, tracked in
-      carve#369. Nothing caught any of them because every existing check
-      compares rendered HTML, which is equal in all of those cases. It is
-      stated rather than left implied: an implementation that satisfies §2 can
-      still fail §1, and §4's comparison is built to be unaffected by that.
 
    1a. THE INVARIANT OUTRANKS THE PER-CONSTRUCT RULES -- NORMATIVE. §1 states
       what the writer must ACHIEVE; §2 through §11 state how it SPELLS each
@@ -73,9 +60,7 @@
       parse(x)` is the requirement. `to_html(fmt(x)) == to_html(x)` is a
       consequence of it and is strictly weaker -- §2a already says that holding
       is necessary, not sufficient -- so a writer satisfying only the HTML form
-      still fails this section. The distinction is easy to lose because the
-      HTML form is what a person can SEE, and reports of these defects are
-      usually written against it; the rule is stated over the parse.
+      still fails this section.
 
       IT IS NOT A LICENSE TO RESPELL. §2a and §6 are unchanged. What this
       section permits is the SMALLEST departure that restores the invariant,
@@ -117,30 +102,13 @@
       side exists at all, not what characters happen to sit on one.
 
       THE FAILURES ARE ONE FAILURE, and only some of them have a visible face.
-      Re-measured 2026-08-18 against carve-js `099db2cc`, carve-php `925f7dcf`
-      and carve-rs `3f8bde7b`, each built from a clone made for the run and each
-      flattening a `<figcaption>` holding two paragraphs. carve-rs emits the
-      separator on every row since markup-carve/carve-rs#1094; carve-js and
-      carve-php agree with each other on every row and lose the boundary:
+      A `<figcaption>` holding two paragraphs flattens with the boundary lost:
 
         <p>one</p><p>two</p>                    ->  onetwo
         <p><strong>a</strong></p>
         <p><strong>b</strong></p>               ->  *a**b*
         <p><code>a</code></p>
         <p><code>b</code></p>                   ->  `a``b`
-
-      The first loses the boundary as CONTENT: `onetwo` re-reads as one word
-      and the reader sees a misspelling. The second and third lose it as
-      STRUCTURE: `*a**b*` re-reads as one strong run holding a literal
-      asterisk, and the third as one code span holding the joined
-      delimiters. Nothing is DROPPED in any of them, which is why no diagnostic
-      fires for any of them -- an importer's unwrap note reports that a `<p>`
-      was unwrapped and says nothing about what the unwrapping joined.
-
-      The third row was not among the two reported at carve#1325. It is the
-      reason the rule is a property: a ruling written to the two shapes in hand
-      would have left the code span for the next release, and the caption slot
-      is not the only inline-only slot either.
 
       THE UNIT IS THE TOKEN, NOT THE NODE, and that difference is the whole
       rule. A node test passes `onetwo` and `one two` alike -- both are a
@@ -150,9 +118,7 @@
 
       IT IS §23's TEST READ BACKWARDS. PART 9 §23 states the forward half for a
       LINE boundary: ONE boundary produces ONE node, "however the boundary is
-      spelled", and a backslash break and a verbatim run are exempt for one
-      reason -- both leave NO NODE, so there is no boundary left in the tree to
-      convert. A flatten is that situation arriving from the other side. The
+      spelled". A flatten is that situation arriving from the other side. The
       block boundary leaves no node either, because the slot has nowhere to put
       one, so it survives only in the BYTES -- and the bytes are read by a
       tokenizer.
@@ -172,23 +138,15 @@
       per report: a character that was TEXT in one of the blocks and becomes a
       live delimiter once its neighbour is beside it is an ESCAPING question,
       and §2 read through §1a already answers it -- the writer reads its own
-      OUTPUT, and escapes what would otherwise change the document. That is
-      already the behavior: `<p>a *b</p><p>c* d</p>` flattens to `a \*bc\* d`
-      in all three engines, with the asterisks correctly escaped and only the
-      word boundary lost. This clause supplies the space and nothing else;
-      §1b and §2 are answering two halves of the same join.
+      OUTPUT, and escapes what would otherwise change the document. This clause
+      supplies the space and nothing else; §1b and §2 are answering two halves
+      of the same join.
 
-      REFUSING TO FLATTEN IS NOT AN ANSWER. The slot cannot hold blocks, so a
+      REFUSING TO FLATTEN IS NOT AN ANSWER: the slot cannot hold blocks, so a
       producer that refuses emits nothing where the author's document has
-      content. That is a strictly larger loss than the one this clause closes,
-      and silent in exactly the same way.
-
-      NEITHER IS ESCAPING THE COLLISION. `*a*\*b*` writes a character the
-      author did not, against §2's if-and-only-if: nothing in either block's
-      own content needs protecting, and the collision exists only at the join.
-      An escape is also per-character where the defect is per-boundary, so it
-      would be re-derived for every delimiter pair two blocks might meet on,
-      where the separator is derived once.
+      content. NEITHER IS ESCAPING THE COLLISION: `*a*\*b*` writes a character
+      the author did not, against §2's if-and-only-if, and an escape is
+      per-character where the defect is per-boundary.
 
       WHAT IS NOT REQUIRED. The flatten need not be REVERSIBLE. Two paragraphs
       written into a caption come back as one paragraph and no spelling of the
@@ -232,26 +190,22 @@
       §10j is. Two shapes have the property today, and they share no node type,
       no vocabulary list and no reason beyond the spelling: a `paragraph` whose
       whole content is one `image`, which writes `![a](u)` and reads back as
-      the standalone image (PART 9 §4's image-paragraph host is a condition on
-      a paragraph's inline content, so the two trees have ONE spelling between
-      them); and a `paragraph` whose whole content is one `comment`, which
-      writes `%% c` and reads back as the block comment. `image` is in the
-      INLINE vocabulary and `comment` is in the BLOCK one (docs/profiles.md),
-      so a rule written over the types would have had to name them one at a
-      time and would not reach the next one. A block whose content spells
-      anything ELSE -- a second node beside it, a text run, a NO-BREAK SPACE
-      (§7) -- keeps its wrapper and no ceiling is reached.
+      the standalone image; and a `paragraph` whose whole content is one
+      `comment`, which writes `%% c` and reads back as the block comment.
+      `image` is in the INLINE vocabulary and `comment` is in the BLOCK one
+      (docs/profiles.md), so a rule written over the types would have had to
+      name them one at a time. A block whose content spells anything ELSE -- a
+      second node beside it, a text run, a NO-BREAK SPACE (§7) -- keeps its
+      wrapper and no ceiling is reached.
 
       DECIDED ON THE SPELLING, NEVER ON RESOLUTION -- and PART 9R R7 does not
-      change that (carve#1784). R7's promotion phase reads the RESOLVED tree;
-      this clause reads what a shape SPELLS, and the two are deliberately
-      independent. A writer that consulted resolution would write the same
-      paragraph differently depending on whether a definition appears somewhere
-      else in the document, possibly far away -- a bad property for a formatter,
-      and the reason `paragraph.blockImage` (PART 12 §23) is a field the writer
-      does not read. So a document whose reference is never defined still writes
-      back as itself, and this clause's ceiling is reached by `![a](u)` and by
-      `![a][r]` alike, defined or not.
+      change that. R7's promotion phase reads the RESOLVED tree; this clause
+      reads what a shape SPELLS, and the two are deliberately independent. A
+      writer that consulted resolution would write the same paragraph
+      differently depending on whether a definition appears somewhere else in
+      the document -- the reason `paragraph.blockImage` (PART 12 §23) is a
+      field the writer does not read. So this clause's ceiling is reached by
+      `![a](u)` and by `![a][r]` alike, defined or not.
 
       THE CEILING IS UNIFORM AND NOT POSITIONAL, which is the half that decides
       the shape rather than merely describing it. At top level the image
@@ -260,22 +214,15 @@
       writer still does not use it. Inside a list item or a definition
       description there is no such spelling at any width: the marker's own
       content column absorbs the padding, so `- ![a](u)` and `-       ![a](u)`
-      are the same tree, and `: ` behaves the same way. A writer preserving
-      the shape at one nesting level and losing it at the next, with nothing
+      are the same tree, and `: ` behaves the same way. A writer preserving the
+      shape at one nesting level and losing it at the next, with nothing
       declaring the difference, is not a preservation rule; and the indented
       form emits meaning-bearing leading whitespace, which editors and
-      pipelines strip. So the wrapper is lost EVERYWHERE, and one sentence
-      describes the writer at every depth.
+      pipelines strip. So the wrapper is lost EVERYWHERE.
 
-      WHY NOT REFUSE. §1's KNOWN GAP and the refusal a writer already owes for
-      a value no source can carry make refusal the honest-looking answer, and
-      it is what an implementation does for an empty raw inline. It loses on
-      two counts. It would fail an editor's round trip on a tree the renderer
-      accepts -- §10j's own reason for bounding a loss rather than rejecting
-      the document, on the path that can least afford it -- and it contradicts
-      a clause that already exists, since `docs/html-import.md` says this exit
-      REPORTS the loss rather than failing. Overturning that needs its own
-      fallback story and is a larger change than the shape asks for.
+      WHY NOT REFUSE. Refusing would fail an editor's round trip on a tree the
+      renderer accepts, and `docs/html-import.md` already says this exit
+      REPORTS the loss rather than failing.
 
       THE WRAPPER IS STILL LOST, and this clause does not pretend otherwise. It
       bounds the loss TO the wrapper -- the content, its attributes and its
@@ -323,21 +270,17 @@
       wrapper, and the fixture is then evidence of nothing. The clause is the
       definition; a fixture is at most an instance of it.
 
-      WHERE THE SET IS SOURCED FROM IS FREE, and the two engines that reached
-      this first source it differently: one states a predicate over what the
-      shape spells and is bounded by construction, the other derives the set
-      from the corpus documents whose pinned canonical form re-parses
+      WHERE THE SET IS SOURCED FROM IS FREE. One engine states a predicate over
+      what the shape spells and is bounded by construction, another derives the
+      set from the corpus documents whose pinned canonical form re-parses
       differently and applies the bound explicitly. Both conform. The bound is
-      the rule; the sourcing is not, and neither spelling is owed a conversion
-      to the other.
+      the rule; the sourcing is not.
 
       A CHECKER THAT WIDENS THE BOUND CANNOT DETECT ITS OWN WIDENING, so the
       width is pinned separately or it is not pinned at all. The dissolution is
       applied to BOTH trees, so widening it can only ever HIDE a difference and
-      never create one: whatever extra shape it swallows, it swallows
-      identically on each side and the two still agree. A corpus sweep
-      therefore stays green under any widening whatsoever, and only a direct
-      assertion on the predicate says how wide it is.
+      never create one, and a corpus sweep stays green under any widening
+      whatsoever.
 
    2. THE ESCAPING RULE -- NORMATIVE. A character is escaped IF AND ONLY IF
       omitting the escape would change the re-parsed AST.
@@ -350,12 +293,9 @@
 
       THE UNIT IS THE OPENER, NOT THE CHARACTER. Where a construct opens on a
       RUN of characters, the whole run is escaped. `--` opens an en dash
-      (PART 9 §8), and `\--` suppresses it just as `\-\-` does, so a
-      character-at-a-time reading of the rule would call the second escape
-      unnecessary and require `\--`. It does not: the escaped form of a
-      suppressed opener is the whole opener escaped. A half-escaped run is a
-      shape that happens to work rather than one that says what it means, it
-      breaks as soon as the surrounding text shifts what the run abuts, and
+      (PART 9 §8), and `\--` suppresses it just as `\-\-` does; the escaped
+      form of a suppressed opener is the whole opener escaped. A half-escaped
+      run breaks as soon as the surrounding text shifts what the run abuts, and
       `\.\.\.` versus `\...` is the same question with the same answer.
 
       So the escape decision is taken per OPENER OCCURRENCE: would omitting the
@@ -381,13 +321,6 @@
       is what it falls back to -- per occurrence now rather than per unit. A
       fallback that spends more escapes than this test asks for is wider than
       the minimum and never narrower, which is the only direction §1 tolerates.
-
-      (Pinned by corpus
-      403-an-idle-escape-does-not-spread-from-the-occurrence-that-needed-one.
-      Like corpus 396 one clause down, its `.fmt` sidecar is the only fixture
-      that can see it: `\{\.note\}` renders the same HTML, re-parses to the
-      same tree and is happily idempotent, so every other gate in every engine
-      was green on the wider form.)
 
    2a. THE WRITER DOES NOT SUBSTITUTE ONE CONSTRUCT FOR ANOTHER -- NORMATIVE.
       §2 governs ESCAPING. It does not license rewriting a construct into a
@@ -440,11 +373,8 @@
       rules out re-parsing a LINE on its own, because a line has lost the
       document's link-reference and footnote definitions and reports a
       difference escaping never caused. That argument is about what the writer
-      PARSES in order to decide, and it stands unchanged. This section is about
-      which BYTES the decision then selects. A writer renders and re-parses
-      WHOLE documents, and takes the conservative spelling only where the
-      minimal one failed -- so the definitions are present for the comparison
-      and the escalation is still local.
+      PARSES in order to decide; this section is about which BYTES the decision
+      then selects.
 
       THE UNIT NESTS, AND IT IS TRIED SMALLEST FIRST. The inline run carrying
       the occurrence is tried before the block that holds it. A failure that
@@ -459,12 +389,6 @@
       IT DOES NOT LOOSEN §2 ANYWHERE. A unit that fails is escaped in full, by
       §2's THE UNIT IS THE OPENER: `\#\# H` and not `\## H`. What narrows is
       the reach of the fallback, not the strength of the escape it applies.
-
-      (Pinned by corpus
-      396-an-idle-escape-does-not-spread-from-the-block-that-needed-one, whose
-      `.fmt` sidecar is the only fixture that can see this: both spellings
-      render the same HTML and re-parse to the same tree, which is why three
-      writers carried the wider scope with every gate green.)
 
    3. WHY A STATIC CHARACTER TABLE CANNOT IMPLEMENT §2. Whether a character
       is significant depends on the line, not on the character:
@@ -487,8 +411,7 @@
       §2 is the rule worth keeping, because it is the one an author can see the
       difference in, and because §3's argument does not lead here: it shows a
       static character TABLE cannot implement §2, not that per-character
-      decisions are impossible. A writer that knows whether a construct would
-      START at a given position decides exactly, and two engines do.
+      decisions are impossible.
 
       The procedure, then, as a strategy:
 
@@ -506,20 +429,6 @@
          A unit is not one knob: the occurrences that survive escaped are the
          ones that failed, not the ones that shared a block with a failure.
 
-      W5 IS WHERE THE STRATEGY COSTS, AND THE COST IS BOUNDED BY SEARCHING
-      RATHER THAN BY ENUMERATING. Offering the occurrences ONE AT A TIME is a
-      render and a re-parse of the whole document per candidate, which is
-      quadratic in the document -- and on ordinary input, not adversarial:
-      a paragraph of indented table rows puts a load-bearing occurrence beside
-      an idle one on every line. Offering a GROUP its bare form and halving the
-      group only where that fails costs a number of renders proportional to how
-      many occurrences FAIL rather than to how many there are. Measured on that
-      shape at 50 / 100 / 200 / 400 rows, in RENDERS rather than in
-      milliseconds: 249 / 499 / 999 / 1999 offering one at a time, flat at
-      about 5 renders per row, against 64 / 72 / 80 / 88 searched -- eight more
-      renders per doubling of the input, which is the logarithm the halving
-      buys. The same bound applies to W4's own search over units.
-
       A WRITER MAY STOP THE SEARCH SHORT, and §2b's fallback is what it returns
       to when it does: the occurrences it did not get to stay escaped. That is
       WIDER than §2's minimum and never narrower, so a spent budget costs
@@ -529,38 +438,28 @@
 
       Two forms and one comparison, with the choice made by the parser rather
       than by a table -- so the writer cannot drift from the grammar as the
-      grammar grows. What it buys is safety without a table; what it costs is
-      precision, and §2 is where the precision is required.
+      grammar grows.
 
       WHY THE COMPARISON IS DOCUMENT-SCOPED, FOR AN IMPLEMENTATION THAT USES
-      IT. An earlier draft decided per line. That cannot be implemented: a line
-      re-parsed on its own has lost the document's link-reference and footnote
-      definitions, so a paragraph carrying `[text][ref]` comes back with an
-      empty destination and reports a difference escaping never caused. Any
-      COMPARISON at a scope smaller than the document has the same defect for
-      the same reason, so W1 and W3 render and parse whole documents.
+      IT. A line re-parsed on its own has lost the document's link-reference
+      and footnote definitions, so a paragraph carrying `[text][ref]` comes
+      back with an empty destination and reports a difference escaping never
+      caused. Any comparison at a scope smaller than the document has that
+      defect, so W1 and W3 render and parse whole documents.
 
       THAT IS NOT A REASON TO ESCALATE THE WHOLE DOCUMENT, and reading it as
       one is what §2b now forbids. Where the two parses differ, they differ
       SOMEWHERE, and W4 takes the conservative spelling only for the smallest
-      unit that fails. The definitions the comparison needs are present either
-      way, because nothing about the comparison changed.
-
-      What remains true is the rest of the trade: this is a strategy rather
-      than the requirement, and an implementation that instead asks, per
-      position, whether a construct would start there needs neither the
-      comparison, nor the scope, nor W5's search.
+      unit that fails.
 
       WHY THE TWO RENDERS ARE COMPARED WITH EACH OTHER, and not the minimal
       render with the document being written. The writer is not required to be
-      AST-faithful for every construct, and in practice is not: a table with a
-      colspan, a doubled alignment marker, some list-item attribute forms and
-      one line-block shape all re-parse to a DIFFERENT document while rendering
-      identical HTML. Comparing against the source document would inherit those
-      defects, flip the escaping decision between passes and break §1's
-      idempotence for a reason that has nothing to do with escaping. Comparing
-      the two renders isolates the only question this decision asks: does
-      dropping the candidate escapes change anything?
+      AST-faithful for every construct: a table with a colspan, a doubled
+      alignment marker, some list-item attribute forms and one line-block shape
+      all re-parse to a DIFFERENT document while rendering identical HTML.
+      Comparing against the source document would inherit those defects and
+      break §1's idempotence for a reason that has nothing to do with
+      escaping.
 
    5. THE TWO SETS.
 
@@ -589,27 +488,18 @@
         weighs the mark; it is not a license to EMIT an escape §2 does not
         ask for. §4 pins the output on §2 and yields to it wherever the two
         differ, and §10g already restates the reach in those terms -- "§5's
-        unconditional set escapes a LEADING caret in TEXT". §2a has filed the
-        other direction as a defect, on `}^p`, where the caret leads nothing,
-        dropping the escape re-derives the same document, and carve-rs and
-        carve-php escape it anyway. So "always escaped in a text node" is the
-        set's membership rule, and §2 is the test the emitted byte answers to.
+        unconditional set escapes a LEADING caret in TEXT". So "always escaped
+        in a text node" is the set's membership rule, and §2 is the test the
+        emitted byte answers to.
 
         THE MARK IS THE PROMOTION, NOT A FIELD, which is why the LEADING case
         needs no exception to §2. `resources/ast-schema.json` declares no
-        field for it and carve-rs publishes none: what the escape changes
-        there is whether the block comes back a PARAGRAPH or a FIGURE, and
-        that is a difference §2 already sees. An engine that reads the
-        paragraph above as promising a field has read a mechanism where the
-        rule is about an outcome.
+        field for it: what the escape changes there is whether the block comes
+        back a PARAGRAPH or a FIGURE, and that is a difference §2 already sees.
 
-        SO THE LEADING CASE IS UNMOVED, and corpus
-        394-a-leading-escaped-caret-keeps-its-escape pins it against the
-        reading that takes the bare `{^^}` above for a general permission.
-        An image over `\^ not a caption` keeps the backslash in all three
-        engines; bare, the same two lines are a `figure` with a
-        `figcaption`. That is §2 requiring the escape, not §5 excusing it,
-        and it is the difference between the two documents.
+        SO THE LEADING CASE IS UNMOVED. An image over `\^ not a caption` keeps
+        the backslash; bare, the same two lines are a `figure` with a
+        `figcaption`. That is §2 requiring the escape, not §5 excusing it.
 
       CANDIDATE -- escaped only when W4 selects the conservative form:
         `* _ ~ / = ,`        emphasis and the braced pair delimiters

--- a/resources/spec/21-writer-carve-markdown.ebnf
+++ b/resources/spec/21-writer-carve-markdown.ebnf
@@ -5,61 +5,27 @@
       choices and the AST records them; changing one would satisfy §1 while
       still surprising the author.
 
-      FENCE LENGTH WAS A THIRD EXAMPLE HERE AND IS NOT ONE (carve#1000). It is
-      removed rather than implemented, on this section's own second half: a
-      spelling is the author's to keep BECAUSE THE AST RECORDS IT, and
-      `code_block` records no fence at all (PART 12 §3). Neither the length of
-      the run nor the character it is made of survives the tree, so
+      FENCE LENGTH WAS A THIRD EXAMPLE HERE AND IS NOT ONE. It is removed
+      rather than implemented, on this section's own second half: a spelling is
+      the author's to keep BECAUSE THE AST RECORDS IT, and `code_block` records
+      no fence at all (PART 12 §3). Neither the length of the run nor the
+      character it is made of survives the tree.
 
-        ```js        all three publish the SAME node, and the writer
-        `````js      has nothing to reproduce
-        ~~~js
-
-      That is §6a's objection to the thematic break, reached one construct over:
-      a rule that cannot be applied leaves the question open rather than
-      answering it. The difference between the two is only that one was noticed.
-
-      THE WRITER COMPUTES THE WIDTH IT NEEDS, which is why removing the example
-      costs no document. A fence is widened to clear the longest fence-character
-      run in its content and narrowed when nothing requires the extra width, and
-      §1 holds through both: content carrying a three-backtick run keeps a
-      four-backtick opener, while plain content under a four-backtick opener
-      comes back as three. Measured in all three engines, and the narrowing row
-      is the one that matters -- it is the behavior this section forbade in
-      words and every engine performed, with the round trip intact through it.
-
-      So the mention was decorative. Had the writer instead relied on the
-      AUTHOR's length, removing it would have broken every document whose
-      content contains its own fence character, and the example would have been
-      load-bearing by accident rather than by design.
+      THE WRITER COMPUTES THE WIDTH IT NEEDS. A fence is widened to clear the
+      longest fence-character run in its content and narrowed when nothing
+      requires the extra width, and §1 holds through both.
 
       The AST therefore RECORDS the combined form -- a `strong` parsed from
       `bold_italic` carries `boldItalic` (PART 12 §3) -- and the writer
-      reproduces it. Without that mark the rule could not be stated as an
-      author's choice at all, because there would be nothing to preserve.
+      reproduces it. `/*x*/` is also the spelling Carve teaches, so normalizing
+      it away would rewrite the documented form into one documented nowhere.
 
-      `/*x*/` is also the spelling Carve teaches (docs/cheatsheet.md,
-      docs/migrate-from-markdown.md), so normalizing it away rewrote the
-      documented form into one documented nowhere. That is the concrete harm
-      behind the general rule.
-
-      THE THEMATIC BREAK JOINS IT ON THE SAME TERMS (carve#976), and needed the
-      same catching up. `---`, `***` and `___` are three spellings of one
-      construct; until now `thematic_break` recorded none of them, so this
-      section's second half was false for it and could not be applied, and §6a
-      pinned `---` in the meantime rather than leaving three writers to pick
-      separately. The AST RECORDS the character now -- `marker` (PART 12 §3) --
-      and the writer reproduces it, so `***` comes back as `***` and `___` as
-      `___`. §6a is REMOVED with the pin it held, which is what its own text
-      said would happen.
-
-      THE MARKER IS THE CHARACTER, NOT THE RUN LENGTH (carve#1000). `***` and
-      `*****` are ONE spelling here and both come back as `***`: three
-      characters is the width §6a already pinned, applied to whichever character
-      the field names. The argument for recording a length was this section's
-      own mention of FENCE length by analogy, and that mention is the one
-      removed above -- so the analogy points at nothing, and no construct's run
-      length is recorded anywhere.
+      THE THEMATIC BREAK JOINS IT ON THE SAME TERMS. `---`, `***` and `___` are
+      three spellings of one construct, and the AST RECORDS the character --
+      `marker` (PART 12 §3) -- so the writer reproduces it. THE MARKER IS THE
+      CHARACTER, NOT THE RUN LENGTH: `***` and `*****` are ONE spelling here
+      and both come back as `***`. No construct's run length is recorded
+      anywhere.
 
       EXCEPT WHERE `---` WOULD OPEN FRONTMATTER. A `---` line at byte 0 of the
       EMITTED document is the frontmatter opener, not a break. Spelling this
@@ -69,40 +35,26 @@
       by the literal reading of this clause it renders NOTHING -- with any
       paragraph standing between them lost too. Where that would happen the
       writer spells the break `***` instead, and that deviation is §1a's --
-      §1's invariant outranks a per-construct rule, and this is the case §1a
-      was reached for.
-      It is CONFORMANT. It is not a divergence from this section, and an
-      implementation that has it is not to be corrected back.
+      §1's invariant outranks a per-construct rule. It is CONFORMANT and not a
+      divergence from this section.
 
       THE CONDITION IS THE WHOLE EMITTED DOCUMENT, NOT ITS FIRST LINE. An
       opener needs a closer, so three hyphens at byte 0 open nothing unless a
       later line closes them -- `***` alone, and `***` above a paragraph, are
-      both written `---` with no exception at all. The document that survives
-      and the document that is destroyed are IDENTICAL on line 1 and differ
-      several lines down, which is why the check this clause most invites, a
-      pattern match on the first line, answers a different question than the
-      one asked. What an implementation owes is §1a's test: read the emitted
-      bytes with its own parser.
+      both written `---` with no exception at all. What an implementation owes
+      is §1a's test: read the emitted bytes with its own parser.
 
       WHICH break moves is not pinned, because more than one departure
       restores §1 and §1a already says to take the smallest. Usually it is the
-      break at byte 0. Where the writer itself PROMOTED something else there --
-      hoisting a definition below the body can leave a paragraph at the head --
-      the text at byte 0 is not the writer's to respell, and the departure
-      available is to respell the CLOSER instead. What IS pinned is the
-      spelling a moved break takes, `***`, for the reason this clause exists at
-      all: a construct left with two admissible spellings normalizes two ways,
-      and an exception is no more exempt from that than the rule is.
+      break at byte 0; where the writer itself PROMOTED something else there,
+      the departure available is to respell the CLOSER instead. What IS pinned
+      is the spelling a moved break takes: `***`.
 
       AN ABSENT MARKER IS `---`, which is what a tree assembled by hand or by a
       converter carries and what every document written before the field means.
-      That default is not arbitrary: `---` is the spelling Carve teaches
-      (docs/cheatsheet.md writes it and names `***` and `___` as its
-      alternatives), so a break with no authored choice to preserve is written
-      the documented way. §1a still outranks this, and the one deviation it
-      licenses here is real -- a `---` the writer emits at byte 0 can gain a
+      §1a still outranks this: a `---` the writer emits at byte 0 can gain a
       frontmatter closer from a later break, and respelling every break in the
-      document is the smallest departure that restores the invariant.
+      document is then the smallest departure that restores the invariant.
 
    6b. A FRONTMATTER OPENER IS WRITTEN `---yaml` -- NORMATIVE. The canonical
       writer spells the format token on the opening delimiter for EVERY
@@ -111,28 +63,18 @@
       `---toml`; nothing about the writer's output turns on which format the
       document named.
 
-      This is §6's REMAINING gap, and the same one the thematic break had until
-      carve#976 closed it: `---` and `---yaml` open the
-      same frontmatter (PART 1, "a bare `---` defaults to `yaml`"), so the two
-      are synonyms with nothing in the tree to tell them apart.
-
-      PART 1 ALREADY NAMES THE FORM. That production calls `---yaml` canonical
-      in as many words, and PART 11 is the canonical writer -- so the writer
-      emits it. The counter-reading is that the word sits in a sentence about
-      the optional SPACE and therefore settles `---yaml` against `--- yaml`
-      only. It does not survive contact with what the sentence names: the
-      string it calls canonical is a WHOLE OPENER, not the space inside one,
-      and reading it to reach one of the two ways an opener can differ from it
-      but not the other takes an argument the sentence does not make.
+      `---` and `---yaml` open the same frontmatter (PART 1, "a bare `---`
+      defaults to `yaml`"), so the two are synonyms with nothing in the tree to
+      tell them apart. PART 1 ALREADY NAMES THE FORM: that production calls
+      `---yaml` canonical in as many words, and it calls a WHOLE OPENER
+      canonical, not the space inside one.
 
       A READER'S LENIENCY IS NOT A WRITER'S LICENSE, which is what the bare
       form would be. "A bare `---` defaults to `yaml`" tells the PARSER what
       to do with an opener that names nothing; the writer is not parsing, it
       is choosing, and `frontmatter_format` is one production over every
-      format with no default case in it. So a writer that omits the token for
-      `yaml` special-cases a value the grammar distinguishes nowhere except in
-      that leniency rule -- and §2 already refuses the mirror of that move,
-      where the writer emits the shortest form that happens to survive
+      format with no default case in it. §2 already refuses the mirror of that
+      move, where the writer emits the shortest form that happens to survive
       re-parsing rather than the form that says what it means.
 
    6c. A VALUE-LESS ATTRIBUTE IS WRITTEN AS A BOOLEAN -- NORMATIVE. An
@@ -145,14 +87,6 @@
       (carve#1450). `_x_=""` stays `{_x_=""}`: emitting `{_x_}` would write a
       forced underline, and `{_u}` would write text. The rule is "use the
       dedicated production where the production applies", and here it does not.
-
-      NOTHING EXTRA PINS THIS, on purpose. §1's `parse(fmt(x)) == parse(x)` is
-      already gated over the corpus for every engine, and corpus
-      389-a-boolean-attribute-does-not-start-with-an-underscore-4 holds
-      `[x]{_u=""}`, so an engine that shortens it breaks its own round-trip the
-      day it ships the reading rule - and not one day earlier, which is what a
-      `.fmt` fixture would have done to a writer that is still correct for the
-      grammar it implements.
 
       THE WRITER USES THE DEDICATED PRODUCTION, which is the one rule behind
       all three of these:
@@ -167,32 +101,15 @@
 
       THIS IS NOT §6b'S MIRROR. That clause makes the writer spell `---yaml`
       rather than the shorter `---`, and its reason is that a bare `---` is
-      NOT a production for yaml frontmatter: it is an opener that names no
-      format, which a PARSER leniency rule then defaults. Leaning on that
-      leniency is what §6b refuses. A boolean attribute is the opposite case --
-      the grammar has a production for exactly this shape, and no default is
-      being relied on. `{kbd=""}` is not more explicit than `{kbd}`; it says
-      the value is an empty STRING, where the tree says the attribute has no
-      value at all.
-
-      THREE `.fmt` FIXTURES ARE WITHDRAWN, not updated, and come back with the
-      pin bump: `297-the-language-sigil-takes-no-padding`,
-      `97-boolean-attributes` and `45-inline-extensions-9`. Those fixtures
-      are read THROUGH the pinned build by
-      `tests/corpus-fmt-roundtrip.test.mjs`, and by the engines through their
-      own `spec` submodule, so a fixture carrying the NEW bytes fails in both
-      places until every writer ships this clause, while one carrying the OLD
-      bytes fails afterwards. There is no spelling of it that is green on both
-      sides of the change, so it is absent for the length of the rollout rather
-      than wrong at one end of it.
+      NOT a production for yaml frontmatter. A boolean attribute is the
+      opposite case -- the grammar has a production for exactly this shape.
+      `{kbd=""}` says the value is an empty STRING, where the tree says the
+      attribute has no value at all.
 
       A COMPACT SEMANTIC SPAN IS WHERE IT SHOWS. `[Tab]{kbd}` is the form PART
-      9 §10 documents and the form an author writes; a writer that returned
-      `[Tab]{kbd=""}` rewrote the documentation's own example into a shape the
-      documentation never shows, and did it for a name whose VALUE is discarded
-      (§10: values on `samp`, `var`, `kbd` and `cite` only
-      select the wrapper). An empty value there is not just longer, it points
-      at a slot that does nothing.
+      9 §10 documents and the form an author writes, and it is a name whose
+      VALUE is discarded. An empty value there points at a slot that does
+      nothing.
 
    6d. A CODE FENCE OPENER IS WRITTEN GLUED TO ITS INFO STRING -- NORMATIVE.
       The canonical writer emits NO padding space between the fence run and
@@ -212,25 +129,13 @@
       spelling canonical in as many words and records that it is what the
       X->Carve converters emit; the READER is lenient and takes either, which
       is a leniency and not a writer's license (§6b makes the same
-      distinction one construct over). This clause is the writer half of that
-      sentence, which nothing stated.
+      distinction one construct over).
 
       THE TREE RECORDS NO SLOT, which is why the writer has to be told. §6
       leaves a spelling to the author BECAUSE THE AST RECORDS IT, and
       `code_block` records the padding slot no more than it records the fence
       length or the fence character (PART 12 §3) -- so the writer has nothing
-      to reproduce and must CHOOSE, exactly as §6b and §6c must. Left
-      unchosen, it was chosen twice: carve-js and carve-php normalize to the
-      glued form, carve-rs to the spaced one (carve#1219).
-
-      NOTHING PINNED IT, and the reason is the one this project keeps
-      rediscovering. The fmt corpus held no document whose canonical form
-      contains an info string at all -- twenty-nine `.fmt` fixtures, and the
-      two carrying a code fence carry a BARE one. So the three writers met
-      only on the shape the corpus pins and drifted on the shape it does not,
-      and the drift was invisible to every gate: the HTML is identical, §1's
-      round trip holds for either spelling, and `compare:impls` had no
-      expected bytes to adjudicate between them. A corpus case pins it now.
+      to reproduce and must CHOOSE, exactly as §6b and §6c must.
 
    6e. A TABLE CELL'S CONTENT IS PADDED -- NORMATIVE.
       The canonical writer emits every cell as its PREFIX glued to the opening
@@ -255,16 +160,8 @@
       THE TREE RECORDS NO SLOT, the same reason §6d gives: `table_cell` records
       its padding no more than `code_block` records the space before its info
       string (PART 12 §3), so the writer has nothing to reproduce and must
-      CHOOSE. Left unchosen it was chosen twice -- carve-js and carve-rs glued
-      a prefixed cell, carve-php glued it except when the cell carried
-      attributes, and carve-php padded those.
+      CHOOSE.
 
-      THE FIXTURES MOVE IN TWO STEPS, as §6d's did. `284-a-ragged-table-keeps-
-      each-row-s-cell-count-2`, `-3` and `285-adjacent-block-openers-in-an-
-      attached-run-stay-separate-2` spell the old form; they are WITHDRAWN with
-      this clause and come back with the engine pin bump, because a fixture
-      carrying the new bytes fails in every engine that has not shipped the
-      clause yet and one carrying the old bytes fails in every engine that has.
 
    6f. PADDING IS NOT AN ESCAPE WHERE THE PRODUCTION ADMITS PADDING --
       NORMATIVE (carve#1601). §6e retires the writer's `<`/`>`/`~`/`{` guards
@@ -286,9 +183,7 @@
       wherever omitting the escape would make the cell re-read as something
       other than content, which is §2 run over the CELL rather than over the
       line. Naming `^` and `<` here would be an enumeration that goes stale the
-      next time a cell-level marker is added, and §6e's own history is what
-      that costs: each writer answered the alignment-sigil class with its own
-      slightly different list of characters.
+      next time a cell-level marker is added.
 
    7. NO WHITESPACE-ONLY LINE -- NORMATIVE. `fmt` never emits a line whose only
       content is ASCII spaces or tabs. Such a line is emitted EMPTY.
@@ -313,20 +208,16 @@
 
       The case this decides is a blank line INSIDE a list item, where the item's
       continuation is indented. Indenting the blank line to the content column
-      keeps the block structure visible in the source, and carve-rs and
-      carve-php did that; carve-js emitted an empty line (carve#375).
+      would keep the block structure visible in the source; the empty line wins
+      anyway.
 
       The empty line is required. A whitespace-only line is not stable: editors
       that strip trailing whitespace on save, `git apply --whitespace=fix`, and
       CI whitespace checks all rewrite it, so a formatter emitting one produces
-      output that ordinary tooling changes behind it -- and `fmt` then reports a
-      diff on a file nobody edited. A formatter whose output cannot survive the
-      tools it will be stored under is not idempotent in practice, whatever §1
-      says about it in isolation.
+      output that ordinary tooling changes behind it, and is not idempotent in
+      practice whatever §1 says about it in isolation.
 
-      AND IT DOES EXTEND to whitespace at the end of a line that HAS content,
-      which is a correction: this text said the opposite twice, and both times
-      it was measurably false.
+      AND IT DOES EXTEND to whitespace at the end of a line that HAS content.
 
         `a` + SPACE + newline + `b`   renders  `<p>a\nb</p>`
         `a` + newline + `b`           renders  `<p>a\nb</p>`
@@ -334,18 +225,12 @@
       The two are the same document. PART 2's NO TRAILING WHITESPACE clause
       drops the run on EVERY content line, including one before a soft break,
       so a writer that strips it changes nothing about
-      `to_html(fmt(x)) == to_html(x)` -- and the rule this clause already ends
-      with, "where the PARSER discards trailing whitespace the writer may too",
-      now reaches every line rather than only the ones that end a block.
+      `to_html(fmt(x)) == to_html(x)`.
 
       A trailing NO-BREAK space is a different matter and IS content, not
       layout -- the author wrote it and it renders as `&nbsp;` -- so an
       implementation whose whitespace test treats U+00A0 as whitespace must
-      exclude it here. That is the same two-character `whitespace` terminal
-      PART 2's clause names, and it is why the rule is simple rather than a
-      list of exceptions. Corpus case 141-trailing-whitespace-boundaries-4 pins
-      it (this text said case 139, which has been an inline-literal category
-      for some time).
+      exclude it here.
 
       THE SAME LINE DECIDES WHAT AN IMPORT KEEPS -- NORMATIVE (carve#1628).
       An HTML importer meeting a BLOCK ELEMENT whose text content is entirely
@@ -375,15 +260,10 @@
       THE DROP IS REPORTED because it is a real loss: an element the input had
       contributes nothing, which is `element-dropped` and needs no new code.
       KEEPING owes nothing and reports nothing, since a kept character survives
-      the write intact. That asymmetry is what decides the two rows against
-      each other where taste would not: `parse(htmlToCarve(h)) == htmlToAst(h)`
-      holds on the first row with no special case, and holds on the second only
-      because the node was never built.
+      the write intact. `parse(htmlToCarve(h)) == htmlToAst(h)` holds on the
+      first row with no special case, and holds on the second only because the
+      node was never built.
 
-      THE SPACER ARGUMENT IS REAL AND IS NOT THIS RULE. Word, CKEditor and
-      TinyMCE emit `<p>&nbsp;</p>` as layout, so a migration may well want it
-      gone -- but that is an OPT-IN on the importer, not a silent default that
-      discards content the language can spell.
 
    7a. AN EMPTY CONTAINER BODY IS A BLANK LINE HERE TOO -- NORMATIVE. A COLON
       FENCE whose body is empty is written with a BLANK LINE between its
@@ -408,28 +288,15 @@
       THE SIBLING CLAUSE ALREADY DECIDED THIS QUESTION one layer out and chose
       the blank line. PART 10 §4 asks what a container whose body renders
       nothing serializes to, and this asks the same of the same document at
-      the other target. Nothing about the emptiness differs between them, so
-      answering it twice with two answers would be a difference the document
-      cannot account for -- and one rule for "an empty body" across both
-      targets is one rule to maintain.
+      the other target, so one rule for "an empty body" serves both.
 
-      THE EXCEPTION IS NOT IMPORTED WITH IT, and §4 is where the reason is
-      written. §4 says of its bare-div exception, in its own words, that it
-      "has no principle behind it", that the split is on "a property of the
-      RENDERING PATH and not of the document", and that a uniform rule "would
-      be easier to state and to implement". What carries the exception there
-      is none of those: it is that overturning a settled three-way agreement
-      to fix a cosmetic inconsistency is the worse trade. That is a reason
-      about the state of §4's own target, and a reason of that shape does not
-      travel to a target it was never about. What is left of §4 once it is set
-      aside is the uniform rule §4 itself prefers, and that is what this clause
-      takes.
-
-      SO THE TWO TARGETS AGREE ON THE RULE AND DIFFER ON ONE SHAPE, which is
-      stated rather than smoothed over: a bare `:::` div closes compactly in
-      HTML and takes the blank line here. That is the cost of §4 keeping an
-      exception it calls principle-free, and it is confined to the one shape
-      §4 names.
+      THE EXCEPTION IS NOT IMPORTED WITH IT. §4 says of its bare-div exception,
+      in its own words, that it "has no principle behind it" and that the split
+      is on "a property of the RENDERING PATH and not of the document". What
+      carries the exception there does not travel to a target it was never
+      about, so this clause takes the uniform rule §4 itself prefers. The two
+      targets therefore agree on the rule and differ on one shape: a bare `:::`
+      div closes compactly in HTML and takes the blank line here.
 
    7b. A FOOTNOTE DEFINITION WITH NO BLOCKS IS WRITTEN WITH THE SENTINEL
       `{empty}` -- NORMATIVE. A `footnote_definition` whose body holds NO
@@ -447,11 +314,8 @@
       §1a IS THE RULE THIS SERVES. Spelling the construct by its own rule
       emits bytes that do not re-parse to the tree they were written from, so
       §1 wins and the writer takes the smallest departure that restores it.
-      THE PARSE RULE IS UNCHANGED HERE: `[^f]:` stays a paragraph, as corpus
-      267-a-definition-marker-s-separator-is-a-space-and-it-is-a-run-9 and
-      corpus 134-footnote-definition-requires-an-inline-body pin it. What this
-      clause governs is what the WRITER emits, which is the half that was
-      defective in two engines (carve#999).
+      THE PARSE RULE IS UNCHANGED HERE: `[^f]:` stays a paragraph. What this
+      clause governs is what the WRITER emits.
 
       THE SENTINEL MUST BE A VALID ATTRIBUTE BLOCK, and this is the part a
       later reader gets wrong, because the two spellings that LOOK like the
@@ -465,10 +329,8 @@
       `block_attributes` requires AT LEAST ONE attribute and there is no
       block-level blessed-empty form -- PART 4 says it of `{}` in as many
       words, and `{ }` is blessed INLINE only -- so on this line neither run
-      is an attribute block. Both stay CONTENT, the body then holds a text
-      node the author never wrote, and §1 fails exactly as it does for the
-      bare marker: a different shape, the same defect. Measured in all three
-      engines rather than derived.
+      is an attribute block. Both stay CONTENT, and §1 fails exactly as it does
+      for the bare marker.
 
       SO EVERY AVAILABLE SPELLING CARRIES MEANING. `{empty}` is a BOOLEAN
       ATTRIBUTE (PART 9 §14): a bare identifier with no value, rendered
@@ -477,10 +339,8 @@
       because a footnote definition's body is its own container, and a
       block-attribute line with no following block inside that container is
       dropped (PART 9 §15 A4) -- the attribute reaches neither the endnote
-      `<li>`, nor the next block, nor the next definition. That is a PARSE
-      RULE and not a property of the word: nothing about `empty` is
-      semantically empty, and it is stated here so the inertness does not
-      read as accidental.
+      `<li>`, nor the next block, nor the next definition. That is a PARSE RULE
+      and not a property of the word.
 
    7c. A LINE BLOCK'S HARD BREAK IS WRITTEN BARE ONLY WHERE THE BARE NEWLINE
       RE-DERIVES IT -- NORMATIVE. A line block hardens every line boundary of
@@ -490,8 +350,8 @@
       form. The depth half is load-bearing and not decoration: a reading under
       which a boundary inside an emphasis run stays soft takes the permission's
       own premise away, and this writer rule then LOSES the break on `*a\` over
-      `b*` while claiming §1 preservation - which is what the pinned build does
-      today (carve#1351). The permission is not general, and it is stated as
+      `b*` while claiming §1 preservation (carve#1351). The permission is not
+      general, and it is stated as
       the PROPERTY it rests on rather than as a list of the places it runs out:
 
         THE WRITER SPELLS A `hard_break` INSIDE A LINE BLOCK AS A BARE
@@ -514,8 +374,7 @@
 
       WHAT THE PROPERTY EXCLUDES -- CONSEQUENCES, NOT THE RULE. A case that is
       not in this list is decided by the property above, not by the absence of
-      a bullet. This clause was first written as a list of the two unsafe
-      cases, and the first entry below is the one it did not reach:
+      a bullet:
 
         - THE LAST BODY LINE, WHATEVER IT ENDS IN. §23 hardens the boundary
           BETWEEN lines, and the body's end is not one. So a `hard_break`
@@ -533,11 +392,10 @@
           GAPS) and survives on its own, so it needs no backslash INSIDE a
           stanza -- at the stanza's end the entry above governs it instead.
 
-      Every condition is visible in the tree with NO new field, so this costs
-      no AST change: the first is a `hard_break` that is the last node of the
-      stanza's own inline sequence, the second is two adjacent `hard_break`
-      nodes with no text between them, the third is a text node whose value
-      ends in one space.
+      Every condition is visible in the tree with NO new field: the first is a
+      `hard_break` that is the last node of the stanza's own inline sequence,
+      the second is two adjacent `hard_break` nodes with no text between them,
+      the third is a text node whose value ends in one space.
 
       A LINE WHOSE LAST NODE IS A COMMENT IS EXEMPT -- NORMATIVE. `%%` runs to
       the END OF ITS LINE, so a trailing space there is INSIDE the note and
@@ -554,9 +412,6 @@
       same exemption reaching the first consequence. A body line whose content
       ends in an `inline_comment` carries NO `hard_break` at the body's end,
       so THE LAST BODY LINE has nothing to spell there and nothing is written.
-      A writer that instead appends `\` to whatever it emitted last on the
-      final line writes it inside the note by the same mechanism, on a line
-      where there was no break to protect in the first place.
 
       WHICH LINE IS LAST IS DECIDED BY THE BREAKS, HOWEVER THEY WERE SPELLED.
       A `hard_break` ENDS the body line it stands at the end of, and what
@@ -570,10 +425,7 @@
 
       the last body line is the COMMENT, not `a `, so the backslash on `a ` is
       there under CONTENT ENDING IN A LONE SPACE and not under THE LAST BODY
-      LINE, and the comment is written back as its own line below it. A writer
-      that treats a boundary the AUTHOR spelled as the end of the body answers
-      one document two ways depending on which spelling reached it: the same
-      note is kept under `a` and dropped under `a \`.
+      LINE, and the comment is written back as its own line below it.
 
       AN EMPTY LINE INSIDE A VERBATIM RUN IS SPELLED `%%`, because there the
       backslash is not a break but content. A run left unclosed on an earlier
@@ -584,18 +436,14 @@
       exactly ONE spelling that does not: a comment line, which the block
       layer removes before the run exists, so `%%` re-reads to the empty line
       it was written for and to nothing else. The author's own comment TEXT is
-      not recoverable here and is not required to be: the run consumed it, and
-      §1 is about the tree.
+      not recoverable here and is not required to be.
 
       THIS IS §1a, NOT AN EXEMPTION FROM IT. The per-construct spelling emits
       bytes that do not re-parse to the tree they were written from, so §1
       wins and the spelling yields to "another spelling of the SAME
-      construct", which for a `hard_break` is its own PART 3 form. Measured on
-      all three engines, the bare newline destroyed a rendered space, split
-      one stanza into two, and dropped a trailing `<br>` from a block's last
-      line, with the three engines settling on three different canonical
-      byte strings for the first of them (carve#1334). The sibling writers
-      already do this: a paragraph and a `::: \` block both emit the backslash.
+      construct", which for a `hard_break` is its own PART 3 form: unguarded,
+      the bare newline destroys a rendered space, splits one stanza into two,
+      and drops a trailing `<br>` from a block's last line.
 
    7d. AN EMPTY DESCRIPTION BODY IS WRITTEN WITH THE SENTINEL `{empty}` --
       NORMATIVE (carve#1827). A `definition_description` whose body holds NO
@@ -629,20 +477,16 @@
         : %%        holds a `comment` child                      -- not written
 
       `: +` IS THE FIRST-BLOCK FORM (PART 9 §17 L4) with nothing flush-left
-      under it. It ATTACHES a following column-0 block -- `:: t` / `: +` /
-      `flush` is a description whose body is `flush` -- so it spells an empty
+      under it. It ATTACHES a following column-0 block, so it spells an empty
       body only when a blank line follows, and a writer emitting it must look
       ahead at the next block to know whether that blank line is required. The
-      sentinel needs no lookahead, and a rule that cannot be got wrong is
-      preferred to one that must be got right.
+      sentinel needs no lookahead.
 
       `: %%` FAILS §1 RATHER THAN LAYOUT. An empty comment renders nothing and
       the rendered HTML matches, so the failure is not visible at the HTML. Its
       `definition_description` carries a `comment` CHILD the source does not
-      have, where the canonical spelling carries an empty children list. PART
-      10's import ceiling forbids that in its own words -- an importer "may add
-      nothing at all" -- and §1 quantifies over `parse`, not over the render, so
-      a spelling that round-trips the HTML and not the TREE does not satisfy it.
+      have, where the canonical spelling carries an empty children list, and §1
+      quantifies over `parse`, not over the render.
 
    8. THE MARKDOWN TARGET'S ESCAPING -- NORMATIVE. The Markdown renderer is not
       the canonical writer and does not follow §2. It has a different
@@ -660,11 +504,8 @@
       typographer, pandoc's default) would NOT read an en dash. Emitting `--`
       bare loses the author's intent exactly where it was explicit, and the
       characters this matters for -- `"` `'` `-` `.` -- are not Markdown
-      metacharacters, so M1 does not cover them. This was divergent across
-      implementations with nothing to notice it (carve#350).
-
-      A document that escapes nothing gains no backslashes from M2, so the
-      cost falls only on documents that asked for it.
+      metacharacters, so M1 does not cover them (carve#350). A document that
+      escapes nothing gains no backslashes from M2.
 
       An implementation whose AST has no `escaped_text` node cannot honour M2:
       it cannot tell an escaped character from a literal one. That is a defect
@@ -703,19 +544,11 @@
           THE HAZARD IS RAW HTML, and it is real. CommonMark and GFM both admit
           it, so a document whose text contains `<b>` emits a line a reader
           turns into a tag -- the author's text silently becomes markup, which
-          is the corruption §8 exists to prevent. Measured through a CommonMark
-          reader:
-
-            a <b> c        ->  a <b> c          the tag opens
-            a </b> c       ->  a </b> c         so does a closing one
-            a <!-- c -->   ->  a <!-- c -->     and a comment
-            a <?php ?>     ->  a <?php ?>       and a processing instruction
-
-          Those four next-characters are the whole hazard. Everything else is
-          inert:
-
-            a < b          ->  a &lt; b         a bare `<` is not markup
-            x > y          ->  x &gt; y         nor is a mid-line `>`
+          is the corruption §8 exists to prevent. An opening tag, a closing
+          tag, a comment and a processing instruction all open through a
+          CommonMark reader; those four next-characters are the whole hazard.
+          Everything else is inert: a bare `<` before a space renders `&lt;`,
+          and so does a mid-line `>`.
 
           ESCAPING THE `<` ALONE IS SUFFICIENT. The closing `>` needs no escape
           of its own, because a tag that cannot open cannot be closed:
@@ -723,88 +556,55 @@
             a \<b> c       ->  a &lt;b&gt; c
 
           A BACKSLASH, NOT AN ENTITY. Every engine wrote `&lt;` and `&gt;` here
-          and no clause said so (carve#1148). The reason it could not be derived
-          from this section is that it is not the operation this section
-          describes: M2 and M3 are written in terms of ESCAPING -- protecting a
-          character so it survives as itself -- and `&lt;` does not protect `<`,
-          it replaces it with a different sequence that happens to render
-          alike. `\<` protects it, and a CommonMark reader gives the character
-          back.
+          and no clause said so (carve#1148). M2 and M3 are written in terms of
+          ESCAPING -- protecting a character so it survives as itself -- and
+          `&lt;` does not protect `<`, it replaces it with a different sequence
+          that happens to render alike. `\<` protects it, and a CommonMark
+          reader gives the character back.
 
           CONDITIONAL, BECAUSE M1b ALREADY ARGUES FOR IT. `<` is the same shape
           as `_`, `#` and `[`: significant before a tag name, inert before a
-          space. Rewriting every `<` in a document -- the overwhelming majority
-          of them harmless -- is the character-table answer M1b abandoned, and
-          the test belongs on the emitted line like every other one here.
+          space, and the test belongs on the emitted line like every other one
+          here.
 
       THE FINDING IS §3'S, ONE TARGET OUT. §3 records, for the canonical
       writer, that "whether a character is significant depends on the line,
-      not on the character", and §4 is that section's answer to it. M1 was the
-      opposite choice, and a deliberate one: §2's test is answered by the
-      Carve parser, this target has no Markdown parser to hand, and a
-      character table was what remained. But §3's finding is about lines and
-      characters, not about which writer is asking. The Markdown writer builds
-      a line too, and what stands on that line is what decides whether a bare
-      metacharacter is read as markup downstream. So the test here is stated
-      over the EMITTED LINE, as §3 says it has to be, and M1b is this
-      section's §4.
+      not on the character". M1 was the opposite choice, taken because this
+      target has no Markdown parser to hand. But the Markdown writer builds a
+      line too, so the test here is stated over the EMITTED LINE and M1b is
+      this section's §4.
 
       THE ASTERISK DIFFERS IN KIND, NOT IN DEGREE, which is what M1a is for.
-      This writer emits `*` as an emphasis delimiter. So the asterisk is not a
+      This writer emits `*` as an emphasis delimiter, so the asterisk is not a
       character that MIGHT meet markup on the line; it is the character the
-      line's markup is made of, and a collision with it is the ordinary case
-      rather than the corner one.
+      line's markup is made of, and a collision with it is the ordinary case.
 
       A document whose emphasis contains two literal asterisks is written
-      under M1 as
-
-        *\*\**
-
-      A narrowing that weighs the delimiter runs in the block sees one
-      four-character run flanking nothing, and drops both escapes:
-
-        ****
-
-      Through a CommonMark reader those are not two spellings of one
-      document:
+      under M1 as `*\*\**`. A narrowing that weighs the delimiter runs in the
+      block sees one four-character run flanking nothing and drops both
+      escapes, giving `****` -- and through a CommonMark reader those are not
+      two spellings of one document:
 
         *\*\**  ->  <p><em>**</em></p>
         ****    ->  <hr />
 
-      Emphasis containing two asterisks is published as a thematic break. The
-      run being weighed was partly the writer's OWN delimiters, which the
-      escaped literals had merged into, and nothing about the character said
-      so. That is a property of this target's output read by this target's
-      consumers, so it holds for any implementation that narrows the asterisk,
-      whichever one writes it first (carve#970).
-
-      M1b would hold this document on its own terms -- both literals are
-      adjacent to a delimiter the writer wrote. M1a is stated anyway, and it
-      is PERMANENT rather than a fix deferred: for `*` the adjacency is not an
-      accident of one document but the shape of the target, and a condition
-      that holds for every document of a construct is better spelled as an
-      exemption than rediscovered per document. It lapses only if this writer
-      stops spelling emphasis with `*`.
+      The run being weighed was partly the writer's OWN delimiters, which the
+      escaped literals had merged into. M1b would hold this document on its own
+      terms, but M1a is stated anyway and is PERMANENT: for `*` the adjacency is
+      the shape of the target rather than an accident of one document.
 
       WHY ADJACENCY IS THE TEST THAT OWES NO PER-READER ARGUMENT. This target
       answers to a re-parser Carve does not control, and there are several of
-      them -- CommonMark, GFM, markdown-it with typographer, pandoc. That is
-      why M1 was blunt, and the reason does not go away: an escape that
-      protects nothing under one of them may protect something under another,
-      so dropping one is an argument owed once per reader. The adjacency case
-      owes none. Every one of those readers resolves a delimiter by RUN
-      LENGTH, so an escape sitting next to a live delimiter of the same
-      character is holding a run boundary apart under all of them at once.
-      M1b keeps exactly those escapes, and that is why the minimum is stated
-      at this width and not another.
+      them, so an escape dropped is an argument owed once per reader. The
+      adjacency case owes none: every one of those readers resolves a delimiter
+      by RUN LENGTH, so an escape sitting next to a live delimiter of the same
+      character holds a run boundary apart under all of them at once.
 
       THE BOUNDARY IS THE CLAUSE, NOT A FLOOR. M1b is written as an
       if-and-only-if on purpose. An escape it drops is dropped and an escape
       it keeps is kept; it is not a minimum an implementation may build a
       wider narrowing on top of, and it is not a permission one engine may
-      take up before another. Three engines implement this clause, and a
-      permissive reading of it yields three outputs -- which is the failure
-      this question came out of, not a latitude worth preserving.
+      take up before another.
 
       SO A WIDER NARROWING IS NOT AUTHORIZED HERE. Not for a fourth
       character, and not for a laxer test on these three. Anything further has
@@ -820,8 +620,7 @@
       it AS AN ESCAPE whatever the character, untouched by anything above. So
       a document that MEANT `[a](b)` as text carries the author's escapes in
       the tree and gets them back on this target under M2, and M1b never sees
-      it. That does not make the two grammars agree and is not claimed to; it
-      takes out of the question every case where the author said which reading
-      they meant, which is where guessing wrong costs the most.
+      it. That does not make the two grammars agree; it takes out of the
+      question every case where the author said which reading they meant.
 
    ============================================================================ *)

--- a/resources/spec/22-writer-targets.ebnf
+++ b/resources/spec/22-writer-targets.ebnf
@@ -21,10 +21,6 @@
       M2c NOTHING ELSE NARROWS. M1, M3 and §8a are untouched, and a character
           Markdown reads as markup at that position keeps M2 as written.
 
-      WHAT M2 IS FOR SURVIVES INTACT. §8 states M2 for smart punctuation, and
-      that part is load-bearing at every position. Measured through a reader
-      with substitution on:
-
         a -- b        ->  a – b
         a \-\- b      ->  a -- b
 
@@ -32,84 +28,22 @@
       reached them and M1's narrowing cannot either. M2a names them so the
       clause that narrows M2 cannot be read as dropping the reason M2 exists.
 
-      THE COST IS ON IDENTIFIERS, AND IT IS THE COST §8a WAS RAISED OVER.
-      carve#970 opened with two examples:
-
-        C\# is a language
-        issue \#123 fixed
-
-      Both are `escaped_text`. In Carve a bare `#` before a word opens a tag,
-      so text holding one can only be spelled as an escape, so neither example
-      was ever an M1 case and §8a's narrowing did not reach the documents that
-      raised it. A backslash inside an identifier breaks exact-match search on
-      the published document, which is the objection §2 calls decisive for the
-      canonical writer: "Escaping MORE than that is a defect, not a safe
-      default."
-
-      THE TARGET ALREADY DISCARDS THE DISTINCTION THE ESCAPE WAS PRESERVING.
-      Markdown has no construct for a tag or a mention, so this target emits
-      the characters and drops the node:
-
-        #tag rest        ->  #tag rest
-        hi @name ok      ->  hi @name ok
-
-      So under M2 as written this target emits a bare `#` for the construct
-      and a backslashed one for text that merely resembles it. No reader acts
-      on that difference, and the document carrying the backslash is the one
-      that never asked for markup.
-
       THE `[` CASE §8a LEANS ON IS UNTOUCHED, and M2a is written positionally
-      so that it is. §8a's account of the link grammars ends by resting on M2:
-      an author who meant `[a](b)` as text carries escapes in the tree and
-      gets them back here, so M1b never has to guess. A `[` can open a link at
-      any position on a line, so M2a keeps its escape everywhere and that
-      argument stands unchanged. `#` is the character that differs, because
+      so that it is. A `[` can open a link at any position on a line, so M2a
+      keeps its escape everywhere. `#` is the character that differs, because
       its reading is positional and every position but one is inert.
 
       A CONTAINER PREFIX IS PART OF THE LINE, WHICH IS WHY M2b MEASURES ON IT.
       M2b's position is the ONLY narrowing in this clause -- M2a keeps the
-      escape by default and M2c closes the set -- so the whole of §8b turns on
-      where that position is. Read as an offset into the BLOCK'S CONTENT it
-      answers a question no reader asks: the string a reader parses is the
-      emitted line, and the two differ by exactly the prefix the writer put in
-      front. Measured on all three engines, which agreed:
+      escape by default and M2c closes the set. Read as an offset into the
+      BLOCK'S CONTENT it answers a question no reader asks: the string a reader
+      parses is the emitted line, and the two differ by exactly the prefix the
+      writer put in front. §10 already decided this one character over, escaping
+      a continuation line whose text reads as a list marker only because item
+      alignment stands in front of it -- "§2 governs whether a character is
+      escaped GIVEN the line the writer emits; §10 fixes the line."
 
-        > \# heading
-
-      emitted as
-
-        > # heading
-
-      and read back, through this project's own importer, as a heading:
-
-        before:  <blockquote><p># heading</p></blockquote>
-        after:   <blockquote><h1 id="heading">heading</h1></blockquote>
-
-      The author escaped the hash so it would stay text, and a round trip
-      returned it as structure. That is content corruption rather than a
-      rendering difference, and it is the case M2 exists to remove: §8a's
-      closing argument rests on M2 taking "out of the question every case
-      where the author said which reading they meant" (carve#1330).
-
-      §10 ALREADY DECIDED THIS, ONE CHARACTER OVER. A list item's continuation
-      line is aligned to the marker's width and kept literal by ESCAPING it:
-
-        1. outer
-           1\. inner
-
-      The inner line's text is `1. inner`, which is a list marker nowhere in
-      isolation. It is one only because three spaces of item alignment stand
-      in front of it, and §10 escapes it for that reason -- "§2 governs
-      whether a character is escaped GIVEN the line the writer emits; §10
-      fixes the line." So this project has already ruled that the escape test
-      is answered against the line as the reader receives it, and has already
-      rejected the alternative that reasons about the content alone: §10
-      refuses to indent less "because its correctness depends on the WIDTH of
-      the marker above it". The reading that produced this defect carries the
-      same dependency and does not notice it.
-
-      STATED OVER THE LINE, NOT AS A LIST OF CONTAINERS THAT COUNT. Two
-      consequences, both measured on all three engines:
+      STATED OVER THE LINE, NOT AS A LIST OF CONTAINERS THAT COUNT:
 
       - A container this target FLATTENS contributes no prefix and needs no
         exemption. A colon fence emits no marker and a definition-list body
@@ -120,81 +54,32 @@
         without naming any of them.
 
       An enumeration would have to be revisited every time the writer gains a
-      prefix. The line does not.
-
-      THE LAZY CASE IS NOT A CASE. Lazy continuation is a PARSER concept: a
-      line belonging to a container without carrying its marker. This writer
-      re-prefixes every line of the container, so M2b always sees the emitted
-      prefix. A rule for source laziness would describe a line this target
-      never writes.
+      prefix. The line does not. Lazy continuation is not a case either: it is
+      a PARSER concept, and this writer re-prefixes every line of the
+      container, so M2b always sees the emitted prefix.
 
       NARROWING BY POSITION IS UNCHANGED, WHICH IS THE HALF THAT IS EASY TO
       LOSE. Moving the position does not widen M2b into "an escape behind a
-      prefix is kept". The two documents carve#970 opened with keep their
-      narrowing inside a container exactly as they had it outside one, because
-      the hash is not at the content position there either:
+      prefix is kept". The narrowing holds inside a container exactly as it
+      does outside one, and so does a hash that stands AT the content position
+      but opens no heading, since M2b's reading is CommonMark's and a run
+      closed by a letter is not one:
 
         > C\# is a language      ->  > C# is a language
         - issue \#123 fixed      ->  - issue #123 fixed
-
-      and so does a hash that stands AT the content position but opens no
-      heading, since M2b's reading is CommonMark's and a run closed by a
-      letter is not one:
-
         > \#tag rest             ->  > #tag rest
-
-      Both directions are pinned in the corpus. The first is what the clause
-      is for; the second is what stops the correction being taken too far.
-
-      WHAT IS LOST IS BOUNDED BY §1. Carve source through this target and back
-      stops recording which hash was text. §1 already defines the round-trip
-      invariant MODULO ESCAPING (carve#370) -- `escaped_text` and `text`
-      compare equal -- and the invariants that admit no latitude,
-      `to_html(fmt(x)) == to_html(x)` and idempotence, are inside the Carve
-      target, which this clause does not touch.
-
-      The importers re-derive what they need, which is why the backslash in
-      the Markdown was not what carried it:
-
-        md-in: Bau #64748b       ->  carve: Bau \#64748b
-        md-in: C# is a language  ->  carve: C# is a language
-
-      The escape comes back where a construct would form and stays absent
-      where none would. The loss is also already taken in the other direction:
-      a tag node does not survive a round trip through this target today,
-      since the writer flattens it and an importer escapes it back to text.
-      This clause makes the two directions agree rather than adding an
-      asymmetry.
-
-      A KNOWN LIMIT, STATED RATHER THAN SOLVED. GFM as deployed on one host
-      autolinks a bare `#` before digits to an issue, and a bare `@` before a
-      name to a user. That exposure is not created here: this target emits
-      both bare today whenever the document holds the construct, and M2's
-      escape covered only the half of the traffic that was text. If it matters
-      it wants a host-aware profile covering both halves, not an
-      unconditional escape covering one.
 
    9. THE MARKDOWN TARGET'S HARD BREAK -- NORMATIVE. A `hard_break` is emitted
       as a BACKSLASH before the newline, never as two trailing spaces.
 
-      Both spellings mean the same thing to a CommonMark reader:
-
-        `a` SPACE SPACE newline `b`   ->  <p>a<br />b</p>
-        `a` BACKSLASH newline `b`     ->  <p>a<br />b</p>
-
-      The difference is what survives handling. Trailing whitespace is removed by
-      editors that strip it on save, by `git apply --whitespace=fix`, and by CI
-      whitespace checks -- and removing ONE of the two spaces is enough:
-
-        `a` SPACE newline `b`         ->  <p>a b</p>
-
-      so the break does not degrade, it VANISHES, silently, in a file nobody
-      edited. The backslash form cannot be damaged that way, and it is the only
-      hard-break spelling this target emits that ordinary tooling will not touch.
-
-      The cost is pre-CommonMark processors, which show a literal backslash
-      instead of a break. That is a visible artifact in a rare consumer, against
-      silent data loss in a common one.
+      Both spellings mean the same thing to a CommonMark reader. The difference
+      is what survives handling: trailing whitespace is removed by editors that
+      strip it on save, by `git apply --whitespace=fix`, and by CI whitespace
+      checks -- and removing ONE of the two spaces is enough, so the break does
+      not degrade, it VANISHES, silently, in a file nobody edited. The cost is
+      pre-CommonMark processors, which show a literal backslash instead of a
+      break: a visible artifact in a rare consumer, against silent data loss in
+      a common one.
 
       This is a property of the MARKDOWN target only. The canonical writer spells
       a hard break the way the Carve grammar does (`hard_break`, PART 3), and
@@ -208,14 +93,6 @@
         1. outer
            1\. inner
 
-      The alternative -- leaving the line at an indent below the nesting
-      threshold so no escape is needed -- looks appealing because it removes an
-      escape the author did not write. It is rejected because its correctness
-      depends on the WIDTH of the marker above it. Two spaces sit below the
-      threshold under `1. ` and reach it under `- `, so the same rule produces
-      a continuation in one list and a nested list in the other, silently
-      changing what the document says (carve#352).
-
       This does not conflict with §2. §2 governs whether a character is escaped
       GIVEN the line the writer emits; §10 fixes the line. A writer may not
       manufacture a layout whose only merit is dodging an escape.
@@ -226,54 +103,26 @@
       it, because HTML has nowhere to put a definition nobody used; the other
       three do not get to drop content the author wrote.
 
-      A LINK REFERENCE DEFINITION IS NOW COVERED TOO. It was excluded while it
-      was the one definition kind with NO NODE IN THE TREE -- `[lbl]: /u` alone
-      parsed to a document with empty `children`, so a renderer walking blocks
-      had nothing to walk and requiring the output would have required an output
-      no engine could produce (carve#592). PART 12 §10 gives it a node, so the
-      exclusion has no cause left: all three kinds walk, and all three emit.
-
-      This clause first said "link, footnote or abbreviation" and was wrong to.
-      PART 12 §3a had already considered the missing node and declined it --
-      "a bigger change than this clause is worth ... a new node type, a new
-      hoisting rule, three engines to move" -- so one section was requiring
-      what another section's recorded decision made unreachable. Narrowed here
-      rather than left contradictory: a spec that demands the impossible is
-      worse than one that admits a gap.
+      A LINK REFERENCE DEFINITION IS COVERED TOO. It was excluded while it was
+      the one definition kind with NO NODE IN THE TREE; PART 12 §10 gives it a
+      node, so all three kinds walk and all three emit.
 
       THE GAP IS REAL AND IS NOT CLOSED BY NARROWING. An unused link reference
       definition currently survives nothing: not the tree, not a round trip
       through the AST, and now explicitly not the non-HTML targets. So
       `carve --markdown` on a document that is only `[lbl]: /u` emits nothing,
-      and the URL the author wrote is gone. That is the same content loss §10a
+      and the URL the author wrote is gone -- the same content loss §10a
       exists to prevent, reached by a different route.
-
-      SETTLED IN PART 12 §10. The node was open on two grounds here -- making a
-      resolved reference's destination recoverable (§3a), and making an unused
-      one survive at all (this clause) -- and a third decided it: without the
-      node a writer cannot reproduce the definition, so PART 11 §1's
-      `parse(fmt(x)) == parse(x)` failed for every resolved reference in all
-      three engines (carve#642).
 
           [^n]: %         ->  markdown  [^n]: %
                               plain     [^n]: %
                               html      (nothing)
 
-      This is PART 11 §6's objection applied one target out: a renderer that
-      silently discards an authored construct makes the round trip lossy, and
-      an unused definition is exactly the construct a person is most likely to
-      be in the middle of writing. Dropping it also makes the output depend on
-      whether a reference exists elsewhere in the document, so adding one
-      reference changes an unrelated line.
-
       THE MARKER IS EMITTED AS WRITTEN. `[^n]: %` is a footnote definition, so
       it renders with its caret. `[n]: %` is not that construct -- it is a LINK
       reference definition, and emitting one where the author wrote the other
       turns a definition into something that parses back as a different
-      construct. Every engine drops the caret on the plain and terminal
-      targets, which is a defect independent of this rule: whichever way the
-      rule had gone, that output was neither the source nor the same
-      definition.
+      construct.
 
   10b. A TABLE ROW KEEPS ITS OWN CELL COUNT -- NORMATIVE. The canonical
       writer emits exactly the cells the row carries. It MAY align the padding
@@ -321,27 +170,14 @@
       every non-interactive target: a renderer MUST preserve the construct's
       CONTENT and may drop only its INTERACTION, and authored text -- a label
       or a title that distinguishes one block from another -- MUST NOT be
-      silently discarded. Three authored tokens were discarded anyway, by all
-      three engines:
+      silently discarded.
 
-      WHAT THIS CLAUSE DECIDES is where those three tokens go on the targets
-      named below, and nothing else. It neither restates the floor nor
-      narrows it: a loss this clause does not name is still a loss, and the
-      floor still forbids it. Reading a construct/target pair as CONFORMING
-      because no rendering for it is written here inverts the clause -- the
-      pairs it leaves open are open, not allowed.
-
-          |= H |             ->  markdown  | H |
-          | a |                            | --- |
-          ^ Table caption                  | a |
-
-          ```js "src/app.js"   ->  plain     const a = 1
-          const a = 1              terminal  ┌── js
-          ```                                  const a = 1
-
-          ```js [Node]         ->  plain     const a = 1
-          const a = 1              terminal  ┌── js
-          ```                                  const a = 1
+      WHAT THIS CLAUSE DECIDES is where a table caption, a fence title and a
+      fence label go on the targets named below, and nothing else. It neither
+      restates the floor nor narrows it: a loss this clause does not name is
+      still a loss, and the floor still forbids it. Reading a construct/target
+      pair as CONFORMING because no rendering for it is written here inverts
+      the clause -- the pairs it leaves open are open, not allowed.
 
       T1 A FENCE'S TITLE AND LABEL RENDER THE WAY A DIV'S ALREADY DO. This
          clause writes down an existing rule rather than a new one. A fenced
@@ -360,15 +196,6 @@
                                                     (blank)
                                                     composer require x
 
-         The language tag is untouched: it keeps whatever slot the target
-         already gives it, which on the terminal is the `┌── ` header line
-         and in plain text is nothing. Folding the title into that header
-         instead was considered and rejected -- the header exists only when
-         the fence has a language, so a titled fence with no language would
-         have needed a header invented for it, and a fence carrying both a
-         title and a label would have needed a separator invented too. The
-         div's shape needs neither and already ships.
-
       T2 A TABLE CAPTION SURVIVES THE MARKDOWN TARGET as body text AFTER the
          table, separated by one blank line. The position is what this target
          already does for the other two captioned hosts -- an image caption
@@ -385,35 +212,17 @@
       ADJACENCY IS NOT AVAILABLE HERE, AND THAT IS THE GENERAL FORM.
       A plain-text target has no delimiter to put around a block, so what it
       has instead is ADJACENCY: dropping the blank line says that the line
-      below belongs to the block above. That move is unavailable to both
-      halves of this clause, and measuring why gives the rule its shape:
-      attachment by adjacency is only available on a target where adjacency
-      does not change what the adjacent block IS.
+      below belongs to the block above. Attachment by adjacency is only
+      available on a target where adjacency does not change what the adjacent
+      block IS. A caption written directly after the last row of a Markdown
+      table is read by a GFM reader as ANOTHER ROW, and a line written
+      directly above a code block in plain text reads as the FIRST LINE OF THE
+      CODE.
 
-      A caption written directly after the last row of a Markdown table is
-      read by a GFM reader as ANOTHER ROW -- `| a |` then `Table caption`
-      yields `<td>a</td>` and `<td>Table caption</td>`. The words survive as
-      a fabricated data cell, which is worse than losing them, because a
-      reader cannot tell an authored cell from a caption and neither can a
-      parser. A line written directly above a code block in plain text reads
-      as the FIRST LINE OF THE CODE, for the same reason: that target draws
-      no delimiter around a code block at all.
-
-      So both halves take the separation their target forces and accept that
-      the ATTACHMENT is weaker than adjacency would have given. That is a
-      floor being met, not a relationship being preserved: this clause is
-      about the words surviving. Modeling a caption as something a round trip
-      can recover on the Markdown target is carve#1121's business, not this
-      clause's. Writing the relationship as an ELEMENT is not open here
-      either, though that target does admit HTML -- a `<caption>` is only
-      valid as the first child of a `<table>`, and the `<table>` a pipe table
-      produces is built by the READER, so there is nowhere to put one.
-
-      TWO MORE LOSSES OF THE SAME TOKENS ARE RECORDED HERE AND LEFT OPEN,
-      both measured on the same build that produced the rows above. Each
-      breaks the floor exactly as the three rows above did; what is missing
-      is a decided rendering, not a rule. Neither is settled by this clause
-      and neither is thereby permitted:
+      TWO MORE LOSSES OF THE SAME TOKENS ARE RECORDED HERE AND LEFT OPEN. Each
+      breaks the floor exactly as this clause's three tokens did; what is
+      missing is a decided rendering, not a rule. Neither is settled by this
+      clause and neither is thereby permitted:
 
         - A fence title on a fence with NO LANGUAGE is dropped by the
           MARKDOWN writer too: ```"src/app.js" emits a bare ``` and the
@@ -431,23 +240,7 @@
       §10a rules the definition NOTHING references: the Markdown, plain-text
       and terminal renderers all emit it, because those targets do not get to
       drop content the author wrote. It says nothing about the definition that
-      IS referenced, and each of the three got that one wrong in its own way:
-
-          *[HTML]: Hyper Text  ->  markdown  *[HTML]: Hyper Text
-                                             (blank)
-          HTML                               <abbr title="Hyper Text">HTML</abbr>
-
-                                   plain     *[HTML]: Hyper Text
-                                             (blank)
-                                             HTML
-
-                                   terminal  *[HTML]: Hyper Text   (dim)
-                                             (blank)
-                                             HTML (Hyper Text)
-
-      On two of them the same words are emitted twice. On the third a line of
-      CARVE SOURCE sits in a plain-text document AND the expansion the author
-      defined never appears anywhere, so that target is wrong on both halves.
+      IS referenced.
 
       WHAT THIS CLAUSE DECIDES is where the definition LINE goes on those
       three targets when the definition is consumed, and what the plain target
@@ -469,25 +262,12 @@
              (blank)                  terminal  HTML (Hyper Text)
              HTML
 
-         Neither half is invented. The terminal already writes
-         `TERM (expansion)` for an automatic expansion; PART 9 §9's
-         authored-`abbr` rule already writes the same shape on the PLAIN
-         target for an authored value (carve#1178). Plain lacked the automatic
-         case for a reason this clause removes -- carve#1178 left it out on
-         the ground that the definition line carried the mapping instead -- so
-         the expansion is not an addition to this ruling but the other half of
-         it. Emitting neither, which is what plain does today, loses the
-         author's expansion outright.
-
       THE TEST IS WHETHER THIS DEFINITION'S EXPANSION IS EMITTED, not whether
       its term appears. The line is dropped on plain and the terminal exactly
       where the same output carries the expansion that definition supplies,
-      and kept otherwise. That is not a refinement for its own sake: the line
-      goes because the content is emitted TWICE, and it is emitted twice only
-      where the expansion is emitted. Three shapes already in the corpus fail
-      the test, and in each the definition's text is carried by its own line
-      and by nothing else, so dropping it would be the content loss §10a
-      exists to prevent:
+      and kept otherwise. Three shapes fail the test, and in each the
+      definition's text is carried by its own line and by nothing else, so
+      dropping it would be the content loss §10a exists to prevent:
 
         - THE TERM NEVER APPEARS. That is §10a, which this clause leaves
           exactly as it stands.
@@ -497,8 +277,7 @@
           child contributes only its visible text there, so the definition's
           own expansion reaches no target. `45-inline-extensions-11` pins
           `HTML (Custom)` on plain and on the terminal with the definition
-          line above it, and this clause leaves that case as carve#1178 left
-          it.
+          line above it, and this clause leaves that case unchanged.
 
         - A LATER DEFINITION OF THE SAME TERM WON. PART 9R R3 is last-wins, so
           in
@@ -510,10 +289,8 @@
 
           only `b` is ever emitted. `*[A]: b` goes and `*[A]: a` stays, on
           plain and on the terminal alike. Dropping every definition of a term
-          that expanded anywhere was considered and rejected: it deletes the
-          string `a` from the document outright, and the reason this clause
-          moves anything at all is that the plain target should not be losing
-          text.
+          that expanded anywhere would delete the string `a` from the document
+          outright, which is the loss this clause moves to prevent.
 
       THE MARKDOWN TARGET NEEDS NONE OF THAT TEST -- it keeps every definition
       line whatever became of it. So does the canonical writer, where PART 11
@@ -597,11 +374,6 @@
       separate as well, so they come back as one. What earns the three is the
       boundary's job, not the run's length.
 
-      Pinned by corpus
-      395-a-longer-run-at-a-list-boundary-is-written-as-exactly-three-blank-lines,
-      whose source has SIX blank lines and whose `.fmt` sidecar has three
-      (carve#1505).
-
   10j. AN UNSPELLABLE BLOCK DOES NOT CANCEL THE ADJACENCY IT CANNOT SPELL --
       NORMATIVE (carve#1621). Where EVERY block between two sibling lists is
       UNSPELLABLE -- it reaches the writer from the AST and leaves no character
@@ -613,22 +385,9 @@
       block that separates the two lists and never writes PART 9 §11 N1a's
       boundary; and it has no Carve spelling, so nothing of it reaches the
       output. The lists come back with ONE blank line between them, which is
-      the loose separator, so they MERGE:
-
-        list, paragraph, list       is written as:   - a
-        -- the paragraph holding                     [blank line]
-        one ASCII SPACE                              - b
-
-      That source re-reads as ONE loose list, so two lists became one and the
-      items changed shape with them. What is lost is a document boundary rather
-      than a blank line, and §1's `to_html(fmt(x)) == to_html(x)` forbids it.
-
-      THE RULE IS ALREADY FOLLOWED ON THE SIBLING SHAPE, which is what settles
-      it without a cross-engine tally. The pinned build writes the boundary
-      across an EMPTY paragraph and not across a whitespace-only one, and those
-      two trees differ in nothing the writer can put on the page. That is one
-      engine reading its own rule two ways, and the reading that keeps §1 is
-      the one that survives.
+      the loose separator, so they MERGE into one loose list. What is lost is a
+      document boundary rather than a blank line, and §1's
+      `to_html(fmt(x)) == to_html(x)` forbids it.
 
       IT IS NOT A PARAGRAPH RULE. Any INTERCHANGE-ONLY block has this shape: a
       `figure` wrapping a `table` (PART 12 §17) is unspellable in the same
@@ -638,13 +397,6 @@
       ANYTHING -- a thematic break, or a paragraph holding a NO-BREAK SPACE
       (§7) -- separates the two lists as it always did, and no boundary is
       written.
-
-      THE BLOCK IS STILL LOST, and this clause does not pretend otherwise. It
-      bounds the loss TO the block, which is what §1 can be held to, instead
-      of letting it take a document boundary with it. Refusing the tree was the
-      alternative and is worse: it fails an editor's round trip on a tree the
-      renderer accepts, trading a silent loss for a loud one on the path that
-      can least afford it.
 
       NO CARVE SOURCE REACHES THIS, so nothing in the parse-driven corpus can
       pin it and the fixture is a hand-built payload entering through the AST

--- a/resources/spec/23-ast-foundations.ebnf
+++ b/resources/spec/23-ast-foundations.ebnf
@@ -4,16 +4,13 @@
 
    A parsed document is exchangeable: an implementation MAY serialize its AST
    to JSON, and a consumer written against one implementation MUST be able to
-   read another's output. Nothing specified this before, and the engines'
-   INTERNAL field names already differ for the same node - one calls a link's
-   destination `href`, another `destination` - so three dialects were the
-   default outcome rather than a risk.
+   read another's output. The engines' INTERNAL field names already differ for
+   the same node - one calls a link's destination `href`, another `destination`
+   - so three dialects were the default outcome rather than a risk.
 
-   1. THE SHAPE IS carve-js's. It is the reference implementation, its AST is
-      already plain data, and the one serializer in the wild (carve-rb, over
-      carve-rs's tree) independently arrived at the same field names. An
-      implementation whose internals differ MAPS on the way out; it does not
-      export its internals.
+   1. THE SHAPE IS carve-js's. It is the reference implementation and its AST
+      is already plain data. An implementation whose internals differ MAPS on
+      the way out; it does not export its internals.
 
       THE TYPE NAME COMES FROM profiles.md, NOT FROM carve-js -- NORMATIVE.
       This clause is about the SHAPE of a node: which fields it carries and
@@ -32,8 +29,7 @@
       the document.
 
       It also makes node-for-node comparison meaningful, which is the only way
-      an engine's divergence from the reference can be MEASURED rather than
-      argued about (the shape check in scripts/ast-conformance.mjs).
+      an engine's divergence from the reference can be MEASURED.
 
       SCOPE. The rule is about `text` nodes only, and only about ADJACENCY
       within one parent's child list. It does not merge across an intervening
@@ -47,9 +43,8 @@
       An implementation that leaves the run split in the parsed tree and joins
       it in the encoder satisfies §1a and BREAKS §6 on the same document: what
       comes back holds one node where the tree held three, so the round trip is
-      not an identity. carve-rs was written that way first and its corpus
-      round-trip test failed on `03-links-12` (carve-rs#441). The tree
-      `parse(x)` returns is therefore already coalesced.
+      not an identity (carve-rs#441). The tree `parse(x)` returns is
+      therefore already coalesced.
 
       POSITIONS. A merged run keeps a span only where its pieces are CONTIGUOUS
       in the source. Where they are not -- the `<` and `>` of an autolink
@@ -57,13 +52,6 @@
       halves of a wrapped table cell -- the merged value is not a slice of the
       source at any offset, and §4 rates a span that selects the wrong text
       worse than no span at all. So such a run publishes NONE.
-
-      That is a real cost and is stated rather than glossed: per-piece spans
-      that existed before the merge are gone in exactly those cases. It only
-      happens where the value was never a source slice to begin with (a
-      manufactured joiner, a dropped delimiter), so nothing that WAS placeable
-      becomes unplaceable -- but a consumer wanting to locate the pieces of such
-      a run works from the source, not from the tree.
 
       `escaped_text` is NOT `text` and does not merge with it: PART 12 §5 keeps
       the two distinct on the wire because an escape is authored form, and
@@ -182,44 +170,29 @@
       every renderer unwraps it at the render seam exactly as it does today.
 
       Flattening it at the encoder is the fold this section exists to forbid,
-      and it is strictly lossier than the case the section opens with. An
-      unresolved reference at least keeps enough to be written back; a nested
-      link's destination does not survive at all. `[[x](y)](z)` published as a
-      link to `z` whose only child is the text `x` has lost `y` from the tree
-      entirely, so `fmt` on the parsed document writes `[[x](y)](z)` back and
-      `fmt` on the same document taken through the AST writes `[x](z)` -- two
-      spellings of the same source, which is the §6 round trip failing. An
-      autolink flattened the same way returns as a bare URL, and that is a
-      DIFFERENT document: a bare URL stays literal where an autolink is a link.
-
-      THE PRECEDENT IS INSIDE THIS RULE ALREADY. A `heading_ref` inside a link
-      is exempt from the flattening for exactly this reason -- it reaches the
-      serialized tree and the renderers suppress the nested anchor instead. A
-      link and an autolink are the same case and take the same treatment. An
-      image and a code span inside a label were never flattened at all, which
-      is what makes this an extension of an existing exemption rather than a
-      new rule about what a label may contain.
+      and it is strictly lossier than the case the section opens with.
+      `[[x](y)](z)` published as a link to `z` whose only child is the text `x`
+      has lost `y` from the tree entirely, so `fmt` on the parsed document and
+      `fmt` on the same document taken through the AST write two different
+      spellings -- the §6 round trip failing. An autolink flattened the same way
+      returns as a bare URL, and that is a DIFFERENT document: a bare URL stays
+      literal where an autolink is a link.
 
       THE NODE CARRIES NO NON-ANCHOR FLAG. Nothing on the wire marks the inner
-      link as unclickable; a consumer infers it from context. A field that
-      exactly one construct ever sets is a special case where the uniform rule
-      is available, and it would carry a RENDER fact -- "HTML cannot nest
-      anchors" -- back into the format that describes the SOURCE, which is the
-      layering this section rejects everywhere else. §3 already gives a link
-      `children`, and those children are inline nodes with `link` and
-      `autolink` among them, so keeping the node needs no new wire surface at
-      all: the flag would be the only reason to add one, on a surface §11 has
-      just made strict. The asymmetry is recorded rather than assumed -- adding
-      the flag later is a normal additive change, removing it later is a break,
-      and a worse one under strict ingest.
+      link as unclickable; a consumer infers it from context. Such a flag would
+      carry a RENDER fact -- "HTML cannot nest anchors" -- back into the format
+      that describes the SOURCE, which is the layering this section rejects
+      everywhere else. §3 already gives a link `children`, and those children
+      are inline nodes with `link` and `autolink` among them, so keeping the
+      node needs no new wire surface at all. The asymmetry is recorded rather
+      than assumed -- adding the flag later is a normal additive change,
+      removing it later is a break.
 
       RENDERED OUTPUT DOES NOT MOVE. Every target still unwraps, so this is a
       wire-format change with no HTML, Markdown, plain or ANSI consequence.
-      What moves is what a consumer of the TREE receives, which is why no
-      corpus golden pins it: a corpus pair here would pass before and after and
-      prove nothing. The pins that can fail are the §6 round trip on the two
-      shapes above and the AST-shape expectation that a `link` and an
-      `autolink` are admissible inside a link's children.
+      What moves is what a consumer of the TREE receives: the §6 round trip on
+      the two shapes above, and that a `link` and an `autolink` are admissible
+      inside a link's children.
 
       A DESTINATION IS THE AUTHOR'S TEXT, UNSANITIZED -- NORMATIVE. `href`,
       `src`, and every other destination field carry what the author wrote,
@@ -239,35 +212,15 @@
       renderer alone -- a scheme blanked in one target and passed through in
       another is not blocked, it is deferred by one step. Handing the tree to
       another tool is the whole purpose of this PART, so the argument applies
-      here with more force than it did to the Markdown target that prompted it:
-      a consumer that wires a serialized `href` into an anchor has published a
-      live `javascript:` URL.
-
-      Feeding the tree back through a conforming engine applies the denylist for
-      you, because the engine is a target. Walking the tree and building output
-      yourself does not.
+      here with more force: a consumer that wires a serialized `href` into an
+      anchor has published a live `javascript:` URL. Feeding the tree back
+      through a conforming engine applies the denylist for you, because the
+      engine is a target. Walking the tree and building output yourself does
+      not.
 
         See [getting started][] here.
 
         [getting started]: /start
-
-      serialized to a `link` with an empty `href`, a `ref`, a `rawRef`, and no
-      record anywhere of `/start`. A consumer that decoded and rendered got a
-      link to nothing, with no second stage available to it -- the input to that
-      stage had been dropped. §6's round trip still held, because both sides
-      carried the same empty `href`; what broke was rendering the tree at all,
-      which is worse and which §6 does not measure. (carve#524)
-
-      §10 HAS SINCE ANSWERED IT: a link reference definition IS a node, hoisted
-      to the document like the footnote definition, and it carries the
-      destination. Both documents above now publish one - measured across all
-      three engines, the definition-only document has a single
-      `link_reference_definition` child holding `/u`, and the resolved one a
-      `paragraph` and a `link_reference_definition` holding `/start`.
-
-      The paragraph above is kept as the REASON rather than deleted, because it
-      is the argument that produced §10 and the thing to re-read before anyone
-      proposes dropping the node again. It describes what was true, not what is.
 
       THE COLLAPSED FORM'S `ref` IS THE DERIVED LABEL. For `[getting started][]`
       the author wrote nothing between the second brackets, and `ref` carries
@@ -275,17 +228,15 @@
       only value a consumer can do anything with. An empty `ref` would say
       "there is a reference here and I will not tell you to what". `rawRef`
       holds the authored spelling, so the empty brackets are not lost by this.
-      The alternative was measured rather than argued: carve-php published
-      `ref: ""` for the collapsed form and carve-js published no `ref` at all
-      once resolved, so all three spellings were in the field at once.
+      A published `ref: ""`, and a `ref` dropped once resolved, are both
+      non-conforming.
 
       AN UNRESOLVED REFERENCE IS STILL A LINK NODE. Where nothing defines
       `[a]`, `see [a][] here` publishes `text`, `link`, `text` -- the link
       carrying `ref` and no `href` -- NOT one text node holding `see [a][]
       here`. Flattening it to text discards the fact that the author wrote a
       reference at all, and it makes the same document have two node counts
-      depending on which engine produced it, which is exactly what §1 and §1a
-      exist to prevent. (carve#486)
+      depending on which engine produced it. (carve#486)
 
       A CROSSREF IS A `heading_ref`, RESOLVED OR NOT -- NORMATIVE. `</#id>` is
       a reference like any other, so the same two halves apply: the authored
@@ -320,37 +271,21 @@
       in the same document, so a consumer reads it from there. This is the one
       place this clause departs from §5's added-alongside rule, and it does so
       because the alternative duplicates an arbitrary amount of inline content
-      per reference -- carve-js's resolved link clones the heading's children
-      into every crossref, which is why it also has to flatten nested crossrefs
-      and cache the clone to stay acyclic. `href` is a fixed-size result; the
-      display text is not.
+      per reference. `href` is a fixed-size result; the display text is not.
 
       SO THERE IS NO `raw_text`. An engine that reverts an unresolved reference
       to literal source needs a node type to carry text that must not be
       escaped again, and no such type is in the vocabulary. Under this clause
       the reversion does not happen, so the need does not arise: what the
-      author wrote is a link, and it stays one. §5 already excludes the
-      formatter-internal `raw_text` from the wire; this says why nothing on the
-      document side has to reach for it. (carve-php#624)
+      author wrote is a link, and it stays one.
 
-      WHY PRE-RESOLVE. Both stages are defensible and both validate against the
-      schema, which is how three engines came to disagree without any of them
-      being wrong (carve#481). The tie is broken by what each one COSTS.
-
-      Post-resolve makes `rawRef`'s stated purpose -- "so it can be restored as
-      literal text" -- unreachable, because the field it would be restored from
-      is gone by the time anyone could use it. It also means `[x][]` cannot
-      survive a format cycle in ANY implementation: the writer cannot reproduce
-      a construct the tree no longer carries, so PART 11's canonical writer
-      silently rewrites one construct into another. That is not a writer bug
-      and cannot be fixed in the writer.
-
-      Pre-resolve keeps both. It also keeps the distinction a linter, a
-      refactoring tool, or an editor round-tripping a file needs: `[a][]` and
-      `[a](#a)` are different things the author chose between, and a format
-      that preserves authored form one layer down (PART 11 §6: bullet
-      characters, delimiters, the bare marker) has no reason to discard this
-      one.
+      WHY PRE-RESOLVE. Post-resolve makes `rawRef`'s stated purpose -- "so it
+      can be restored as literal text" -- unreachable, and `[x][]` cannot
+      survive a format cycle: the writer cannot reproduce a construct the tree
+      no longer carries, so PART 11's canonical writer would silently rewrite
+      one construct into another. Pre-resolve also keeps the distinction a
+      linter, a refactoring tool, or an editor round-tripping a file needs:
+      `[a][]` and `[a](#a)` are different things the author chose between.
 
       WHAT IS STILL SERIALIZED. §5's rule is unchanged and is not in tension
       with this one: resolution RESULTS a consumer would otherwise have to
@@ -362,16 +297,6 @@
       which is the same shape: the authored construct is still there to be read,
       and the resolution result sits beside it.
 
-      WHAT WOULD MAKE `href: ""` DEFENSIBLE, and is not proposed here: a
-      `link_reference_definition` node in the vocabulary, hoisted to the
-      document like the footnote definition. Then the destination
-      survives serialization and a consumer can resolve for itself. It is a
-      bigger change than this clause is worth -- a new node type, a new hoisting
-      rule, three engines to move, and every consumer obliged to run a
-      resolution pass before it can render anything -- and the reason to prefer
-      it would be purity rather than a capability anyone is missing. Recorded so
-      the choice is visible as a choice.
-
    4. POSITIONS ARE REQUIRED. Every node EXCEPT the document root carries
       `pos`:
 
@@ -381,39 +306,21 @@
       Lines are 1-based. Columns are 1-based and offsets 0-based, both counted
       in UNICODE CODEPOINTS. `endColumn` and `endOffset` are exclusive.
 
-      The unit is stated because there is no convention to inherit: every
-      implementation otherwise reports whatever its own strings are indexed by,
-      and the differences are invisible on ASCII. Measured on `\u{1F600} *b*`,
-      where the delimiter sits at codepoint 2, UTF-16 unit 3 and byte 5:
-      djot.js and commonmark.js report 3, carve-js reported 3, and a byte-indexed
-      engine would report 5 -- three implementations, three answers, all
-      believing they were right.
-
       Codepoints rather than bytes or UTF-16 code units because a codepoint index
       always lands on a CHARACTER BOUNDARY. A byte offset can point inside a
       UTF-8 sequence and a UTF-16 offset inside a surrogate pair; either lets a
-      consumer slice a document into invalid text. This also follows djot's
-      reference implementation, which builds a byte-to-charpos table specifically
-      so it can report characters from a byte-indexed language -- the format's
-      author paid that conversion deliberately rather than exporting the host's
-      unit.
-
-      Every implementation therefore converts, and each pays it once per document
-      rather than per position: the mapping is a single pass, and it is the
-      identity for any document without an astral character.
+      consumer slice a document into invalid text. Every implementation
+      therefore converts, and each pays it once per document rather than per
+      position.
 
       The document root is exempt because it spans the whole source by
       definition, so a span on it carries no information a consumer does not
-      already have. The first draft of this section said "every node" without
-      that carve-out, which made the reference implementation non-conformant
-      with a rule written a day earlier - the conformance checker found it on
-      its first run.
+      already have.
 
       This is the field that makes a serialized AST worth exchanging: an
       editor, a language server or a tool grounding output back to source needs
-      to say WHERE, and a tree without positions can only be re-parsed rather
-      than navigated. Making it optional would mean every consumer has to
-      handle its absence, which in practice means not using it.
+      to say WHERE. Making it optional would mean every consumer has to handle
+      its absence, which in practice means not using it.
 
       A SPAN CONTAINS ITS CHILDREN'S SPANS -- NORMATIVE. A node's span
       covers every placed node inside it: a child's `startOffset` is not
@@ -422,17 +329,6 @@
       breaking the chain -- the comparison is against the nearest ANCESTOR
       that has one.
 
-      This is the one structural rule a checker can apply without knowing
-      what a node covers, which is why it matters: a span is compared against
-      the text it selects only for a `text` node, so every other node's span
-      was checked for being present, integral and in range, and never for
-      pointing at the right place. Adding this rule found 70 wrong spans the
-      day it was written -- 66 in carve-rs, 4 in carve-php, 5 more in
-      carve-js's serialized form -- in list items, a figure's quote target, a
-      table's caption, a footnote's body, and a crossref's cloned display
-      text. Every one was a span taken before the rest of the node had been
-      parsed, or copied from a node somewhere else.
-
       A CONSEQUENCE, worth stating because it settled a question of its own:
       a node whose content is not a contiguous slice of its own source MUST
       omit `pos` rather than publish a PARTIAL span. A `+` continuation cell
@@ -440,16 +336,12 @@
       and a span covering only the first fragment leaves the cell's own text
       children outside it -- which this rule reports. Omitting is already
       permitted below; this says the partial span is not an alternative to it.
-      (carve#541, carve#565.)
 
-      CHECKED ON ITS OWN, not as a consequence of the opening-markup clause
-      below. The two point the same way today -- a span covering the
-      construct's markup contains the children inside it -- and that is
-      precisely why containment is asserted separately: were the convention
-      ever revisited, a checker that derived containment from it would go quiet
-      with nothing failing. So the conformance run examines parent and child
-      spans in a pass of its own, and COUNTS the pairs it examined, so the pass
-      cannot come back clean by having compared nothing. (carve#913.)
+      CONTAINMENT IS CHECKED ON ITS OWN, not derived from the opening-markup
+      clause below. The two point the same way today, and that is precisely why
+      containment is asserted separately: were the convention ever revisited, a
+      check that derived containment from it would go quiet with nothing
+      failing.
 
       A SPAN COVERS THE MARKUP THE AUTHOR WROTE -- NORMATIVE. Where a node
       has markup of its own, its span covers that markup and not merely the
@@ -470,15 +362,6 @@
       the node begins and ends before the markup that gave it half its
       content.
 
-      This follows from the sentence above rather than adding to it -- an
-      attribute block is markup of the node's own by the same reading that
-      makes a break's backslash part of the break. carve-rs covers the block
-      and carve-js stops at the content, so carve-js moves (carve#521).
-
-      No corpus document has an attributed inline today, which is why two
-      answers coexisted. One case pins it; `*x*{#i}` is enough, and the
-      combined form `/*x*/{#i}` is worth a second because it is where the
-      derived inner span makes the difference observable.
 
       A break the parser SYNTHESIZED is a different case and keeps the bare
       newline: a line block's implied break and a hard-break fence's converted
@@ -500,14 +383,6 @@
       item's marker is placed by the whitespace before it, so a span that
       started at the marker would leave the characters deciding the item's
       column outside the item.
-
-      THE ALTERNATIVE WAS CONTENT-ONLY, and it is rejected for a structural
-      reason rather than a stylistic one: with it, a nested construct's span is
-      no longer contained by its parent's, so the span tree stops being a tree
-      and the clause above stops being enforceable. Its one advantage was that
-      fewer engines move. Recorded so it is not revisited: carve-js and
-      carve-php both move under this reading, and every consumer indexing on
-      content offsets moves with them.
 
       TWO EXCEPTIONS, both already stated elsewhere in this section and neither
       an opt-out from the rule:
@@ -569,10 +444,9 @@
 
       spans the emptied `block_quote` as `> ` and the hoisted
       `link_reference_definition` over the whole line, and offsets 0 to 2 sit in
-      two document-level siblings at once. Neither engine that publishes that is
-      wrong: §7, the emptied-container paragraph above and the sibling-overlap
-      rule cannot all three hold on this document, and the exception is where it
-      gives. (carve#1571, which leaves §7 and carve#1522 exactly as they are.)
+      two document-level siblings at once. §7, the emptied-container paragraph
+      above and the sibling-overlap rule cannot all three hold on this document,
+      and the exception is where it gives.
 
       THE EXCEPTION IS ABOUT THE PAIR, NOT ABOUT A DEFINITION. It does not say a
       hoisted definition overlaps nothing. Two definitions that claim the same
@@ -593,13 +467,6 @@
       paragraphs above rather than under this one. The exception excuses an
       overlap; it does not extend a container's span, and nothing here permits a
       host to cover source no child of it owns.
-
-      THE TRADE IS DELIBERATE. A list reports a shorter extent than the author
-      typed, which is worse for folding. An editor wanting the region the author
-      typed can recompute it from the item's content column; a consumer that
-      needs one unambiguous answer for one offset cannot recover it from two
-      overlapping spans, so the span carries the half that cannot be
-      reconstructed. (carve#1522.)
 
       An unattached attribute block is the same rule reached from the other
       clause above rather than a second one. `{.x}` written below an item
@@ -646,13 +513,10 @@
       next to the two above. The end rule asks where a container's CONTENT
       stops, so its last placed child is the right boundary; this one asks where
       the CONSTRUCT begins, and a construct begins at its own markup, which
-      exists whether or not any child was placed. An unplaced child says nothing
-      about where the construct was written. Read symmetrically, a line block
-      stanza whose first line holds a tab -- reassembled around expanded tabs,
-      so it carries no position by the clause below -- started its paragraph on
-      the line BELOW that one, which also put the break ending the tab-bearing
-      line outside the paragraph holding it and so contradicted the containment
-      clause above. (markup-carve/carve-rs#1247.)
+      exists whether or not any child was placed. Read symmetrically, a line
+      block stanza whose first line holds a tab -- reassembled around expanded
+      tabs, so it carries no position -- would start its paragraph on the line
+      BELOW that one, contradicting the containment clause above.
 
       A CONTAINER ENDS AT THE MARKUP THAT CLOSES IT EVEN WHERE ITS LAST CHILD
       IS UNPLACED -- NORMATIVE. A container whose last child omits `pos` ends
@@ -665,11 +529,8 @@
       container starts at the markup that opens it, and ends at the markup that
       closes it. "Ends at its last placed child" is the case for a container
       whose closer is IMPLICIT -- a list, an item, a definition list -- where
-      the last child's end is what the container has instead of a closer, and
-      where the source past it belongs to a hoisted sibling or to nothing. It
-      was the only rule written because it was the only case measured; it does
-      not narrow a container over source its own child covers.
-
+      the last child's end is what the container has instead of a closer. It
+      does not narrow a container over source its own child covers.
       A closerless container whose last child is unplaced therefore ends where
       its content ends, which is line geometry the block layer knows even where
       the text on that line cannot be sliced out of the source. A line block
@@ -691,15 +552,10 @@
       positions, not a parse without them.
 
       This is a concession to where the cost falls. Recording a span for every
-      node is not free -- carve-rs builds its line map only when the
-      source-line render option asks for it, precisely so an ordinary parse does
-      not pay -- and serialization is an operation most callers never perform.
-      Charging every parse in the fastest engine for a feature used by
-      exporters, editors and language servers would be the wrong trade, and a
-      spec that demanded it would be quietly ignored or quietly unimplemented.
-
-      The contract a consumer relies on is unchanged: JSON it is handed carries
-      positions. How the producer arranged that is the producer's business.
+      node is not free, and serialization is an operation most callers never
+      perform. The contract a consumer relies on is unchanged: JSON it is
+      handed carries positions. How the producer arranged that is the
+      producer's business.
 
       A REASSEMBLED NODE MUST OMIT `pos` -- NORMATIVE. A node whose value is not
       a contiguous slice of the source, because the producer joined it from
@@ -721,14 +577,9 @@
       rules left a producer no conformant answer at all: coalesce and carry a
       span over characters the value drops, or coalesce and omit the span the
       paragraph below appears to demand. §1a's own POSITIONS note already chose
-      the second; this is where §4 agrees to it. (carve#490)
-
-      Stated in the spec rather than left to each engine because §1a is
-      normative: any implementation following it faithfully arrives at the same
-      fork, so an answer chosen per engine would be three answers. That the
-      three engines' residues already converged -- same three documents, same
-      kind of content -- is the evidence that this is a property of the rules
-      and not of anyone's parser.
+      the second; this is where §4 agrees to it. It is stated here rather than
+      left to each engine because §1a is normative: any implementation
+      following it faithfully arrives at the same fork.
 
       A discontiguous node therefore has no span. A first-fragment span is not
       an alternative: it locates the beginning but falsely describes `pos` as
@@ -749,10 +600,6 @@
       a hoisted definition against the container it was authored in, per the
       clause of that name above.
 
-      The cost is an absent navigation target for that node; its contiguous
-      children may still be placed. This keeps `pos` meaning one thing:
-      the exact extent the node owns. (carve#541, carve#1060.)
-
       THE EXEMPTION IS NARROW. The test is whether a true span EXISTS, not
       whether one was computed. A node the producer has simply not placed yet
       is still a gap, and a text run lifted whole out of the source has a span
@@ -764,9 +611,7 @@
       The conformance checker still REPORTS an absent `pos`, because it cannot
       tell a reassembled node from an unplaced one from the tree alone. That is
       why the position half of that check is a report and the §1a half is a
-      gate. A report is the right instrument here: the distinction needs a human
-      reading the document, and the numbers below are what such a reading
-      produced.
+      gate.
 
       An implementation that cannot yet produce positions MUST NOT emit `pos`
       with invented values, and MUST NOT omit it silently: it does not yet

--- a/resources/spec/24-ast-contract.ebnf
+++ b/resources/spec/24-ast-contract.ebnf
@@ -14,13 +14,9 @@
       of the heading. Dedup assigns the next free suffix in document order, so
       two `# Notes` headings yield `Notes` and then `Notes-2` (PART 9 §13; the
       slug and dedup rules are syntax.md §4.1, and PART 9 §13's namespace is
-      shared with every other generated id). Deriving the second one therefore
-      requires having seen every heading before it and replicating the dedup
-      spelling, in the same order. A consumer holding only the tree cannot do
-      that, and a table of contents, a go-to-definition jump and a
-      cross-document index each need the exact id, not a plausible one. This is
-      a stronger case than footnote numbering, where the missing state is a
-      counter the consumer could keep itself.
+      shared with every other generated id). A consumer holding only the tree
+      cannot replicate that, and a table of contents, a go-to-definition jump
+      and a cross-document index each need the exact id, not a plausible one.
 
       §3a IS NOT IN TENSION WITH THIS. §3a forbids folding a resolution result
       in place of the construct the author wrote; here nothing authored is
@@ -46,9 +42,9 @@
       An implementation MUST NOT emit parsed key/value pairs in its place:
       parsing YAML or TOML is not the markup parser's job, the raw text plus
       `format` lets any consumer do it, and a parsed map cannot represent a
-      document whose frontmatter is malformed. carve-rs holds a parsed map
-      internally; that is an internal choice, and §1 already requires mapping
-      on the way out rather than exporting internals.
+      document whose frontmatter is malformed. A parsed map held internally is
+      an internal choice, and §1 already requires mapping on the way out rather
+      than exporting internals.
 
       A FOOTNOTE DEFINITION IS A BLOCK NODE, `type: "footnote"`, carrying:
         label     the label as written, without the `[^` and `]:`
@@ -68,9 +64,7 @@
         abbr       the term as written, without the `*[` and `]:`
         expansion  the expansion text, without the separating space
       It renders nothing itself; it is what the inline `abbreviation` resolves
-      against. The node was named here in two clauses before it was described
-      in any, so its field names lived only in resources/ast-schema.json --
-      the shape a reader of this grammar could not see.
+      against.
 
       THE HOISTING CLAUSE ABOVE IS ABOUT FOOTNOTES. An `abbreviation_def` is
       never hoisted, because there is never one to hoist: the construct is
@@ -96,43 +90,20 @@
       line "is preserved as text" there too. The rule is reused, not invented.
 
       WHY ABBREVIATIONS AND NOT FOOTNOTES. An abbreviation is the only
-      definition kind with NO marker at the use site. A footnote needs `[^a]`
-      and a reference link needs `[text][ref]`, so their reach is bounded by
-      references the author wrote deliberately; an abbreviation rewrites EVERY
+      definition kind with NO marker at the use site: it rewrites EVERY
       occurrence of the term in the whole document, with nothing at the use
       site to point back at the definition. Hoisting is safe for a definition
-      that is inert until referenced and unsafe for one that acts on its own.
-      A container is exactly where quoted and foreign material lives, so
-      hoisting would let a quoted `*[X]: y` inject a document-wide rewrite into
-      the quoting document.
-
-      WHY NOT HOIST AN INERT NODE. The rejected alternative kept the hoist and
-      made a container-authored definition expand nothing: in the tree at
-      document level, but without effect. It loses information. Once hoisted,
-      an inert definition and a real one are the SAME wire shape, so a consumer
-      that decodes the tree expands what the parser did not -- §6's round trip
-      fails on a document the engine itself produced. The distinction has to be
-      recorded somewhere, and tree position records it for free; the
-      alternatives were a new wire field on every definition or an accepted
-      lossy round trip.
+      that is inert until referenced and unsafe for one that acts on its own,
+      and a container is exactly where quoted and foreign material lives.
 
       THE FORMATTER CONSEQUENCE IS ACCEPTED, NOT OVERLOOKED. Hoisting means
       PART 11's writer emits the definition after the container the author
       wrote it in, which reads like a violation of PART 11 §6 ("fmt does not
-      reorder ... those are the author's choices and the AST records them").
-      It is not, because §6 governs what the writer may do with what the tree
-      HOLDS, and this clause is what the tree holds. The consequence is already
-      shipping and corpus-pinned for footnotes:
-
-        See [^a].
-
-        > [^a]: note body
-
-      formats to the definition after an emptied `>`, and corpus
-      `115-footnote-definition-inside-a-container-is-collected` pins the
-      collection it follows from. It is accepted for footnotes because a
-      footnote definition renders as a footnote either way, so the move costs
-      the author placement and nothing else.
+      reorder ... those are the author's choices and the AST records them"). It
+      is not, because §6 governs what the writer may do with what the tree
+      HOLDS, and this clause is what the tree holds. It is accepted for
+      footnotes because a footnote definition renders as a footnote either way,
+      so the move costs the author placement and nothing else.
 
       Definitions appear in DOCUMENT ORDER by source position. Numbering is a
       resolution result and stays on the reference (§5).
@@ -152,21 +123,12 @@
       the rule the rendered list already shows -- so the grouping is derivable
       and is not published.
 
-      NOT publishing it is the decision, and it has three reasons.
-
-      A plain `{terms, definitions}` object CANNOT CARRY `pos`. §4 requires one
-      on every node but the root because a tree without positions can only be
-      re-parsed rather than navigated, and a term is exactly what an editor
-      jumps to and a language server renames. Under the object form a term was
-      the only content in a serialized document that could not be navigated to
-      -- the same argument §7 makes for frontmatter and footnote definitions,
-      which is why they are block nodes rather than root fields.
-
-      `definition_term` and `definition_description` are in the profiles.md
-      block vocabulary, so a profile can NAME them. Under the object form those
-      two entries named nothing: a host writing `denyBlock(['definition_term'])`
-      got silence, which profiles.md calls the specific failure a normative
-      vocabulary exists to prevent.
+      NOT publishing it is the decision. `definition_term` and
+      `definition_description` are in the profiles.md block vocabulary, so a
+      profile can NAME them; under an object form those two entries named
+      nothing, and a host writing `denyBlock(['definition_term'])` got silence,
+      which profiles.md calls the specific failure a normative vocabulary
+      exists to prevent.
 
       A SPELLED LOOSENESS IS A FIELD; A DERIVED ONE IS NOT. `definition_list`
       MAY carry `loose: true`, and it means what PART 9 §17 L7's consumed
@@ -190,13 +152,11 @@
       everything except the case the derivation cannot see.
 
       THE NAME IS `loose` AND NOT `tight`, and the divergence from `list` is
-      the point rather than an inconsistency. A `tight` field would be absent on
-      almost every definition list, and an absent boolean read as false says
-      LOOSE -- the opposite of the default, in the one place a consumer is most
-      likely to write `if (node.tight)`. `loose: true` has no such reading:
-      absent means derived, which is the truth. It also matches L7's own key,
-      and follows `list.bareMarker`, the other field here that records an
-      authored distinction the default spelling cannot express.
+      the point. An absent `tight` read as false would say LOOSE, the opposite
+      of the default; `loose: true` absent means derived, which is the truth.
+      It matches L7's own key, and follows `list.bareMarker`, the other field
+      here that records an authored distinction the default spelling cannot
+      express.
 
    9. HOW DEEP AN INGESTED AST MAY NEST -- NORMATIVE. Reading a serialized AST
       is a recursive descent over attacker-controlled structure, so it needs a
@@ -221,22 +181,17 @@
           because (a) and (b) are the whole of what a caller can rely on. An
           implementation MUST NOT publish its unit as a shared contract.
 
-      THE TRAP, stated once, because all three reference engines fell into a
-      different corner of it: an ingest bound is NOT measured in the same unit
+      THE TRAP, stated once: an ingest bound is NOT measured in the same unit
       as MAX_NESTING_DEPTH, and the conversion factor is NOT A CONSTANT. One
       AST level costs two JSON structural levels for a blockquote or div (the
       object plus its `children` array) and four for a list (list, items,
       item, children); in node terms a list level costs two nodes and a div
-      level one. At MAX_NESTING_DEPTH = 200 a blockquote chain therefore
-      encodes past 400 structural levels and a list ladder past 800 -- four
-      times the parser's own number, from the same document depth.
-
-      So neither MAX_NESTING_DEPTH nor "MAX_NESTING_DEPTH plus a small margin"
-      is a safe bound in either unit. An implementation MUST DERIVE its bound
-      from MAX_NESTING_DEPTH by the worst per-level cost of its own encoding,
-      and MUST NOT restate the parser's number as its ingest number -- a
-      second copy of a value is exactly how (a) gets violated. A bound written
-      down twice diverges; one derived from the other cannot.
+      level one. So neither MAX_NESTING_DEPTH nor "MAX_NESTING_DEPTH plus a
+      small margin" is a safe bound in either unit. An implementation MUST
+      DERIVE its bound from MAX_NESTING_DEPTH by the worst per-level cost of
+      its own encoding, and MUST NOT restate the parser's number as its ingest
+      number -- a bound written down twice diverges; one derived from the other
+      cannot.
 
       The root type is not a leniency point: §7 fixes it at `document`, and
       the schema pins it as a `const`. An ingest accepting some other root
@@ -263,30 +218,14 @@
       ABBREVIATION DEFINITION IS RECOGNIZED ONLY AT DOCUMENT LEVEL says the
       opposite for that one: inside a container the line is not a definition
       at all, it is paragraph text, and nothing is hoisted because nothing was
-      collected. Reading this section first, "the other two definition kinds"
-      said the reverse and made the abbreviation look like an unimplemented
-      hoist rather than a ruled-out one (carve#1267).
+      collected.
 
-      WHY A NODE AND NOT A ROOT MAP. §7 fixes the root at three fields, and its
-      reason is the one that decides this: §4 requires every node except the
-      root to carry `pos`, and a root FIELD cannot carry one. A definition is a
-      source construct occupying real bytes -- an editor jumps to it, a
-      formatter reproduces it, a language server renames its label. On the root
-      it would be the only content in the document that cannot be navigated to.
-      A node also answers "which definition wins" by document order rather than
-      by merge order, and holds its own attributes without a second rule.
-
-      WHAT THE NODE CLOSES. Three clauses wanted it and each named a different
-      loss:
-        §3a   a resolved reference published `href: ""` with the destination
-              recoverable from nothing
-        §10a  an unused definition survived neither the tree nor a round trip,
-              so `carve --markdown` on a document that is only `[lbl]: /u`
-              emitted nothing
-        §15 A2b  definition attributes had to be materialized onto every
-              resolved link, because there was nowhere to put them once
-      and the fourth is why it landed: a writer cannot reproduce a construct the
-      tree does not carry, so PART 11 §1's `parse(fmt(x)) == parse(x)` fails.
+      WHY A NODE AND NOT A ROOT MAP. §4 requires every node except the root to
+      carry `pos`, and a root FIELD cannot carry one, while a definition is a
+      source construct occupying real bytes that an editor jumps to and a
+      language server renames. A node also answers "which definition wins" by
+      document order rather than by merge order, and holds its own attributes
+      without a second rule.
 
       A DEFINITION IS STILL INVISIBLE IN HTML. The node renders nothing on that
       target; it feeds the links and images that resolve its label (PART 9R R1).
@@ -301,30 +240,18 @@
       offending property and the PATH it appeared at, so a caller can find it
       in a tree it did not write. Not a silent drop, and not a pass-through.
 
-      THE PASS-THROUGH IS THE ONE ANSWER THAT CANNOT BE RIGHT, and it is worth
-      saying why separately: an implementation that copies a wire record
-      wholesale re-emits the unknown property when it serializes again, so its
-      OWN OUTPUT no longer validates. A consumer that reads a tree here and
-      publishes it again then emits something the format rejects, having been
-      told nothing.
+      THE PASS-THROUGH IS THE ONE ANSWER THAT CANNOT BE RIGHT. An
+      implementation that copies a wire record wholesale re-emits the unknown
+      property when it serializes again, so its OWN OUTPUT no longer validates,
+      and a consumer that reads a tree here and publishes it again emits
+      something the format rejects, having been told nothing.
 
       REFUSE RATHER THAN DROP, for the reason §9(b) already gives about depth:
       "an ingest that accepts a tree and then silently renders only part of it
-      is the worst of the three, because the caller is told nothing". An
-      unknown property is the same shape of problem one field down. If a later
+      is the worst of the three, because the caller is told nothing". If a later
       version of this format gives that property a meaning, an engine that
       dropped it rendered a document that says something else and reported
       success; an engine that refused sent the caller to a version mismatch.
-      The root-type note under §9 settles the same question for the root and
-      points the same way: half-reading a foreign format is worse than
-      declining it.
-
-      FORWARD COMPATIBILITY IS NOT AN ARGUMENT FOR LENIENCY HERE. `parse` and
-      the schema ship together in one build, so an unknown property means the
-      payload came from a DIFFERENT version, and no engine can render a field
-      it does not implement whatever it does with it. Refusing makes the
-      version mismatch visible at the boundary where it can still be handled;
-      dropping defers it to whatever the missing field was load-bearing for.
 
       A DOCUMENTED LEGACY ALIAS IS THE ONE NARROW EXCEPTION. An implementation
       MAY accept a property it once published itself, PROVIDED it decodes that
@@ -411,15 +338,9 @@
           (carve#881). Types and required fields together, at DECODE, refused
           with the same typed error (a), (b) and (c) already require. Not a
           fourth list of leniency points -- the schema is the list, it already
-          describes every one of them, and the rows below were only ever
-          divergent because nothing consulted it.
-
-          One clause rather than a row per field: the schema already defines
-          the complete payload contract.
-
-          The rows already fixed are NOT reopened: an unnamed property under
-          §11 and a missing or non-string `type` under (c) landed separately
-          and keep their own clauses.
+          describes every one of them. An unnamed property under §11 and a
+          missing or non-string `type` under (c) keep their own clauses and are
+          not reopened.
 
       A `srcByteLength` THAT IS PRESENT BUT WRONG IS NOT THIS CLAUSE'S
       BUSINESS. It is derivable from the payload and nothing in the tree

--- a/resources/spec/25-ast-extensions.ebnf
+++ b/resources/spec/25-ast-extensions.ebnf
@@ -45,17 +45,14 @@
       output would carry the caption text as literal body prose instead of
       losing it cleanly, and the loss would stop being observable as a loss.
 
-      A FIGURE GROUP'S TABLE PANEL IS NOT THIS WRAPPER. PART 9 §4c has since
-      made `:::` a captionable host (carve#1122), and a reader arriving here
-      will ask whether `::: figure` around a table now spells the shape. It
-      does not. §16 holds a `figure_group`'s panels in `children` as exactly
-      the nodes the inner caption rules built, so a table panel is a plain
-      `table` child of the group -- carrying its own `caption` if it has one --
-      and never a `figure` whose target is a table. The two say different
-      things: a group wraps a SEQUENCE of panels and captions the sequence,
-      while this wrapper wraps ONE table and captions that table. Carve 0.1
-      source still spells no `figure{target: table}`, which is what makes the
-      writer's loss unavoidable rather than a choice.
+      A FIGURE GROUP'S TABLE PANEL IS NOT THIS WRAPPER. §16 holds a
+      `figure_group`'s panels in `children` as exactly the nodes the inner
+      caption rules built, so a table panel is a plain `table` child of the
+      group -- carrying its own `caption` if it has one -- and never a `figure`
+      whose target is a table. A group wraps a SEQUENCE of panels and captions
+      the sequence, while this wrapper wraps ONE table and captions that table.
+      Carve 0.1 source still spells no `figure{target: table}`, which is what
+      makes the writer's loss unavoidable rather than a choice.
 
       THE TABLE IS THE ONLY HOST IN THIS POSITION. PART 9 §4b states what a
       caption makes of its host: every other captionable host -- an image, a
@@ -84,20 +81,6 @@
       at the use site, and §3 makes field names spec surface: one construct
       identified two ways in one document is the collision §1 exists to stop.
 
-      NEITHER CURRENT BEHAVIOR STANDS, and the two lose different halves of
-      what §10 keeps (carve#1276):
-
-        consuming the line at parse time    discards `pos` entirely, so the
-                                            line cannot be reproduced and an
-                                            AST round trip deletes it
-        leaving the line a paragraph        publishes the parser's failure to
-                                            recognize it: a `citation_group`
-                                            followed by the literal text
-                                            `: {author=` and the rest of the
-                                            entry, which a ProseMirror bridge
-                                            hands an editor as prose and round
-                                            trips as prose
-
       NO RENDERED OUTPUT MOVES ON ANY TARGET. The node renders nothing where it
       sits; the entry's text renders in the references list the extension
       builds, exactly as it did before. That is why the divergence survived so
@@ -115,11 +98,8 @@
       reference definition out of a container while §7 rules that an
       abbreviation definition inside one is not a definition at all, and this
       clause is about the node's SHAPE rather than about which lines produce
-      one. Measured on carve-js `620def4`, a `[@key]: entry` line inside a
-      block quote or a list item is paragraph text and defines nothing, which
-      is §7's answer rather than §10's; that is a measurement of one engine and
-      not a ruling. An implementation emitting the node for a definition it
-      recognizes satisfies this clause whichever way that question lands.
+      one. An implementation emitting the node for a definition it recognizes
+      satisfies this clause whichever way that question lands.
 
    18a. A CITATION ITEM IS A POSITIONED INLINE NODE -- NORMATIVE.
       Every item in `citation_group.items` carries `type: "citation"` and the
@@ -231,34 +211,20 @@
 
       THIS MIRRORS THE PARSE BOUNDARY, which is the whole of the rule: PART 0
       INPUT performs the same replacement on source, and PART 9 §29 carves
-      U+0000 out of the content class on that basis. A wire format that
-      admitted the character would put an authored NUL and an ingested one on
-      different footings - one replaced, one content - which is precisely the
-      divergence §29 exists to remove. An AST is a second door into the same
-      renderers; it takes the same doormat.
+      U+0000 out of the content class on that basis. An AST is a second door
+      into the same renderers; it takes the same doormat.
 
       A READER DOES NOT REFUSE THE VALUE, which is the choice worth stating.
       §11 and §12 refuse an unknown property and a deviant root, because those
-      are structure a producer got wrong and repairing them silently would
-      accept attacker-controlled shape. This is different: the replacement is
+      are structure a producer got wrong. This is different: the replacement is
       what the parse boundary already does to the identical string, so
-      performing it is not a repair, it is the documented reading. Refusing
-      instead would make an ingested document stricter than the same document
-      written as source, and a host that builds a tree programmatically would
-      have to implement CommonMark 2.3 itself before it could hand the tree
-      back.
-
-      Applying this rule at every ingest boundary gives parsers, renderers and
-      canonical writers the same guarantee and prevents U+0000 from colliding
-      with internal sentinels (carve-rs#1217, carve-js#1294).
+      performing it is the documented reading rather than a repair. Refusing
+      would make an ingested document stricter than the same document written
+      as source.
 
       AN IMPORTER IS THE SAME BOUNDARY BY THE SAME REASONING, and is stated
       here as a SHOULD rather than a MUST because the format being imported may
-      have its own rule. Carve's Markdown importer performs the replacement,
-      following CommonMark 2.3 (markup-carve/carve-js#1293); its BBCode
-      importer passes a raw NUL straight through into its Carve output, which
-      is not a substitution and BBCode has no clause to follow, but is the same
-      missing normalization arriving by a third door.
+      have its own rule.
 
    22. AN INGESTED VALUE THE SCHEMA CALLS ABSENT IS NORMALIZED AWAY --
       NORMATIVE (carve#1615). `resources/ast-schema.json` describes a list's
@@ -276,19 +242,14 @@
       value; §6 never promised to hand it back.
 
       THE DECIDING ASYMMETRY IS THAT NORMALIZING IS LOSSLESS. `start: 1` and no
-      `start` describe the same document -- the field is inert, and the renderer
-      emits no `start` attribute for either, `1` being the HTML default.
-      Nothing an author wrote is discarded. Preserving the value keeps a field
-      that makes the encoder's output depend on WHERE THE TREE CAME FROM, which
-      is the property §6's round trip exists to remove.
+      `start` describe the same document, so nothing an author wrote is
+      discarded, while preserving the value makes the encoder's output depend
+      on WHERE THE TREE CAME FROM.
 
       REFUSING THE PAYLOAD IS NOT THE ANSWER, though §11 refuses an unnamed
       property and §12 refuses a deviant root. `start` is a property the schema
       NAMES, and its value is in range; what is out of contract is only that the
-      value happens to be the default. Refusing would break editors that
-      round-trip a tree they did not author, and no engine does it today. This
-      clause is about a NAMED field carrying the value the schema describes as
-      absent, which is a narrower thing than either refusal clause covers.
+      value happens to be the default.
 
       WHAT THE RULE IS NOT. It is not "drop `start` always". `start: 0` and
       `start: 2` are carried through unchanged, and an implementation that
@@ -314,12 +275,10 @@
       runs rather than by one render target's limitation.
 
       NOT A DISTINCT NODE TYPE, deliberately. `block_image` is the honest shape
-      -- it IS a different construct, and the caption would have an obvious
-      home on it -- but it breaks every consumer that switches on node type and
-      it ripples through the engines, the importers, `fmt` and this schema at
-      once. A field is additive: a consumer that ignores it still works, and one
-      that reads it stops re-deriving. A type stays available later; going
-      field-first puts the phase and its call sites in place first.
+      -- it IS a different construct -- but it breaks every consumer that
+      switches on node type and it ripples through the engines, the importers,
+      `fmt` and this schema at once. A field is additive, and a type stays
+      available later.
 
       ON INGEST, TRUST THE PROPERTY -- NORMATIVE. A reader that receives
       `blockImage` USES it. It runs the promotion phase itself only for a tree
@@ -339,24 +298,12 @@
       reference is never defined still round-trips to itself (§6). The
       alternative makes the writer non-local: the same paragraph would be
       written differently depending on whether a definition appears somewhere
-      else in the document, possibly far away. PART 11 §1c already collapses on
-      the writer side, so teaching `fmt` about resolution buys nothing.
+      else in the document.
 
       AN IMPORTER READS THE FIELD RATHER THAN GUESSING. An HTML importer that
       escapes a following `^ ` line because the image above it "would capture
       it" is deriving R7 a third time, in a pipeline with no access to the
       phase (`docs/html-import.md`, the detached-caption case). It reads
       `blockImage` on the tree it built instead.
-
-      NO HTML MOVES. This is a wire-format clause: every render target already
-      produced the promoted output, so nothing in the corpus changes because of
-      the field. What the corpus pins is R7's OBSERVABLE half, and it was
-      already half-pinned: categories 201, 207, 209 and 412 hold the resolved
-      and unresolved reference image, each with and without a caption, and 209 -
-      the unresolved image whose caption line folds into the paragraph - is the
-      row a syntactic binding fails. Category 434 adds the two give-back paths
-      on which a LINE can be lost and that no CORPUS document held: a slot more
-      than one line wide, held only against the oracle by a unit test no engine
-      runs, and a slot inside a container, held by nothing at all.
 
    ============================================================================ *)


### PR DESCRIPTION
## Summary

- reduce `resources/grammar.ebnf` from 12,371 lines to 10,179 lines
- remove implementation archaeology, issue narratives, repeated examples, rejected alternatives, and extended rationale while retaining the active rules
- keep all 183 single-line EBNF productions byte-identical and preserve all 245 stable normative rule ids
- restore the full citation contract that an earlier cleanup draft had over-condensed, including integral mode, typed-locator boundaries, and rendered metadata ordering

## Semantic-preservation audit

This is a prose-only specification cleanup. It does not change grammar productions, syntax, field names, cardinalities, ordering, defaults, phases, scopes, or exceptions.

The audit specifically checked:

- every `-- NORMATIVE` heading remains represented by the same stable rule id
- the assembled grammar still matches all 26 source modules
- all single-line EBNF productions compare byte-for-byte with the pre-cleanup grammar
- the citation recognition rule, item shape, bibliography reservation, output modes, integral marker, typed-locator rules, abbreviation vocabulary, and `data-*` ordering remain explicit
- the rebase preserves `origin/main`'s refreshed canonical `: ` definition examples and current engine pin

Claude CLI reviewed the cleanup in multiple passes. It caught and prompted fixes for an over-condensed citation clause, a missing canonical fence-width term (`d^2 + 5d`), a temporarily shortened normative title, and mechanical duplicate/separator defects. Those findings were corrected before the final test run. Its main remaining caution was the deliberate reduction in historical traceability; the removed background remains available in Git history and existing history documentation.

No changelog entry is included.

## Verification

- `npm run spec:check`
- `npm run spec:rules:check`
- `npm test` on Node 24.19.0: 3,253 passed, 1 skipped, 0 failed

After rebasing, `npm ci` refreshed the newly updated engine pin before the final suite run.
