### PR TITLE
chore: publish the Dependency Map when it changed, not when time passed

### DIFF
--- a/.github/workflows/dependency-map.yml
+++ b/.github/workflows/dependency-map.yml
@@ -62,13 +62,34 @@ jobs:
         with:
           node-version: 24
 
+      # Cloned BEFORE generating, because the published page is an input now:
+      # the generator compares against it to say whether the run is worth a
+      # commit.
+      - name: Clone the wiki
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git clone --quiet \
+            "https://x-access-token:$TOKEN@github.com/${{ github.repository }}.wiki.git" wiki
+
       # No `npm ci`: the generator imports nothing outside node: builtins and
       # one local module, and shells out to `gh` and `git`. Installing the repo's
       # full dev tree would be minutes spent on nothing this step reads.
+      #
+      # `--changed-vs` reports substantive or cosmetic and decides nothing. The
+      # page is written either way, so a later step can still publish it if the
+      # policy here ever changes.
       - name: Generate
+        id: generate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node tools/dependency-map.mjs --out "$RUNNER_TEMP/Dependency-Map.md"
+        run: |
+          set -euo pipefail
+          VERDICT="$(node tools/dependency-map.mjs \
+            --out "$RUNNER_TEMP/Dependency-Map.md" \
+            --changed-vs wiki/Dependency-Map.md | tail -n 1)"
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+          echo "Change since the published page: $VERDICT"
 
       # A generator that fails halfway can still exit 0 with a plausible file, and
       # this page's whole failure mode is a section that is missing rather than
@@ -88,13 +109,18 @@ jobs:
             exit 1
           fi
 
+      # SKIPPED WHEN THE ONLY MOVEMENT IS THE CLOCK. `+N` past a tag and
+      # `N behind main` tick on every commit to the target, so a plain diff
+      # differs on nearly every run and the page's history would record the
+      # passage of time rather than any change in the org. The published page
+      # still carries the true counters - the mask decides whether to publish,
+      # never what to publish.
       - name: Push it, if it moved
+        if: steps.generate.outputs.verdict == 'substantive'
         env:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          git clone --quiet \
-            "https://x-access-token:$TOKEN@github.com/${{ github.repository }}.wiki.git" wiki
           cp "$RUNNER_TEMP/Dependency-Map.md" wiki/Dependency-Map.md
           cd wiki
           if git diff --quiet -- Dependency-Map.md; then

--- a/tests/dependency-map.test.mjs
+++ b/tests/dependency-map.test.mjs
@@ -20,7 +20,7 @@ import * as nodePath from 'node:path'
 import { parseDependencyLedger, auditDependencyLedger } from '../scripts/lib/drift-ledger.mjs'
 import { test } from 'node:test'
 
