### PR TITLE
chore: release 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-08-27
+
 ### Added
 
 - **An empty description body is written with the `{empty}` sentinel**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carve-docs",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "carve-docs",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "chart.js": "^4.5.1",
         "mermaid": "^11.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carve-docs",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "description": "Documentation site for Carve, a post-Markdown markup language",


### PR DESCRIPTION
RELEASING.md steps 1-2 for the spec repo: `package.json` reaches 0.1.4 and `## [Unreleased]` is cut to `## [0.1.4] - 2026-08-27` with a fresh empty section above it.

Step 3 has nothing left to do - the pin was moved and the drift file emptied in markup-carve/carve#1840, and `pre-tag-check.sh 0.1.4` already reports `engine pin drift matches what is declared` and `every owed declaration list is empty`. The only two failures it reports are the dirty tree and the branch name, both of which this PR resolves.