### PR TITLE
spec: retire structure-split and gate the taxonomy in both directions

### DIFF
--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -1147,12 +1147,6 @@ lossy decision should be observable. The common diagnostic codes are:
   no spelling for, so it survives in the AST and not in written Carve. The
   AST-returning entry point loses nothing and reports nothing; the one that
   writes source reports this.
-- `structure-split`: one source structure was written as more than one,
-  because writing it as one would have changed what its parts mean. Everything
-  inside is kept exactly and every part is spellable; what is lost is the
-  grouping. It is not `structure-unspellable`, which is for a shape the syntax
-  cannot spell at all. The AST-returning entry point loses nothing and reports
-  nothing; the one that writes source reports this.
 - `encoding-assumed`: the source did not declare how to read a value, and the
   importer assumed an encoding to map it. An importer MUST emit this whenever
   the node it produced is only correct if that assumption holds. The motivating
@@ -1160,6 +1154,19 @@ lossy decision should be observable. The common diagnostic codes are:
   never says what `alttext` contains, so reading it as TeX is a guess, and the
   math node may hold something that is not TeX at all.
 - `diagnostics-truncated`: the diagnostic cap was reached.
+
+**Every code here has a producer.** A code the format names and nothing can emit
+is a promise to a consumer that no import will keep, and `structure-split` was
+one for as long as the shape that produced it existed: a dropped empty `<dd>`
+split a `<dl>` in two until that entry gained the `{empty}` sentinel, after
+which no engine could emit the code and the taxonomy still named it. The
+fixtures gate this in both directions, with one exemption - `diagnostics-truncated`
+reports the state of the report rather than a loss at a place, and no fixture
+reaches a cap.
+
+Retiring a code is not a compatibility event and adding one back is not either:
+a reader must already tolerate a code it does not know, so the list may grow the
+day a shape needs it.
 
 `encoding-assumed` is deliberately not filed under `element-unwrapped`.
 Unwrapping is a note about the input's structure and loses no meaning;

