### PR TITLE
docs: list rouge-carve in the ecosystem table

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -60,6 +60,7 @@ Syntax highlighting, structural editing, and diagnostics inside editors.
 | [tree-sitter-carve](https://github.com/markup-carve/tree-sitter-carve) | Tree-sitter | Grammar for highlighting and structural editing. |
 | [highlightjs-carve](https://github.com/markup-carve/highlightjs-carve) | Highlight.js | Syntax grammar for highlighted Carve source. |
 | [pygments-carve](https://github.com/markup-carve/pygments-carve) | Pygments | Lexer for Python documentation and highlighting tools. |
+| [rouge-carve](https://github.com/markup-carve/rouge-carve) | Rouge | Lexer for Jekyll, Redcarpet and other Ruby highlighting. |
 | [carve-lsp](https://github.com/markup-carve/carve-lsp) | LSP | Language server - syntax diagnostics, Djot/Markdown collision hints. *Early.* |
 
 ## Framework integrations


### PR DESCRIPTION
[rouge-carve](https://github.com/markup-carve/rouge-carve) joins the grammar rows, beside highlight.js, Pygments and Tree-sitter.

Rouge does not take new languages into core - the maintainers point contributors to a plug-in instead - so it ships as its own gem and registers the lexer on require. That covers Jekyll, Redcarpet and the other Ruby highlighting paths.