### PR TITLE
docs: bring the playground demo up to current Carve idiom

### DIFF
--- a/docs/.vitepress/examples/demo.crv
+++ b/docs/.vitepress/examples/demo.crv
@@ -36,10 +36,13 @@ the line directly above it:
 
 /italic/, *bold*, /*bold italic*/, _underline_, ~strikethrough~, =highlight=,
 super{^script^} and sub{,script,}. Inline `code span`, and raw inline passthrough
-`<abbr>HTML</abbr>`{=html} emitted verbatim.
+`<q>quoted</q>`{=html} emitted verbatim.
 
-Editorial markup: {+ added text +}, {- deleted text -},
-{~ old phrase ~> new phrase ~}, and an {# editorial note #}.
+Semantic spans reach elements that have no delimiter of their own: press
+[Ctrl+C]{kbd} to copy, and expand [HTML]{abbr="HyperText Markup Language"}.
+
+Editorial markup: {+added text+}, {-deleted text-},
+{~old phrase~>new phrase~}, and an {#editorial note#}.
 
 Escapes keep specials literal: \*not bold\*, \/not italic\/, \#not-a-tag.
 
@@ -56,7 +59,7 @@ Cross-reference to a heading by id: jump to </#top>.
 [site]: https://example.com "Reference definition"
 
 ![A descriptive alt text](images/diagram.png)
-^ Figure 1: images may carry a caption line.
+^ Figure #: images may carry a caption line.
 
 ## Lists
 
@@ -70,11 +73,11 @@ Unordered:
 
 Ordered:
 
-1. clone the repo
-2. install dependencies
-   - run the build
-   - run the tests
-3. ship it
+. clone the repo
+. install dependencies
+  - run the build
+  - run the tests
+. ship it
 
 Tasks:
 
@@ -100,7 +103,7 @@ Definition list:
 | Apple        |    1.20 |   In     |
 | Banana       |    0.50 |   In     |
 | Dragon fruit |    4.00 |   Out    |
-^ Table 1: column alignment - left, right, center.
+^ Table #: column alignment - left, right, center.
 
 ## Code and raw blocks
 
@@ -179,7 +182,9 @@ This block has only an id and classes, so it renders as a plain
 ## Mentions, tags, and inline extensions
 
 Mention a person with @alice and reference a tag like #release-1.0.
-An inline extension names a role: press :kbd[Ctrl+C] to copy.
+An inline extension names a role for a handler to render: :youtube[dQw4w9WgXcQ]
+becomes an embed where the handler is registered, and degrades to its content
+where it is not.
 
 ## Footnotes
 

--- a/tests/examples/demo.html
+++ b/tests/examples/demo.html
@@ -32,9 +32,11 @@ the line directly above it:</p>
     <h2>Inline formatting</h2>
     <p><em>italic</em>, <strong>bold</strong>, <strong><em>bold italic</em></strong>, <u>underline</u>, <s>strikethrough</s>, <mark>highlight</mark>,
 super<sup>script</sup> and sub<sub>script</sub>. Inline <code>code span</code>, and raw inline passthrough
-<abbr>HTML</abbr> emitted verbatim.</p>
-    <p>Editorial markup: <ins> added text </ins>, <del> deleted text </del>,
-<del> old phrase </del><ins> new phrase </ins>, and an <span class="critic-comment"> editorial note </span>.</p>
+<q>quoted</q> emitted verbatim.</p>
+    <p>Semantic spans reach elements that have no delimiter of their own: press
+<kbd>Ctrl+C</kbd> to copy, and expand <abbr title="HyperText Markup Language">HTML</abbr>.</p>
+    <p>Editorial markup: <ins>added text</ins>, <del>deleted text</del>,
+<del>old phrase</del><ins>new phrase</ins>, and an <span class="critic-comment">editorial note</span>.</p>
     <p>Escapes keep specials literal: *not bold*, /not italic/, #not-a-tag.</p>
   </section>
   <section id="Links-and-images">
@@ -163,7 +165,9 @@ the fence:</p>
   <section id="Mentions-tags-and-inline-extensions">
     <h2>Mentions, tags, and inline extensions</h2>
     <p>Mention a person with <span class="mention"><strong>@alice</strong></span> and reference a tag like <span class="tag"><strong>#release-1.0</strong></span>.
-An inline extension names a role: press <span class="ext-kbd">Ctrl+C</span> to copy.</p>
+An inline extension names a role for a handler to render: <span class="ext-youtube">dQw4w9WgXcQ</span>
+becomes an embed where the handler is registered, and degrades to its content
+where it is not.</p>
   </section>
   <section id="Footnotes">
     <h2>Footnotes</h2>


### PR DESCRIPTION
The Playground seeds its editor from `docs/.vitepress/examples/demo.crv`, so that
document is the first Carve most visitors read. It **lints clean** against
carve-js 0.1.5 - which is why the stale spellings in it survived. None of them is
an error; they are Markdown-era habits that still parse. This is an audit of the
whole file against the docs, not a fix for one construct.

Six changes, each with the doc that establishes the preferred spelling.

### 1. Ordered list: numbered markers to the bare dot

Authority: `docs/migrate-from-markdown.md:51` ("prefer Carve's `. ` for native
auto-numbering with stable nesting indentation") and `docs/cheatsheet.md:66`
(". auto-numbered (preferred native Carve form)"). Recommended in #1837.

Before:

```
1. clone the repo
2. install dependencies
   - run the build
   - run the tests
3. ship it
```

After:

```
. clone the repo
. install dependencies
  - run the build
  - run the tests
. ship it
```

The nested bullets move to column 2, the content column the two-character marker
sets. Rendered HTML is byte-identical.

### 2. Captions: hardcoded numbers to the auto-number placeholder

Authority: `docs/cheatsheet.md`, "Captions" - "A `#` in the caption is the auto
number", spelled `^ Figure #:`.

Before / after:

```
^ Figure 1: images may carry a caption line.
^ Table 1: column alignment - left, right, center.
```

```
^ Figure #: images may carry a caption line.
^ Table #: column alignment - left, right, center.
```

Both still render "Figure 1" and "Table 1" - identical HTML - and stay correct
when a figure or table is inserted above them.

### 3. Keyboard hint: inline extension to core semantic span

`:kbd[Ctrl+C]` renders `<span class="ext-kbd">Ctrl+C</span>` - the generic
unknown-extension fallback, because there is no kbd handler. kbd, abbr and time
are **core** semantic spans.

Authority: `docs/index.md:36` ("Keyboard hints and the other semantic spans are
core attributes instead - `[Tab]{kbd}`"), `docs/migrate-from-markdown.md:62`, and
`docs/blocks-and-attributes.md:233`.

Before, in "Mentions, tags, and inline extensions":

```
An inline extension names a role: press :kbd[Ctrl+C] to copy.
```

After, the core spelling moves up into "Inline formatting" beside the other
inline constructs:

```
Semantic spans reach elements that have no delimiter of their own: press
[Ctrl+C]{kbd} to copy, and expand [HTML]{abbr="HyperText Markup Language"}.
```

and the extension sentence now names a role the core grammar really does leave
to a handler (`:youtube[ID]` is the cheat sheet's own illustration):

```
An inline extension names a role for a handler to render: :youtube[dQw4w9WgXcQ]
becomes an embed where the handler is registered, and degrades to its content
where it is not.
```

Rendered: `<kbd>Ctrl+C</kbd>` and `<abbr title="…">HTML</abbr>` instead of a
class-only span.

### 4. Raw inline: stop passing through an element Carve spells natively

`docs/migrate-from-markdown.md:62` lists `abbr` among the three names a span
attribute reaches *precisely because* raw HTML is off - so demonstrating the
`{=html}` passthrough with an `<abbr>` taught the opposite of the guide.

Before / after:

```
`<abbr>HTML</abbr>`{=html} emitted verbatim.
```

```
`<q>quoted</q>`{=html} emitted verbatim.
```

`<q>` has no Carve spelling, so the example now shows what the passthrough is
for.

### 5. Editorial markup: drop the padding spaces

Authority: `docs/cheatsheet.md:276` - `{+inserted+}  {-deleted-}  {~old~>new~}  {#a comment#}`.

Before / after:

```
Editorial markup: {+ added text +}, {- deleted text -},
{~ old phrase ~> new phrase ~}, and an {# editorial note #}.
```

```
Editorial markup: {+added text+}, {-deleted text-},
{~old phrase~>new phrase~}, and an {#editorial note#}.
```

The padded form put the spaces inside the emitted element:
`<ins> added text </ins>` becomes `<ins>added text</ins>`.

## Deliberately left alone

- **The numbered `1.` marker as a form.** Still valid, and the migration guide
  lists it as portable. The showcase should teach Carve's own spelling; the
  guide covers the portable one.
- **The tilde code fence (`~~~yaml`).** Normative in `resources/grammar.ebnf`,
  and the demo is the right place to show the alternative fence character.
- **The definition list.** Its separator was canonicalized to `: ` in #1776 last
  week. The `{empty}` sentinel does not fit here - every entry has a body, and
  adding an empty one to show the sentinel would be padding the showcase.
- **Constructs the document does not show** - the inline literal, the `::: >`
  fenced blockquote, the `+` continuation marker, `{loose}`. These are absences,
  not stale idiom, and a landing document earns its length.
- **Emphasis, sup/sub, attribute lines, colon fences.** Already current
  throughout: `/italic/` `*bold*` `_underline_`, braced `{^script^}` / `{,script,}`,
  every attribute block on the line above its target, every `:::` fence with its
  separating space.

## Verification

Rendered through **released carve-js 0.1.5** with the Playground's extension set,
before and after: the ordered list and both captions produce byte-identical HTML,
and the other three changes produce the improved tree shown above. `carve lint`
reports **0 findings** on the result (it reported 0 before too - these were never
lint-visible). `tests/examples/demo.html`, the committed golden snapshot, is
regenerated via `npm run examples:snapshot`; that is the only file outside
`docs/.vitepress/examples/` this PR touches.
