### PR TITLE
chore: trim the executable spec's task-state comments

### DIFF
--- a/scripts/spec/html.mjs
+++ b/scripts/spec/html.mjs
@@ -794,10 +794,7 @@ function renderItem(item, list, depth, ctx) {
   // nothing new is written in English and nothing is translated twice. An item
   // whose first block is not a paragraph, or whose text derives to nothing,
   // takes NO attribute: an empty name is worse than none.
-  // PART 10 S11 (carve#1870): the four extended states render the same box as
-  // `[ ]`, so the item names the state it was written with. `[ ]` and `[x]`
-  // carry nothing - the box already says which they are. It is STRUCTURAL, so
-  // it leads the authored attributes (S1).
+  // PART 10 S11. Structural, so it leads the authored attributes (S1).
   if (item.taskState !== undefined) {
     liAttrs = ` data-task-state="${escapeAttr(item.taskState)}"${liAttrs}`
   }

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -3364,8 +3364,7 @@ function collectItems(lines, i, list, state, ind, meas) {
     const item = { }
     if (head.attrs && head.attrs.replace(/[{} ]/g, '') !== '') item.attrs = head.attrs
     if (list.task) item.checked = /^[xX]$/.test(head.task)
-    // PART 11 S6g / PART 10 S11: the authored state, when it is not the
-    // default for the box. `X` folds to `x` - the two spell one state.
+    // PART 11 S6g. `X` folds to `x` - the two spell one state.
     if (list.task && !item.checked && head.task !== ' ') item.taskState = head.task
     // The marker line's text opens the item paragraph -- unless that text is
     // itself a construct that opens none. `. >` is an EMPTY quote, so nothing


### PR DESCRIPTION
Comment density in the executable spec, on the two seams markup-carve/carve#1870 added.

The clause is normative prose in PART 10 and PART 11; the oracle repeating a paragraph of it beside two `if` statements adds nothing a reader of those parts needs. Each keeps the clause reference and the one fact the code does not say.

The corpus renders identically.