-import { classify, parseManifest, renderMermaid, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance, staleSourceBanner } from '../tools/dependency-map.mjs'
+import { classify, parseManifest, renderMermaid, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance, staleSourceBanner, volatileMask, isSubstantiveChange } from '../tools/dependency-map.mjs'
 
 const cases = [
   ['github: shorthand', '@markup-carve/carve', 'github:markup-carve/carve-js#3ba8ba32', 'carve-js', '3ba8ba32'],
@@ -505,4 +505,71 @@ test('the banner names both commits, short, so the reader can tell what ran', ()
   assert.match(text, /01234567/, 'the commit it should have come from')
   assert.doesNotMatch(text, /deadbeefcafe1234/, 'abbreviated, not the full sha')
   assert.match(text, /Regenerate from/, 'and what to do about it')
+})
+/*
+ * WHICH DIFFERENCES ARE WORTH A COMMIT.
+ *
+ * Both real cases below happened on 2026-08-27, forty minutes apart, and they
+ * are the reason the mask exists rather than a plain `git diff`: the first pair
+ * differed only because time had passed, the second because seven repos had
+ * released. A plain diff calls both a change and the wiki history stops meaning
+ * anything.
+ *
+ * The dangerous direction is a change wrongly called cosmetic, since that one
+ * is never published and leaves no trace - so the tag distance is asserted
+ * separately from the head distance, which is the pair most easily confused.
+ */
+const TREE_LINE = '  carve-php                0.1.6      +2'
+const EDGE_NOTE = '| `x` | `y` | `0.1.4` | 34 BEHIND 0.1.4, 44 behind main |'
+
+test('a commit landing on a target repo is not a change to the map', () => {
+  const before = [TREE_LINE, EDGE_NOTE].join('\n')
+  const after = before.replace('+2', '+3').replace('44 behind main', '45 behind main')
+  assert.notEqual(before, after, 'the raw text really does differ')
+  assert.equal(isSubstantiveChange(before, after), false, 'and it is still only the clock')
+})
+
+test('distance from a TAG is news, and stays unmasked', () => {
+  // `34 BEHIND 0.1.4` moves when the target releases or when the pin moves.
+  // Masking it alongside `behind main` would silence the two events this page
+  // exists to report, and silence them invisibly.
+  const before = EDGE_NOTE
+  const after = EDGE_NOTE.replace('34 BEHIND', '35 BEHIND')
+  assert.equal(isSubstantiveChange(before, after), true)
+  assert.match(volatileMask(after), /35 BEHIND 0\.1\.4/)
+})
+
+test('a release is substantive even though its lag counter moved too', () => {
+  // The shape of the 12:21 run: seven repos went UNRELEASED to 0.1.0, and their
+  // lag counters reset in the same render. The masked fields must not swallow
+  // the version beside them.
+  const before = '    ├── astro-carve              UNRELEASED'
+  const after = '    ├── astro-carve              0.1.0'
+  assert.equal(isSubstantiveChange(before, after), true)
+})
+
+test('a page that does not exist yet is always worth writing', () => {
+  assert.equal(isSubstantiveChange(null, 'anything'), true)
+  assert.equal(isSubstantiveChange(undefined, 'anything'), true)
+})
+
+test('the mask leaves everything it does not target byte-identical', () => {
+  const untouched = [
+    '| 🔴 not a release | A commit that was never tagged. |',
+    '  carve_rs -->|"0.1.4"| carve_wasm',
+    'Read 56 repositories, 86 edges, from each repository default branch.',
+  ].join('\n')
+  assert.equal(volatileMask(untouched), untouched)
+})
+
+test('a lag counter is masked where it sits mid-line, not only at end of line', () => {
+  // Found by running the real thing rather than by reading the regex: a repo
+  // with couplings prints its lag BEFORE that list, so an end-of-line anchor
+  // masked the bare rows and missed exactly the rows that tick most often.
+  // intellij-carve going +3 to +4 was still forcing a publish.
+  const before = '  intellij-carve           0.1.6      +3  <- carve, carve-css, carve-js'
+  const after = '  intellij-carve           0.1.6      +4  <- carve, carve-css, carve-js'
+  assert.equal(isSubstantiveChange(before, after), false)
+  const soft = '  carve-go                 v0.1.0     +13  ~ carve, carve-rb'
+  assert.equal(isSubstantiveChange(soft, soft.replace('+13', '+14')), false)
 })

--- a/tools/dependency-map.mjs
+++ b/tools/dependency-map.mjs
@@ -37,13 +37,17 @@
  *   node tools/dependency-map.mjs --json          # the same data, unrendered
  *   node tools/dependency-map.mjs --out FILE      # write instead of printing
  *   node tools/dependency-map.mjs --org NAME      # default markup-carve
+ *   node tools/dependency-map.mjs --out F --changed-vs G
+ *                                                 # ...and say whether F differs
+ *                                                 # from G by more than the lag
+ *                                                 # counters: substantive|cosmetic
  *
  * Needs `gh` authenticated. Roughly one request per repo plus a few per
  * dependency target; well inside the authenticated hourly limit.
  */
 
 import { execFile } from 'node:child_process'
