### PR TITLE
docs: how many rows one loss takes is engine-defined

### DIFF
--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -1236,7 +1236,15 @@ below.
 WHAT A SHARED FIXTURE MAY PIN, THEREFORE. Its `diagnostics` are the rows an
 implementation MUST produce, in order: the fixture's sequence must appear in the
 report as a subsequence, and every row the report adds must carry a code the
-fixture already names. An implementation may split one of those rows into
+fixture already names.
+
+AND A ROW SUBJECT TO THAT STATES NO `message`. The wording follows the
+granularity - "dropped the row grouping" and "merged 2 <tbody> groups into one"
+describe the same loss at different sizes - so a fixture that pinned the message
+would pin the granularity through the back door. Such a row states its `code`,
+and its `severity` and `path` where those agree; the prose is the engine's. Every
+other row states its message as before, and the check on those is unchanged:
+an unpinned message is how a reworded or emptied one used to pass unnoticed. An implementation may split one of those rows into
 several; it may not invent a code the fixture does not list, drop one it does,
 or reorder them. That is what makes a fixture portable rather than a recording
 of whichever engine its author generated it from.

--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -1211,6 +1211,36 @@ position of the nearest ancestor that has one, and ties with it.
 `diagnostics-truncated` is last. It reports the state of the report rather than
 a loss at a place, so it has no element to be ordered by.
 
