### PR TITLE
feat: a gated ledger for the dependencies no detector can read

### DIFF
--- a/resources/undeclared-dependencies.txt
+++ b/resources/undeclared-dependencies.txt
@@ -1,0 +1,52 @@
+# Dependencies between org repos that no manifest, bundle header or CI
+# checkout can be read for.
+#
+# `tools/dependency-map.mjs` finds an edge four ways: a package manifest, a
+# submodule gitlink, a provenance header inside a committed build, and a
+# workflow that checks another repo out. Each of those is a machine-readable
+# statement by the repo itself, and between them they cover most of the org.
+#
+# They do not cover everything, and the two gaps are opposite in shape:
+#
+#   - A dependency that exists and NOTHING declares. emacs-carve vendors
+#     carve-grammars' block-battery table and says so in a code comment, which
+#     is prose. A file copied without a header, a format implemented from
+#     reading another repo, a runtime that shells out to a binary it does not
+#     install - all real, none readable.
+#
+#   - An edge the tool FINDS and that is not a dependency. carve-rs checks out
+#     the homebrew tap in its release workflow to update a formula. That is a
+#     push. Telling it from a checkout-to-consume needs the job's intent, and a
+#     pattern does not recover intent.
+#
+# WHY A FILE AND NOT A PARAGRAPH. The Dependency Map exists because the wiki's
+# prose could not be re-derived: a pin that went stale read exactly like one
+# that had not. A hand-written note about a hand-written dependency has the
+# same defect one level up. This file is checked in both directions instead:
+#
+#   - a line whose edge the tool can NOW find on its own is STALE. The
+#     detection caught up; delete the line in the commit that made it true.
+#   - a line naming a repo that does not exist, a kind that is not in the list,
+#     or the same pair twice, is an error.
+#
+# So the file can only ever hold what detection genuinely cannot reach, and it
+# shrinks as the detectors improve rather than accumulating.
+#
+# FORMAT: <repo> -> <target>  <kind>  <reason>
+#
+# KINDS
+#   vendors    A copy of the target is in this repo's tree, with no header to
+#              read. Containment: it LAYERS, exactly like a declared pin,
+#              because releasing this repo ships that code.
+#   couples    The two are bound at build or test time without either
+#              containing the other. Shown with `~`, and never layers.
+#   not-a-dependency
+#              Suppresses an edge the tool finds and should not have. The
+#              reason has to say what the reference actually is.
+#
+# Keep the reason specific enough that a reader can check it: name the file,
+# the workflow or the mechanism, not "needs it".
+
+emacs-carve -> carve-grammars  vendors  tests/lib/block-battery.json is carve-grammars' block battery, copied with no provenance header and no CI check; only a code comment records where it came from
+
+carve-rs -> homebrew-carve  not-a-dependency  the release workflow checks out the tap to write a formula into it, so the arrow points the other way: the tap consumes carve-rs releases

--- a/scripts/lib/drift-ledger.mjs
+++ b/scripts/lib/drift-ledger.mjs
@@ -116,6 +116,105 @@ export function parseConverterLedger(path) {
   return { entries, failures }
 }
 