-import { existsSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
@@ -1023,6 +1027,47 @@ function renderReleaseOrder(edges, states, allRepos) {
   return lines.join('\n')
 }
 
+/*
+ * THE PAGE HOLDS TWO CLOCKS, AND THEY ARE NOT NEWS.
+ *
+ * `+N` in the release order is how far a repo has moved past its own tag, and
+ * `N behind main` on an edge is how far a pin sits behind a moving head. Both
+ * tick on every commit to the target, whether or not anything about who
+ * depends on whom changed. Published as-is that is correct; used as the test
+ * for WHETHER TO PUBLISH it means every run differs from the last, so the
+ * automation commits on every run and the page's history stops being a record
+ * of anything.
+ *
+ * So the decision to publish is taken on the page with those two fields
+ * blanked, and the page that gets published is the real one. Masking is a
+ * comparison device, never an output.
+ *
+ * NOT MASKED, deliberately: `34 BEHIND 0.1.4`. That is distance from a TAG.
+ * It moves when the target releases or when the pin moves, and both of those
+ * are exactly what this page exists to report.
+ */
+function volatileMask(text) {
+  return text
+    .replace(/, \d+ behind main/g, ', N behind main')
+    // Anchored to a token boundary rather than end of line: a repo that is
+    // coupled to others carries its lag BEFORE that list, so `+3` in
+    // `intellij-carve 0.1.6 +3  <- carve, carve-css` sits mid-line. An
+    // end-of-line anchor masked the bare rows and missed exactly the busiest
+    // rows, which are the ones that tick most often.
+    .replace(/(\s)\+\d+(?=\s|$)/gm, '$1+N')
+}
+
+/*
+ * Is the difference between two renderings worth a commit?
+ *
+ * A page that does not exist yet is always worth writing, and so is one whose
+ * masked form moved. Everything else is the clock.
+ */
+function isSubstantiveChange(before, after) {
+  if (before === null || before === undefined) return true
+  return volatileMask(before) !== volatileMask(after)
+}
+
 const TICK = '`'
 const STALE_HEAD = '**Generated from a checkout that is not `main`.** '
 const RUN_FROM = 'This run came from `'
@@ -1189,7 +1234,7 @@ function renderMarkdown(edges, { repos, skipped, generatedFrom, states, source }
 
 // ---------------------------------------------------------------------------
 
-export { classify, parseManifest, renderMermaid, renderSpine, renderConsumers, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance, staleSourceBanner }
+export { classify, parseManifest, renderMermaid, renderSpine, renderConsumers, releaseLayers, renderReleaseOrder, ciReferences, notARelease, vendorProvenance, staleSourceBanner, volatileMask, isSubstantiveChange }
 
 /*
  * What this run was generated FROM, for staleSourceBanner above.
@@ -1355,8 +1400,20 @@ async function main() {
     source: await sourceProvenance(),
   })}\n`
   const out = value('out', null)
+
+  // `--changed-vs FILE` answers "should this be published?" without deciding
+  // it. The file is still written either way: a caller that wants the page
+  // wants it whichever verdict comes back, and one that acts on the verdict
+  // should act on it rather than on this tool's exit status. Printed on stdout
+  // because --out is what frees stdout up; without --out the page is the
+  // output and the verdict has nowhere to go that is not the page.
+  const against = value('changed-vs', null)
   if (out) writeFileSync(out, markdown)
   else process.stdout.write(markdown)
+  if (against && out) {
+    const before = existsSync(against) ? readFileSync(against, 'utf8') : null
+    process.stdout.write(isSubstantiveChange(before, markdown) ? 'substantive\n' : 'cosmetic\n')
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) await main()


### PR DESCRIPTION
Follow-up to #1857. The automation works, and it commits on nearly every run - so the wiki history records that time passed rather than that anything changed.

Two counters on the page are clocks: `+N` past a repo's own tag in the release order, and `N behind main` on an edge. Both tick on every commit to the target, independently of who depends on whom. Today's two automated pushes are the case in miniature - the 11:42 run moved only counters, the 12:21 run carried seven repos going from unreleased to `0.1.0`, and nothing in the mechanism could tell them apart.

**The publish decision is now taken on the page with those two fields blanked; the page that gets published is the real one, counters and all.** Masking is a comparison device, never an output.

`34 BEHIND 0.1.4` stays unmasked. That is distance from a *tag* - it moves when the target releases or when the pin moves, which are the two events this page exists to report. Masking it alongside the head distance would silence the page invisibly, and that is the failure direction that leaves no trace: a change wrongly called cosmetic is never published and nobody finds out.

The comparison lives in the generator rather than in workflow shell, because the strings being masked are printed two functions away and a regex in YAML would drift from them silently. `--changed-vs FILE` reports `substantive` or `cosmetic` and decides nothing - the page is written either way, so the policy stays in the workflow where it can be read.

Both of today's pushes are pinned as tests. So is the boundary I got wrong on the first attempt: an end-of-line anchor masked the bare rows and missed every row with a coupling list after the counter, so `intellij-carve 0.1.6 +3  <- carve, carve-css` kept forcing a publish - which is most of the busy repos. That surfaced by running the tool against the live wiki page, not by reading the regex, and the widened boundary has its own regression test.

Confirmed end to end against the real org, current wiki page as the baseline: verdict `substantive`, driven by three lines - highlightjs-carve released `0.1.0` and its carve-grammars range moved `^0.1.4` to `^0.1.5`. The `carve-js +1 → +2`, `carve-rs +6 → +7` and `intellij-carve +3 → +4` ticks in the same run were correctly ignored.
