### PR TITLE
docs: stamp data-theme so carve-css follows the site's theme

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -82,6 +82,26 @@ export default defineConfig({
   },
 
   head: [
+    // VitePress signals dark with a `dark` CLASS on <html>. carve-css keys its
+    // palette off `data-theme`, with `prefers-color-scheme` as the fallback for
+    // an unstamped root. Left alone that breaks BOTH ways: a dark page keeps the
+    // light tokens (white cards on a dark ground), and on a dark-OS machine a
+    // LIGHT page picks up the dark tokens, because nothing said otherwise.
+    //
+    // So stamp both directions, never just dark. In head rather than the theme so
+    // it lands before first paint - a sync at hydration flashes the wrong palette.
+    [
+      'script',
+      {},
+      `(function () {
+  var root = document.documentElement
+  function sync() {
+    root.setAttribute('data-theme', root.classList.contains('dark') ? 'dark' : 'light')
+  }
+  sync()
+  new MutationObserver(sync).observe(root, { attributes: true, attributeFilter: ['class'] })
+})()`,
+    ],
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/carve/logo.svg' }],
     ['meta', { name: 'theme-color', content: '#3c8772' }],
     ['meta', { property: 'og:type', content: 'website' }],


### PR DESCRIPTION
Dark mode on the new recipes page rendered white cards and pale washes on a dark ground.

VitePress signals dark with a `dark` **class** on `<html>`. carve-css keys its palette off `data-theme`, falling back to `prefers-color-scheme` for an unstamped root. Neither fired, so the tokens stayed light - measured: `--carve-surface: #ffffff` on a page whose background was `rgb(27, 27, 31)`.

The inverse was broken too, and would have been harder to notice. On a dark-OS machine a **light** page stamps nothing, so `:root:not([data-theme="light"])` inside the `prefers-color-scheme` block matched and the dark tokens applied to a light page. So this stamps both directions rather than only adding dark.

It sits in `head` rather than the theme entry because a sync at hydration paints the wrong palette first.

## carve-css needed no change

Audited rather than assumed:

- `recipes.css` contains no literal colours at all, so nothing can strand a light value.
- With `data-theme` set, every text-on-background pair measures between **6.8 and 12.8** contrast - cards, both badge tones, ok/warn rows, the aside, the step marker, tree text.

The gap is that a host whose theme signal is a class has to map it, which this does. Worth a note in the carve-css README so the next integration does not rediscover it.