### PR TITLE
ci: a missing bump branch is not a moved one

### DIFF
--- a/.github/workflows/bump-downstream.yml
+++ b/.github/workflows/bump-downstream.yml
@@ -209,6 +209,15 @@ jobs:
           # not exist'.
           observed="$(gh api "repos/$REPO/git/ref/heads/automation/bump-spec" \
                 --jq '.object.sha' 2>/dev/null || true)"
+          # gh prints a 404 BODY ON STDOUT, so a missing branch arrives here as
+          # `{"message":"Not Found",...}` rather than as the empty string this
+          # says means "no branch". git was then handed that JSON as the lease's
+          # expected object name and refused every push with `cannot parse
+          # expected object name`, on every repo whose branch did not exist yet.
+          # Anything that is not a full sha means the branch is not there.
+          if ! printf '%s' "$observed" | grep -Eq '^[0-9a-f]{40}$'; then
+            observed=""
+          fi
 
           foreign=0
           if ahead="$(gh api "repos/$REPO/compare/main...automation/bump-spec" \
@@ -408,7 +417,10 @@ jobs:
             if [ -n "${CODEX_API_KEY:-}" ]; then
               echo "CODEX_API_KEY present -> attempting implementation with codex"
               npm install -g @openai/codex >/dev/null 2>&1 || true
-              OPENAI_API_KEY="$CODEX_API_KEY" codex exec --full-auto \
+              # `--full-auto` was removed from the CLI; the sandbox policy is
+              # its own flag now, and the run failed with `unexpected argument`
+              # before it reached the model.
+              OPENAI_API_KEY="$CODEX_API_KEY" codex exec --sandbox workspace-write \
                 "The git submodule '$SUB' (the Carve spec corpus) was just bumped to a newer version. Implement the minimal parser/renderer changes in THIS repository so that the command '$TEST_CMD' passes. Do not edit anything under '$SUB'. Match existing code style." \
                 || true
               if bash -c "$TEST_CMD"; then


### PR DESCRIPTION
Every bump job except `carve-lsp` has been failing on every run - including before the last merge, so this is not new breakage - with:

```
error: cannot parse expected object name '{"message":"Not Found","documentation_url":"...","status":"404"}'
##[error]Bump aborted for markup-carve/carve-php: automation/bump-spec moved after this run read it
```

**`gh api` prints a 404 body on STDOUT.** So `2>/dev/null` silences nothing, and a repo whose `automation/bump-spec` does not exist yet captures `{"message":"Not Found",...}` where the code expects a sha or the empty string. That JSON is then handed to `--force-with-lease` as the expected object name, git refuses to parse it, and the run reports the one thing it was not: a concurrent push to the branch.

The comment directly above the capture already says what should happen - "Empty means the branch does not exist yet, which the push treats as 'must still not exist'". Only the capture disagreed. Anything that is not a 40-character sha now reads as absent, which the lease's own second branch already handles.

Checked against the four inputs it has to separate:

| captured | lease |
| --- | --- |
| the 404 JSON body | absent |
| empty | absent |
| a real 40-char sha | that sha |
| a short hash | absent |

**Second fix in the same job**: the codex step failed before reaching the model with `error: unexpected argument '--full-auto' found`. That flag was removed from the CLI and the sandbox policy is its own flag now, so it is `--sandbox workspace-write` - write inside the checkout, no network, which is what that step wants.

This does not touch the one genuine conformance failure underneath: carve-php reports 1 failure in 10,909 at `CarveCorpusTest.php:1014` against corpus `e5042db`. That is an engine-vs-corpus disagreement and wants its own look - the lease bug was hiding whatever the other seven jobs would have said about theirs.
