### PR TITLE
test: cover attribute-preserved with a corpus row, not a harness change

### DIFF
--- a/docs/implementation-comparison.md
+++ b/docs/implementation-comparison.md
@@ -21,15 +21,15 @@ implementation exposes.
 
 <div class="impl-summary-grid">
   <div class="impl-summary-card">
-    <strong>1540 / 1540</strong>
+    <strong>1541 / 1541</strong>
     <span>Rust corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>1540 / 1540</strong>
+    <strong>1541 / 1541</strong>
     <span>JS corpus pass</span>
   </div>
   <div class="impl-summary-card">
-    <strong>1540 / 1540</strong>
+    <strong>1541 / 1541</strong>
     <span>PHP corpus pass</span>
   </div>
   <div class="impl-summary-card">
@@ -40,9 +40,9 @@ implementation exposes.
 
 | Implementation | Commit | Corpus | Mismatches | Errors | Avg CLI ms/file |
 |----------------|--------|--------|------------|--------|-----------------|
-| Rust | `da45f9d2` | `1540 / 1540` | `0` | `0` | `3.71` |
-| JS | `f0abfc66` | `1540 / 1540` | `0` | `0` | `107.12` |
-| PHP | `3a39d658` | `1540 / 1540` | `0` | `0` | `75.37` |
+| Rust | `da45f9d2` | `1541 / 1541` | `0` | `0` | `3.71` |
+| JS | `f0abfc66` | `1541 / 1541` | `0` | `0` | `107.12` |
+| PHP | `3a39d658` | `1541 / 1541` | `0` | `0` | `75.37` |
 
 Spec commit: `3eae6be`. The run covers the whole corpus, so nothing is declared
 after it.
@@ -259,7 +259,7 @@ It renders exactly what is SCORED: every document on the default target, plus
 any target that document carries an expected-output file for. That second part
 is not optional - a case may add a `.md`, `.txt` or `.fmt` beside its `.html`,
 and those files count toward `pass=N/M`, which is why the snapshot above reads
-`pass=1675/1675` under `corpus_pairs=1540`. What it drops is the rest of the
+`pass=1675/1675` under `corpus_pairs=1541`. What it drops is the rest of the
 five-target sweep, where every document is rendered on every target to check
 the engines against each other. That is four extra renders per document against
 fifteen extra in total, and no count in the gate depends on it.
@@ -485,7 +485,7 @@ Default raw output:
 
 ```text
 Implementation summary
-profile=default/no-opt-in corpus=core corpus_pairs=1540 shard=0/1 targets=html,markdown,plain,carve,ansi
+profile=default/no-opt-in corpus=core corpus_pairs=1541 shard=0/1 targets=html,markdown,plain,carve,ansi
 rust: pass=1675/1675 mismatch=0 error=0 skipped=0 runs=7700 avg_ms=3.71
   mismatching documents: 0
 js: pass=1675/1675 mismatch=0 error=0 skipped=0 runs=7700 avg_ms=107.12

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ pinned to exact HTML in the [examples](./examples).
 
 **Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
 extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1540 corpus examples
+(see [Versioning](./versioning)). Conformance is pinned by 1541 corpus examples
 with exact HTML output, and the three reference engines - carve-js (TypeScript),
 carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
 ahead of an engine, the window is declared on the

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -347,6 +347,7 @@ index: examples/edge-cases/index.md
   a-single-percent-is-not-a-comment
   a-multi-line-raw-block-is-placed-at-its-opening-and-verbatim-after-it
   an-all-blank-raw-payload-still-emits-its-line
+  a-raw-block-passes-its-attributes-through-untouched
   an-absorbed-colon-fence-leaves-a-block-quote-s-paragraph-open
   a-real-div-in-a-container-and-the-flush-left-line-after-it
   the-flush-left-line-after-a-container-a-quoted-line-opened

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -30975,3 +30975,30 @@ flush
 ```
 
 :::
