### PR TITLE
fix: separate release versions from tag names

### DIFF
--- a/scripts/pre-tag-check.sh
+++ b/scripts/pre-tag-check.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 #
-# pre-tag-check.sh <version> [repo-dir]
+# pre-tag-check.sh <version> [repo-dir] [--tag <tag>]
 #
-# Validates that a repository is ready to be tagged <version>, so a release is
+# Validates that a repository is ready to release <version>, so a release is
 # never cut with a stale version field, an un-cut changelog, or - in the spec
 # repo - an engine pin drift file nobody reconciled. Run it from a repo root (or
 # pass the repo dir) BEFORE publishing the draft release / tagging.
 #
 #   bash scripts/pre-tag-check.sh 0.1.2                 # check the current repo
 #   bash /path/to/carve/scripts/pre-tag-check.sh 0.1.1 ../carve-rs
+#   bash scripts/pre-tag-check.sh 0.1.4 ../carve-lsp --tag v0.1.4
 #
 # Exit status is non-zero if anything fails. This mirrors the CI release guards
 # in carve-js/carve-rs (which block npm/cargo publish on a version or changelog
@@ -18,12 +19,36 @@
 set -u
 
 VERSION="${1:-}"
-DIR="${2:-.}"
-
 if [ -z "$VERSION" ]; then
-  echo "usage: pre-tag-check.sh <version> [repo-dir]" >&2
+  echo "usage: pre-tag-check.sh <version> [repo-dir] [--tag <tag>]" >&2
   exit 2
 fi
+shift
+
+DIR="."
+DIR_SET=0
+TAG="$VERSION"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tag)
+      [ "$#" -ge 2 ] && [ -n "$2" ] \
+        || { echo "--tag requires a tag name" >&2; exit 2; }
+      TAG="$2"
+      shift 2
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      [ "$DIR_SET" -eq 0 ] \
+        || { echo "unexpected argument: $1" >&2; exit 2; }
+      DIR="$1"
+      DIR_SET=1
+      shift
+      ;;
+  esac
+done
 
 cd "$DIR" || { echo "cannot cd into $DIR" >&2; exit 2; }
 
@@ -32,7 +57,12 @@ ok()   { echo "  [ok]   $*"; }
 bad()  { echo "  [FAIL] $*"; fail=1; }
 skip() { echo "  [skip] $*"; }
 
-echo "Pre-tag check for $VERSION in $(pwd)"
+if ! git check-ref-format "refs/tags/$TAG" >/dev/null 2>&1; then
+  echo "invalid tag name: $TAG" >&2
+  exit 2
+fi
+
+echo "Pre-tag check for version $VERSION (tag $TAG) in $(pwd)"
 
 # A dot-escaped copy of the version for anchored greps.
 ESCV="${VERSION//./\\.}"
@@ -57,12 +87,12 @@ else
 fi
 
 # 3. Tag not already present (local or remote).
-if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null 2>&1; then
-  bad "tag $VERSION already exists locally"
-elif git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
-  bad "tag $VERSION already exists on origin"
+if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1; then
+  bad "tag $TAG already exists locally"
+elif git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+  bad "tag $TAG already exists on origin"
 else
-  ok "tag $VERSION not yet present"
+  ok "tag $TAG not yet present"
 fi
 
 # 4. Version field matches the target (auto-detect the manifest).
@@ -261,7 +291,7 @@ fi
 
 echo
 if [ "$fail" -ne 0 ]; then
-  echo "PRE-TAG CHECK FAILED - do not tag $VERSION yet."
+  echo "PRE-TAG CHECK FAILED - do not tag $TAG yet."
   exit 1
 fi
-echo "PRE-TAG CHECK PASSED - ready to tag $VERSION."
+echo "PRE-TAG CHECK PASSED - ready to tag $TAG."

