### PR TITLE
spec: keep the task-state conditional inside the validator subset

### DIFF
--- a/resources/ast-schema.json
+++ b/resources/ast-schema.json
@@ -2317,7 +2317,7 @@
             ">",
             "?"
           ],
-          "description": "Task marker character AS AUTHORED (PART 11 section 6g), on a task item whose state is not the default for `checked`: absent means `x` when checked is true and ` ` when it is false. `X` is folded to `x`, which is a case, not a state (carve#1866)."
+          "description": "Task marker character AS AUTHORED (PART 11 section 6g), on a task item whose state is not the default for `checked`: absent means `x` when checked is true and ` ` when it is false. `X` is folded to `x`, which is a case, not a state (carve#1866). The two branches below spell the states rather than negating `x`: an engine validator that skips a keyword it does not implement accepts everything the keyword was added to reject, so this schema stays inside the subset every engine implements."
         },
         "attrs": {
           "$ref": "#/$defs/attrs"
@@ -2356,9 +2356,13 @@
             ],
             "properties": {
               "taskState": {
-                "not": {
-                  "const": "x"
-                }
+                "enum": [
+                  " ",
+                  "-",
+                  "_",
+                  ">",
+                  "?"
+                ]
               }
             }
           },


### PR DESCRIPTION
Follow-up to markup-carve/carve#1867, found by carve-php's own gate while implementing the engine half of markup-carve/carve#1866.

The `if` branch for the unchecked task states was written as `not: {const: "x"}`. That is correct JSON Schema, and it is outside the keyword subset carve-php's validator implements. That engine deliberately fails rather than skip an unknown keyword - a skipped keyword accepts everything it was added to reject - so `testTheSchemaUsesNoKeywordTheValidatorIgnores` reported `not` the moment the vendored schema was synced.

Spelling the five states with `enum` says the same thing inside the subset every engine implements, and reads better beside the `x` branch above it. No behavior changes: the constraint admitted and refused exactly the same payloads before.
