### PR TITLE
docs: keep retired readings out of normative rules

### DIFF
--- a/docs/spec-history.md
+++ b/docs/spec-history.md
@@ -159,6 +159,51 @@ same space-only model in carve#904 and carve#906. Marker separators remain a
 different role and take the cardinality their own productions declare
 (carve#892).
 
+The `lang` shorthand briefly carried a caveat because the executable checker
+merged a repeated boolean key differently from every engine. Before carve#1125,
+`{a=1 a}` became `a="1" a=""` in the checker instead of the last-value result
+`a=""`. The checker was corrected; boolean, key/value and `:lang` spellings now
+share one merge slot.
+
+## Clarifications moved out of active clauses
+
+Several current rules accumulated sentences describing what an older clause
+said rather than what the language does now. Those sentences were removed from
+the active algorithm together and are retained here for traceability:
+
+- Trailing ASCII space is discarded on every content line. An older paragraph
+  said the opposite for a run before a soft break, while PART 12 repeated the
+  rule at greater length (carve#926).
+- An unclosed comment fence degrades to a line comment instead of mirroring an
+  unclosed div. The older comment clause quoted a stale description of the div
+  behavior and would have hidden the rest of the document (carve#1717).
+- A below-column definition or attribute line that folds as text folds into
+  the open paragraph belonging to its container. The older text left that host
+  implicit, allowing a document-level reading (carve#1800).
+- HTML security requirements first lived only in `docs/security.md`; moving
+  them into PART 9 made them conformance requirements rather than guidance.
+- Non-HTML output of link-reference definitions became an explicit consequence
+  of PART 11 §10a when those definitions gained AST nodes.
+- Canonical table padding replaced writer guards for `<`, `>`, `~` and `{` in
+  the three glued table-prefix positions (carve#1601). The current writer rule
+  states the required strategy without narrating that transition.
+- `|{#x}< content |` is an older spelling for a cell attribute followed by an
+  alignment marker. It now parses as unaligned literal content; canonical form
+  puts the alignment run before the attributes.
+- PART 11 originally introduced its invariants because writer behavior had
+  been inferred from three implementations agreeing. That origin does not
+  qualify the current invariants.
+- A failed extension-definition probe originally collected the candidate line,
+  on the mistaken reasoning that declining it would delete the author's text.
+  Collecting is what removes a definition from visible output. Before the
+  correction, a 4,000-line stress case lost 3,858 lines; R1a now fails toward
+  keeping the authored text (carve#1881).
+- Canonical task markers once fell back to rendered checkbox state, turning
+  `[-]`, `[_]`, `[>]` and `[?]` into `[ ]`. The AST now retains the authored
+  state and the writer reproduces it (carve#1866).
+- Raw blocks formerly also accepted a `` ```raw FORMAT `` keyword spelling.
+  Block and inline raw now share the `=FORMAT` spelling.
+
 ## AST position implementation history
 
 Position coverage used to be reported inside PART 12 with per-engine counts and

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -1966,9 +1966,7 @@ raw_content = (* any content until closing fence *) ;
    `abc<SP>` renders <p>abc</p>; so does `abc<SP>` followed by `def`, where the
    run sits before a SOFT BREAK; and so do a heading, a list item, a block
    quote line, a definition term or description, a footnote body line, a table
-   caption and a line-block line. This clause used to say the opposite of the
-   soft-break half, and PART 12 §7 used to say it at greater length
-   (carve#926).
+   caption and a line-block line.
 
    THE RUN IS `whitespace` -- `' ' | '\t'` -- the same two-character terminal
    `blank_line = {whitespace}` and `indent` take (PART 1; carve#890). Every
@@ -1999,7 +1997,6 @@ raw_content = (* any content until closing fence *) ;
    meaning in whitespace nothing can see.) Pinned by corpus
    104-paragraph-trailing-whitespace and 268. *)
 paragraph = inline_content+, [blank_line] ;
-
 
 (* ============================================================================
    PART 3: INLINE ELEMENTS
@@ -3132,11 +3129,8 @@ attribute = language_attribute | id_attribute | class_attribute
 
    A BOOLEAN `lang` IS THE SAME KEY AS WELL: `{lang}` means `lang=""` under
    PART 4's boolean rule, so `{:fr lang}` ends at `lang=""` and `{lang :fr}` at
-   `lang="fr"`. This paragraph carried a caveat until carve#1125: the executable
-   spec used to emit a boolean unconditionally, so `{a=1 a}` came out as
-   `a="1" a=""` where every engine gave `a=""`. That is fixed, the three
-   spellings of the key now meet in one slot everywhere, and the corpus pins the
-   boolean form beside the other two rather than leaving it to prose. *)
+   `lang="fr"`. The three spellings of the key meet in one slot, and the corpus
+   pins the boolean form beside the other two. *)
 language_attribute = ':', [ language_tag ] ;
 language_tag       = language_subtag, { '-', language_subtag } ;
 language_subtag    = ( letter | digit ), { letter | digit } ;
@@ -3955,9 +3949,9 @@ EOF = (* end of file *) ;
          makes it ordinary content (T4's `{.x} <` is unchanged), and the
          validity rule is T8's.
 
-         The canonical writer uses this order. The retired
-         `|{#x}< content |` spelling is parsed as unaligned literal content;
-         row attributes (T8) are unaffected.
+         The canonical writer uses this order. The `|{#x}< content |` spelling
+         is parsed as unaligned literal content; row attributes (T8) are
+         unaffected.
 
       T11 A MARKER RUN ENDS AT A SPACE -- NORMATIVE. A cell's marker run is
          the kind marker `=`, the alignment run and the attribute block, in
@@ -5405,9 +5399,9 @@ EOF = (* end of file *) ;
       fence, PART 2) emits its verbatim content UNESCAPED when FORMAT
       matches the output format and drops it otherwise; the inline form
       follows. Block and inline raw share the `=FORMAT` spelling (```=html
-      / `…`{=html}); the former ```raw FORMAT keyword form was removed. A code span whose trailing attribute block
-      is EXACTLY `{=format}` (a single `=`-prefixed format name, with no
-      other classes/ids/keys) is raw passthrough: the verbatim span content
+      / `…`{=html}). A code span whose trailing attribute block is EXACTLY
+      `{=format}` (a single `=`-prefixed format name, with no other
+      classes/ids/keys) is raw passthrough: the verbatim span content
       is emitted UNESCAPED when `format` matches the output format (`html`),
       and DROPPED otherwise. The `{=format}` tag is consumed, not rendered.
       A code span with any OTHER trailing `{…}` is a generic attributed code
@@ -5803,8 +5797,7 @@ EOF = (* end of file *) ;
             discards it and the author's characters reach neither the page nor
             any table (carve#1801).
 
-            THE FOLD IS INTO THE CONTAINER, in every host, which is the half
-            this clause used to leave to the reader. "Folds as TEXT" and
+            THE FOLD IS INTO THE CONTAINER, in every host. "Folds as TEXT" and
             I5's "lazy paragraph text" name one operation on one open
             paragraph, and that paragraph belongs to the container whose
             content column the line fell below. Ending the container and
@@ -5868,11 +5861,10 @@ EOF = (* end of file *) ;
          column and stay siblings.
 
    25. SECURITY REQUIREMENTS -- NORMATIVE (HTML output target). These rules
-      bind any implementation that emits HTML for UNTRUSTED input. They were
-      previously stated only in docs/security.md (non-normative); they are
-      hoisted here so an implementation written to this grammar + the corpus
-      cannot be conformant yet a trivial XSS vector. The corpus pins
-      representative cases (resources/examples/edge-cases.md "Security hardening").
+      bind any implementation that emits HTML for UNTRUSTED input, so an
+      implementation written to this grammar + the corpus cannot be conformant
+      yet expose a trivial XSS vector. The corpus pins representative cases
+      (resources/examples/edge-cases.md "Security hardening").
       - URL SINK SCHEME DENYLIST. On every clickable URL sink -- link
         destination (`href`), image source (`src`), and autolink -- an HTML
         renderer MUST reject any URL whose scheme is `javascript`, `vbscript`,
@@ -6259,9 +6251,7 @@ EOF = (* end of file *) ;
         of input, and the difference is VISIBILITY: an unclosed div still
         renders the blocks it swallowed, so a forgotten closer costs the
         reader a stray wrapper, while an unclosed comment would HIDE them and
-        silently delete the rest of the document. This clause used to claim it
-        MIRRORED §12, quoting a §12 sentence that has since been removed for
-        saying the opposite of what §12 means (carve#1717). An implementation that
+        silently delete the rest of the document. An implementation that
         surfaces diagnostics SHOULD report an unterminated comment fence;
         emitting one is OPTIONAL, since not every implementation has a
         warning channel.
@@ -6687,21 +6677,6 @@ EOF = (* end of file *) ;
       is one a reader can see -- a reference to the uncollected label renders as
       its literal `[^f]`, on the page, where someone can report it.
 
-      THIS CLAUSE SAID THE OPPOSITE, and named the wrong loss to justify it. It
-      required collecting, on the reasoning that "suppressing deletes the
-      author's line from the page". It is collecting that deletes the line: the
-      definition is taken OUT of the source, and what renders is the remainder --
-      a bare `-` where the author wrote `- [^f]: body`. Suppressing leaves every
-      character on the page and declines only to register metadata, so the
-      failure a reader meets is a reference that renders as its literal
-      `[^f]` -- visible, and diagnosable, which is what the old reasoning wanted
-      and did not get.
-
-      Measured before the correction (carve#1881): at four thousand such lines
-      the engine implementing this clause faithfully removed 3,858 of them.
-      Being conformant was the reason it did, which is why the clause moved
-      rather than the engine alone.
-
    R1b A MATCHER'S COORDINATES ARE LOCAL, NOT ABSOLUTE -- NORMATIVE
       (carve#1437). The `lines` array handed to a block matcher MAY begin at a
       CONTAINER'S CONTENT rather than at the document, re-based so that index 0
@@ -7125,8 +7100,7 @@ EOF = (* end of file *) ;
    ============================================================================
 
    The canonical writer (`carve fmt`, the `carve` render target) serializes a
-   document back to Carve source. Nothing here specified it before, so its
-   behavior was defined only by three implementations happening to agree.
+   document back to Carve source.
 
    1. THE INVARIANTS. For any document x:
 
@@ -7784,8 +7758,8 @@ EOF = (* end of file *) ;
       `=` or of an attribute block makes it literal cell content (PART 9 §5
       T10, corpus `table cell attributes`), so only the CONTENT side is the
       writer's to choose. An UNPREFIXED cell was always padded (`| a | b |`);
-      this makes one rule of what was two, and the padded side is the one a
-      reader can scan.
+      prefixed and unprefixed cells therefore share one padding rule, and the
+      padded side is the one a reader can scan.
 
       THE TREE RECORDS NO SLOT, the same reason §6d gives: `table_cell` records
       its padding no more than `code_block` records the space before its info
@@ -7794,11 +7768,12 @@ EOF = (* end of file *) ;
 
 
    6f. PADDING IS NOT AN ESCAPE WHERE THE PRODUCTION ADMITS PADDING --
-      NORMATIVE (carve#1601). §6e retires the writer's `<`/`>`/`~`/`{` guards
-      because those three slots are read GLUED to the opening pipe, so one
-      space in front of the content puts it out of their reach. That argument
-      holds only where the construct's OWN production forbids the padding, and
-      one class of cell construct is written WITH the padding inside it:
+      NORMATIVE (carve#1601). §6e's padding removes the need for
+      `<`/`>`/`~`/`{` guards because its three prefix slots are read GLUED to
+      the opening pipe, so one space in front of the content puts it out of
+      their reach. That argument holds only where the construct's OWN production
+      forbids the padding, and one class of cell construct is written WITH the
+      padding inside it:
 
         span_cell      = rowspan_marker | colspan_marker ;
         rowspan_marker = {space}, '^', {space} ;
@@ -7816,11 +7791,9 @@ EOF = (* end of file *) ;
       next time a cell-level marker is added.
 
    6g. A TASK MARKER IS WRITTEN WITH THE STATE THE AUTHOR CHOSE -- NORMATIVE
-      (carve#1866). PART 2 admits seven task states and the rendering collapses
-      them to two, so the writer had nothing to reproduce and wrote `[x]` or
-      `[ ]`: `carve fmt -w` turned `[-]`, `[_]`, `[>]` and `[?]` into `[ ]` and
-      the author's distinction was gone from the file. The AST now records the
-      character (PART 12, `list_item.taskState`) and the writer emits it.
+      (carve#1866). PART 2 admits seven task states while rendering collapses
+      them to two. The AST records the authored character (PART 12,
+      `list_item.taskState`) and the writer emits it.
 
       THE FIELD IS THE SPELLING, `checked` IS THE MEANING. This is §6's own
       rule, not an exception to it: a spelling is the author's to keep BECAUSE
@@ -9530,8 +9503,7 @@ EOF = (* end of file *) ;
 
       A DEFINITION IS STILL INVISIBLE IN HTML. The node renders nothing on that
       target; it feeds the links and images that resolve its label (PART 9R R1).
-      The non-HTML targets emit it, which is what §10a says and could not
-      previously require of this kind.
+      The non-HTML targets emit it, as §10a requires.
 
    11. A PROPERTY THE SCHEMA DOES NOT NAME IS REJECTED ON INGEST -- NORMATIVE.
       The wire shape is pinned by `resources/ast-schema.json` with

--- a/resources/spec/05-blocks-paragraphs.ebnf
+++ b/resources/spec/05-blocks-paragraphs.ebnf
@@ -23,9 +23,7 @@
    `abc<SP>` renders <p>abc</p>; so does `abc<SP>` followed by `def`, where the
    run sits before a SOFT BREAK; and so do a heading, a list item, a block
    quote line, a definition term or description, a footnote body line, a table
-   caption and a line-block line. This clause used to say the opposite of the
-   soft-break half, and PART 12 §7 used to say it at greater length
-   (carve#926).
+   caption and a line-block line.
 
    THE RUN IS `whitespace` -- `' ' | '\t'` -- the same two-character terminal
    `blank_line = {whitespace}` and `indent` take (PART 1; carve#890). Every
@@ -56,5 +54,4 @@
    meaning in whitespace nothing can see.) Pinned by corpus
    104-paragraph-trailing-whitespace and 268. *)
 paragraph = inline_content+, [blank_line] ;
-
 

--- a/resources/spec/08-attributes.ebnf
+++ b/resources/spec/08-attributes.ebnf
@@ -105,11 +105,8 @@ attribute = language_attribute | id_attribute | class_attribute
 
    A BOOLEAN `lang` IS THE SAME KEY AS WELL: `{lang}` means `lang=""` under
    PART 4's boolean rule, so `{:fr lang}` ends at `lang=""` and `{lang :fr}` at
-   `lang="fr"`. This paragraph carried a caveat until carve#1125: the executable
-   spec used to emit a boolean unconditionally, so `{a=1 a}` came out as
-   `a="1" a=""` where every engine gave `a=""`. That is fixed, the three
-   spellings of the key now meet in one slot everywhere, and the corpus pins the
-   boolean form beside the other two rather than leaving it to prose. *)
+   `lang="fr"`. The three spellings of the key meet in one slot, and the corpus
+   pins the boolean form beside the other two. *)
 language_attribute = ':', [ language_tag ] ;
 language_tag       = language_subtag, { '-', language_subtag } ;
 language_subtag    = ( letter | digit ), { letter | digit } ;

--- a/resources/spec/13-semantics-foundations.ebnf
+++ b/resources/spec/13-semantics-foundations.ebnf
@@ -433,9 +433,9 @@
          makes it ordinary content (T4's `{.x} <` is unchanged), and the
          validity rule is T8's.
 
-         The canonical writer uses this order. The retired
-         `|{#x}< content |` spelling is parsed as unaligned literal content;
-         row attributes (T8) are unaffected.
+         The canonical writer uses this order. The `|{#x}< content |` spelling
+         is parsed as unaligned literal content; row attributes (T8) are
+         unaffected.
 
       T11 A MARKER RUN ENDS AT A SPACE -- NORMATIVE. A cell's marker run is
          the kind marker `=`, the alignment run and the attribute block, in

--- a/resources/spec/15-semantics-resolution-rendering.ebnf
+++ b/resources/spec/15-semantics-resolution-rendering.ebnf
@@ -560,9 +560,9 @@
       fence, PART 2) emits its verbatim content UNESCAPED when FORMAT
       matches the output format and drops it otherwise; the inline form
       follows. Block and inline raw share the `=FORMAT` spelling (```=html
-      / `…`{=html}); the former ```raw FORMAT keyword form was removed. A code span whose trailing attribute block
-      is EXACTLY `{=format}` (a single `=`-prefixed format name, with no
-      other classes/ids/keys) is raw passthrough: the verbatim span content
+      / `…`{=html}). A code span whose trailing attribute block is EXACTLY
+      `{=format}` (a single `=`-prefixed format name, with no other
+      classes/ids/keys) is raw passthrough: the verbatim span content
       is emitted UNESCAPED when `format` matches the output format (`html`),
       and DROPPED otherwise. The `{=format}` tag is consumed, not rendered.
       A code span with any OTHER trailing `{…}` is a generic attributed code

--- a/resources/spec/16-semantics-comments-security.ebnf
+++ b/resources/spec/16-semantics-comments-security.ebnf
@@ -384,8 +384,7 @@
             discards it and the author's characters reach neither the page nor
             any table (carve#1801).
 
-            THE FOLD IS INTO THE CONTAINER, in every host, which is the half
-            this clause used to leave to the reader. "Folds as TEXT" and
+            THE FOLD IS INTO THE CONTAINER, in every host. "Folds as TEXT" and
             I5's "lazy paragraph text" name one operation on one open
             paragraph, and that paragraph belongs to the container whose
             content column the line fell below. Ending the container and
@@ -449,11 +448,10 @@
          column and stay siblings.
 
    25. SECURITY REQUIREMENTS -- NORMATIVE (HTML output target). These rules
-      bind any implementation that emits HTML for UNTRUSTED input. They were
-      previously stated only in docs/security.md (non-normative); they are
-      hoisted here so an implementation written to this grammar + the corpus
-      cannot be conformant yet a trivial XSS vector. The corpus pins
-      representative cases (resources/examples/edge-cases.md "Security hardening").
+      bind any implementation that emits HTML for UNTRUSTED input, so an
+      implementation written to this grammar + the corpus cannot be conformant
+      yet expose a trivial XSS vector. The corpus pins representative cases
+      (resources/examples/edge-cases.md "Security hardening").
       - URL SINK SCHEME DENYLIST. On every clickable URL sink -- link
         destination (`href`), image source (`src`), and autolink -- an HTML
         renderer MUST reject any URL whose scheme is `javascript`, `vbscript`,

--- a/resources/spec/17-semantics-unicode-controls.ebnf
+++ b/resources/spec/17-semantics-unicode-controls.ebnf
@@ -87,9 +87,7 @@
         of input, and the difference is VISIBILITY: an unclosed div still
         renders the blocks it swallowed, so a forgotten closer costs the
         reader a stray wrapper, while an unclosed comment would HIDE them and
-        silently delete the rest of the document. This clause used to claim it
-        MIRRORED §12, quoting a §12 sentence that has since been removed for
-        saying the opposite of what §12 means (carve#1717). An implementation that
+        silently delete the rest of the document. An implementation that
         surfaces diagnostics SHOULD report an unterminated comment fence;
         emitting one is OPTIONAL, since not every implementation has a
         warning channel.

--- a/resources/spec/18-resolution.ebnf
+++ b/resources/spec/18-resolution.ebnf
@@ -167,21 +167,6 @@
       is one a reader can see -- a reference to the uncollected label renders as
       its literal `[^f]`, on the page, where someone can report it.
 
-      THIS CLAUSE SAID THE OPPOSITE, and named the wrong loss to justify it. It
-      required collecting, on the reasoning that "suppressing deletes the
-      author's line from the page". It is collecting that deletes the line: the
-      definition is taken OUT of the source, and what renders is the remainder --
-      a bare `-` where the author wrote `- [^f]: body`. Suppressing leaves every
-      character on the page and declines only to register metadata, so the
-      failure a reader meets is a reference that renders as its literal
-      `[^f]` -- visible, and diagnosable, which is what the old reasoning wanted
-      and did not get.
-
-      Measured before the correction (carve#1881): at four thousand such lines
-      the engine implementing this clause faithfully removed 3,858 of them.
-      Being conformant was the reason it did, which is why the clause moved
-      rather than the engine alone.
-
    R1b A MATCHER'S COORDINATES ARE LOCAL, NOT ABSOLUTE -- NORMATIVE
       (carve#1437). The `lines` array handed to a block matcher MAY begin at a
       CONTAINER'S CONTENT rather than at the document, re-based so that index 0

--- a/resources/spec/20-writer-invariants.ebnf
+++ b/resources/spec/20-writer-invariants.ebnf
@@ -3,8 +3,7 @@
    ============================================================================
 
    The canonical writer (`carve fmt`, the `carve` render target) serializes a
-   document back to Carve source. Nothing here specified it before, so its
-   behavior was defined only by three implementations happening to agree.
+   document back to Carve source.
 
    1. THE INVARIANTS. For any document x:
 

--- a/resources/spec/21-writer-carve-markdown.ebnf
+++ b/resources/spec/21-writer-carve-markdown.ebnf
@@ -154,8 +154,8 @@
       `=` or of an attribute block makes it literal cell content (PART 9 §5
       T10, corpus `table cell attributes`), so only the CONTENT side is the
       writer's to choose. An UNPREFIXED cell was always padded (`| a | b |`);
-      this makes one rule of what was two, and the padded side is the one a
-      reader can scan.
+      prefixed and unprefixed cells therefore share one padding rule, and the
+      padded side is the one a reader can scan.
 
       THE TREE RECORDS NO SLOT, the same reason §6d gives: `table_cell` records
       its padding no more than `code_block` records the space before its info
@@ -164,11 +164,12 @@
 
 
    6f. PADDING IS NOT AN ESCAPE WHERE THE PRODUCTION ADMITS PADDING --
-      NORMATIVE (carve#1601). §6e retires the writer's `<`/`>`/`~`/`{` guards
-      because those three slots are read GLUED to the opening pipe, so one
-      space in front of the content puts it out of their reach. That argument
-      holds only where the construct's OWN production forbids the padding, and
-      one class of cell construct is written WITH the padding inside it:
+      NORMATIVE (carve#1601). §6e's padding removes the need for
+      `<`/`>`/`~`/`{` guards because its three prefix slots are read GLUED to
+      the opening pipe, so one space in front of the content puts it out of
+      their reach. That argument holds only where the construct's OWN production
+      forbids the padding, and one class of cell construct is written WITH the
+      padding inside it:
 
         span_cell      = rowspan_marker | colspan_marker ;
         rowspan_marker = {space}, '^', {space} ;
@@ -186,11 +187,9 @@
       next time a cell-level marker is added.
 
    6g. A TASK MARKER IS WRITTEN WITH THE STATE THE AUTHOR CHOSE -- NORMATIVE
-      (carve#1866). PART 2 admits seven task states and the rendering collapses
-      them to two, so the writer had nothing to reproduce and wrote `[x]` or
-      `[ ]`: `carve fmt -w` turned `[-]`, `[_]`, `[>]` and `[?]` into `[ ]` and
-      the author's distinction was gone from the file. The AST now records the
-      character (PART 12, `list_item.taskState`) and the writer emits it.
+      (carve#1866). PART 2 admits seven task states while rendering collapses
+      them to two. The AST records the authored character (PART 12,
+      `list_item.taskState`) and the writer emits it.
 
       THE FIELD IS THE SPELLING, `checked` IS THE MEANING. This is §6's own
       rule, not an exception to it: a spelling is the author's to keep BECAUSE

--- a/resources/spec/24-ast-contract.ebnf
+++ b/resources/spec/24-ast-contract.ebnf
@@ -223,8 +223,7 @@
 
       A DEFINITION IS STILL INVISIBLE IN HTML. The node renders nothing on that
       target; it feeds the links and images that resolve its label (PART 9R R1).
-      The non-HTML targets emit it, which is what §10a says and could not
-      previously require of this kind.
+      The non-HTML targets emit it, as §10a requires.
 
    11. A PROPERTY THE SCHEMA DOES NOT NAME IS REJECTED ON INGEST -- NORMATIVE.
       The wire shape is pinned by `resources/ast-schema.json` with

--- a/tests/normativity.test.mjs
+++ b/tests/normativity.test.mjs
@@ -241,6 +241,40 @@ test('volatile implementation history stays outside the normative grammar', () =
   }
 })
 
+test('retired readings stay in spec-history, not active normative modules', () => {
+  const phrases = [
+    /\bused to\b/i,
+    /\bpreviously\b/i,
+    /\buntil carve#/i,
+    /\bretired\b/i,
+    /\bimplementations? happening to agree\b/i,
+    /\bsaid the opposite\b/i,
+    /\bmeasured before\b/i,
+    /\bformer\b.*\bwas removed\b/i,
+  ]
+  const offenders = []
+  for (const module of readdirSync(resolve(repo, 'resources/spec'))) {
+    if (!module.endsWith('.ebnf') || module === '00-preamble.ebnf') continue
+    const lines = readFileSync(resolve(repo, 'resources/spec', module), 'utf8').split('\n')
+    for (const [index, line] of lines.entries()) {
+      for (const phrase of phrases) {
+        if (phrase.test(line)) offenders.push(`${module}:${index + 1}: ${line.trim()}`)
+      }
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `retired readings belong in docs/spec-history.md:\n${offenders.join('\n')}`,
+  )
+
+  const history = readFileSync(resolve(repo, 'docs/spec-history.md'), 'utf8')
+  assert.match(history, /^## Clarifications moved out of active clauses$/m)
+  for (const issue of ['926', '1125', '1601', '1717', '1800', '1866', '1881']) {
+    assert.match(history, new RegExp(`carve#${issue}\\b`), `history keeps carve#${issue}`)
+  }
+})
+
 test('the section index finds a plausible set for every sectioned PART', () => {
   // Sanity: parsing worked. A floor per PART, so a regex that silently stopped
   // matching shows up here rather than as a citation test that passes because


### PR DESCRIPTION
## Summary

- move retired readings, compatibility measurements, and implementation history out of active normative modules
- preserve that rationale in `docs/spec-history.md`
- reject common historical narration in normative modules with module-and-line diagnostics
- verify that the migrated issue history remains present

No language behavior or stable rule IDs change.

## Verification

- `npm run spec:check`
- `npm run spec:rules:check`
- `node --test tests/normativity.test.mjs` — 21 passed
- `npm test` — 3,310 passed, 1 skipped, 8 failed; the same eight fixture/reference-build failures reproduce on clean `origin/main`

## Guard demonstration

Mutation: appended `Its behavior used to be inferred.` to the PART 11 introduction.

Observed failure:

```text
not ok 8 - retired readings stay in spec-history, not active normative modules
/\bused to\b/i narrates a retired reading; move it to docs/spec-history.md
```

After restoring the present-tense text, all 21 normativity tests pass.

The guard catches the named historical phrasings in `resources/spec/*.ebnf`; it cannot identify arbitrary historical narration that avoids those phrases, so review remains responsible for semantic equivalents.

## Review

Claude reviewed the completed diff twice. The first pass identified additional historical passages, weak diagnostics, missing positive history assertions, and a dangling antecedent; those findings were addressed. The second pass found semantic preservation clean.
