### PR TITLE
feat: generate the release order from the dependency graph

### DIFF
--- a/tests/dependency-map.test.mjs
+++ b/tests/dependency-map.test.mjs
@@ -16,7 +16,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 
-import { classify, parseManifest, renderMermaid } from '../tools/dependency-map.mjs'
+import { classify, parseManifest, renderMermaid, releaseLayers, renderReleaseOrder } from '../tools/dependency-map.mjs'
 
 const cases = [
   ['github: shorthand', '@markup-carve/carve', 'github:markup-carve/carve-js#3ba8ba32', 'carve-js', '3ba8ba32'],
@@ -119,4 +119,71 @@ test('each node is declared once', () => {
   const rendered = renderMermaid([edge('a-carve', 'carve-js'), edge('b-carve', 'carve-js')])
   const declarations = [...rendered.matchAll(/^\s*carve_js\["carve-js"\]/gm)]
   assert.equal(declarations.length, 1)
+})
+
+/*
+ * THE RELEASE ORDER, AND THE TWO WAYS IT SILENTLY LIES.
+ *
+ * Both of these were live defects in the first cut of the renderer, and neither
+ * one produces an error - they produce a shorter list, which reads exactly like
+ * a smaller org.
+ */
+
+const edgesFor = (pairs, field = 'dependencies') =>
+  pairs.map(([repo, target]) => ({ repo, target, field, verdict: 'released', note: '' }))
+
+test('a repo that declares no dependency still appears in the order', () => {
+  // Seeding the node set from the edges drops every repo that declares nothing.
+  // That is the whole unconstrained tail - the editors, the standalone tools -
+  // and its absence is invisible: the page just stops mentioning them.
+  const { layer } = releaseLayers(edgesFor([['engine', 'carve']]), ['carve', 'engine', 'lonely'])
+  assert.equal(layer.get('lonely'), 0, 'a repo with no edge belongs in stage 0')
+  assert.equal(layer.get('carve'), 0)
+  assert.equal(layer.get('engine'), 1)
+})
+
+test('the order covers every repo it was given', () => {
+  const repos = ['carve', 'engine', 'binding', 'lonely']
+  const { layer } = releaseLayers(edgesFor([['engine', 'carve'], ['binding', 'engine']]), repos)
+  assert.deepEqual([...layer.keys()].sort(), [...repos].sort())
+})
+
+test('the spec devDependency cycle does not decide the layering', () => {
+  // The spec dev-depends on its engines to render its own corpus, and they
+  // submodule the spec back. Honouring that direction makes the graph
+  // unlayerable and asserts something false - that the spec cannot be tagged
+  // before its own consumers.
+  const cycle = [
+    { repo: 'carve-js', target: 'carve', field: 'submodule', verdict: 'released', note: '' },
+    { repo: 'carve', target: 'carve-js', field: 'devDependencies', verdict: 'released', note: '' },
+  ]
+  const { layer } = releaseLayers(cycle, ['carve', 'carve-js'])
+  assert.equal(layer.get('carve'), 0, 'the spec releases first')
+  assert.equal(layer.get('carve-js'), 1, 'the engine follows it')
+})
+
+test('a cycle the drop rule does not cover still terminates', () => {
+  // Two ordinary repos pointing at each other is not a shape the org has, but a
+  // renderer that recurses forever on it fails in the least debuggable way.
+  const mutual = [
+    { repo: 'a', target: 'b', field: 'dependencies', verdict: 'released', note: '' },
+    { repo: 'b', target: 'a', field: 'dependencies', verdict: 'released', note: '' },
+  ]
+  const { layer } = releaseLayers(mutual, ['a', 'b'])
+  assert.ok(layer.has('a') && layer.has('b'), 'both nodes are placed rather than hanging')
+})
+
+test('the rendered order names every repo exactly once', () => {
+  const repos = ['carve', 'carve-js', 'carve-php', 'binding', 'lonely']
+  const states = new Map(repos.map((r) => [r, { latestRelease: '0.1.0', latestTag: '0.1.0', behindTag: 3 }]))
+  const text = renderReleaseOrder(
+    edgesFor([['carve-js', 'carve'], ['carve-php', 'carve'], ['binding', 'carve-js']]),
+    states,
+    repos,
+  )
+  for (const repo of repos) {
+    const hits = text.split('\n').filter((line) => line.includes(repo.padEnd(24))).length
+    assert.equal(hits, 1, `${repo} should be listed once, found ${hits}`)
+  }
+  assert.match(text, /NO ORG DEPENDENCY/, 'the unconstrained tail has its own heading')
 })

--- a/tools/dependency-map.mjs
+++ b/tools/dependency-map.mjs
@@ -357,13 +357,23 @@ async function targetState(repo) {
     ])
     const bySha = new Map()
     for (const tag of tags ?? []) bySha.set(tag.commit.sha, tag.name)
