### PR TITLE
docs: say what rouge-carve highlights, not which sites it runs on

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -60,7 +60,7 @@ Syntax highlighting, structural editing, and diagnostics inside editors.
 | [tree-sitter-carve](https://github.com/markup-carve/tree-sitter-carve) | Tree-sitter | Grammar for highlighting and structural editing. |
 | [highlightjs-carve](https://github.com/markup-carve/highlightjs-carve) | Highlight.js | Syntax grammar for highlighted Carve source. |
 | [pygments-carve](https://github.com/markup-carve/pygments-carve) | Pygments | Lexer for Python documentation and highlighting tools. |
-| [rouge-carve](https://github.com/markup-carve/rouge-carve) | Rouge | Lexer for Jekyll, Redcarpet and other Ruby highlighting. |
+| [rouge-carve](https://github.com/markup-carve/rouge-carve) | Rouge | Lexer coloring Carve source wherever Rouge highlights. |
 | [carve-lsp](https://github.com/markup-carve/carve-lsp) | LSP | Language server - syntax diagnostics, Djot/Markdown collision hints. *Early.* |
 
 ## Framework integrations


### PR DESCRIPTION
The row I added in #1859 read as Jekyll support, which is [jekyll-carve](https://github.com/markup-carve/jekyll-carve)'s job - that one is a `Jekyll::Converter` rendering `.crv` pages through `carve-lang`.

rouge-carve colours Carve **source** instead. Naming Jekyll and Redcarpet as if they were the feature blurred the two.