### PR TITLE
chore: bump the reference pin to the engine that writes the task state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@djot/djot": "^0.3.2",
-        "@markup-carve/carve": "github:markup-carve/carve-js#37ed8904f2a5dd540fd0bddb2294fe348f17eb7d",
+        "@markup-carve/carve": "github:markup-carve/carve-js#5748d425360a45b03770fea60acea258ab989ce6",
         "@markup-carve/carve-css": "^0.1.0",
         "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
         "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",
@@ -987,8 +987,8 @@
     },
     "node_modules/@markup-carve/carve": {
       "version": "0.1.5",
-      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#37ed8904f2a5dd540fd0bddb2294fe348f17eb7d",
-      "integrity": "sha512-qcMO1SduRurB5HrKvxWhU7/si8EnKf2ljN53f3qxreEZ+No/9eE67ELYJktuYNQAktSzzTc3E4FzLbqlYzkqew==",
+      "resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#5748d425360a45b03770fea60acea258ab989ce6",
+      "integrity": "sha512-v2b6uLNjNF0lOekmGgmevaX2wAgqb0YXzz2jcHslRrW/q3EBAAxm8NZu5B538YOL0R98DFdbLC+1QcLEzGQAcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@djot/djot": "^0.3.2",
-    "@markup-carve/carve": "github:markup-carve/carve-js#37ed8904f2a5dd540fd0bddb2294fe348f17eb7d",
+    "@markup-carve/carve": "github:markup-carve/carve-js#5748d425360a45b03770fea60acea258ab989ce6",
     "@markup-carve/carve-css": "^0.1.0",
     "@markup-carve/carve-grammars": "github:markup-carve/carve-grammars#086d9603736466092c4517e76513b4915c1f94a7",
     "@markup-carve/vite-plugin-carve": "git+https://github.com/markup-carve/vite-plugin-carve.git#0b3552413ff1de6302921c8144497931fbd0124f",

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,6 +1,6 @@
 {
   "engine": "@markup-carve/carve",
-  "engineCommit": "e0119621381f67abec8d80f169fecf5b7b7b9327",
+  "engineCommit": "5748d425360a45b03770fea60acea258ab989ce6",
   "corpusDocuments": 1538,
   "htmlImportPopulation": {
     "completed": 1537,
@@ -11,7 +11,7 @@
     ]
   },
   "renderImportRoundTrips": {
-    "html": 661,
-    "markdown": 399
+    "html": 660,
+    "markdown": 398
   }
 }

--- a/tests/schema-fields-are-produced.test.mjs
+++ b/tests/schema-fields-are-produced.test.mjs
@@ -65,7 +65,6 @@ const OPT_IN_ONLY = {
 const ENGINE_ROLLOUT_PENDING = {
   'figure.shortCaption': 'structural publishing field: Carve 0.1 source has no spelling; produced only by AST/Pandoc consumers',
   'table.shortCaption': 'structural publishing field: Carve 0.1 source has no spelling; produced only by AST/Pandoc consumers',
-  'list_item.taskState': 'carve#1866: the schema records the task state before the engines emit it; 06-task-lists-2 covers it the moment the pin moves',
 }
 
 /**


### PR DESCRIPTION
Moves the reference pin to markup-carve/carve-js#1575, which implements the markup-carve/carve#1866 ruling: `list_item.taskState` is recorded and the canonical writer puts it back.

With the pin moved the field has a producer, so the `ENGINE_ROLLOUT_PENDING` entry that markup-carve/carve#1867 added comes out in the same commit - the list is checked in both directions, so leaving it would fail on its own.

No new fixture is needed. Corpus `06-task-lists-2` already spells all four extended states, so `tests/corpus-fmt-roundtrip.test.mjs` now gates `parse(fmt(x)) == parse(x)` over them: before this pin the two sides agreed because the state was absent from both, and now they agree because the writer reproduces it.

The import ratchet moves DOWN by one on both targets, and that is the correct reading rather than a regression to fix here. `06-task-lists-2` now canonicalizes to the states the author wrote:

```
- [-] dropped
- [_] paused
- [>] deferred
- [?] maybe
```

and a render/import cycle returns

```
- [ ] dropped
- [ ] paused
- [ ] deferred
- [ ] maybe
```

on both targets. Neither can spell the states: HTML renders every state but `x` as the same unchecked box, and GFM has `[ ]` and `[x]` only. The cycle matched before only because the state was absent from BOTH sides. The HTML half is recoverable and is the subject of a follow-up; the Markdown half is a target limit and stays.