### PR TITLE
chore: the pin and the manifest follow carve-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#d5ca3554318128b78f80ceb849bab56ec6618372",
+        "@markup-carve/carve": "github:markup-carve/carve-js#6dff251aa1bb1a4f6e34ba43677659038aa21f1a",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
         "@mermaid-lint/cli": "^0.53.1",
@@ -986,7 +986,7 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#d5ca3554318128b78f80ceb849bab56ec6618372",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#6dff251aa1bb1a4f6e34ba43677659038aa21f1a",
       "integrity": "sha512-O1HywXWdSjF/gcepHSimSREh5eYAtw9rO78ks4MO/BaTJRxVQSmOLNyMlEqo/sg1hlyqRNO2NJk7LmbDnm+7Yg==",
       "dev": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#d5ca3554318128b78f80ceb849bab56ec6618372",
+    "@markup-carve/carve": "github:markup-carve/carve-js#6dff251aa1bb1a4f6e34ba43677659038aa21f1a",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
     "@mermaid-lint/cli": "^0.53.1",

--- a/scripts/declaration-audit.mjs
+++ b/scripts/declaration-audit.mjs
@@ -294,7 +294,7 @@ const MANIFEST = [
   { repo: 'carve-rs', path: 'tests/corpus_render_fixtures.rs', name: 'FMT_AHEAD_OF_PIN', kind: 'rust', policy: 'owed', guard: 'two-way', staleness: 'the pin has caught up; delete its FMT_AHEAD_OF_PIN entry', owner: 'tests/corpus_render_fixtures.rs' },
   { repo: 'carve-rs', path: 'tests/optional_corpus.rs', name: 'DECLARED_UNIMPLEMENTED', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/optional_corpus.rs' },
   { repo: 'carve-rs', path: 'tests/optional_corpus.rs', name: 'AHEAD_OF_PIN', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'tests/optional_corpus.rs' },
-  { repo: 'carve-rs', path: 'tests/html_import.rs', name: 'BEHIND_THE_RULING', kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'mirrors spec PIN_LAG' },
+  { repo: 'carve-rs', path: 'tests/html_import.rs', name: 'AHEAD_OF_PIN',      kind: 'rust', policy: 'owed', guard: 'two-way', owner: 'mirrors spec PIN_LAG' },
   // Not a waiver: the set of JSON Schema keywords this hand-written validator
   // implements. Meeting one that is NOT listed is the failure, which is the
   // opposite direction from every other row here.


### PR DESCRIPTION
The pin reaches carve-js main, whose commits since are a test file and a CHANGELOG entry - no `src/`, so the move is render-neutral.

carve-rs renamed its own `BEHIND_THE_RULING` list to `AHEAD_OF_PIN` when the direction of the window it describes changed, and the manifest still named the old constant: the audit reported the row `UNPARSEABLE` and the constant itself `UNDECLARED`, one rename read as two findings.

The remaining owed rows retire with markup-carve/carve-rs#1460, which is what takes the release-mode audit to PASSED.

No changelog entry, no version field, nothing tagged.