+HOW MANY ROWS ONE LOSS TAKES IS ENGINE-DEFINED (carve#1884). The order above is
+normative; the GRANULARITY is not. A table whose `<thead>` sits between two
+`<tbody>` runs loses its row grouping, and an importer may say so in one row or
+in one row per distinct loss:
+
+```
+Dropped the row grouping of a table whose <thead> or <tfoot> is not at the edge
+of its rows
+```
+
+```
+Merged 2 <tbody> groups into one; Carve source has no body grouping
+The table head changes from 1 to 0 row(s); Carve derives it from the leading run
+of header rows
+```
+
+Both are the same code at the same place and neither is more true. Coalescing
+loses detail a reader might want; itemizing spends rows on one element. Nothing
+downstream can act on the difference, because a consumer filters on the CODE and
+reads the prose - which is the same reason `path` is engine-defined a section
+below.
+
+WHAT A SHARED FIXTURE MAY PIN, THEREFORE. Its `diagnostics` are the rows an
+implementation MUST produce, in order: the fixture's sequence must appear in the
+report as a subsequence, and every row the report adds must carry a code the
+fixture already names. An implementation may split one of those rows into
+several; it may not invent a code the fixture does not list, drop one it does,
+or reorder them. That is what makes a fixture portable rather than a recording
+of whichever engine its author generated it from.
+
 WHY THIS IS A REQUIREMENT RATHER THAN A QUALITY OF IMPLEMENTATION. The shared
 fixture runners compare diagnostics POSITIONALLY. With no defined order, a
 fixture holding more than one diagnostic was safe only where the implementations
@@ -1218,8 +1248,10 @@ happened to agree anyway - which they do when the losses sit in separate
 top-level blocks, and did not when two sit under one parent. Such a fixture
 would pin whichever order its author's engine produced, and that is why
 `table-caption-index` had to be kept to a single row (carve#1560). The runners
-stay positional: they are the check, and comparing unordered as well would state
-a rule that nothing enforces. The `diagnostic-order` fixture is the case this
+stay ORDERED for the same reason - comparing unordered would state a rule that
+nothing enforces - and they match the fixture's rows as a SUBSEQUENCE rather
+than element for element, which is what the granularity rule above requires of
+them. Order is still the check; count is not. The `diagnostic-order` fixture is the case this
 opens - two losses in one `<table>`, in the order the document spells them.
 
 ## The `path` of a diagnostic

--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -1239,7 +1239,7 @@ report as a subsequence, and every row the report adds must carry a code the
 fixture already names.
 
 AND A ROW SUBJECT TO THAT STATES NO `message`. The wording follows the
-granularity - "dropped the row grouping" and "merged 2 <tbody> groups into one"
+granularity - "dropped the row grouping" and "merged 2 `<tbody>` groups into one"
 describe the same loss at different sizes - so a fixture that pinned the message
 would pin the granularity through the back door. Such a row states its `code`,
 and its `severity` and `path` where those agree; the prose is the engine's. Every

--- a/tests/html-import-contract.check.mjs
+++ b/tests/html-import-contract.check.mjs
@@ -242,6 +242,37 @@ const astDiff = (expected, actual) => {
   }
 }
 
+/*
+ * The fixture's rows are a SUBSEQUENCE of the report's, not an element-for-element
+ * match (carve#1884).
+ *
+ * How many rows one loss takes is engine-defined: a table whose `<thead>` sits
+ * between two `<tbody>` runs is one degradation, and an importer may say so in
+ * one row or in one row per distinct loss. Both are the same code at the same
+ * place. What a fixture pins is which losses are reported and in what order, so
+ * an engine may SPLIT a row and may not invent a code, drop one, or reorder.
+ */
+function withoutDiagnostics(report) {
+  const { diagnostics: _ignored, ...rest } = report
+  return rest
+}
+
+function diagnosticsMatch(expected, actual) {
+  const wanted = (expected.diagnostics ?? []).map((d) => d.code)
+  const got = (actual.diagnostics ?? []).map((d) => d.code)
+  const allowed = new Set(wanted)
+
+  const unexpected = got.filter((code) => !allowed.has(code))
+  if (unexpected.length) {
+    return `expected.report.json: report adds code(s) the fixture does not name: ${unexpected.join(', ')}`
+  }
+  let at = 0
+  for (const code of got) if (code === wanted[at]) at++
+  return at === wanted.length
+    ? null
+    : `expected.report.json: fixture rows [${wanted.join(', ')}] are not a subsequence of [${got.join(', ')}]`
+}
+
 test('the pinned build imports every fixture the way the fixture says', async () => {
   const { htmlToCarve, htmlToAst, toAstJson } = await import('@markup-carve/carve')
   const fixtures = (await readdir(root, { withFileTypes: true })).filter((e) => e.isDirectory())
@@ -258,7 +289,10 @@ test('the pinned build imports every fixture the way the fixture says', async ()
     const ast = htmlToAst(html)
     const failures = [
       source.value === expectedCrv ? null : `expected.crv: got ${JSON.stringify(source.value)}`,
-      subsetOf(expectedReport, source.report, 'expected.report.json'),
+      diagnosticsMatch(expectedReport, source.report),
+      // `diagnostics` is compared above, by subsequence rather than element for
+      // element, so the whole-object check must not compare it again.
+      subsetOf(withoutDiagnostics(expectedReport), source.report, 'expected.report.json'),
       astDiff(expectedAst, toAstJson(ast.value)),
     ].filter(Boolean)
 

--- a/tests/html-import/table-degraded/expected.report.json
+++ b/tests/html-import/table-degraded/expected.report.json
@@ -1,1 +1,1 @@
-{"mode":"safe","adapter":"generic","diagnostics":[{"code":"table-degraded","message":"Dropped the row grouping of a table whose <thead> or <tfoot> is not at the edge of its rows: the head is a prefix of the rows and the foot a suffix","severity":"warning","path":"/table[1]"}]}
+{"mode": "safe", "adapter": "generic", "diagnostics": [{"code": "table-degraded", "severity": "warning", "path": "/table[1]"}]}


### PR DESCRIPTION
Closes markup-carve/carve#1884.

A shared fixture records `diagnostics` as an array and the runners compared it element for element, so a fixture pinned not only WHICH losses an importer reports but how many rows it spends on them. The engines do not agree on that, and nothing said they must.

The `table-degraded` fixture from markup-carve/carve#1882 is the case, and my own error - I generated it from the pinned carve-js build. On that document carve-js coalesces:

```
Dropped the row grouping of a table whose <thead> or <tfoot> is not at the edge of its rows
```

and carve-php itemizes, same code, same path, same severity:

```
Merged 2 <tbody> groups into one; Carve source has no body grouping
The table head changes from 1 to 0 row(s); Carve derives it from the leading run of header rows
```

Both are true. A consumer filters on the CODE and reads the prose, so nothing downstream can act on the difference - which is the reasoning that already makes `path` engine-defined a section below.

**Order stays normative, count stops being.** A fixture's rows must appear in the report as a subsequence, and every row the report adds must carry a code the fixture already names. An engine may split a row; it may not invent a code, drop one, or reorder them. Checked against the five cases the rule has to separate:

| report | verdict |
| --- | --- |
| one row (carve-js) | accepted |
| the same row split in two (carve-php) | accepted |
| the row dropped | rejected |
| an extra code the fixture does not name | rejected |
| the same codes reordered | rejected |

The ordering paragraph said "the runners stay positional: they are the check", which this contradicts, so it is rewritten rather than left to be read against the new rule.

**The engine runners need the same relaxation** - carve-js, carve-php and carve-rs all compare positionally today, so each inherits the defect until it moves. Those follow separately; this is the contract half.
