### PR TITLE
chore: pin the released carve-js, not a commit between releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#6dff251aa1bb1a4f6e34ba43677659038aa21f1a",
+        "@markup-carve/carve": "github:markup-carve/carve-js#37ed8904f2a5dd540fd0bddb2294fe348f17eb7d",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
         "@mermaid-lint/cli": "^0.53.1",
@@ -985,9 +985,9 @@
       "license": "MIT"
     },
     "node_modules/@markup-carve/carve": {
-      "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#6dff251aa1bb1a4f6e34ba43677659038aa21f1a",
-      "integrity": "sha512-O1HywXWdSjF/gcepHSimSREh5eYAtw9rO78ks4MO/BaTJRxVQSmOLNyMlEqo/sg1hlyqRNO2NJk7LmbDnm+7Yg==",
+      "version": "0.1.5",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#37ed8904f2a5dd540fd0bddb2294fe348f17eb7d",
+      "integrity": "sha512-qcMO1SduRurB5HrKvxWhU7/si8EnKf2ljN53f3qxreEZ+No/9eE67ELYJktuYNQAktSzzTc3E4FzLbqlYzkqew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#6dff251aa1bb1a4f6e34ba43677659038aa21f1a",
+    "@markup-carve/carve": "github:markup-carve/carve-js#37ed8904f2a5dd540fd0bddb2294fe348f17eb7d",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
     "@mermaid-lint/cli": "^0.53.1",


### PR DESCRIPTION
The pin now names the commit `carve-js 0.1.5` was tagged at, rather than a commit that happened to be main when the bump ran.

It stays a 40-char sha because that is enforced: `scripts/bump-carve-pin.mjs` resolves every ref to one and `tests/engine-pin-matches-the-lock.test.mjs` asserts the form. `node scripts/bump-carve-pin.mjs 0.1.5` is what produced it.

`engine:report --check`, `npm test`, `core:check`, `html-import:check` and `declarations:check --mode=release` all pass; the drift file is still empty and the corpus still reproduces 1538 of 1538.