+    const latestTag = tags?.[0]?.name ?? null
+    const latestRelease = release?.tag_name ?? null
+    // HOW FAR THIS REPO ITSELF HAS MOVED PAST ITS OWN LATEST TAG, which is a
+    // different question from any edge verdict: an edge says whether a PIN
+    // names a release, this says whether there is anything here to release at
+    // all. Counts every commit, docs and CI included, so it reports that a
+    // release is POSSIBLE rather than that one is warranted.
+    const base = latestRelease ?? latestTag
+    const own = base ? await distance(repo, base, meta.default_branch) : null
     return {
       branch: meta.default_branch,
       head: null,
       tags: tags ?? [],
       tagBySha: bySha,
-      latestTag: tags?.[0]?.name ?? null,
-      latestRelease: release?.tag_name ?? null,
+      latestTag,
+      latestRelease,
+      behindTag: own?.ahead ?? null,
     }
   })()
   targetCache.set(repo, promise)
@@ -513,6 +523,15 @@ const TIERS = [
 
 const TIER_MEMBERS = new Set(TIERS.flatMap(([, members]) => members))
 
+/*
+ * Derived from TIERS rather than restated, so a tier edit cannot leave two
+ * lists disagreeing about which repo is the spec and which are engines. The
+ * release order below reads both: the spec is the one repo every layer is
+ * measured from, and the engines are the hubs stage 2 is grouped by.
+ */
+const SPEC_REPO = TIERS[0][1][0]
+const ENGINES = TIERS[1][1]
+
 /** A label Mermaid can hold: no node syntax, no edge syntax, not too long. */
 function edgeLabel(edge) {
   const raw = String(edge.resolved ?? edge.ref ?? edge.spec ?? '?')
@@ -629,7 +648,135 @@ function renderMermaid(edges) {
   return lines.join('\n')
 }
 
-function renderMarkdown(edges, { repos, skipped, generatedFrom }) {
+/*
+ * THE RELEASE ORDER, WHICH IS THE QUESTION THE GRAPH ABOVE DOES NOT ANSWER.
+ *
+ * The mermaid pictures show every edge, which is what makes them accurate and
+ * what makes them unreadable for the one thing a maintainer actually asks:
+ * "what may I release, and what has to go first". Nineteen repos pin carve-js,
+ * so the fan is a funnel, and a funnel does not tell you the order.
+ *
+ * This layers the same edge list topologically. A repo may be released once
+ * everything it depends on has been; repos in one layer do not depend on each
+ * other, so they carry no order between them.
+ *
+ * THE SPEC'S OWN devDependencies ARE DROPPED. `carve` dev-depends on carve-js
+ * and carve-grammars to render its own corpus, and both submodule the spec
+ * back. That is a cycle, and it is not a build dependency in either direction -
+ * it is verification. Keeping it would make the graph unlayerable and would
+ * assert something false: that the spec cannot be tagged before its own
+ * consumers. Every other edge is a real build or vendor dependency.
+ *
+ * `behindTag` is per REPO, not per edge: how far a repo's own default branch
+ * has moved past its own latest tag. The edge notes above answer "is this pin a
+ * release"; this answers "is there anything here to release at all". They are
+ * different questions and a repo can be red on one and clean on the other.
+ */
+function releaseLayers(edges, allRepos) {
+  const dep = new Map()
+  // EVERY repo, not only the ones an edge names. A repo that declares no org
+  // dependency has no edge at all, so seeding this from `edges` would drop the
+  // entire unconstrained tail - the editors, the standalone tools - from a
+  // list whose whole claim is that it covers the org. They belong in stage 0.
+  const nodes = new Set(allRepos)
+  for (const edge of edges) {
+    nodes.add(edge.repo)
+    nodes.add(edge.target)
+    if (edge.repo === edge.target) continue
+    // The verification cycle, described above.
+    if (edge.repo === SPEC_REPO && edge.field === 'devDependencies') continue
+    if (!dep.has(edge.repo)) dep.set(edge.repo, new Set())
+    dep.get(edge.repo).add(edge.target)
+  }
+  const layer = new Map()
+  const level = (node, seen = new Set()) => {
+    if (layer.has(node)) return layer.get(node)
+    // A cycle we did not name above would otherwise recurse forever. Treat the
+    // back edge as absent rather than throwing: a wrong layer is visible in the
+    // output and a stack overflow is not.
+    if (seen.has(node)) return 0
+    const targets = [...(dep.get(node) ?? [])].filter((t) => nodes.has(t))
+    const value = targets.length
+      ? 1 + Math.max(...targets.map((t) => level(t, new Set([...seen, node]))))
+      : 0
+    layer.set(node, value)
+    return value
+  }
+  for (const node of nodes) level(node)
+  return { layer, dep }
+}
+
+function renderReleaseOrder(edges, states, allRepos) {
+  const { layer, dep } = releaseLayers(edges, allRepos)
+  const byLayer = new Map()
+  for (const [node, value] of layer) {
+    if (!byLayer.has(value)) byLayer.set(value, [])
+    byLayer.get(value).push(node)
+  }
+
+  const describe = (repo) => {
+    const state = states.get(repo)
+    const version = state?.latestRelease ?? state?.latestTag ?? 'UNRELEASED'
+    const lag = state?.behindTag ? `+${state.behindTag}` : ''
+    return `${repo.padEnd(24)} ${version.padEnd(10)} ${lag}`.trimEnd()
+  }
+  const branch = (items, extra = () => '') =>
+    items.map((repo, index) => {
+      const stem = index === items.length - 1 ? '└──' : '├──'
+      return `    ${stem} ${describe(repo)}${extra(repo)}`
+    })
+
+  const lines = ['```text']
+  const zero = (byLayer.get(0) ?? []).filter((repo) => repo !== SPEC_REPO).sort()
+
+  lines.push(`STAGE 0  the spec - everything downstream verifies against it`)
+  lines.push(`  ${describe(SPEC_REPO)}`)
+
+  for (const value of [...byLayer.keys()].filter((v) => v > 0).sort((a, b) => a - b)) {
+    const members = byLayer.get(value).sort()
+    lines.push('')
+    if (value === 1) {
+      lines.push('STAGE 1  engines and the spec-only consumers')
+      for (const repo of members) lines.push(`  ${describe(repo)}`)
+      continue
+    }
+    lines.push(`STAGE ${value}`)
+    if (value !== 2) {
+      for (const repo of members) {
+        const targets = [...(dep.get(repo) ?? [])].sort().join(', ')
+        lines.push(`  ${describe(repo)}${targets ? `  <- ${targets}` : ''}`)
+      }
+      continue
+    }
+    {
+      // Grouped by hub, because a flat list of twenty-one at this layer is the
+      // same funnel the mermaid fan already is.
+      const claimed = new Set()
+      for (const hub of ENGINES) {
+        const fan = members.filter((r) => !claimed.has(r) && (dep.get(r) ?? new Set()).has(hub)).sort()
+        if (!fan.length) continue
+        for (const repo of fan) claimed.add(repo)
+        lines.push(`  from ${hub}`)
+        lines.push(...branch(fan))
+      }
+      const rest = members.filter((r) => !claimed.has(r)).sort()
+      if (rest.length) {
+        lines.push('  several hubs')
+        lines.push(...branch(rest, (repo) => `  <- ${[...(dep.get(repo) ?? [])].sort().join(', ')}`))
+      }
+    }
+  }
+
+  if (zero.length) {
+    lines.push('')
+    lines.push('NO ORG DEPENDENCY  release whenever, in any order')
+    for (const repo of zero) lines.push(`  ${describe(repo)}`)
+  }
+  lines.push('```')
+  return lines.join('\n')
+}
+
+function renderMarkdown(edges, { repos, skipped, generatedFrom, states }) {
   const worst = [...edges].sort(
     (a, b) => VERDICTS[b.verdict].rank - VERDICTS[a.verdict].rank || a.repo.localeCompare(b.repo),
   )
@@ -651,6 +798,31 @@ function renderMarkdown(edges, { repos, skipped, generatedFrom }) {
   )
   out.push('')
   out.push(`Read ${repos} repositories, ${edges.length} edges, from ${generatedFrom}.`)
+  out.push('')
+  out.push('## Release order')
+  out.push('')
+  out.push(
+    'The graphs further down show every edge, which is what makes them complete and what makes ' +
+      'them hard to read as an ORDER. This is the same data layered: a repo may be released once ' +
+      'everything it depends on has been.',
+  )
+  out.push('')
+  out.push(
+    'Within a stage there is no order - those repos do not depend on each other, so they go in ' +
+      'parallel or not at all. Across stages the order binds: releasing against an unreleased ' +
+      'dependency ships a build no release names. The trailing count is commits past that repo' +
+      "'s own latest tag, so it says a release is possible, not that one is warranted - the " +
+      'CHANGELOG says that.',
+  )
+  out.push('')
+  out.push(renderReleaseOrder(edges, states, [...states.keys()]))
+  out.push('')
+  out.push(
+    'The spec\'s own devDependencies are left out of the layering: `' + SPEC_REPO + '` dev-depends ' +
+      'on its engines to render its own corpus and they submodule the spec back, which is a ' +
+      'verification cycle rather than a build dependency. It does mean a spec cut wants the ' +
+      'engine pin bumped first, and an engine cut wants its spec submodule current.',
+  )
   out.push('')
   out.push('## What the verdicts mean')
   out.push('')
@@ -716,7 +888,7 @@ function renderMarkdown(edges, { repos, skipped, generatedFrom }) {
 
 // ---------------------------------------------------------------------------
 
-export { classify, parseManifest, renderMermaid, renderSpine, renderConsumers }
+export { classify, parseManifest, renderMermaid, renderSpine, renderConsumers, releaseLayers, renderReleaseOrder }
 
 async function main() {
   const repos = await api(`orgs/${ORG}/repos?per_page=100&type=public`)
@@ -760,9 +932,18 @@ async function main() {
     return
   }
 
+  // EVERY repo's state, not just the ones an edge points at. A repo with no
+  // incoming edge still has a tag and still has commits past it, and leaving it
+  // out would silently drop the whole unconstrained tail of the release order -
+  // the editors and the standalone tools - from a list that claims to be one.
+  const states = new Map(
+    await mapLimit(live, CONCURRENCY, async (repo) => [repo.name, await targetState(repo.name)]),
+  )
+
   const markdown = `${renderMarkdown(resolved, {
     repos: live.length,
     skipped,
+    states,
     generatedFrom: 'each repository\'s default branch',
   })}\n`
   const out = value('out', null)


### PR DESCRIPTION
The map answers "who depends on whom" and "is this pin a release". It does not answer the question a maintainer opens it with: **what may be released now, and what has to go first.** The mermaid pictures cannot answer it either - nineteen repos pin `carve-js`, so the fan is a funnel, and a funnel carries no order.

This layers the same edge list topologically and renders it as a text tree at the top of the page:

```text
STAGE 0  the spec - everything downstream verifies against it
  carve                    0.1.3      +283

STAGE 1  engines and the spec-only consumers
  carve-js                 0.1.4      +254
  carve-php                0.1.5      +255
  carve-rs                 0.1.3      +249
  intellij-carve           0.1.5      +10

STAGE 2
  from carve-js
    ├── carve-grammars           v0.1.4     +58
    ├── carve-lsp                v0.1.3     +50
    └── ...
```

A repo may be released once everything it depends on has been. Within a stage there is no order; across stages the order binds.

## Two things worth reviewing

**The spec's own devDependencies are dropped from the layering.** `carve` dev-depends on carve-js and carve-grammars to render its own corpus, and both submodule the spec back. Honouring that direction makes the graph unlayerable and asserts something false - that the spec cannot be tagged before its own consumers. It is verification, not a build dependency. The page states the consequence rather than hiding it: a spec cut wants the engine pin bumped first, an engine cut wants its spec submodule current.

**Per-repo lag is new data, and not the question the edge notes answer.** An edge note says whether a PIN names a release. The lag says whether there is anything in that repo to release at all - its default branch against its own latest tag. A repo can be clean on one and red on the other. `targetState` already fetched the tags, so it costs one compare per repo.

## Two defects in the first cut

Both produce a SHORTER list rather than an error, which is why they are tested rather than eyeballed:

- seeding the node set from the edges dropped every repo that declares no dependency - the whole unconstrained tail, thirteen repos, gone from a page whose claim is that it covers the org
- a stage whose members are top-level was drawn with the child stems the hub groups use, so stages 3 and 4 read as children of a parent that is not there

The tests assert both, plus that the cycle rule decides the spec/engine order and that an uncovered mutual cycle terminates. Each was verified by mutation rather than assumed: reverting the node seeding fails three, honouring the cycle fails one.

Once this merges the wiki's Dependency-Map page can be regenerated and will carry the tree, so the "generated - do not edit by hand" banner stays true for the release order too.
