### PR TITLE
chore: generate the Dependency Map from main, on a schedule

### DIFF
--- a/.github/workflows/dependency-map.yml
+++ b/.github/workflows/dependency-map.yml
@@ -1,0 +1,113 @@
+name: Dependency Map
+
+# Regenerate the wiki's Dependency Map and push it, so that page is produced by
+# a machine reading current main rather than by whoever last remembered to run
+# the tool.
+#
+# WHY THIS EXISTS RATHER THAN A NOTE IN A RUNBOOK. The page carries "generated -
+# do not edit by hand", and the hand-edit is not what broke it. A regeneration
+# run from a checkout parked on a feature branch produced it from a generator
+# predating the CI-read edges (#1847) and the declaration ledger (#1851): 86
+# edges came back as 61 and the whole Release order section vanished. A
+# regeneration rewrites every line anyway, so the diff hid it completely, and the
+# page read as one that had got shorter because releases had landed. The next
+# commit hand-patched that degraded page - counts, mermaid classes and table rows
+# retyped in place - which is how a generated document quietly stops being one.
+#
+# Nothing about that sequence was careless; it is what a manual step does over
+# enough runs. So the manual step goes away, and the generator additionally
+# stamps a warning on any page it produces from something that is not main
+# (staleSourceBanner in tools/dependency-map.mjs), which covers the local runs
+# this workflow does not.
+#
+# THE TOKEN. A repo's wiki is a separate git repository, `<repo>.wiki.git`, and
+# GITHUB_TOKEN with `contents: write` is what pushes to it. If an org policy ever
+# refuses that, the push step is what fails, loudly and on its own - swap in a
+# fine-grained PAT with Contents: read & write on this repo (BUMP_TOKEN already
+# exists for the downstream bumps and would do) rather than dropping the step.
+
+on:
+  # The map reads every repo in the org, so it goes stale from OTHER repos'
+  # activity, not this one's. That makes the schedule the primary trigger here,
+  # unlike most of this repo's automation.
+  schedule:
+    - cron: '37 5 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    # A change to the generator changes the page by definition. Waiting for the
+    # next nightly to see it is how a generator lands and its output does not.
+    paths:
+      - 'tools/dependency-map.mjs'
+      - 'scripts/lib/drift-ledger.mjs'
+      - 'resources/undeclared-dependencies.txt'
+      - '.github/workflows/dependency-map.yml'
+
+# One run at a time, and let a newer one win: two runs pushing to the same wiki
+# ref differ only in which was slower to finish.
+concurrency:
+  group: dependency-map
+  cancel-in-progress: true
+
+jobs:
+  regenerate:
+    name: Regenerate and push the wiki page
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # the wiki repo, not this one
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # No `npm ci`: the generator imports nothing outside node: builtins and
+      # one local module, and shells out to `gh` and `git`. Installing the repo's
+      # full dev tree would be minutes spent on nothing this step reads.
+      - name: Generate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node tools/dependency-map.mjs --out "$RUNNER_TEMP/Dependency-Map.md"
+
+      # A generator that fails halfway can still exit 0 with a plausible file, and
+      # this page's whole failure mode is a section that is missing rather than
+      # wrong. So assert the shape before it is allowed to overwrite anything.
+      - name: The page has the sections it is supposed to have
+        run: |
+          set -euo pipefail
+          PAGE="$RUNNER_TEMP/Dependency-Map.md"
+          for heading in '## Release order' '## The spine' '## Every edge, worst first'; do
+            grep -qxF "$heading" "$PAGE" || { echo "::error::generated page is missing '$heading'"; exit 1; }
+          done
+          # The banner fires when the run did not come from main. In this job it
+          # always does, so its presence means the checkout is not what it claims
+          # and the page must not be published.
+          if grep -q 'Generated from a checkout that is not' "$PAGE"; then
+            echo "::error::generated from something other than main; refusing to publish"
+            exit 1
+          fi
+
+      - name: Push it, if it moved
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone --quiet \
+            "https://x-access-token:$TOKEN@github.com/${{ github.repository }}.wiki.git" wiki
+          cp "$RUNNER_TEMP/Dependency-Map.md" wiki/Dependency-Map.md
+          cd wiki
+          if git diff --quiet -- Dependency-Map.md; then
+            echo "No change since the last run."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add Dependency-Map.md
+          # Two -m rather than an embedded newline: a heredoc here would carry
+          # this block's indentation into the commit body.
+          git commit \
+            -m 'Regenerate the Dependency Map' \
+            -m "Generated from ${{ github.sha }} by .github/workflows/dependency-map.yml."
+          git push --quiet
+          echo "Pushed."

--- a/tests/dependency-map.test.mjs
+++ b/tests/dependency-map.test.mjs
@@ -20,7 +20,7 @@ import * as nodePath from 'node:path'
 import { parseDependencyLedger, auditDependencyLedger } from '../scripts/lib/drift-ledger.mjs'
 import { test } from 'node:test'
 
