### PR TITLE
docs: remove volatile corpus count from homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,8 +67,8 @@ show Carve source beside its HTML output.
 - Cross-references and numbered captions keep labels and link text in sync.
 - Tables support captions, alignment, rowspan, colspan, and multiline cells
   without HTML.
-- JavaScript, PHP, and Rust are tested with the same 1554 Carve inputs and
-  expected HTML outputs.
+- JavaScript, PHP, and Rust are tested with the same Carve inputs and expected
+  HTML outputs.
 - A document can be rendered as HTML, Markdown, plain text, or ANSI terminal
   text. Rendering methods can warn when an output format omits content.
 - If an application does not recognize an extension, its content remains in an

--- a/tests/implementation-comparison-counts.test.mjs
+++ b/tests/implementation-comparison-counts.test.mjs
@@ -271,13 +271,11 @@ test('a quoted run\'s diff total matches its own per-target rows', () => {
   assert.ok(checked >= 2, `expected both quoted runs to carry a diff total; checked ${checked}`)
 })
 
-test('the landing page quotes the real corpus size', () => {
-  const live = countPairs('tests/corpus')
-  const m = landing.match(/same (\d+) Carve inputs/)
-  assert.ok(m, 'docs/index.md no longer states the number of shared Carve inputs')
-  assert.equal(
-    Number(m[1]),
-    live,
-    `docs/index.md says the implementations share ${m[1]} inputs; the test set holds ${live}`,
+test('the landing page states that implementations share inputs without a volatile count', () => {
+  assert.match(landing, /tested with the same Carve inputs and expected\n  HTML outputs/)
+  assert.doesNotMatch(
+    landing,
+    /same \d+ Carve inputs/,
+    'the landing-page advantage should not require an update whenever the corpus grows',
   )
 })


### PR DESCRIPTION
## Summary

- remove the volatile corpus count from the homepage advantage
- keep the stable claim that JavaScript, PHP, and Rust share inputs and expected outputs
- update the regression test to reject concrete counts in this homepage sentence

