### PR TITLE
docs: a fixture's report block is an assertion, not a configuration

### DIFF
--- a/docs/html-import.md
+++ b/docs/html-import.md
@@ -1430,6 +1430,19 @@ minimum. AST comparison ignores object-key order and absent optional fields;
 source comparison uses the canonical writer byte-for-byte. Diagnostic fixture
 objects are minimum matches: implementations may add optional location fields.
 
+`expected.report.json` IS THE REPORT, NOT A CONFIGURATION (carve#1886). Its
+`mode` and `adapter` are fields the import RETURNS, asserted like any other, and
+a fixture cannot ask to be imported some other way: every runner imports with
+default options, so a fixture declaring `"mode": "roundtrip"` would be run in
+`safe` and fail on the very field it set. That is why all of them read `safe`.
+
+A SHAPE THAT ONLY ANOTHER MODE REACHES GOES ELSEWHERE, and it is already
+covered: the vocabulary gate sweeps the whole corpus in `safe`, `semantic` and
+`roundtrip`, which is how `attribute-preserved` - reachable only under
+`roundtrip` - is exercised without a fixture (carve#1878). An engine-local test
+is the other home. Teaching four runners to read the field would buy the fixture
+set a mode it has never needed.
+
 The shared set is deliberately small and each directory has one subject:
 
 | fixture | subject |


### PR DESCRIPTION
Closes markup-carve/carve#1886, by contradicting its premise rather than doing what it proposes.

The ticket reads the `mode` in `expected.report.json` as configuration that silently does nothing, and proposes teaching four runners to apply it. **It is not configuration.** `mode` and `adapter` are fields the import RETURNS - the report is `{mode, adapter, diagnostics}` - so the fixture asserts them exactly like it asserts a diagnostic's `severity`.

That means there is nothing to apply, and no runner is ignoring anything. A fixture cannot ask to be imported another way, and one declaring `"mode": "roundtrip"` would be run in `safe` and then fail on the very field it set. Which is why every fixture reads `safe`, and why the field has "never been exercised" - it is exercised on every fixture, as an assertion.

Saying that plainly in the contract removes the wart the ticket is actually about: a reader can no longer mistake it for a knob.

A shape only another mode reaches is already covered elsewhere, and the ticket says so itself - the vocabulary gate sweeps the whole corpus in `safe`, `semantic` and `roundtrip`, which is how `attribute-preserved` got covered in markup-carve/carve#1878 with no harness change. An engine-local test is the other home.

So the four-repo sequencing the ticket sketches buys the fixture set a mode it has never needed, and the alternative it offers - dropping the field - would delete a live assertion that the importer reports the mode it ran in.