+/** The kinds `resources/undeclared-dependencies.txt` accepts. */
+export const DEPENDENCY_KINDS = new Set(['vendors', 'couples', 'not-a-dependency'])
+
+/**
+ * `resources/undeclared-dependencies.txt`, whose lines are
+ * `<repo> -> <target>  <kind>  <reason>`.
+ *
+ * A third shape rather than a third parser: the key is a PAIR like the
+ * converter ledger's, and the value carries a kind as well as a reason, because
+ * this ledger says what sort of dependency it is declaring and not only that
+ * one exists. Everything else is the house rule - `#` comments, blank lines,
+ * two or more spaces before the reason, and one entry per key.
+ *
+ * Failures are collected rather than thrown, matching `parseConverterLedger`
+ * and for the same reason: the caller is a run that takes minutes over the
+ * whole org, and a bad line should report itself alongside every other finding
+ * instead of aborting the report someone was waiting for.
+ *
+ * @param {string} path
+ * @returns {{ entries: Map<string, { repo: string, target: string, kind: string, reason: string, line: number }>, failures: Array<string> }}
+ */
+export function parseDependencyLedger(path) {
+  const name = basename(path)
+  const entries = new Map()
+  const failures = []
+  const lines = readFileSync(path, 'utf8').split('\n')
+  for (const [index, rawLine] of lines.entries()) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+    const parsed = /^(\S+) *-> *(\S+) {2,}(\S+) {2,}(.+)$/.exec(line)
+    if (!parsed) {
+      failures.push(
+        `${name} line ${index + 1} unparseable: ${JSON.stringify(rawLine)} ` +
+          '(format: repo -> target  kind  reason)',
+      )
+      continue
+    }
+    const [, repo, target, kind, reason] = parsed
+    if (!DEPENDENCY_KINDS.has(kind)) {
+      failures.push(
+        `${name} line ${index + 1}: unknown kind ${JSON.stringify(kind)} - ` +
+          `one of ${[...DEPENDENCY_KINDS].join(', ')}`,
+      )
+      continue
+    }
+    if (repo === target) {
+      failures.push(`${name} line ${index + 1}: ${repo} cannot depend on itself`)
+      continue
+    }
+    const key = `${repo} -> ${target}`
+    if (entries.has(key)) {
+      failures.push(
+        `${name}: duplicate entry: ${key} - already declared as ` +
+          `${JSON.stringify(entries.get(key).reason)}, and this line says ${JSON.stringify(reason)}. ` +
+          'One of the two reasons is being thrown away; keep the true one.',
+      )
+      continue
+    }
+    entries.set(key, { repo, target, kind, reason, line: index + 1 })
+  }
+  return { entries, failures }
+}
+
+/**
+ * The two-directional check the ledger's value depends on.
+ *
+ * A hand-written note about a hand-written dependency rots exactly the way the
+ * wiki prose the Dependency Map replaced did, so neither direction is allowed
+ * to pass quietly: a declaration the tool can now read for itself is redundant,
+ * and a suppression with nothing left to suppress is describing a world that
+ * moved. Both name the line to delete.
+ *
+ * @param {Iterable<{ repo: string, target: string, kind: string, line: number }>} rows
+ * @param {Array<{ repo: string, target: string }>} detected edges the run found on its own.
+ * @param {Set<string>} known live repo names.
+ * @returns {Array<string>}
+ */
+export function auditDependencyLedger(rows, detected, known) {
+  const failures = []
+  const found = new Set(detected.map((edge) => `${edge.repo}|${edge.target}`))
+  for (const row of rows) {
+    for (const repo of [row.repo, row.target]) {
+      if (!known.has(repo)) failures.push(`line ${row.line}: no such repo ${JSON.stringify(repo)}`)
+    }
+    const isDetected = found.has(`${row.repo}|${row.target}`)
+    if (row.kind === 'not-a-dependency' && !isDetected) {
+      failures.push(
+        `line ${row.line}: ${row.repo} -> ${row.target} suppresses an edge nothing detects any more - delete the line`,
+      )
+    }
+    if (row.kind !== 'not-a-dependency' && isDetected) {
+      failures.push(
+        `line ${row.line}: ${row.repo} -> ${row.target} is detected on its own now - delete the line`,
+      )
+    }
+  }
+  return failures
+}
+
 /*
  * The same ledger, spelled as an object literal.
  *

--- a/tests/dependency-map.test.mjs
+++ b/tests/dependency-map.test.mjs
@@ -16,7 +16,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 
-import { classify, parseManifest, renderMermaid, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance } from '../tools/dependency-map.mjs'
+import { classify, parseManifest, renderMermaid, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance, parseDeclaredDependencies, auditDeclared } from '../tools/dependency-map.mjs'
 
 const cases = [
   ['github: shorthand', '@markup-carve/carve', 'github:markup-carve/carve-js#3ba8ba32', 'carve-js', '3ba8ba32'],
@@ -340,4 +340,105 @@ test('a vendored build layers like a declared edge, a CI checkout does not', () 
   const { layer } = releaseLayers(edges, ['carve-rs', 'plugin', 'other'])
   assert.equal(layer.get('plugin'), 1, 'the vendored build layers above its source')
   assert.equal(layer.get('other'), 0, 'the CI checkout leaves it unconstrained')
+})
+
+/*
+ * THE DECLARATION LEDGER.
+ *
+ * It holds what no detector can read, which is exactly the content that rots
+ * without a gate - the failure the Dependency Map was built to end. So the
+ * parse is strict and the audit runs in BOTH directions.
+ */
+
+const LIVE = new Set(['carve', 'carve-js', 'emacs-carve', 'carve-grammars', 'carve-rs', 'homebrew-carve'])
+
+test('a well formed declaration parses', () => {
+  const { rows, problems } = parseDeclaredDependencies(
+    '# a comment\n\nemacs-carve -> carve-grammars  vendors  a copied table with no header\n',
+  )
+  assert.deepEqual(problems, [])
+  assert.equal(rows.length, 1)
+  assert.deepEqual(
+    { ...rows[0], line: undefined },
+    { repo: 'emacs-carve', target: 'carve-grammars', kind: 'vendors', reason: 'a copied table with no header', line: undefined },
+  )
+})
+
+test('a malformed line is reported rather than skipped', () => {
+  // Skipping it silently is how a ledger comes to describe less than it claims.
+  const { rows, problems } = parseDeclaredDependencies('emacs-carve depends on carve-grammars\n')
+  assert.equal(rows.length, 0)
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /line 1/)
+})
+
+test('an unknown kind is refused', () => {
+  const { problems } = parseDeclaredDependencies('a -> b  sortof  because\n')
+  assert.match(problems[0], /unknown kind/)
+})
+
+test('the same pair cannot be declared twice', () => {
+  const { problems } = parseDeclaredDependencies(
+    'a -> b  vendors  one reason\na -> b  couples  another reason\n',
+  )
+  assert.match(problems[0], /declared twice/)
+})
+
+test('a declaration the tool can now detect on its own is stale', () => {
+  // The good failure: someone taught a detector to read this dependency, so the
+  // hand-written note is redundant and has to go, or the ledger becomes the
+  // prose it replaced.
+  const rows = [{ repo: 'emacs-carve', target: 'carve-grammars', kind: 'vendors', reason: 'x', line: 3 }]
+  const detected = [{ repo: 'emacs-carve', target: 'carve-grammars' }]
+  const problems = auditDeclared(rows, detected, LIVE)
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /detected on its own now - delete the line/)
+})
+
+test('a suppression that no longer suppresses anything is stale', () => {
+  const rows = [{ repo: 'carve-rs', target: 'homebrew-carve', kind: 'not-a-dependency', reason: 'x', line: 5 }]
+  const problems = auditDeclared(rows, [], LIVE)
+  assert.match(problems[0], /suppresses an edge nothing detects any more/)
+})
+
+test('a suppression that still has something to suppress is clean', () => {
+  const rows = [{ repo: 'carve-rs', target: 'homebrew-carve', kind: 'not-a-dependency', reason: 'x', line: 5 }]
+  const detected = [{ repo: 'carve-rs', target: 'homebrew-carve' }]
+  assert.deepEqual(auditDeclared(rows, detected, LIVE), [])
+})
+
+test('a declaration naming a repo that does not exist is refused', () => {
+  const rows = [{ repo: 'emacs-carve', target: 'carve-nope', kind: 'vendors', reason: 'x', line: 2 }]
+  const problems = auditDeclared(rows, [], LIVE)
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /no such repo "carve-nope"/)
+})
+
+test('the committed ledger is valid and every line is still needed', async () => {
+  // The file itself, not a fixture: a ledger that parses in theory and is
+  // malformed on disk has gated nothing.
+  const { readFileSync, existsSync } = await import('node:fs')
+  const { resolve, dirname } = await import('node:path')
+  const { fileURLToPath } = await import('node:url')
+  const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  const path = resolve(root, 'resources/undeclared-dependencies.txt')
+  assert.ok(existsSync(path), 'the ledger exists')
+  const { rows, problems } = parseDeclaredDependencies(readFileSync(path, 'utf8'))
+  assert.deepEqual(problems, [], 'the committed ledger parses cleanly')
+  assert.ok(rows.length > 0, 'it holds at least one declaration')
+})
+
+test('a vendor header whose commit is on a later line still pins', () => {
+  // intellij-carve's CSS header puts the repo on one line and the commit on the
+  // next. A same-line pattern called that unpinned, which is true of the line
+  // and false of the file.
+  const head = [
+    '/*',
+    ' * VENDORED from markup-carve/carve-js src/recipes.css',
+    ' * version 0.1.0, commit e0042b9',
+    ' */',
+  ].join('\n')
+  const found = vendorProvenance(head, 'intellij-carve', LIVE)
+  assert.equal(found?.target, 'carve-js')
+  assert.equal(found?.ref, 'e0042b9')
 })

