### PR TITLE
fix: the degradation claim reads the row's current wording

### DIFF
--- a/scripts/degradation-claims.mjs
+++ b/scripts/degradation-claims.mjs
@@ -92,8 +92,8 @@ const hasCollapsedDisclosure = (html) =>
 const CLAIMS = [
   {
     row: 'Spoiler',
-    quote: 'blurred until revealed | revealed | degrades natively (hiding is meaningless offline)',
-    phrase: 'hiding is meaningless offline',
+    quote: 'blurred until revealed | revealed | hiding is not retained',
+    phrase: 'hiding is not retained',
     source: '::: spoiler\nhidden text\n:::\n',
     check: (staticHtml, interactive) => {
       if (!staticHtml.includes('hidden text')) return 'the body is missing from the static output'
@@ -108,7 +108,7 @@ const CLAIMS = [
   {
     row: 'Spoiler (inline)',
     quote: 'blurred until revealed | revealed',
-    phrase: 'hiding is meaningless offline',
+    phrase: 'hiding is not retained',
     source: 'a :spoiler[hidden] b\n',
     check: (staticHtml, interactive) => {
       if (!staticHtml.includes('hidden')) return 'the content is missing from the static output'


### PR DESCRIPTION
carve main is red on `Graceful-degradation claims, in every engine`.

The Spoiler row now reads:

    | Spoiler | blurred until revealed | revealed | hiding is not retained |

`scripts/degradation-claims.mjs` grepped for `hiding is meaningless offline` in two places — the wording the row carried before it was shortened. Both now read the row's current text.

The doc is right and the gate was stale: the shorter phrasing says the same thing for the table's purpose, and the concision matches markup-carve/carve#1908, #1912 and #1913.

Not verifiable locally by design — the checker exits 2 with "need all three engines, found 0" rather than reporting a pass it did not earn, so CI is the first place it can run.