### PR TITLE
spec: an exhausted work budget no longer licenses collecting nothing

### DIFF
--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -6737,16 +6737,40 @@ EOF = (* end of file *) ;
       and never in a matcher.
 
       AN UNANSWERABLE PROBE KEEPS THE CANDIDATE TEXT -- NORMATIVE
-      (carve#1881). An implementation that cannot answer -- no probe, an
-      exhausted work budget,
-      a construct it does not recognize -- collects NOTHING from the candidate
-      line.
+      (carve#1881, narrowed by carve#1895). An implementation that cannot
+      answer -- no probe available, or a construct it does not recognize --
+      collects NOTHING from the candidate line.
+
+      AN EXHAUSTED WORK BUDGET IS NOT ONE OF THOSE REASONS (carve#1895). It was
+      listed here and is removed. Exhaustion is a property of the METHOD an
+      implementation chose, not of the question it was asked: the double
+      re-parse above costs 4x per doubling -- 178ms at 50 marker-led
+      definitions, 40 seconds at 800 -- while an engine that answers the same
+      question from pre-pass state answers a 3200-line document correctly in
+      47ms, spending no budget at all. An engine that declines it spends about
+      the same wall clock to do so, so the escape bought nothing that choosing
+      another method would not have bought outright. A processor that CAN
+      determine a candidate line's position collects the definition AT ANY
+      DOCUMENT SIZE. Ten definitions under a heading is an ordinary document,
+      and "past ten they stop resolving" is not graceful degradation -- a
+      reader cannot tell it from a typo in a label, and adding a definition at
+      the end of a list retroactively changes whether an unrelated reference
+      above it resolves.
+
+      BOUNDING THE PROBE IS STILL SOUND, and this clause does not forbid it.
+      What it forbids is spending the bound as an ANSWER. An implementation
+      that keeps the re-parse and its budget must reach the answer another way
+      once the budget is gone -- the position is derivable without the probe
+      wherever no extension matcher may have consumed the line above, which is
+      the one thing static reasoning cannot see and the case the probe was
+      written for.
 
       THAT IS CONSERVATIVE, NOT IDENTICAL TO THE AFFORDABLE ANSWER, and the
-      difference is the point. Where the probe would have said the line opens
-      something, it would have been collected, and this fallback declines it:
-      the document loses a definition it should have had. What it does not lose
-      is the line, which stays exactly as the author typed it. The two errors
+      difference is the point wherever the fallback still applies. Where the
+      probe would have said the line opens something, it would have been
+      collected, and this fallback declines it: the document loses a definition
+      it should have had. What it does not lose is the line, which stays exactly
+      as the author typed it. The two errors
       available here are under-collecting and deleting text, and only the first
       is one a reader can see -- a reference to the uncollected label renders as
       its literal `[^f]`, on the page, where someone can report it.

--- a/resources/spec/18-resolution.ebnf
+++ b/resources/spec/18-resolution.ebnf
@@ -154,16 +154,40 @@
       and never in a matcher.
 
       AN UNANSWERABLE PROBE KEEPS THE CANDIDATE TEXT -- NORMATIVE
-      (carve#1881). An implementation that cannot answer -- no probe, an
-      exhausted work budget,
-      a construct it does not recognize -- collects NOTHING from the candidate
-      line.
+      (carve#1881, narrowed by carve#1895). An implementation that cannot
+      answer -- no probe available, or a construct it does not recognize --
+      collects NOTHING from the candidate line.
+
+      AN EXHAUSTED WORK BUDGET IS NOT ONE OF THOSE REASONS (carve#1895). It was
+      listed here and is removed. Exhaustion is a property of the METHOD an
+      implementation chose, not of the question it was asked: the double
+      re-parse above costs 4x per doubling -- 178ms at 50 marker-led
+      definitions, 40 seconds at 800 -- while an engine that answers the same
+      question from pre-pass state answers a 3200-line document correctly in
+      47ms, spending no budget at all. An engine that declines it spends about
+      the same wall clock to do so, so the escape bought nothing that choosing
+      another method would not have bought outright. A processor that CAN
+      determine a candidate line's position collects the definition AT ANY
+      DOCUMENT SIZE. Ten definitions under a heading is an ordinary document,
+      and "past ten they stop resolving" is not graceful degradation -- a
+      reader cannot tell it from a typo in a label, and adding a definition at
+      the end of a list retroactively changes whether an unrelated reference
+      above it resolves.
+
+      BOUNDING THE PROBE IS STILL SOUND, and this clause does not forbid it.
+      What it forbids is spending the bound as an ANSWER. An implementation
+      that keeps the re-parse and its budget must reach the answer another way
+      once the budget is gone -- the position is derivable without the probe
+      wherever no extension matcher may have consumed the line above, which is
+      the one thing static reasoning cannot see and the case the probe was
+      written for.
 
       THAT IS CONSERVATIVE, NOT IDENTICAL TO THE AFFORDABLE ANSWER, and the
-      difference is the point. Where the probe would have said the line opens
-      something, it would have been collected, and this fallback declines it:
-      the document loses a definition it should have had. What it does not lose
-      is the line, which stays exactly as the author typed it. The two errors
+      difference is the point wherever the fallback still applies. Where the
+      probe would have said the line opens something, it would have been
+      collected, and this fallback declines it: the document loses a definition
+      it should have had. What it does not lose is the line, which stays exactly
+      as the author typed it. The two errors
       available here are under-collecting and deleting text, and only the first
       is one a reader can see -- a reference to the uncollected label renders as
       its literal `[^f]`, on the page, where someone can report it.


### PR DESCRIPTION
Closes #1895

PART 9R R1a listed three reasons an implementation may collect nothing from a candidate definition line: no probe, an exhausted work budget, a construct it does not recognize. The budget is removed. The other two stay, and so does the conservative fallback they reach - a processor that cannot price the question keeps the author's characters and loses only the entry.

## Why the budget was not one of them

Exhaustion is a property of the METHOD, not of the question. carve-js answers a 3200-line marker-led document correctly in 47ms spending no budget at all, because its probe is gated behind a registered block matcher and the answer otherwise comes from pre-pass state. carve-rs spends about the same wall clock to decline the same document. So the escape was buying nothing that choosing another method would not have bought outright.

The clause says that, and says the other half too, because removing the budget without changing the method is not viable: unbounded, that double re-parse costs 4x per doubling - 178ms at 50 definitions, 40 seconds at 800. `BOUNDING THE PROBE IS STILL SOUND` is explicit that the bound may stay; what is forbidden is spending the bound as an ANSWER.

The observable half is what makes this worth a clause rather than three engine tickets. Ten definitions under a heading is an ordinary document, and a reader cannot tell "past ten they stop resolving" from a typo in a label - the same size-dependence #1881 ruled out for the half where an engine removed text.

## Scope

Clause text only, in `resources/spec/18-resolution.ebnf` plus the regenerated aggregate. The rule keeps its title and its ID (`CARVE-P9R-008`), so `resources/spec/rules.json` and `resources/normative-clauses.txt` are unchanged; `spec:rules:check` and the normativity inventory confirm that rather than my saying so.

No corpus row here. One pinning resolution past any engine's old threshold would fail two engines on merge, which is the order #1881 and #1892 both used - it follows the ports (markup-carve/carve-rs#1490, and carve-php once markup-carve/carve-php#1854 lands).

## Gates

Ran green: `npm test`, `npm run core:check`, `spec:check`, `spec:rules:check`, `html-import:check`, `escape:check`, `grammar:reach`, `property:check -- --count=2000`, `engine:report -- --check`, `docs:build`, `lint:mermaid`, `declarations:pr -- --no-fetch`.

NOT run, and why: `ast:check`, `claims:check`, `degradation:check`, `fmt:check`, `compare:impls` and `compare:convert` need carve-js, carve-php and carve-rs checked out beside this repo, which only the scheduled `ast-conformance` workflow provisions.