-import { classify, parseManifest, renderMermaid, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance } from '../tools/dependency-map.mjs'
+import { classify, parseManifest, renderMermaid, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance, staleSourceBanner } from '../tools/dependency-map.mjs'
 
 const cases = [
   ['github: shorthand', '@markup-carve/carve', 'github:markup-carve/carve-js#3ba8ba32', 'carve-js', '3ba8ba32'],
@@ -465,4 +465,44 @@ test('a vendor header whose commit is on a later line still pins', () => {
   const found = vendorProvenance(head, 'intellij-carve', LIVE)
   assert.equal(found?.target, 'carve-js')
   assert.equal(found?.ref, 'e0042b9')
+})
+
+/*
+ * THE BANNER IS THE ONLY THING THAT CAN REPORT A RUN FROM A STALE TREE.
+ *
+ * A regeneration rewrites every line of the page, so a section that stopped
+ * being emitted leaves no trace a reviewer could catch in the diff - it looks
+ * like data that moved. That is not a hypothetical shape: a run from a branch
+ * older than the CI-read edges published 61 edges instead of 86 with the Release
+ * order section gone, and it went unnoticed until somebody asked where their
+ * dependency information had gone.
+ *
+ * Both directions are asserted, because a banner that fires when it should not
+ * is worse than none: the workflow REFUSES TO PUBLISH when it sees one, so a
+ * false positive stops the nightly regeneration outright.
+ */
+test('the stale-source banner fires only when the run did not come from main', () => {
+  assert.equal(
+    staleSourceBanner({ sha: 'a'.repeat(40), mainSha: 'a'.repeat(40) }),
+    null,
+    'a run from the tip of main carries no banner',
+  )
+})
+
+test('a banner needs both sides of the comparison, and says neither when it has one', () => {
+  // No .git, no network, a remote not called origin: none of those mean the run
+  // was stale, they mean the question went unanswered. A banner on "unknown"
+  // would fire on every tarball and be tuned out inside a week - and it would
+  // also break the workflow, which treats a banner as a reason not to publish.
+  assert.equal(staleSourceBanner({}), null)
+  assert.equal(staleSourceBanner({ sha: 'a'.repeat(40) }), null)
+  assert.equal(staleSourceBanner({ mainSha: 'b'.repeat(40) }), null)
+})
+
+test('the banner names both commits, short, so the reader can tell what ran', () => {
+  const text = staleSourceBanner({ sha: 'deadbeefcafe1234', mainSha: '0123456789abcdef' })
+  assert.match(text, /deadbeef/, 'the commit the run came from')
+  assert.match(text, /01234567/, 'the commit it should have come from')
+  assert.doesNotMatch(text, /deadbeefcafe1234/, 'abbreviated, not the full sha')
+  assert.match(text, /Regenerate from/, 'and what to do about it')
 })

--- a/tools/dependency-map.mjs
+++ b/tools/dependency-map.mjs
@@ -1023,7 +1023,44 @@ function renderReleaseOrder(edges, states, allRepos) {
   return lines.join('\n')
 }
 
-function renderMarkdown(edges, { repos, skipped, generatedFrom, states }) {
+const TICK = '`'
+const STALE_HEAD = '**Generated from a checkout that is not `main`.** '
+const RUN_FROM = 'This run came from `'
+
+/*
+ * WAS THIS RUN MADE FROM A CHECKOUT THAT COULD SEE THE WHOLE GENERATOR?
+ *
+ * The page says "generated - do not edit by hand", which is honest about hand
+ * edits while saying nothing about the other way it rots: a run from a checkout
+ * parked on a feature branch, by a generator predating whatever the tool has
+ * learned since that branch was cut.
+ *
+ * That is not hypothetical. A run from a branch older than the CI-read edges
+ * (#1847) and the declaration ledger (#1851) rewrote the wiki page with 61
+ * edges instead of 86 and dropped the whole Release order section - and the
+ * result was indistinguishable from a page that had got shorter because
+ * releases landed. Nobody could see it in the diff, because a regeneration
+ * rewrites every line anyway. The next commit then hand-patched the degraded
+ * page, which is how a generated document stops being generated.
+ *
+ * A missing section cannot announce itself, so the provenance has to. Silent
+ * when the run came from the tip of main - which is what the automation in
+ * .github/workflows/dependency-map.yml produces, and the case that should not
+ * carry a banner.
+ */
+function staleSourceBanner({ sha, mainSha }) {
+  if (!sha || !mainSha || sha === mainSha) return null
+  return (
+    STALE_HEAD +
+    RUN_FROM + sha.slice(0, 8) + TICK + ', ' +
+    'while ' + TICK + 'main' + TICK + ' is at ' + TICK + mainSha.slice(0, 8) + TICK + '. ' +
+    'A generator older than the tree it ran from emits whatever it knew then, so a section it has ' +
+    'since gained is MISSING here rather than empty, and that reads exactly like data that moved. ' +
+    'Regenerate from ' + TICK + 'main' + TICK + ' before trusting this page.'
+  )
+}
+
+function renderMarkdown(edges, { repos, skipped, generatedFrom, states, source }) {
   const worst = [...edges].sort(
     (a, b) => VERDICTS[b.verdict].rank - VERDICTS[a.verdict].rank || a.repo.localeCompare(b.repo),
   )
@@ -1044,6 +1081,11 @@ function renderMarkdown(edges, { repos, skipped, generatedFrom, states }) {
       'this page is only the part a machine can re-derive.',
   )
   out.push('')
+  const stale = staleSourceBanner(source ?? {})
+  if (stale) {
+    out.push(stale)
+    out.push('')
+  }
   out.push(`Read ${repos} repositories, ${edges.length} edges, from ${generatedFrom}.`)
   out.push('')
   out.push('## Release order')
@@ -1147,7 +1189,31 @@ function renderMarkdown(edges, { repos, skipped, generatedFrom, states }) {
 
 // ---------------------------------------------------------------------------
 
-export { classify, parseManifest, renderMermaid, renderSpine, renderConsumers, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance }
+export { classify, parseManifest, renderMermaid, renderSpine, renderConsumers, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance, staleSourceBanner }
+
+/*
+ * What this run was generated FROM, for staleSourceBanner above.
+ *
+ * `ls-remote` rather than `fetch`: asking a question about the remote must not
+ * write to the checkout somebody is working in, and a stale remote-tracking ref
+ * is exactly the thing that would make this answer wrong.
+ *
+ * Every failure here is silent by design. A tarball with no `.git`, no network,
+ * a remote named something other than `origin` - none of those say the run is
+ * stale, they say the question cannot be answered, and a banner that fires on
+ * "unknown" would be ignored within a week.
+ */
+async function sourceProvenance() {
+  const git = async (args) => (await run('git', args, { cwd: repoRoot })).stdout.trim()
+  try {
+    const sha = await git(['rev-parse', 'HEAD'])
+    const remote = await git(['ls-remote', 'origin', 'refs/heads/main'])
+    const mainSha = remote.split(/\s+/)[0]
+    return { sha, mainSha }
+  } catch {
+    return {}
+  }
+}
 
 async function main() {
   const repos = await api(`orgs/${ORG}/repos?per_page=100&type=public`)
@@ -1286,6 +1352,7 @@ async function main() {
     skipped,
     states,
     generatedFrom: 'each repository\'s default branch',
+    source: await sourceProvenance(),
   })}\n`
   const out = value('out', null)
   if (out) writeFileSync(out, markdown)


### PR DESCRIPTION
The wiki's Dependency Map lost its Release order section and every undeclared edge this morning - 86 edges published as 61, 512 lines as 346. Nobody deleted anything. A regeneration ran from a checkout parked on a feature branch, so it came from a generator predating the CI-read edges (#1847) and the declaration ledger (#1851), and emitted what that generator knew.

The part worth fixing is that **the diff could not show it**. A regeneration rewrites every line, so a section that stopped being emitted looks exactly like data that moved, and the page read as one that had simply got shorter because releases landed. The next wiki commit then hand-patched the degraded page - counts, mermaid classes and table rows retyped in place - which is how a page that says "generated - do not edit by hand" stops being generated.

Nothing there was careless; it is what a manual step does given enough runs. So:

**The manual step goes away.** `.github/workflows/dependency-map.yml` regenerates and pushes the page nightly, on dispatch, and whenever the generator itself changes. It pushes only when the page actually moved. The schedule is the primary trigger rather than a fallback, which is unusual for this repo's automation and follows from what the map reads: it goes stale from *other* repos' activity, not this one's.

**Local runs get a stamp.** `staleSourceBanner` puts a warning at the top of any page generated from something that is not the tip of `main`, naming both commits. The workflow treats that banner as a refusal to publish, next to a check that the three sections a truncated run would drop are actually present.

Two deliberate calls in the lookup: `git ls-remote` rather than a fetch, because asking a question about the remote must not write to the checkout somebody is working in; and every failure of the lookup is silent, because a tarball with no `.git` does not mean the run was stale, it means the question went unanswered - a banner on "unknown" would be tuned out within a week *and* would stop the nightly run, since the workflow refuses to publish when it sees one.

Both directions are asserted in `tests/dependency-map.test.mjs`, and both were also confirmed end to end against the real org: run from `main`, no banner and 86 edges; run from this branch's HEAD, the banner naming `165715bf` against `fa4824f8` and the workflow's guard refusing to publish. A false positive is the expensive direction here, so it is tested as hard as the true one.

The wiki page itself is already restored, regenerated from `main` at `fa4824f8` - every fact the hand edit had asserted is present, machine-derived, and `rouge-carve` is placed better than by hand: it is not a repo that declares nothing, it is an undeclared edge onto `carve` that its own `ci.yml` names.

**On the token.** A repo's wiki is a separate git repository and `GITHUB_TOKEN` with `contents: write` is what pushes to it. I could not verify that from here - the first dispatch run proves it. If an org policy refuses, the push step fails on its own and the fix is a fine-grained PAT (`BUMP_TOKEN` already exists and would do), not dropping the step.
