### PR TITLE
fix: bump the import population with the two corpus rows that grew it

### DIFF
--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,17 +1,17 @@
 {
   "engine": "@markup-carve/carve",
   "engineCommit": "4e2023768c81e12db09cfb8a9da56e12327c017e",
-  "corpusDocuments": 1538,
+  "corpusDocuments": 1540,
   "htmlImportPopulation": {
-    "completed": 1537,
-    "canonicalFixedPoints": 1536,
-    "renderedTextPreserved": 1522,
+    "completed": 1539,
+    "canonicalFixedPoints": 1538,
+    "renderedTextPreserved": 1524,
     "expectedRejections": [
       "182-openers-past-the-nesting-cap-are-one-paragraph.crv"
     ]
   },
   "renderImportRoundTrips": {
-    "html": 661,
+    "html": 663,
     "markdown": 398
   }
 }


### PR DESCRIPTION
`main` is red: the `HTML import contract` step of CI fails on 9f90269 in both matrix legs.

#1873 appended two corpus documents for the description-marker ruling and left `resources/import-roundtrip-baseline.json` at the population measured before them, so the ratchet fired on a document set that had grown rather than on drift.

The ratchet's own comment names two causes and asks which one applies. It is not the engine: `package.json` and the baseline's `engineCommit` are both `4e20237`, unmoved. So the corpus grew, and every count moves by exactly the two documents added.

| count | was | now |
| --- | --- | --- |
| `corpusDocuments` | 1538 | 1540 |
| `htmlImportPopulation.completed` | 1537 | 1539 |
| `htmlImportPopulation.canonicalFixedPoints` | 1536 | 1538 |
| `htmlImportPopulation.renderedTextPreserved` | 1522 | 1524 |
| `renderImportRoundTrips.html` | 661 | 663 |
| `renderImportRoundTrips.markdown` | 398 | 398 |

The comment also asks that a count which does **not** move be accounted for, so: neither document survives the Markdown route, because no definition list does. The Markdown writer has no construct for one, so it writes the term as strong emphasis and the description as a bare colon line, which imports back as a paragraph:

```
:: t
: text
```

renders to Markdown as

```
**t**
: text
```

and imports back as `*t*` followed by the colon line, not as a definition list. Measured across the whole corpus, 0 of the 83 documents holding a definition list round-trip through Markdown. The two new rows landing on every count except that one is what the route already did.