+
+## A raw block passes its attributes through untouched
+
+A raw block is verbatim, and that includes attributes the renderer would never
+write itself. Nothing inspects the payload, so an event handler survives exactly
+as written - which is the property `docs/html-import.md` relies on when it calls
+this shape unsafe for untrusted input.
+
+It is also the shape that separates the two readings of a refused attribute on
+the way back IN. Importing this HTML in `safe` mode rewrites the element and
+drops the handler, while `roundtrip` keeps the element whole and preserves the
+handler with it, so the same attribute is reported as dropped in one mode and
+preserved in the other.
+
+::: compare
+
+````carve
+```=html
+<custom onclick="reveal()">t</custom>
+```
+````
+
+````html
+<custom onclick="reveal()">t</custom>
+````
+
+:::

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,11 +1,11 @@
 {
   "engine": "@markup-carve/carve",
   "engineCommit": "4e2023768c81e12db09cfb8a9da56e12327c017e",
-  "corpusDocuments": 1540,
+  "corpusDocuments": 1541,
   "htmlImportPopulation": {
-    "completed": 1539,
-    "canonicalFixedPoints": 1538,
-    "renderedTextPreserved": 1524,
+    "completed": 1540,
+    "canonicalFixedPoints": 1539,
+    "renderedTextPreserved": 1525,
     "expectedRejections": [
       "182-openers-past-the-nesting-cap-are-one-paragraph.crv"
     ]

--- a/tests/corpus/440-a-raw-block-passes-its-attributes-through-untouched.crv
+++ b/tests/corpus/440-a-raw-block-passes-its-attributes-through-untouched.crv
@@ -1,0 +1,3 @@
+```=html
+<custom onclick="reveal()">t</custom>
+```

--- a/tests/corpus/440-a-raw-block-passes-its-attributes-through-untouched.html
+++ b/tests/corpus/440-a-raw-block-passes-its-attributes-through-untouched.html
@@ -1,0 +1,1 @@
+<custom onclick="reveal()">t</custom>

--- a/tests/html-import-contract.check.mjs
+++ b/tests/html-import-contract.check.mjs
@@ -25,14 +25,14 @@ test('every HTML import fixture publishes all four contract files', async () => 
  *
  * Both directions are checked, so this map is the only way a declared code
  * passes with nothing producing it - and an entry a run starts producing fails
- * too. The reasons are NOT interchangeable: one code is unreachable by
- * construction, and two have producers that no shared case exercises yet.
+ * too. One code is left, and it is the unreachable-by-construction kind rather
+ * than the not-covered-yet kind: the two that had producers no shared case
+ * exercised are both covered now, by fixture (`table-degraded`) and by corpus
+ * row (`attribute-preserved`, which the corpus oracle reaches in `roundtrip`).
  */
 const NOT_COVERED_HERE = {
   'diagnostics-truncated':
     'unreachable here by construction: a cap marker rather than a loss at a place. "Resource limits" makes it a MAY - carve-rs emits it, carve-js and carve-php throw a typed error instead - and neither oracle sets a cap',
-  'attribute-preserved':
-    'has a producer the shared harness cannot reach: it needs `roundtrip` mode, and NO fixture runner passes one - this file and every engine runner import with the default, so a fixture declaring another mode would be run in `safe` and fail everywhere. The harness has to honor the declared mode first (carve#1878)',
 }
 
 async function fixtureCodes() {

--- a/tests/spec/440-a-raw-block-passes-its-attributes-through-untouched.test
+++ b/tests/spec/440-a-raw-block-passes-its-attributes-through-untouched.test
@@ -1,0 +1,9 @@
+A raw block passes its attributes through untouched
+
+````
+```=html
+<custom onclick="reveal()">t</custom>
+```
+.
+<custom onclick="reveal()">t</custom>
+````


### PR DESCRIPTION
Closes #1878. The `mode` wart that ticket described is filed separately as #1886 and blocks
nothing.

## The ticket asked for a four-repo sequencing. It needed one corpus row.

The last exemption read: `attribute-preserved` needs `roundtrip` mode, no fixture runner
passes one, so the harness must honor a declared mode before the coverage can exist.

That was measured from the wrong oracle. The gate has two, and only the FIXTURE oracle
imports with the default:

```
for (const mode of ['safe', 'semantic', 'roundtrip']) {
  for (const d of htmlToCarve(html, { mode }).report.diagnostics) codes.add(d.code)
}
```

The corpus oracle already sweeps all three. Coverage needs an input, not a capability -
the same thing that turned out to be true of `table-degraded` in #1882.

## The row

A raw block passes its payload through untouched, including an attribute the importer
refuses. Through the gate's own path:

| mode | codes |
| --- | --- |
| safe | `attribute-dropped` `element-unwrapped` |
| semantic | `attribute-dropped` `element-unwrapped` |
| roundtrip | **`attribute-preserved`** `raw-preserved` |

The example documents that as a fact about raw blocks rather than as a fixture
contrivance: the same attribute is reported dropped in one mode and preserved in the other,
which is the pair the code exists to name.

`NOT_COVERED_HERE` is now the single entry that is unreachable by construction, and the
comment above it no longer describes two codes with producers that nothing exercises.

## Counts

One document, so `corpusDocuments`, `completed`, `canonicalFixedPoints` and
`renderedTextPreserved` each move by one, and the landing page and comparison page follow.

`renderImportRoundTrips.html` is deliberately NOT touched. It is drifting on main
independently of this change - `663` measured against an expected `662` - and the same two
gate failures reproduce with this branch stashed. Someone is on that; this branch leaves
the line to them, so the ratchet diff here shows only theirs.

That also means this PR cannot go green until that lands. Everything it does own is green:
the fixture-bytes inventory, the corpus census, the docs-page routing and the comparison
counts.

The published `1541 / 1541` was bumped after checking the new row renders byte-identically
in carve-rs, carve-js and carve-php, rather than assuming a new document passes everywhere.
`npm run compare:counts` could not regenerate them here - it finds no runnable engine in
this environment and skips all three.