--- a/tests/test-manifest.test.mjs
+++ b/tests/test-manifest.test.mjs
@@ -12,9 +12,10 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { execFileSync } from 'node:child_process'
-import { readFileSync, readdirSync } from 'node:fs'
-import { resolve, dirname } from 'node:path'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
@@ -93,4 +94,57 @@ test('the AST verdict cannot close on narrower or disposable evidence', () => {
     'green computes which required gates its run skipped',
   )
   assert.match(workflow, /if \[ -n "\$missing" \]; then[\s\S]*?#\$issue remains open/)
+})
+
+function run(command, args, cwd) {
+  return spawnSync(command, args, { cwd, encoding: 'utf8' })
+}
+
+function releaseRepository() {
+  const dir = mkdtempSync(join(tmpdir(), 'carve-pre-tag-'))
+  const work = join(dir, 'work')
+  const origin = join(dir, 'origin.git')
+  mkdirSync(work)
+  assert.equal(run('git', ['init', '--bare', origin], dir).status, 0)
+  assert.equal(run('git', ['init', '-b', 'main'], work).status, 0)
+  assert.equal(run('git', ['config', 'user.email', 'test@example.invalid'], work).status, 0)
+  assert.equal(run('git', ['config', 'user.name', 'pre-tag test'], work).status, 0)
+  writeFileSync(join(work, 'package.json'), '{"version":"0.1.4"}\n')
+  writeFileSync(join(work, 'CHANGELOG.md'), '# Changelog\n\n## [0.1.4] - 2026-08-27\n')
+  assert.equal(run('git', ['add', '.'], work).status, 0)
+  assert.equal(run('git', ['commit', '-m', 'release'], work).status, 0)
+  assert.equal(run('git', ['remote', 'add', 'origin', origin], work).status, 0)
+  assert.equal(run('git', ['push', '-u', 'origin', 'main'], work).status, 0)
+  return work
+}
+
+test('the pre-tag check separates a prefixed tag from the bare version', () => {
+  const work = releaseRepository()
+  const checker = resolve(repo, 'scripts/pre-tag-check.sh')
+  const result = run('bash', [checker, '0.1.4', work, '--tag', 'v0.1.4'], repo)
+
+  assert.equal(result.status, 0, result.stdout + result.stderr)
+  assert.match(result.stdout, /tag v0\.1\.4 not yet present/)
+  assert.match(result.stdout, /package\.json version = 0\.1\.4/)
+  assert.match(result.stdout, /CHANGELOG\.md has a '## \[0\.1\.4\]' section/)
+})
+
+test('the pre-tag check tests the real prefixed ref for existence', () => {
+  const work = releaseRepository()
+  const checker = resolve(repo, 'scripts/pre-tag-check.sh')
+  assert.equal(run('git', ['tag', 'v0.1.4'], work).status, 0)
+  const result = run('bash', [checker, '0.1.4', '--tag', 'v0.1.4', work], repo)
+
+  assert.equal(result.status, 1, result.stdout + result.stderr)
+  assert.match(result.stdout, /\[FAIL\] tag v0\.1\.4 already exists locally/)
+  assert.doesNotMatch(result.stdout, /expected v0\.1\.4/)
+})
+
+test('the pre-tag check keeps the existing bare-tag invocation', () => {
+  const work = releaseRepository()
+  const checker = resolve(repo, 'scripts/pre-tag-check.sh')
+  const result = run('bash', [checker, '0.1.4', work], repo)
+
+  assert.equal(result.status, 0, result.stdout + result.stderr)
+  assert.match(result.stdout, /tag 0\.1\.4 not yet present/)
 })


### PR DESCRIPTION
## Summary

- separate the release version from the Git tag checked by `pre-tag-check.sh`
- add an explicit `--tag <tag>` option while preserving existing bare-tag calls
- reject malformed tag names and unexpected arguments before running checks
- cover prefixed tags, existing prefixed refs, and backward compatibility

## Verification

- `bash -n scripts/pre-tag-check.sh`
- `shellcheck scripts/pre-tag-check.sh`
- `node --test tests/test-manifest.test.mjs`

Closes #1852.
