### PR TITLE
chore: take carve-css from the registry, not a commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@djot/djot": "^0.3.2",
         "@markup-carve/carve": "github:markup-carve/carve-js#37ed8904f2a5dd540fd0bddb2294fe348f17eb7d",
-        "@markup-carve/carve-css": "github:markup-carve/carve-css#e0042b967ad0aee4e6d6109531d9c98c15686f3c",
+        "@markup-carve/carve-css": "^0.1.0",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
         "@mermaid-lint/cli": "^0.53.1",
@@ -1011,8 +1011,8 @@
     },
     "node_modules/@markup-carve/carve-css": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-css.git#e0042b967ad0aee4e6d6109531d9c98c15686f3c",
-      "integrity": "sha512-WFNJVq8f7Xp6HO+V9gQmvMhetvQfy16NYW4WIjnSJ4VmF26FmAicLC/O2HnamFXsb5zh/oZyec9ZP2/kv6fSqg==",
+      "resolved": "https://registry.npmjs.org/@markup-carve/carve-css/-/carve-css-0.1.0.tgz",
+      "integrity": "sha512-EVdaHBLt/v0VdxEDztLCyG160iuroiSfSByPkhudFfdIy67TWiPw4kXAtnDD4Hsd3EOIXoEJpGNjqemjWSS8Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@djot/djot": "^0.3.2",
     "@markup-carve/carve": "github:markup-carve/carve-js#37ed8904f2a5dd540fd0bddb2294fe348f17eb7d",
-    "@markup-carve/carve-css": "github:markup-carve/carve-css#e0042b967ad0aee4e6d6109531d9c98c15686f3c",
+    "@markup-carve/carve-css": "^0.1.0",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
     "@mermaid-lint/cli": "^0.53.1",


### PR DESCRIPTION
carve-css published `0.1.0`, so the git pin can go.

The tag is the tree the recipes page was written against plus the two fixes that landed after it: a step's number no longer sits flush against its text (carve-css#4), and the README now says a host with its own theme toggle has to map it (carve-css#5).

Checked the **published tarball** rather than trusting that the tag and the release agreed - `npm pack @markup-carve/carve-css@0.1.0` carries `--carve-step-marker`, so the fix is really in what consumers install.