### PR TITLE
Fix optional-corpus Rust ListTable adapter

### DIFF
--- a/.github/workflows/ast-conformance.yml
+++ b/.github/workflows/ast-conformance.yml
@@ -244,6 +244,18 @@ jobs:
           CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
         run: npm run compare:convert
 
+      # Tier-2/Tier-3 fixtures need explicit extension adapters, so the default
+      # corpus sweep in the formatter job cannot exercise them. Run the small
+      # optional corpus against the same already-built engines and fail on a
+      # wrong adapter command or a cross-engine output difference.
+      - name: Cross-engine optional-corpus comparison
+        if: always()
+        env:
+          CARVE_JS_DIR: ${{ github.workspace }}/carve-js
+          CARVE_RS_DIR: ${{ github.workspace }}/carve-rs
+          CARVE_PHP_DIR: ${{ github.workspace }}/carve-php
+        run: npm run compare:impls -- --corpus=optional --fail-on-diff
+
 
       # The grammar names engines and says what they do - "all impls support
       # it", "carve-rs is the reference here", "carve-php additionally accepts

--- a/scripts/compare-impls.mjs
+++ b/scripts/compare-impls.mjs
@@ -351,9 +351,6 @@ const impls = [
       if (SOURCE_TYPOGRAPHY_FEATURES.has(feature)) {
         return [...rustBaseCommand, '--smart-typography', 'source', ...flags]
       }
-      if (feature === 'list-table-columns-1344') {
-        return [...rustBaseCommand, '--extensions', ...flags]
-      }
       return null
     },
     hooks: [

--- a/tests/optional-feature-adapters.test.mjs
+++ b/tests/optional-feature-adapters.test.mjs
@@ -123,6 +123,7 @@ const DECLARED_UNREACHABLE = {
   'rust:code-callouts': 'no CLI flag for the code-callouts extension',
   'rust:details': 'no CLI flag for the details extension',
   'rust:list-table': 'no CLI flag for the list-table extension',
+  'rust:list-table-columns-1344': 'no CLI flag for the list-table extension',
   'rust:list-table-local-headers-1248': 'no CLI flag for the list-table extension',
   'rust:semantic-span': 'no CLI flag for the semantic-span extension',
   'rust:spoiler': 'no CLI flag for the spoiler extension',


### PR DESCRIPTION
## Summary

- stop invoking carve-rs with `--extensions` for `list-table-columns-1344`, because that flag does not register `ListTable`
- declare the Rust CLI adapter unavailable for that feature, consistently with the other ListTable cases
- run the optional corpus cross-engine comparison in the scheduled conformance workflow so adapter regressions are gated

## Verification

- `node --test tests/optional-feature-adapters.test.mjs`
- `npm run compare:impls -- --corpus=optional --fail-on-diff`
- `git diff --check`

Closes #1849.
