### PR TITLE
docs: make primary entry points concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,421 +1,175 @@
 # Carve
 
-A lightweight markup language with visual mnemonics and human-centered design.
+Carve is a markup language for documents. Its file extension is `.crv`.
 
-This repository is the normative definition of the language: the [formal
-grammar](resources/grammar.ebnf), the conformance corpus every implementation is
-tested against, and the design rationale behind each decision.
+```carve
+# Release notes
 
-## Status
+This has /italic/, *bold*, _underline_, ~strikethrough~, and =highlight=.
 
-**Carve 0.1 is specified and shipping.**
+- [x] Publish the release
+- [ ] Update the package
 
-| | |
-|---|---|
-| **Specification** | 0.1. Tier-1 core and Tier-2 standard extensions are normative and stable; Tier-3 app-level extensions ship but evolve. See [VERSIONING.md](VERSIONING.md). |
-| **Conformance** | Over 1,500 corpus examples pinning exact HTML output, plus 49 optional-corpus examples for host-dependent extensions. |
-| **Engines** | [carve-js](https://github.com/markup-carve/carve-js) (TypeScript, reference), [carve-php](https://github.com/markup-carve/carve-php), [carve-rs](https://github.com/markup-carve/carve-rs) - all three run the same corpus, with no open or intentional divergences ([tracker](MAINTAINING.md#known-cross-impl-divergences)). |
-| **Bindings** | Python, Ruby, Go, and WebAssembly, all over carve-rs. |
-| **Tooling** | Language server, tree-sitter grammar, formatter and linter (`carve fmt` / `carve lint`), converters from Markdown, HTML, Djot, and BBCode. |
-| **Editors** | VS Code, JetBrains, Sublime Text, Vim/Neovim, Emacs, Zed, Helix. |
-| **Integrations** | Laravel, Symfony, WordPress, Shopware, Hugo, Astro, Eleventy, Jekyll, Docusaurus, webpack/Next.js, Obsidian, and a Pandoc bridge to LaTeX, Typst, DOCX, and PDF. |
-| **Ecosystem** | The [Ecosystem page](https://markup-carve.github.io/carve/ecosystem) groups every project by role with conformance status; [Awesome Carve](https://github.com/markup-carve/awesome-carve) is the curated list. |
+|= Package |= Version |
+| carve-js | 0.1 |
+^ Published packages
 
-Pre-1.0, a minor release may still change the grammar; the stability tiers and
-the release lockstep between the spec and the engines are defined in
-[VERSIONING.md](VERSIONING.md) and [MAINTAINING.md](MAINTAINING.md). Every
-project maintained here is listed at <https://github.com/markup-carve#projects>;
-[Awesome Carve](https://github.com/markup-carve/awesome-carve) curates the same
-ground for readers and is where third-party tools built outside the organization
-are submitted.
-
-**File extension:** `.crv`
-
-## Why Carve?
-
-Markdown's reach, Djot's consistency, web-native features by default - without
-turning your content into a JavaScript program. What sets Carve apart:
-
-- **Cross-references that just work** - `</#id>` auto-fills its link text from the
-  target heading, and `[Heading][]` resolves to a heading with no separate
-  definition. A `#` placeholder in a caption (`^ Figure #: …`) auto-numbers
-  figures, tables, listings, and equations, and `</#id>` to one fills in "Figure 1".
-  Neither Markdown nor Djot offers this natively.
-- **Case-preserving heading ids, case-insensitive references** - ids keep their
-  original case and Unicode verbatim with zero normalization (a portable,
-  zero-dependency slug), while `</#id>` and `[Heading][]` cross-references
-  resolve case-insensitively, so a lowercase reference still finds a
-  capitalized heading. GitHub-style lowercase anchors and ASCII-folded
-  fragments are available opt-in.
-- **Batteries in core, not plugin soup** - math, footnotes, admonitions,
-  definition lists, frontmatter, smart typography, editorial markup, and tables
-  with rowspan/colspan/captions are all part of one spec - not a dozen plugins
-  to discover, install, and keep in sync.
-- **Opinionated, author-safe defaults** - a stray `-` never becomes a list (a
-  marker requires content), there is no invisible/whitespace-significant syntax,
-  and visual mnemonics mean the syntax looks like its output.
-- **Predictable output across implementations** - php, js, and rust impls are
-  tested against one shared spec corpus, so the same input produces the same
-  output everywhere. Markdown has many divergent parsers; Djot has essentially one.
-- **Safe with untrusted input** - raw HTML is off by default and a safe mode is
-  built in. Carve never executes embedded code (unlike MDX).
-
-### Extension system, built for many targets
-
-Carve's core syntax stays small; everything else is an extension behind a defined
-contract. Crucially, **rendering is target-aware** - the same parsed document can
-be emitted to different endpoints by swapping the renderer:
-
-- **HTML** for the web (the default),
-- **ANSI** for terminal / CLI output,
-- **Markdown** for interop and round-tripping,
-- **plain text** for search indexes, previews, and notifications.
-
-Extensions hook into this pipeline per target, so an extension can render rich
-HTML for the web while degrading cleanly to plain text elsewhere - one source,
-many endpoints. See the [Extensions Contract](https://markup-carve.github.io/carve/extensions)
-and the [Carve vs Markdown, Djot & MDX comparison](https://markup-carve.github.io/carve/comparison).
-
-## Get started
-
-Try it with nothing installed in the [Playground](https://markup-carve.github.io/carve/playground),
-or render Carve in your own project:
-
-```bash
-npm install @markup-carve/carve      # JavaScript / TypeScript
-composer require markup-carve/carve-php   # PHP
-cargo install carve-lang             # Rust, incl. the `carve` CLI
+::: note
+Carve also has fenced containers, footnotes, math, and attributes.
+:::
 ```
 
+## Syntax
+
+````text
+INLINE
+  /italic/  *bold*  /*bold italic*/
+  _underline_  ~strikethrough~  =highlight=
+  {^superscript^}  {,subscript,}  `code`
+
+HEADINGS AND LINKS
+  # Heading
+  [text](https://example.com)  ![alt](image.jpg)
+  [Heading][]                  link to a heading
+  </#heading-id>               cross-reference with generated text
+
+LISTS
+  - unordered item
+  1. ordered item
+  - [ ] task  - [x] done
+
+CODE AND CONTAINERS
+  ```js
+  const value = 1
+  ```
+
+  ::: warning
+  Container content
+  :::
+
+TABLES
+  |= Name |= Value |           header cells start with |=
+  | One    | 1     |
+  ^ Table caption
+
+CAPTIONS AND ATTRIBUTES
+  ![alt](image.jpg)
+  ^ Figure caption
+
+  {#id .class key=value}
+
+OTHER
+  $`inline math`  [^note]  @user  #tag
+  %% comment
+  :name[extension content]
+````
+
+See the [complete cheat sheet](https://markup-carve.github.io/carve/cheatsheet)
+for definition lists, table spans and alignment, references, metadata,
+editorial markup, raw content, includes, and extension syntax.
+
+## Why Carve
+
+- Cross-references and numbered captions keep labels and link text in sync.
+- Tables support captions, alignment, rowspan, colspan, and multiline cells
+  without HTML.
+- A formal grammar and shared corpus cover the JavaScript, PHP, and Rust
+  implementations.
+- One AST renders to HTML, Markdown, plain text, and ANSI; checked APIs report
+  lossy output.
+- Unknown extensions remain ordinary spans or divs instead of losing content.
+- Bare HTML is literal text. Explicit `=html` passthrough can be disabled for
+  untrusted input.
+
+## Install
+
+Use the [playground](https://markup-carve.github.io/carve/playground) without
+installing anything, or install one of the three reference implementations:
+
+```bash
+npm install @markup-carve/carve
+composer require markup-carve/carve-php
+cargo install carve-lang
+```
+
+JavaScript:
+
 ```ts
-import { carveToHtml, carveToHtmlWithReport } from '@markup-carve/carve'
+import { carveToHtml } from '@markup-carve/carve'
 
 const html = carveToHtml('/italic/, *bold*, and _underline_')
 ```
 
-Raw nodes are routed to a named output format. Use the checked render API when
-content must not disappear silently on another target:
+PHP:
 
-```ts
-const result = carveToHtmlWithReport('`x`{=latex}')
-// result.losses[0].code === 'raw-format-dropped'
+```php
+use MarkupCarve\Carve\CarveConverter;
+
+$html = (new CarveConverter())->convert('/italic/, *bold*, and _underline_');
 ```
 
-The compatible string APIs remain available. Checked APIs return the rendered
-value plus bounded, source-positioned losses; strict mode refuses to publish a
-value when a renderer would drop one. The CLI provides the same policy through
-`--strict-losses`, `--report-losses`, and `--allow-loss raw-format-dropped`.
+Rust CLI:
 
-Full instructions, including the Python, Ruby, Go, and WebAssembly bindings, are
-in [Get Started](https://markup-carve.github.io/carve/get-started).
-
-## Demo
-
-- [Interactive Playground](https://markup-carve.github.io/carve/playground) - Type Carve, see the rendered HTML live in your browser
-- [Examples](https://markup-carve.github.io/carve/examples) - Side-by-side Carve source and output
-
-## Quick Reference
-
-````
-EMPHASIS
-  /italic/  *bold*  /*bold italic*/
-  _underline_  ~strikethrough~
-  =highlight=  {^super^}  {,sub,}
-
-HEADINGS
-  # H1  ## H2  ### H3  #### H4
-
-LINKS & IMAGES
-  [link text](https://url.com)
-  [Page Name][]              (wiki-style)
-  ![alt text](image.jpg)
-
-CAPTIONS (images, quotes, tables)
-  ![Photo](img.jpg)
-  ^ Figure 1: Caption text
-
-LISTS
-  - unordered item            (bullets: - or *; + is NOT a bullet)
-  1. ordered item
-  - [ ] task
-  - [x] done
-  - step                       (+ on its own line = list-continuation
-  +                             marker: attaches the next flush-left
-  > note                        block to the item, keeping it tight)
-
-CODE
-  `inline code`
-  ```language
-  code block
-  ```
-
-QUOTES & ADMONITIONS
-  > quoted text
-  ^ Attribution
-
-  ::: note
-  admonition content
-  :::
-
-TABLES
-  |= Header |= Header |      (|= for headers)
-  | Cell    | Cell    |
-  ^ Table caption
-
-  |=> Right |=>^ Top  |      (< ~ > horizontal, ^ ~ v vertical)
-  |<v Cell  |?~ Cell  |      (?  keeps the column's horizontal)
-
-  | ^       | ...     |      (^ rowspan)
-  | ...     | <       |      (< colspan)
-  + continuation      |      (+ multiline)
-
-ABBREVIATIONS
-  *[HTML]: HyperText Markup Language
-
-ATTRIBUTES
-  {#id .class key=value}
-
-EXTENSIONS
-  @username  #tagname
-  :youtube[VIDEO_ID]
-
-COMMENTS
-  %% whole-line comment
-  text %% trailing comment
-  %%%
-  block comment
-  %%%
-````
-
-## Design Principles
-
-Carve takes its parsing rationale from Djot and its authoring ergonomics from
-Markdown, and extends both. The additions are grounded in human-factors work on
-how non-technical writers actually mark up text - the reasoning is recorded in
-the [Case Study](https://markup-carve.github.io/carve/case-study/) and the
-[technical rationale](https://markup-carve.github.io/carve/technical-rationale).
-
-### From Djot
-
-1. **Linear parsing** - Parse in linear time with no backtracking. Inline
-   emphasis is resolved with a delimiter stack in a single left-to-right pass;
-   document-level definitions (link/footnote/abbreviation references, heading
-   IDs) are collected in a first pass before inline resolution. Both are O(n);
-   neither requires backtracking.
-2. **Local inline parsing** - Inline *tokenization and syntax highlighting*
-   never depend on later content. Semantic *expansion* that does need the
-   definition table (abbreviation `<abbr>`, `</#id>` auto-text, `[text][ref]`
-   targets) runs after the first-pass collection above — a definition that
-   appears later in document order is still resolved. This is the defined
-   two-pass model, not backtracking.
-3. **Simple emphasis** - Single characters, no complex disambiguation rules
-4. **No expressive blind spots** - All outputs achievable without workarounds
-5. **Simple list indentation** - Indented content belongs to the list item
-6. **Reduced parser complexity** - No HTML recognition, entity parsing, or case-folding during tokenization (heading-id slugs are case-preserving with no normalization; cross-reference matching is case-insensitive, but that is a resolve-time transform, not parsing)
-7. **Uniform composition** - Content meaning consistent inside/outside containers
-8. **Arbitrary attributes** - `{#id .class key=value}` on any element
-9. **Generic containers** - Fenced divs (`:::`) for extensibility
-10. **Syntax simplicity** - One way to do things, no redundant syntax
-11. **No invisible syntax** - No trailing-space hard breaks (Djot uses a visible end-of-line backslash) and no significant-whitespace tricks
-
-### From Markdown
-
-12. **Paragraph interruption** - A block opener on a new line starts a block, no blank line required (§10). Djot requires a blank line here; Carve follows Markdown instead.
-
-### Carve Additions
-
-13. **Visual mnemonics** - Syntax characters suggest their output:
-    - `/italic/` - slashes lean like italic text
-    - `*bold*` - asterisks are heavy/bold
-    - `_underline_` - underscore is literally underneath
-    - `~strikethrough~` - tilde resembles a line through text
-    - `{^super^}` - caret points up
-    - `{,sub,}` - comma pulls down
-
-14. **Ten-Second Rule** - Syntax should be:
-    - Learnable in 10 seconds for basic use
-    - Memorable after 10 days without use
-    - Unambiguous within 10 characters of context
-
-15. **Cross-references** - `</#id>` auto-fills its link text from the target heading (neither Markdown nor Djot offers this natively)
-
-16. **Auto-resolving wiki links** - `[Page Name][]` resolves to a heading with no separate `[Page Name]: url` definition
-
-17. **Case-preserving heading ids** - Unicode-preserving, zero-normalization anchors by default with case-insensitive cross-reference resolution; opt-in lowercase (GitHub-style) and ASCII fold for share-safe URL fragments
-
-18. **Simpler tables** - `|=` marks headers (from Creole), no separator row required
-
-19. **Table spanning** - `^` for rowspan, `<` for colspan, `+` for multi-line cells
-
-20. **Captions** - `^` prefix adds captions to images, blockquotes, and tables
-
-21. **List continuation** - a lone `+` attaches a flush-left block (code, table, quote) to the current list item with no indentation, keeping the item tight; `+` is the continuation marker, not a bullet
-
-22. **Admonitions** - two-tier fenced divs (`::: word`): canonical names render to `<aside>`, custom to `<div class=word>`
-
-23. **Abbreviations** - `*[ABBR]: expansion` for automatic `<abbr>` tags
-
-24. **Comments** - visible `%%` line, `text %% trailing`, and `%%%` block comments (not HTML comments)
-
-25. **Social integration** - `@mentions` and `#tags` are built into the syntax
-
-26. **Extension system** - `:type[content]{attrs}` for custom inline elements
-
-27. **Target-aware rendering** - one parsed document emits to HTML, ANSI, Markdown, or plain text by swapping the renderer
-
-## Comparison with Markdown and Djot
-
-> **"Markdown" here** = CommonMark plus widely-supported GitHub-Flavored Markdown
-> (GFM). `n/a` means there is no standard Markdown syntax for the feature; some
-> flavors or Pandoc may add one.
-
-### Inline emphasis
-
-| Feature | Markdown | Djot | Carve |
-|---------|----------|------|------|
-| Italic | `*text*` / `_text_` | `_text_` | `/text/` |
-| Bold | `**text**` | `*text*` | `*text*` |
-| Bold italic | `***text***` | `_*text*_` | `/*text*/` |
-| Underline | n/a | `{+text+}` (→ `<ins>`) | `_text_` |
-| Strikethrough | `~~text~~` (GFM, → `<del>`) | `{-text-}` (→ `<del>`) | `~text~` (→ `<s>`) |
-| Highlight | n/a | `{=text=}` | `=text=` |
-| Superscript | n/a | `^text^` | `{^text^}` |
-| Subscript | n/a | `~text~` | `{,text,}` |
-
-> **Heads-up for Djot users:** `~text~` is *subscript* in Djot but
-> *strikethrough* in Carve, and Carve writes subscript as the braced
-> `{,text,}` only (there is no bare sub/sup delimiter — a comma or caret in
-> prose is always literal). This is the one inline delimiter whose meaning
-> flips between the two languages.
-
-### Links & references
-
-| Feature | Markdown | Djot | Carve |
-|---------|----------|------|------|
-| Links | `[text](url)` | `[text](url)` | `[text](url)` |
-| Wiki-style links | n/a (no auto wiki links) | `[Page Name][]` (reference link; needs a `[Page Name]: url` definition) | `[Page Name][]` (auto-resolves, no definition) |
-| Cross-references | n/a (manual `[](#id)`) | n/a (manual `[](#id)`) | `</#id>` (auto-fills link text from the target heading) |
-| Heading IDs | n/a (auto only on some renderers, e.g. GitHub) | Auto-generated (Unicode, case-preserving) | Auto-generated (Unicode, case-preserving, CSS-selector-safe; case-insensitive references; opt-in lowercase + ASCII fold) |
-| Heading structure | n/a (flat `<h1>`–`<h6>`, no wrappers) | `<section id="…"><h*>…</h*></section>` with level-aware nesting | `<section id="…"><h*>…</h*></section>` with level-aware nesting; only the id hoists, other attributes stay on the `<h*>`; optional `sections: false` renders flat with the id back on the `<h*>` |
-
-### Lists & tables
-
-| Feature | Markdown | Djot | Carve |
-|---------|----------|------|------|
-| Definition lists | n/a | `: term` + indented def | `:: term` / `: def` |
-| Ordered list dialects | `1.` / `1)` (decimal only) | decimal/alpha/roman; `.` `)` `(1)` delimiters | decimal/alpha/roman; `.` `)` delimiters (`(1)` deliberately omitted — prose-ambiguity) |
-| Table headers | `\|---\|` separator (GFM) | `\|---\|` separator | `\|=` prefix |
-| Table alignment | `:--` / `--:` (GFM), horizontal only | `:--` / `--:` separator, horizontal only | horizontal `\|=<` / `\|=>` / `\|=~` (column) and `\|<` / `\|>` / `\|~` (cell), plus a vertical axis on a second marker: `\|=>^` right+top, `\|<v` left+bottom, `\|?~` middle keeping the column's horizontal value. A marker run is glued to the pipe and ends at a space |
-| Headerless tables | n/a (header + separator required) | n/a (header + separator required) | omit `\|=` |
-| Table rowspan | n/a (raw HTML only) | n/a (raw HTML only) | `^` marker |
-| Table colspan | n/a (raw HTML only) | n/a (raw HTML only) | `<` marker |
-| Multi-line cells | n/a (raw HTML only) | n/a (raw HTML only) | `+` continuation |
-| Captions | n/a | Tables only (`^ caption`) | `^ caption` (images, quotes, tables) |
-
-### Blocks & structure
-
-| Feature | Markdown | Djot | Carve |
-|---------|----------|------|------|
-| Footnotes | `[^ref]` + `[^ref]: def` (GitHub / Pandoc ext) | `[^ref]` + `[^ref]: def` | `[^ref]` + `[^ref]: def` + inline `^[content]` |
-| Math | `$…$` / `$$…$$` (GitHub) | `` $`…` `` / `` $$`…` `` | `` $`…` `` / `` $$`…` `` (djot form) |
-| Generic divs | n/a | `:::` (→ `<div>`) | bare `:::` / `::: {…}` → plain `<div>`; `::: word` two-tier (canonical → `<aside>`, custom → `<div class=word>`) |
-| Inline spans | n/a | `[text]{.c}` (→ `<span>`) | `[text]{.c}` (→ `<span>`) |
-| Editorial markup | n/a | `{+ +}` `{- -}` `{= =}` | `{+ +}` `{- -}` `{~ ~> ~}` `{= =}` `{# #}` |
-| Comments | `<!-- … -->` (HTML) | `{% … %}` | `%%` line / `text %% trailing` / `%%%` block |
-| Raw / passthrough | inline / block HTML | inline `` `…`{=html} `` + ` ```=html ` block | inline `` `…`{=html} `` + ` ```=html ` block |
-| Includes | n/a | n/a | `{{ path/to/file }}` |
-| Abbreviations | n/a (PHP-Markdown ext: `*[ABBR]: ...`) | n/a | `*[ABBR]: ...` |
-| Attributes | n/a | `{.class}` | `{.class}` |
-
-### Social & extensibility
-
-| Feature | Markdown | Djot | Carve |
-|---------|----------|------|------|
-| Extensions | n/a | Fenced divs | `:type[content]{attrs}` |
-| Mentions | n/a (auto-linked on GitHub only) | n/a | `@user` |
-| Tags | n/a | n/a | `#tag` |
-
-### Mention and tag rendering
-
-Carve parses `@user` and `#tag` into dedicated AST nodes. The default HTML
-renderer does **not** invent destination URLs. Without renderer config, they
-render as non-link spans:
-
-```html
-<span class="mention"><strong>@alice</strong></span>
-<span class="tag"><strong>#release</strong></span>
+```bash
+carve input.crv
 ```
 
-If your application has real routes, provide URL templates at render time:
+Python, Ruby, Go, WebAssembly, editors, and framework integrations are listed
+in [Get Started](https://markup-carve.github.io/carve/get-started) and the
+[Ecosystem](https://markup-carve.github.io/carve/ecosystem).
 
-```ts
-carveToHtml(source, {
-  mentionUrl: 'https://github.com/{user}',
-  tagUrl: '/topics/{name}',
-})
+## Compatibility and scope
+
+Carve is not Markdown. Some familiar constructs have different meanings:
+
+| Construct | Markdown | Carve |
+|---|---|---|
+| `*text*` | italic | bold |
+| `/text/` | plain text | italic |
+| `_text_` | italic | underline |
+| `~text~` | plain text in CommonMark | strikethrough |
+| `|= Head |` | plain table text | header cell |
+
+Converters from Markdown, HTML, Djot, and BBCode are available, but a `.crv`
+file should not be passed to a Markdown parser. See [Migration from
+Markdown](https://markup-carve.github.io/carve/migrate-from-markdown) and the
+[format bridges](https://markup-carve.github.io/carve/format-bridges) for the
+supported interchange paths.
+
+Core syntax is enabled by default. Citations, automatic URL linking, diagrams,
+and some application features are extensions. The [extension
+table](https://markup-carve.github.io/carve/extensions#feature-tiers-quick-reference)
+states which features are portable.
+
+Bare HTML is literal text, but explicit `=html` passthrough is enabled by
+default in the JavaScript and Rust renderers. Disable it for untrusted input.
+Renderers also restrict unsafe URL schemes and attributes; see the [security
+model](https://markup-carve.github.io/carve/security).
+
+## Specification and implementations
+
+Carve 0.1 is specified. Before 1.0, minor releases may change the grammar.
+
+- [Formal grammar](resources/grammar.ebnf)
+- [Conformance examples](tests/corpus)
+- [Versioning policy](VERSIONING.md)
+- [JavaScript implementation](https://github.com/markup-carve/carve-js)
+- [PHP implementation](https://github.com/markup-carve/carve-php)
+- [Rust implementation](https://github.com/markup-carve/carve-rs)
+- [Documentation](https://markup-carve.github.io/carve/)
+
+The three reference implementations use the same conformance corpus. Over 1,500 corpus examples
+plus 49 optional-corpus examples cover core and host-dependent features. Current
+differences are recorded in the [implementation comparison](https://markup-carve.github.io/carve/implementation-comparison).
+
+## Development
+
+This repository contains the specification, corpus, and documentation site.
+
+```bash
+npm install
+npm test
+npm run docs:build
 ```
 
-Suggested CSS:
-
-```css
-.mention,
-.tag {
-  font: inherit;
-}
-
-.mention strong,
-.tag strong {
-  font-weight: 600;
-}
-
-a.mention,
-a.tag {
-  font-weight: 600;
-  text-decoration-thickness: 0.08em;
-  text-underline-offset: 0.14em;
-}
-```
-
-Guidelines:
-
-- Keep the default non-link styling close to body text; mentions and tags are identifiers, not calls to action.
-- Reserve stronger color and hover treatment for real links so users can tell whether interaction is available.
-- Target `.mention` and `.tag` in shared rules so switching from `<span>` to `<a>` does not require a CSS rewrite.
-
-> **Djot accuracy notes:** Djot defines captions for pipe **tables only** (a
-> `^ ` line after the table); Carve extends the same `^` prefix to images and
-> block quotes. Djot has **no abbreviation syntax** — the nearest workaround is
-> a titled generic span (`[ABBR]{title="..."}`), which only yields a tooltip,
-> not managed `<abbr>` expansion.
-
-## Key Differences from Markdown
-
-- Single `*` for bold (not `**`)
-- `/italic/` visual mnemonic (not `*` or `_`)
-- `|=` table headers (no separator rows needed)
-- `^` captions for images, quotes, tables
-- `^` rowspan, `<` colspan, `+` multi-line in tables
-- Built-in abbreviations with `*[ABBR]: ...`
-- Unambiguous parsing rules
-- Built-in extension system
-
-## Documentation
-
-The full site renders at <https://markup-carve.github.io/carve/>: the
-[cheat sheet](https://markup-carve.github.io/carve/cheatsheet), the
-[extensions contract](https://markup-carve.github.io/carve/extensions), the
-[security model](https://markup-carve.github.io/carve/security), the
-[technical rationale](https://markup-carve.github.io/carve/technical-rationale),
-and [Build Your Own Implementation](https://markup-carve.github.io/carve/implementing-carve).
-
-The [Case Study](https://markup-carve.github.io/carve/case-study/) records the
-original design research the language grew out of; it is history, not the
-normative spec.
-
-## Influences
-
-- **Djot** (John MacFarlane) - Rigorous parsing, attributes, foundation
-- **Org-mode** - `/italic/` syntax, TODO states
-- **Creole** - `|=` table headers
-- **AsciiDoc** - Admonitions, document structure
-- **CriticMarkup** - Editorial annotations
+See [MAINTAINING.md](MAINTAINING.md) for release and cross-implementation work.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,13 @@
 # Carve documentation (source)
 
-This directory is the **source** for the Carve documentation site, built with
-[VitePress](https://vitepress.dev/). It is **not meant to be read directly here
-on GitHub** - the pages use VitePress-specific syntax (`:::` containers,
-code-group tabs, frontmatter, custom components) that GitHub's Markdown viewer
-does not render, so the raw files look broken.
+This directory contains the source for the [Carve documentation
+site](https://markup-carve.github.io/carve/), built with
+[VitePress](https://vitepress.dev/). Some pages use VitePress containers,
+frontmatter, and components that GitHub does not render.
 
-## 📖 Read the docs online
+## Read the documentation
 
-👉 **<https://markup-carve.github.io/carve/>**
-
-That is the rendered, navigable site - working code tabs, search, the syntax
-reference, the migration guide, and the interactive playground.
+<https://markup-carve.github.io/carve/>
 
 ## Building locally
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -5,20 +5,13 @@ description: Every Carve construct on one scannable page.
 
 # Cheat Sheet
 
-The whole syntax, one page. Carve's mnemonic: **the markup looks like its output**.
+Rows marked **✦** require an opt-in extension. Other entries are core syntax.
+See the [feature tier table](/extensions#feature-tiers-quick-reference) for
+availability.
 
-Everything here is **core** (Tier-1) — on by default, identical across every
-implementation — except rows marked **✦**, which are opt-in extensions
-(Tier-2/3) you enable in your processor. Look any feature up in the
-[feature → tier table](/extensions#feature-tiers-quick-reference).
-
-Two kinds of block appear below. A block tagged `carve` is a **document**: paste
-it into the [Playground](/playground) and you get what the text around it says.
-A block tagged `text` is **notation** - several constructs packed onto a line
-each, with the explanation in a right-hand column. That is how a reference card
-fits on one page, and it is not a document: pasted anywhere, the annotations
-make every line prose. For the working version of a notation block, see
-[Blocks & Attributes](/blocks-and-attributes) and [Examples](/examples).
+`carve` code blocks are valid documents. `text` blocks are compact notation;
+their right-hand comments are not part of the syntax. [Examples](/examples)
+shows complete input and output.
 
 ## Inline
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -5,25 +5,13 @@ description: Try Carve in 30 seconds, then render it in your own project.
 
 # Get Started
 
-## Interactive online, readable offline
+Use the [Playground](/playground) without installing anything. The [Cheat
+Sheet](/cheatsheet) lists the syntax.
 
-One of Carve's design principles: it targets the interactive web first. The [Playground](/playground), live preview, and hydration extensions (Mermaid, D2, Graphviz, Vega-Lite, Chart.js, math, tabs, details) render rich, interactive output when JavaScript is present. But interactivity is an enhancement, never a requirement — Carve only ever emits the marker element, and the client library hydrates it.
+## Install a renderer
 
-With no JavaScript — RSS readers, email, `curl`, archived pages, PDF, Markdown or terminal exports — every construct degrades to self-describing semantic HTML: a `mermaid` fence renders as `<pre class="mermaid">` showing its source, `:::details` is a native `<details>`, `list-table` is a real `<table>`, captions are `<figure>` / `<figcaption>`. The document is always whole; online just makes it richer.
-
-## 1. Try it now — no install
-
-The fastest path is the **[Playground](/playground)**: type Carve on the left, watch the HTML render live on the right. Nothing to set up.
-
-Or skim the **[Cheat Sheet](/cheatsheet)** — the whole syntax fits on one page.
-
-## 2. Render Carve in your project
-
-There are three reference engines. All of them turn a Carve string into HTML and pass the shared Tier-1 corpus.
-
-::: tip Published packages
-The three reference engines are published: npm [`@markup-carve/carve`](https://www.npmjs.com/package/@markup-carve/carve), Packagist [`markup-carve/carve-php`](https://packagist.org/packages/markup-carve/carve-php), and crates.io [`carve-lang`](https://crates.io/crates/carve-lang). The install commands below use them.
-:::
+The JavaScript, PHP, and Rust implementations use the same core conformance
+corpus.
 
 ### JavaScript / TypeScript — [`carve-js`](https://github.com/markup-carve/carve-js)
 
@@ -37,11 +25,9 @@ import { carveToHtml } from '@markup-carve/carve'
 const html = carveToHtml('/italic/, *bold*, and a heading')
 ```
 
-`carveToHtml` is the one-call entry point; the package also exposes the AST (`parse`) and the Markdown / plain-text / ANSI renderers.
+The package also exposes `parse` and Markdown, plain-text, and ANSI renderers.
 
 ### Rust — [`carve-rs`](https://github.com/markup-carve/carve-rs)
-
-The Rust engine is a third reference-quality implementation — Tier-1 corpus passing — and ships a `carve` CLI tool.
 
 ```bash
 cargo install carve-lang
@@ -54,7 +40,8 @@ carve input.crv
 
 ### Browser / Node via WebAssembly — [`carve-wasm`](https://github.com/markup-carve/carve-wasm)
 
-carve-wasm wraps carve-rs as a WebAssembly module, usable in the browser or any Node/Bun/Deno environment. It is early-stage; see the repository for the current API.
+`carve-wasm` wraps `carve-rs`. See its repository for the current browser and
+server-side JavaScript APIs.
 
 ### PHP — [`carve-php`](https://github.com/markup-carve/carve-php)
 
@@ -68,11 +55,12 @@ use MarkupCarve\Carve\CarveConverter;
 $html = (new CarveConverter())->convert('/italic/, *bold*, and a heading');
 ```
 
-`CarveConverter::convert()` returns HTML; the package also ships `parse()` plus Markdown / plain-text / ANSI renderers and HTML/Markdown/Djot converters.
+`CarveConverter::convert()` returns HTML. The package also provides `parse`,
+other output formats, and format converters.
 
 ### Language bindings
 
-Higher-level wrappers built on carve-rs are available for other languages. Ruby is on RubyGems and Go is fetched by module path; Python is not on PyPI yet (install from Git).
+These bindings use `carve-rs`:
 
 | Language | Project | Install |
 |---|---|---|
@@ -80,38 +68,35 @@ Higher-level wrappers built on carve-rs are available for other languages. Ruby 
 | Ruby | [carve-rb](https://github.com/markup-carve/carve-rb) | `gem install carve-lang` |
 | Go | [carve-go](https://github.com/markup-carve/carve-go) | `go get github.com/markup-carve/carve-go` |
 
-The full ecosystem — editor integrations, framework plugins, and more — is listed on the **[Ecosystem](/ecosystem)** page.
+Editor and framework integrations are listed in the [Ecosystem](/ecosystem).
 
-## 3. Learn the syntax
+## Read the reference
 
-- **[Cheat Sheet](/cheatsheet)** — every construct, one scannable page.
-- **[Examples](/examples)** — Carve source next to the exact HTML it produces.
-- **[Formal Grammar](/grammar)** — the normative block and inline grammar.
-- **[Case Study](/case-study/)** — the design research the language grew out of (historical, not normative).
+- [Cheat Sheet](/cheatsheet): syntax reference.
+- [Examples](/examples): Carve source and HTML output.
+- [Formal Grammar](/grammar): normative block and inline grammar.
+- [Migration from Markdown](/migrate-from-markdown): incompatible syntax and conversion.
 
-## 4. Core vs extensions
+## Core and extensions
 
-Almost everything you write is **core** (Tier-1): headings, lists, tables,
-links, code, math, footnotes, admonitions, attributes, and the rest of the
-cheat sheet. Core is **on by default** and renders identically across every
-implementation — no configuration, no plugins.
+Core includes headings, lists, tables, links, code, math, footnotes,
+admonitions, and attributes. It is enabled by default.
 
 A few things are **opt-in**:
 
-- **Tier-2** — spec-defined but off by default, e.g. citations `[@key]`,
+- **Tier-2** — specified but off by default, for example citations `[@key]`,
   bare-URL autolinking, mention/tag → URL templates, a collapsible `details`
   widget, `list-table`. Enable them in your processor.
-- **Tier-3** — per-implementation extensions, e.g. Mermaid diagrams, a
+- **Tier-3** — implementation-specific extensions, for example Mermaid diagrams, a
   table of contents, heading permalinks. Register the ones you want.
 
-The `:name[…]` (inline) and `::: name` (block) **syntax** is core, but whether a
-given `name` does something special depends on whether a handler is registered;
-an unknown one just renders as a plain span/div, so documents always stay
-readable. The full **[feature → tier table](/extensions#feature-tiers-quick-reference)**
-is the place to look up any feature.
+The `:name[…]` inline form and `::: name` block form are core syntax. A named
+handler may change how they render. Unknown names render as a span or div. See
+the [feature tier table](/extensions#feature-tiers-quick-reference).
 
 ## Build your own parser
 
-Carve's grammar is small and unambiguous. To implement it in another language, start from **[Build Your Own Implementation](/implementing-carve)** and the **[Formal Grammar](/grammar)**.
+Start with [Build Your Own Implementation](/implementing-carve) and the [Formal
+Grammar](/grammar).
 
 **File extension:** `.crv`

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,8 +67,8 @@ show Carve source beside its HTML output.
 - Cross-references and numbered captions keep labels and link text in sync.
 - Tables support captions, alignment, rowspan, colspan, and multiline cells
   without HTML.
-- A formal grammar and shared corpus cover the JavaScript, PHP, and Rust
-  implementations.
+- Core behavior is pinned by 1545 corpus examples shared by the JavaScript,
+  PHP, and Rust implementations.
 - One AST renders to HTML, Markdown, plain text, and ANSI; checked APIs report
   lossy output.
 - Unknown extensions remain ordinary spans or divs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,125 +3,114 @@ layout: home
 
 hero:
   name: Carve
-  text: A post-Markdown markup language
-  tagline: Visual mnemonics, human-centered design — markup you can feel.
+  text: A markup language for documents
+  tagline: Headings, tables, captions, references, math, and extensions in .crv files.
   image:
     src: /logo.svg
     alt: Carve logo
   actions:
     - theme: brand
-      text: Try Carve →
+      text: Open Playground
       link: /playground
     - theme: alt
-      text: Get Started
+      text: Install
       link: /get-started
     - theme: alt
-      text: View on GitHub
-      link: https://github.com/markup-carve
+      text: Full Cheat Sheet
+      link: /cheatsheet
 
 features:
-  - title: Visual Mnemonics
-    details: "/italic/ slashes lean, *bold* asterisks are heavy, _underline_ sits below, ~strikethrough~ runs through. Syntax that looks like its output."
-  - title: Linear-Time Rigor
-    details: "Djot-style linear-time parsing with no backtracking and unambiguous rules (Djot is the markup Carve builds on), extended with captions, abbreviations, and social conventions."
-  - title: Ten-Second Rule
-    details: Learnable in 10 seconds for basic use. Memorable after 10 days without practice. Unambiguous within 10 characters of context.
-  - title: Interactive Online, Readable Offline
-    details: "Built for the interactive web first — diagrams, math, charts and tabs hydrate into rich output online. With no JavaScript every block degrades to clean semantic HTML: a Mermaid fence still shows its source, <details> stays native, tables stay tables."
-  - title: Captions Everywhere
-    details: One ^ prefix captions images, blockquotes, tables, listings, equations and composite figure groups — emitting semantic figure / figcaption / caption HTML.
-  - title: Friendly Tables
-    details: "|= for headers, ^ for rowspan, < for colspan, + for multi-line cells. No separator row required."
-  - title: Built-in Extensions
-    details: ":type[content]{attrs} for video embeds and the rest of the handler family. Keyboard hints and the other semantic spans are core attributes instead — [Tab]{kbd}. @mentions and #tags as you'd expect from social platforms."
-  - title: Hardened Rendering
-    details: "Always-on URL-scheme and attribute hardening, Trojan-Source stripping in presentation targets, and linear-time DoS limits neutralize common Markdown attack classes. For untrusted documents, disable the one trusted-content feature: explicit raw HTML passthrough. Carve never executes embedded code (unlike MDX)."
-description: Carve is a post-Markdown markup language with visual mnemonics, a formal grammar, and hardened rendering.
+  - title: Specification
+    details: A formal grammar and shared conformance corpus define the language.
+  - title: Implementations
+    details: Reference implementations are available for JavaScript, PHP, and Rust.
+  - title: Output
+    details: Render to HTML, Markdown, plain text, or ANSI. Checked APIs report dropped content.
+description: Carve syntax, installation, specification, and reference implementations.
 ---
 
-## What it looks like
-
-Emphasis you can read at a glance - slashes lean, asterisks are heavy,
-underscores sit below, tildes run through:
+## Syntax
 
 ```carve
-/italic/  *bold*  _underline_  ~strikethrough~  =highlight=
+# Release notes
 
-H{,2,}O and E=mc{^2^}
+This has /italic/, *bold*, _underline_, ~strikethrough~, and =highlight=.
+
+- [x] Publish the release
+- [ ] Update the package
+
+|= Package |= Version |
+| carve-js | 0.1 |
+^ Published packages
+
+::: note
+Containers can represent admonitions and application-defined blocks.
+:::
 ```
 
-Tables without a separator row. `|=` marks a header cell and `|=>` aligns that
-column right; a bare `|>` aligns one body cell. Every marker run is glued to the
-pipe and ends at a space, and a second marker adds the vertical axis - `|=>^` is
-right and top, `|<v` left and bottom. One `^` line captions the whole thing:
+| Construct | Syntax |
+|---|---|
+| Heading | `# Heading` |
+| Link | `[text](https://example.com)` |
+| Image | `![alt](image.jpg)` |
+| Cross-reference | `</#heading-id>` |
+| Footnote | `[^note]` |
+| Inline math | `` $`x + y` `` |
+| Attributes | `{#id .class key=value}` |
+| Extension | `:name[content]` |
 
-```carve
-|= Fruit  |=>^ Price |
-| Apple    | $1       |
-| Pear     | $2       |
-|~ Total   |<v $3     |
-^ Table 1: no separator row needed
+The [cheat sheet](./cheatsheet) lists every construct. [Examples](./examples)
+show Carve source beside its HTML output.
+
+## Why Carve
+
+- Cross-references and numbered captions keep labels and link text in sync.
+- Tables support captions, alignment, rowspan, colspan, and multiline cells
+  without HTML.
+- A formal grammar and shared corpus cover the JavaScript, PHP, and Rust
+  implementations.
+- One AST renders to HTML, Markdown, plain text, and ANSI; checked APIs report
+  lossy output.
+- Unknown extensions remain ordinary spans or divs.
+- Bare HTML is literal text. Explicit `=html` passthrough can be disabled for
+  untrusted input.
+
+## Install
+
+```bash
+npm install @markup-carve/carve
+composer require markup-carve/carve-php
+cargo install carve-lang
 ```
 
-The same `^` captions an image or attributes a quote:
+```ts
+import { carveToHtml } from '@markup-carve/carve'
 
-```carve
-![Apollo 11](apollo.jpg)
-^ Figure 1: first moon landing
-
-> Stay hungry, stay foolish.
-^ Steve Jobs
+const html = carveToHtml('/italic/ and *bold*')
 ```
 
-Abbreviations expand wherever the word appears, defined once anywhere in the
-document:
+See [Get Started](./get-started) for PHP, the Rust CLI, WebAssembly, and language
+bindings.
 
-```carve
-The HTML spec is essential reading.
+## Scope
 
-*[HTML]: HyperText Markup Language
-```
+Carve is a separate language, not a Markdown extension. Use a Carve parser for
+`.crv` files. The [Markdown migration guide](./migrate-from-markdown) lists
+syntax differences and the [format bridges](./format-bridges) describe
+conversion limits.
 
-Plus the conventions you already type - mentions, tags, and semantic spans:
+Core syntax is enabled by default. Some features, including citations,
+automatic URL linking, and diagrams, are opt-in. Check the [feature tier
+table](./extensions#feature-tiers-quick-reference) before depending on an
+extension.
 
-```carve
-Hey @alice, see #release-1.0.
+## Reference
 
-Press [Tab]{kbd} to indent.
-```
+- [Formal grammar](./grammar)
+- [Extensions](./extensions)
+- [Security](./security)
+- [Implementation comparison](./implementation-comparison)
+- [Ecosystem](./ecosystem)
 
-Every construct is on the [cheat sheet](./cheatsheet), and every one of them is
-pinned to exact HTML in the [examples](./examples).
-
-## Status
-
-**Carve 0.1 is specified and shipping.** Tier-1 core and Tier-2 standard
-extensions are normative and stable; Tier-3 app-level extensions ship but evolve
-(see [Versioning](./versioning)). Conformance is pinned by 1545 corpus examples
-with exact HTML output, and the three reference engines - carve-js (TypeScript),
-carve-php, and carve-rs - all run the same corpus. Where the corpus pins a rule
-ahead of an engine, the window is declared on the
-[implementation comparison](./implementation-comparison) page rather than left
-for a reader to discover.
-Pre-1.0, a minor release may still change the grammar.
-
-Reference material covers the normative [grammar](./grammar) and
-[extensions contract](./extensions), the [security model](./security), the
-[technical rationale](./technical-rationale), [parsing ambiguities](./parsing-ambiguities),
-[specification decision history](./spec-history),
-[native features](./native-features-analysis), and the
-[broader markup landscape](./markup-languages). The [Case Study](./case-study/)
-records the original design research the language grew out of; it is history,
-not the normative spec.
-
-Looking for a parser, editor plugin, or framework integration? See the [Ecosystem](./ecosystem). Want to write your own? Start with [Build Your Own Implementation](./implementing-carve).
-
-**File extension:** `.crv`
-
-## Influences
-
-- **[Djot](https://djot.net/)** (John MacFarlane) — rigorous parsing, attributes, foundation
-- **Org-mode** — `/italic/` syntax, TODO states
-- **Creole** — `|=` table headers
-- **AsciiDoc** — admonitions, document structure
-- **CriticMarkup** — editorial annotations
+Carve 0.1 is specified. Minor releases may change the grammar before 1.0; see
+[Versioning](./versioning).

--- a/scripts/lib/authored-documents.mjs
+++ b/scripts/lib/authored-documents.mjs
@@ -130,5 +130,5 @@ export function authoredDocuments() {
  * message says which way it moved and what to do, because a red gate whose fix
  * is "look up how this file works" is a red gate that gets deleted.
  */
-export const AUTHORED_POPULATION = 100
-export const AUTHORED_ANSWERED = 99
+export const AUTHORED_POPULATION = 96
+export const AUTHORED_ANSWERED = 95


### PR DESCRIPTION
## Summary

- put working Carve syntax at the top of the repository README and documentation homepage
- replace promotional prose with concise installation, compatibility, and scope information
- add a factual `Why Carve` section covering cross-references, tables, conformance, render targets, extension fallback, and raw HTML behavior
- shorten the getting-started and cheat-sheet introductions

## Verification

- `npm run docs:build`
- `node --test tests/doc-carve-samples.test.mjs tests/readme-corpus-count.test.mjs tests/repo-links.test.mjs`
- `git diff --check`

All 100 focused tests pass. VitePress reports its existing large-chunk warning.