--- a/tests/dependency-map.test.mjs
+++ b/tests/dependency-map.test.mjs
@@ -14,9 +14,13 @@
  * "anything with a slash".
  */
 import { strict as assert } from 'node:assert'
+import * as nodeFs from 'node:fs'
+import * as nodeOs from 'node:os'
+import * as nodePath from 'node:path'
+import { parseDependencyLedger, auditDependencyLedger } from '../scripts/lib/drift-ledger.mjs'
 import { test } from 'node:test'
 
-import { classify, parseManifest, renderMermaid, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance, parseDeclaredDependencies, auditDeclared } from '../tools/dependency-map.mjs'
+import { classify, parseManifest, renderMermaid, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance } from '../tools/dependency-map.mjs'
 
 const cases = [
   ['github: shorthand', '@markup-carve/carve', 'github:markup-carve/carve-js#3ba8ba32', 'carve-js', '3ba8ba32'],
@@ -350,12 +354,26 @@ test('a vendored build layers like a declared edge, a CI checkout does not', () 
  * parse is strict and the audit runs in BOTH directions.
  */
 
+/* The shared parser reads a PATH, which is right for the real ledger and awkward
+ * for a one-line fixture. This writes the fixture out rather than reimplementing
+ * the parse - a second parser in the tests is the duplication this refactor
+ * removed from the tool. */
+function parseFixture(text) {
+  const { mkdtempSync, writeFileSync: write } = nodeFs
+  const dir = mkdtempSync(nodeOs.tmpdir() + '/carve-ledger-')
+  const file = nodePath.join(dir, 'undeclared-dependencies.txt')
+  write(file, text)
+  return parseDependencyLedger(file)
+}
+
 const LIVE = new Set(['carve', 'carve-js', 'emacs-carve', 'carve-grammars', 'carve-rs', 'homebrew-carve'])
 
 test('a well formed declaration parses', () => {
-  const { rows, problems } = parseDeclaredDependencies(
+  const { entries, failures } = parseFixture(
     '# a comment\n\nemacs-carve -> carve-grammars  vendors  a copied table with no header\n',
   )
+  const rows = [...entries.values()]
+  const problems = failures
   assert.deepEqual(problems, [])
   assert.equal(rows.length, 1)
   assert.deepEqual(
@@ -366,22 +384,28 @@ test('a well formed declaration parses', () => {
 
 test('a malformed line is reported rather than skipped', () => {
   // Skipping it silently is how a ledger comes to describe less than it claims.
-  const { rows, problems } = parseDeclaredDependencies('emacs-carve depends on carve-grammars\n')
+  const { entries, failures } = parseFixture('emacs-carve depends on carve-grammars\n')
+  const rows = [...entries.values()]
+  const problems = failures
   assert.equal(rows.length, 0)
   assert.equal(problems.length, 1)
   assert.match(problems[0], /line 1/)
 })
 
 test('an unknown kind is refused', () => {
-  const { problems } = parseDeclaredDependencies('a -> b  sortof  because\n')
+  const { failures: problems } = parseFixture('a -> b  sortof  because\n')
   assert.match(problems[0], /unknown kind/)
 })
 
 test('the same pair cannot be declared twice', () => {
-  const { problems } = parseDeclaredDependencies(
+  const { failures: problems } = parseFixture(
     'a -> b  vendors  one reason\na -> b  couples  another reason\n',
   )
-  assert.match(problems[0], /declared twice/)
+  // The shared parser names BOTH reasons, so the author can see which one is
+  // being thrown away rather than only that a collision happened.
+  assert.match(problems[0], /duplicate entry: a -> b/)
+  assert.match(problems[0], /one reason/)
+  assert.match(problems[0], /another reason/)
 })
 
 test('a declaration the tool can now detect on its own is stale', () => {
@@ -390,26 +414,26 @@ test('a declaration the tool can now detect on its own is stale', () => {
   // prose it replaced.
   const rows = [{ repo: 'emacs-carve', target: 'carve-grammars', kind: 'vendors', reason: 'x', line: 3 }]
   const detected = [{ repo: 'emacs-carve', target: 'carve-grammars' }]
-  const problems = auditDeclared(rows, detected, LIVE)
+  const problems = auditDependencyLedger(rows, detected, LIVE)
   assert.equal(problems.length, 1)
   assert.match(problems[0], /detected on its own now - delete the line/)
 })
 
 test('a suppression that no longer suppresses anything is stale', () => {
   const rows = [{ repo: 'carve-rs', target: 'homebrew-carve', kind: 'not-a-dependency', reason: 'x', line: 5 }]
-  const problems = auditDeclared(rows, [], LIVE)
+  const problems = auditDependencyLedger(rows, [], LIVE)
   assert.match(problems[0], /suppresses an edge nothing detects any more/)
 })
 
 test('a suppression that still has something to suppress is clean', () => {
   const rows = [{ repo: 'carve-rs', target: 'homebrew-carve', kind: 'not-a-dependency', reason: 'x', line: 5 }]
   const detected = [{ repo: 'carve-rs', target: 'homebrew-carve' }]
-  assert.deepEqual(auditDeclared(rows, detected, LIVE), [])
+  assert.deepEqual(auditDependencyLedger(rows, detected, LIVE), [])
 })
 
 test('a declaration naming a repo that does not exist is refused', () => {
   const rows = [{ repo: 'emacs-carve', target: 'carve-nope', kind: 'vendors', reason: 'x', line: 2 }]
-  const problems = auditDeclared(rows, [], LIVE)
+  const problems = auditDependencyLedger(rows, [], LIVE)
   assert.equal(problems.length, 1)
   assert.match(problems[0], /no such repo "carve-nope"/)
 })
@@ -423,9 +447,9 @@ test('the committed ledger is valid and every line is still needed', async () =>
   const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
   const path = resolve(root, 'resources/undeclared-dependencies.txt')
   assert.ok(existsSync(path), 'the ledger exists')
-  const { rows, problems } = parseDeclaredDependencies(readFileSync(path, 'utf8'))
-  assert.deepEqual(problems, [], 'the committed ledger parses cleanly')
-  assert.ok(rows.length > 0, 'it holds at least one declaration')
+  const { entries, failures } = parseDependencyLedger(path)
+  assert.deepEqual(failures, [], 'the committed ledger parses cleanly')
+  assert.ok(entries.size > 0, 'it holds at least one declaration')
 })
 
 test('a vendor header whose commit is on a later line still pins', () => {

--- a/tools/dependency-map.mjs
+++ b/tools/dependency-map.mjs
@@ -43,8 +43,13 @@
  */
 
 import { execFile } from 'node:child_process'
-import { writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
+
+/** This file lives in tools/, so the repo root is one level up. */
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
 const run = promisify(execFile)
 
@@ -195,14 +200,105 @@ const VENDOR_CANDIDATE = /\.(iife\.js|bundle\.js|min\.js|umd\.js|wasm|css)$|\/(s
  * Only the first bytes are read. A range request over raw content turns a 1.4MB
  * bundle into 300 bytes, so this is cheap enough to run over every candidate.
  */
-const VENDOR_HEADER = /(?:Bundled|Generated|Vendored|Copied)\s+from\s+markup-carve\/([a-z0-9][a-z0-9.-]*)(?:[^\n]*?\bcommit\s+([0-9a-f]{7,40}))?/i
+const VENDOR_HEADER = /(?:Bundled|Generated|Vendored|Copied)\s+from\s+markup-carve\/([a-z0-9][a-z0-9.-]*)/i
+
+/*
+ * THE COMMIT IS NOT ALWAYS ON THE SAME LINE as the repo it names, and requiring
+ * that quietly downgraded a real pin to "unpinned". intellij-carve's CSS header
+ * reads
+ *
+ *   VENDORED from markup-carve/carve-css src/recipes.css
+ *   version 0.1.0, commit e0042b9
+ *
+ * which a same-line pattern reports as a dependency with no version - true of
+ * the line it looked at and false of the file. The whole header window is
+ * searched instead, which is the unit the writer was working in.
+ */
+const VENDOR_COMMIT = /\bcommit\s+([0-9a-f]{7,40})\b/i
 
 function vendorProvenance(head, self, known) {
   const match = VENDOR_HEADER.exec(head)
   if (!match) return null
   const target = match[1].replace(/\.git$/, '')
   if (target === self || !known.has(target)) return null
-  return { target, ref: match[2] ?? null }
+  return { target, ref: VENDOR_COMMIT.exec(head)?.[1] ?? null }
+}
+
+/*
+ * THE HAND-WRITTEN HALF, AND WHY IT IS GATED HARDER THAN THE READ HALF.
+ *
+ * resources/undeclared-dependencies.txt holds the edges no manifest, bundle
+ * header or checkout can be read for, and the edges the tool finds that are not
+ * dependencies at all. Its own file comment carries the rules; this parses it.
+ *
+ * A hand-written note about a hand-written dependency rots the same way the
+ * wiki prose did, so parsing is strict and the caller checks both directions: a
+ * line the tool can now find on its own is STALE and must go, a line naming a
+ * repo or kind that does not exist is an error. The file can only hold what
+ * detection cannot reach.
+ */
+const DECLARED_KINDS = new Set(['vendors', 'couples', 'not-a-dependency'])
+
+function parseDeclaredDependencies(text) {
+  const rows = []
+  const problems = []
+  const seen = new Set()
+  const lines = text.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (!line.trim() || line.trimStart().startsWith('#')) continue
+    const match = /^(\S+)\s*->\s*(\S+)\s\s+(\S+)\s\s+(.+?)\s*$/.exec(line)
+    if (!match) {
+      problems.push(`line ${i + 1}: not "<repo> -> <target>  <kind>  <reason>"`)
+      continue
+    }
+    const [, repo, target, kind, reason] = match
+    if (!DECLARED_KINDS.has(kind)) {
+      problems.push(`line ${i + 1}: unknown kind "${kind}" (${[...DECLARED_KINDS].join(', ')})`)
+      continue
+    }
+    if (repo === target) {
+      problems.push(`line ${i + 1}: ${repo} cannot depend on itself`)
+      continue
+    }
+    const key = `${repo}|${target}`
+    if (seen.has(key)) {
+      problems.push(`line ${i + 1}: ${repo} -> ${target} is declared twice`)
+      continue
+    }
+    seen.add(key)
+    rows.push({ repo, target, kind, reason, line: i + 1 })
+  }
+  return { rows, problems }
+}
+
+/*
+ * The two-directional check. `found` is what the run detected on its own.
+ *
+ * A declared line the run now finds is the good failure: someone taught the
+ * tool to read that dependency and the note is redundant. It is reported rather
+ * than tolerated, because a ledger nobody prunes becomes the prose again.
+ */
+function auditDeclared(rows, found, known) {
+  const problems = []
+  const detected = new Set(found.map((edge) => `${edge.repo}|${edge.target}`))
+  for (const row of rows) {
+    for (const name of [row.repo, row.target]) {
+      if (!known.has(name)) problems.push(`line ${row.line}: no such repo "${name}"`)
+    }
+    const isDetected = detected.has(`${row.repo}|${row.target}`)
+    if (row.kind === 'not-a-dependency' && !isDetected) {
+      problems.push(
+        `line ${row.line}: ${row.repo} -> ${row.target} suppresses an edge nothing detects any more - delete the line`,
+      )
+    }
+    if (row.kind !== 'not-a-dependency' && isDetected) {
+      problems.push(
+        `line ${row.line}: ${row.repo} -> ${row.target} is detected on its own now - delete the line`,
+      )
+    }
+  }
+  return problems
 }
 
 function ciReferences(text, self, known) {
@@ -542,6 +638,12 @@ async function resolveEdge(edge) {
       verdict: tagged ? (tagged === latest ? 'released' : 'behind-release') : 'unreleased',
       note,
     }
+  }
+
+  // A HAND-DECLARED dependency pins nothing - that is why it had to be written
+  // down. The reason carries the evidence a pin would otherwise have carried.
+  if (edge.kind === 'vendor-declared') {
+    return { ...edge, verdict: 'undeclared', note: `declared by hand: ${edge.declaredReason}` }
   }
 
   // A workflow checkout pins nothing by construction - it takes whatever the
@@ -1120,7 +1222,7 @@ function renderMarkdown(edges, { repos, skipped, generatedFrom, states }) {
 
 // ---------------------------------------------------------------------------
 
-export { classify, parseManifest, renderMermaid, renderSpine, renderConsumers, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance }
+export { classify, parseManifest, renderMermaid, renderSpine, renderConsumers, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance, parseDeclaredDependencies, auditDeclared }
 
 async function main() {
   const repos = await api(`orgs/${ORG}/repos?per_page=100&type=public`)
@@ -1195,7 +1297,38 @@ async function main() {
     else byPin.set(key, { ...edge, paths: [edge.path] })
   }
   const flat = [...byPin.values()]
-  const resolved = await mapLimit(flat, CONCURRENCY, resolveEdge)
+
+  // THE HAND-WRITTEN HALF, APPLIED AFTER DETECTION so the audit can tell a line
+  // that is still needed from one the detectors have caught up with.
+  const ledgerPath = resolve(repoRoot, 'resources/undeclared-dependencies.txt')
+  const ledger = existsSync(ledgerPath)
+    ? parseDeclaredDependencies(readFileSync(ledgerPath, 'utf8'))
+    : { rows: [], problems: [] }
+  const ledgerProblems = [
+    ...ledger.problems,
+    ...auditDeclared(ledger.rows, flat, liveNames),
+  ]
+
+  const suppressed = new Set(
+    ledger.rows.filter((row) => row.kind === 'not-a-dependency').map((row) => `${row.repo}|${row.target}`),
+  )
+  const kept = flat.filter((edge) => !suppressed.has(`${edge.repo}|${edge.target}`))
+  for (const row of ledger.rows) {
+    if (row.kind === 'not-a-dependency') continue
+    kept.push({
+      kind: row.kind === 'vendors' ? 'vendor-declared' : 'ci',
+      ref: null,
+      target: row.target,
+      name: row.target,
+      spec: '',
+      field: 'declared',
+      path: 'resources/undeclared-dependencies.txt',
+      repo: row.repo,
+      declaredReason: row.reason,
+    })
+  }
+
+  const resolved = await mapLimit(kept, CONCURRENCY, resolveEdge)
   const skipped = live.filter((repo) => !resolved.some((edge) => edge.repo === repo.name)).map((repo) => repo.name)
 
   if (flag('json')) {
@@ -1213,6 +1346,14 @@ async function main() {
   const states = new Map(
     await mapLimit(live, CONCURRENCY, async (repo) => [repo.name, await targetState(repo.name)]),
   )
+
+  if (ledgerProblems.length) {
+    // Reported on stderr rather than thrown: the tool's contract is that it
+    // describes the org and does not fail on it (see the header). A ledger
+    // problem is still loud, and `--check` is where a gate belongs.
+    console.error('resources/undeclared-dependencies.txt:')
+    for (const problem of ledgerProblems) console.error(`  ${problem}`)
+  }
 
   const markdown = `${renderMarkdown(resolved, {
     repos: live.length,

--- a/tools/dependency-map.mjs
+++ b/tools/dependency-map.mjs
@@ -43,10 +43,12 @@
  */
 
 import { execFile } from 'node:child_process'
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
+
+import { parseDependencyLedger, auditDependencyLedger } from '../scripts/lib/drift-ledger.mjs'
 
 /** This file lives in tools/, so the repo root is one level up. */
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -222,83 +224,6 @@ function vendorProvenance(head, self, known) {
   const target = match[1].replace(/\.git$/, '')
   if (target === self || !known.has(target)) return null
   return { target, ref: VENDOR_COMMIT.exec(head)?.[1] ?? null }
-}
-
-/*
- * THE HAND-WRITTEN HALF, AND WHY IT IS GATED HARDER THAN THE READ HALF.
- *
- * resources/undeclared-dependencies.txt holds the edges no manifest, bundle
- * header or checkout can be read for, and the edges the tool finds that are not
- * dependencies at all. Its own file comment carries the rules; this parses it.
- *
- * A hand-written note about a hand-written dependency rots the same way the
- * wiki prose did, so parsing is strict and the caller checks both directions: a
- * line the tool can now find on its own is STALE and must go, a line naming a
- * repo or kind that does not exist is an error. The file can only hold what
- * detection cannot reach.
- */
-const DECLARED_KINDS = new Set(['vendors', 'couples', 'not-a-dependency'])
-
-function parseDeclaredDependencies(text) {
-  const rows = []
-  const problems = []
-  const seen = new Set()
-  const lines = text.split('\n')
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
-    if (!line.trim() || line.trimStart().startsWith('#')) continue
-    const match = /^(\S+)\s*->\s*(\S+)\s\s+(\S+)\s\s+(.+?)\s*$/.exec(line)
-    if (!match) {
-      problems.push(`line ${i + 1}: not "<repo> -> <target>  <kind>  <reason>"`)
-      continue
-    }
-    const [, repo, target, kind, reason] = match
-    if (!DECLARED_KINDS.has(kind)) {
-      problems.push(`line ${i + 1}: unknown kind "${kind}" (${[...DECLARED_KINDS].join(', ')})`)
-      continue
-    }
-    if (repo === target) {
-      problems.push(`line ${i + 1}: ${repo} cannot depend on itself`)
-      continue
-    }
-    const key = `${repo}|${target}`
-    if (seen.has(key)) {
-      problems.push(`line ${i + 1}: ${repo} -> ${target} is declared twice`)
-      continue
-    }
-    seen.add(key)
-    rows.push({ repo, target, kind, reason, line: i + 1 })
-  }
-  return { rows, problems }
-}
-
-/*
- * The two-directional check. `found` is what the run detected on its own.
- *
- * A declared line the run now finds is the good failure: someone taught the
- * tool to read that dependency and the note is redundant. It is reported rather
- * than tolerated, because a ledger nobody prunes becomes the prose again.
- */
-function auditDeclared(rows, found, known) {
-  const problems = []
-  const detected = new Set(found.map((edge) => `${edge.repo}|${edge.target}`))
-  for (const row of rows) {
-    for (const name of [row.repo, row.target]) {
-      if (!known.has(name)) problems.push(`line ${row.line}: no such repo "${name}"`)
-    }
-    const isDetected = detected.has(`${row.repo}|${row.target}`)
-    if (row.kind === 'not-a-dependency' && !isDetected) {
-      problems.push(
-        `line ${row.line}: ${row.repo} -> ${row.target} suppresses an edge nothing detects any more - delete the line`,
-      )
-    }
-    if (row.kind !== 'not-a-dependency' && isDetected) {
-      problems.push(
-        `line ${row.line}: ${row.repo} -> ${row.target} is detected on its own now - delete the line`,
-      )
-    }
-  }
-  return problems
 }
 
 function ciReferences(text, self, known) {
@@ -1222,7 +1147,7 @@ function renderMarkdown(edges, { repos, skipped, generatedFrom, states }) {
 
 // ---------------------------------------------------------------------------
 
-export { classify, parseManifest, renderMermaid, renderSpine, renderConsumers, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance, parseDeclaredDependencies, auditDeclared }
+export { classify, parseManifest, renderMermaid, renderSpine, renderConsumers, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance }
 
 async function main() {
   const repos = await api(`orgs/${ORG}/repos?per_page=100&type=public`)
@@ -1302,18 +1227,19 @@ async function main() {
   // that is still needed from one the detectors have caught up with.
   const ledgerPath = resolve(repoRoot, 'resources/undeclared-dependencies.txt')
   const ledger = existsSync(ledgerPath)
-    ? parseDeclaredDependencies(readFileSync(ledgerPath, 'utf8'))
-    : { rows: [], problems: [] }
+    ? parseDependencyLedger(ledgerPath)
+    : { entries: new Map(), failures: [] }
+  const declared = [...ledger.entries.values()]
   const ledgerProblems = [
-    ...ledger.problems,
-    ...auditDeclared(ledger.rows, flat, liveNames),
+    ...ledger.failures,
+    ...auditDependencyLedger(declared, flat, liveNames),
   ]
 
   const suppressed = new Set(
-    ledger.rows.filter((row) => row.kind === 'not-a-dependency').map((row) => `${row.repo}|${row.target}`),
+    declared.filter((row) => row.kind === 'not-a-dependency').map((row) => `${row.repo}|${row.target}`),
   )
   const kept = flat.filter((edge) => !suppressed.has(`${edge.repo}|${edge.target}`))
-  for (const row of ledger.rows) {
+  for (const row of declared) {
     if (row.kind === 'not-a-dependency') continue
     kept.push({
       kind: row.kind === 'vendors' ? 'vendor-declared' : 'ci',


### PR DESCRIPTION
Four detectors now cover the org: package manifests, submodule gitlinks, provenance headers inside committed builds, and workflow checkouts. Between them they read most of it. Two gaps are left, opposite in shape.

**A dependency that exists and nothing declares.** `emacs-carve` vendors carve-grammars' block-battery table and records that in a code comment - prose, not a contract. A file copied without a header, a format implemented by reading another repo, a runtime that shells out to a binary it does not install: all real, none readable.

**An edge the tool finds that is not a dependency.** `carve-rs` checks out the homebrew tap in its release workflow to write a formula into it. That is a push, and the arrow points the other way. Telling it from a checkout-to-consume needs the job's intent, which no pattern recovers.

So `resources/undeclared-dependencies.txt`:

```text
<repo> -> <target>  <kind>  <reason>

vendors            a copy is in this repo's tree with no header to read.
                   Containment: it LAYERS, exactly like a declared pin.
couples            bound at build or test time without either containing the
                   other. Shown with `~`, never layers.
not-a-dependency   suppresses an edge the tool finds and should not have.
```

## Why it is gated harder than the read half

The Dependency Map exists because prose could not be re-derived - a stale pin read exactly like a current one. A hand-written note about a hand-written dependency has that defect one level up. So the file is checked in **both** directions:

- a declared line the tool can now find on its own is **stale** and says so, naming the line to delete
- a suppression with nothing left to suppress is stale the same way
- an unknown repo, unknown kind, repeated pair or malformed line is an **error**, not a skipped line - skipping quietly is how a ledger comes to describe less than it claims

The file can therefore only hold what detection genuinely cannot reach, and it shrinks as the detectors improve.

## A defect the CSS found

`intellij-carve` vendored carve-css while this was being written, with a header naming the repo on one line and the commit on the next:

```text
VENDORED from markup-carve/carve-css src/recipes.css
version 0.1.0, commit e0042b9
```

The same-line pattern reported a dependency with **no version** - true of the line it read, false of the file, and exactly the downgrade a ledger entry would then have papered over. The whole header window is searched now, so the edge resolves to `e0042b9` and needs no declaration:

```text
intellij-carve  0.1.5  +13  <- carve, carve-css, carve-js, carve-lsp
```

Both ledger entries are the residue after that fix. Every rule is asserted - including that the committed file parses cleanly, not just a fixture - and each assertion was checked by mutation.