--- a/resources/html-import-schema.json
+++ b/resources/html-import-schema.json
@@ -15,7 +15,7 @@
         "required": ["code", "message", "severity"],
         "additionalProperties": false,
         "properties": {
-          "code": { "enum": ["element-dropped", "element-unwrapped", "attribute-dropped", "attribute-preserved", "style-unmapped", "table-degraded", "raw-preserved", "structure-unspellable", "structure-split", "encoding-assumed", "diagnostics-truncated"] },
+          "code": { "enum": ["element-dropped", "element-unwrapped", "attribute-dropped", "attribute-preserved", "style-unmapped", "table-degraded", "raw-preserved", "structure-unspellable", "encoding-assumed", "diagnostics-truncated"] },
           "message": { "type": "string" },
           "severity": { "enum": ["info", "warning", "error"] },
           "path": {

--- a/scripts/declaration-audit.mjs
+++ b/scripts/declaration-audit.mjs
@@ -230,6 +230,11 @@ const MANIFEST = [
 
   // -- the spec repo's declaration CONSTANTS, which the ledgers do not cover -
   { repo: 'spec', path: 'tests/html-import-contract.check.mjs', name: 'PIN_LAG', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'npm run html-import:check' },
+  // Codes the fixture and corpus oracles cannot reach (carve#1835). PRINTED
+  // rather than judged, because no rule separates the two kinds it holds: one
+  // entry is unreachable by construction - a cap marker, and a spec MAY at that
+  // - and two name coverage that carve#1878 may or may not close.
+  { repo: 'spec', path: 'tests/html-import-contract.check.mjs', name: 'NOT_COVERED_HERE', kind: 'js', policy: 'manual', guard: 'two-way', owner: 'npm run html-import:check' },
   { repo: 'spec', path: 'tests/ast-positions.test.mjs', name: 'DECLARED_OVER_REACH', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'tests/ast-positions.test.mjs' },
   { repo: 'spec', path: 'tests/the-two-import-exits-agree.test.mjs', name: 'UNMET', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'tests/the-two-import-exits-agree.test.mjs' },
   { repo: 'spec', path: 'tests/optional-corpus.test.mjs', name: 'AHEAD_OF_PIN', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'tests/optional-corpus.test.mjs' },

--- a/tests/html-import-contract.check.mjs
+++ b/tests/html-import-contract.check.mjs
@@ -4,6 +4,7 @@ import { test } from 'node:test'
 import './binding-contract.check-helper.mjs'
 import './html-import-construct-coverage.check-helper.mjs'
 import './import-roundtrip-ratchets.check-helper.mjs'
+import { carveToCarve, carveToHtml, htmlToCarve } from '@markup-carve/carve'
 
 const root = new URL('./html-import/', import.meta.url)
 
@@ -19,14 +20,110 @@ test('every HTML import fixture publishes all four contract files', async () => 
   }
 })
 
-test('the report schema and fixture vocabulary agree', async () => {
-  const schema = JSON.parse(await readFile(new URL('../resources/html-import-schema.json', import.meta.url), 'utf8'))
-  const allowed = new Set(schema.properties.diagnostics.items.properties.code.enum)
+/*
+ * Codes the two oracles below cannot reach, and why (carve#1835).
+ *
+ * Both directions are checked, so this map is the only way a declared code
+ * passes with nothing producing it - and an entry a run starts producing fails
+ * too. The reasons are NOT interchangeable: one code is unreachable by
+ * construction, and two have producers that no shared case exercises yet.
+ */
+const NOT_COVERED_HERE = {
+  'diagnostics-truncated':
+    'unreachable here by construction: a cap marker rather than a loss at a place. "Resource limits" makes it a MAY - carve-rs emits it, carve-js and carve-php throw a typed error instead - and neither oracle sets a cap',
+  'attribute-preserved':
+    'has a producer, no shared case: it needs `roundtrip` mode and an element kept whole as raw HTML that also carried a refused attribute, and every fixture here is `safe` (carve#1878)',
+  'table-degraded':
+    'has a producer, no shared case: no corpus document and no fixture holds a table the importer cannot do structurally (carve#1878)',
+}
+
+async function fixtureCodes() {
+  const codes = new Set()
   for (const fixture of await readdir(root, { withFileTypes: true })) {
     if (!fixture.isDirectory()) continue
     const report = JSON.parse(await readFile(new URL(`${fixture.name}/expected.report.json`, root), 'utf8'))
-    for (const diagnostic of report.diagnostics) assert.ok(allowed.has(diagnostic.code), diagnostic.code)
+    for (const diagnostic of report.diagnostics) codes.add(diagnostic.code)
   }
+  return codes
+}
+
+/*
+ * THE SECOND ORACLE, and the reason the first one alone would not do.
+ *
+ * The shared fixture set is deliberately small - one subject per directory -
+ * so five live codes have no fixture and would read as orphans. The corpus
+ * rendered and re-imported through the pinned build reaches them, which is the
+ * same population `import-roundtrip-ratchets` already walks.
+ */
+async function corpusCodes() {
+  const corpus = new URL('./corpus/', import.meta.url)
+  const codes = new Set()
+  for (const name of (await readdir(corpus)).filter((file) => file.endsWith('.crv'))) {
+    const canonical = carveToCarve(await readFile(new URL(name, corpus), 'utf8'))
+    const html = carveToHtml(canonical)
+    for (const mode of ['safe', 'semantic', 'roundtrip']) {
+      try {
+        for (const d of htmlToCarve(html, { mode }).report.diagnostics) codes.add(d.code)
+      } catch {
+        // A document the importer refuses says nothing about the vocabulary.
+      }
+    }
+  }
+  return codes
+}
+
+const declaredCodes = async () =>
+  JSON.parse(await readFile(new URL('../resources/html-import-schema.json', import.meta.url), 'utf8'))
+    .properties.diagnostics.items.properties.code.enum
+
+test('the report schema and fixture vocabulary agree', async () => {
+  const allowed = new Set(await declaredCodes())
+  for (const code of await fixtureCodes()) assert.ok(allowed.has(code), code)
+})
+
+/*
+ * THE OTHER DIRECTION, which is the one that was missing (carve#1835).
+ *
+ * `structure-split` sat in the enum after the shape that produced it was
+ * spelled away, and every gate stayed green: the check above asks whether a
+ * fixture's code is declared, and nothing asked whether a declared code is
+ * produced. That is a promise to a consumer - a `case` on a code no import can
+ * emit reads as live and is dead - and it is the question
+ * tests/schema-fields-are-produced.test.mjs already asks one level down, for
+ * AST fields.
+ */
+test('every declared diagnostic code is produced, or named as not covered here', async () => {
+  const produced = new Set([...(await fixtureCodes()), ...(await corpusCodes())])
+  const orphans = (await declaredCodes())
+    .filter((code) => !produced.has(code) && !(code in NOT_COVERED_HERE))
+    .sort()
+
+  assert.deepEqual(
+    orphans,
+    [],
+    `code(s) the schema declares that nothing here produces: ${orphans.join(', ')}. ` +
+      'Either a case is missing, or the code describes something no importer can emit. ' +
+      'Add a fixture or a corpus document, or name it in NOT_COVERED_HERE with the reason.',
+  )
+})
+
+test('every not-covered exemption is still needed', async () => {
+  const produced = new Set([...(await fixtureCodes()), ...(await corpusCodes())])
+  const stale = Object.keys(NOT_COVERED_HERE).filter((code) => produced.has(code)).sort()
+
+  assert.deepEqual(
+    stale,
+    [],
+    `NOT_COVERED_HERE names code(s) something now produces: ${stale.join(', ')}. ` +
+      'Delete the entry so the code is gated like every other one.',
+  )
+})
+
+test('every not-covered exemption names a code the schema still declares', async () => {
+  const declared = new Set(await declaredCodes())
+  const unknown = Object.keys(NOT_COVERED_HERE).filter((code) => !declared.has(code)).sort()
+
+  assert.deepEqual(unknown, [], `NOT_COVERED_HERE names retired code(s): ${unknown.join(', ')}.`)
 })
 
 /*


### PR DESCRIPTION
Closes markup-carve/carve#1835, per the ruling on the ticket.

`structure-split` was declared and nothing could emit it. Its producer was a dropped empty `<dd>` splitting one `<dl>` in two; markup-carve/carve#1827 gave that entry the `{empty}` sentinel, so nothing is dropped and nothing splits. Retired rather than held: the shape did not get postponed, it got spelled, and an enum grows without breaking readers - so re-adding the code the day a real splitter arrives costs what adding it now costs, while holding the slot spends a promise a consumer cannot keep.

**The gate is the larger half.** The contract check asked whether a fixture's code is declared and never whether a declared code is produced, which is why this went unnoticed rather than red. It is the question `tests/schema-fields-are-produced.test.mjs` already asks one level down, for AST fields.

Two oracles, because the fixtures alone are the wrong one. The shared set is deliberately small - one subject per directory - so five live codes have no fixture and would read as orphans. The corpus rendered and re-imported through the pinned build in all three modes reaches them:

```
attribute-dropped: 222
element-dropped: 18
element-unwrapped: 373
raw-preserved: 14
structure-unspellable: 9
style-unmapped: 65
```

`NOT_COVERED_HERE` holds what neither oracle reaches, and its reasons are deliberately not interchangeable:

- `diagnostics-truncated` is unreachable by construction - a cap marker rather than a loss at a place, and a `MAY` that carve-rs takes while carve-js and carve-php throw a typed error instead. Permanent.
- `attribute-preserved` and `table-degraded` have producers and no shared case. That is markup-carve/carve#1878, and the exemption is standing in for coverage rather than describing a limit.

The manifest entry is `manual` rather than `owed` for exactly that reason: no rule separates the permanent entry from the two that may clear, so the rows are printed for a reader instead of counted as debt.

**One thing here is new prose, not a restatement.** The taxonomy section gains the rule the retirement rests on: every code has a producer, a reader tolerates a code it does not know, and so retiring or re-adding one is not a compatibility event. Nothing said that before; it is worth reading as a ruling rather than a tidy-up.

The engines drop the code and the machinery behind it at their own pin bumps - carve-js's `split` field, comment and drain loop; carve-rs's variant and `migration.rs` mapping; carve-php's comment - since the byte-equal list assertion only bites when a repository moves its own pin.
