### PR TITLE
spec: restore the corpus as the authority on a disagreement

### DIFF
--- a/docs/case-study/syntax.md
+++ b/docs/case-study/syntax.md
@@ -1770,8 +1770,6 @@ indentation, void elements, tight/loose `<p>` wrapping, table styles —
 are pinned normatively in **`resources/grammar.ebnf` PART 10** (HTML
 Serialization Conventions). They exist so a second implementation (for
 example carve-php) can match the corpus without copying the reference
-renderer byte-for-byte. A disagreement between a clause and a committed
-corpus pair is a defect to resolve in both artifacts; neither silently
-overrides the other.
+renderer byte-for-byte. The corpus wins on any disagreement.
 
 ---

--- a/docs/rules/imports-security-extensions.md
+++ b/docs/rules/imports-security-extensions.md
@@ -29,8 +29,8 @@ Return to the [rule index](./) or read the complete [formal grammar](../grammar)
 | [`CARVE-P9-064`](https://github.com/markup-carve/carve/blob/main/resources/spec/17-semantics-unicode-controls.ebnf#L234) | 9 | AN EXTENSION WRITES INTO THE SAME MAP |
 | [`CARVE-P9-065`](https://github.com/markup-carve/carve/blob/main/resources/spec/17-semantics-unicode-controls.ebnf#L255) | 9 | AN IMPORTER DOES NOT BAKE A DERIVED NAME INTO SOURCE |
 | [`CARVE-P9-066`](https://github.com/markup-carve/carve/blob/main/resources/spec/17-semantics-unicode-controls.ebnf#L308) | 9 | A DERIVED VALUE IS ONE THE IMPORTER CAN RECONSTRUCT |
-| [`CARVE-P10-008`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L238) | 10 | THE OTHER SEMANTIC NAMES ARE AN EXTENSION |
-| [`CARVE-P10-009`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L257) | 10 | AN EXTENDED TASK STATE NAMES ITSELF ON THE ITEM |
+| [`CARVE-P10-008`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L237) | 10 | THE OTHER SEMANTIC NAMES ARE AN EXTENSION |
+| [`CARVE-P10-009`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L256) | 10 | AN EXTENDED TASK STATE NAMES ITSELF ON THE ITEM |
 | [`CARVE-P12-009`](https://github.com/markup-carve/carve/blob/main/resources/spec/23-ast-foundations.ebnf#L201) | 12 | A CONSUMER THAT RENDERS A DESTINATION OWNS THE DENYLIST |
 | [`CARVE-P12-032`](https://github.com/markup-carve/carve/blob/main/resources/spec/24-ast-contract.ebnf#L344) | 12 | SOURCE LAYOUT IS A SEPARATE OPT-IN SIDECAR |
 | [`CARVE-P12-033`](https://github.com/markup-carve/carve/blob/main/resources/spec/24-ast-contract.ebnf#L418) | 12 | A CAPTION MAY CARRY AN OPTIONAL STRUCTURED SHORT CAPTION |

--- a/docs/rules/resolution-rendering.md
+++ b/docs/rules/resolution-rendering.md
@@ -44,10 +44,10 @@ Return to the [rule index](./) or read the complete [formal grammar](../grammar)
 | [`CARVE-P9R-006`](https://github.com/markup-carve/carve/blob/main/resources/spec/18-resolution.ebnf#L248) | 9R | DERIVED DISPLAY TEXT CLONES THE SAME NODES |
 | [`CARVE-P9R-007`](https://github.com/markup-carve/carve/blob/main/resources/spec/18-resolution.ebnf#L274) | 9R | R7 BLOCK IMAGE PROMOTION |
 | [`CARVE-P9R-008`](https://github.com/markup-carve/carve/blob/main/resources/spec/18-resolution.ebnf#L156) | 9R | AN UNANSWERABLE PROBE KEEPS THE CANDIDATE TEXT |
-| [`CARVE-P10-001`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L102) | 10 | AN EMPTY CONTAINER BODY |
-| [`CARVE-P10-002`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L131) | 10 | A ROW IS A ROW, IN EVERY SECTION |
-| [`CARVE-P10-003`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L149) | 10 | SEMANTIC SPAN ATTRIBUTES |
-| [`CARVE-P10-004`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L161) | 10 | A DERIVED ATTRIBUTE YIELDS TO AN AUTHORED ONE OF THE SAME NAME |
-| [`CARVE-P10-005`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L170) | 10 | LEFTOVER ATTRIBUTES RIDE THE OUTERMOST SEMANTIC ELEMENT |
-| [`CARVE-P10-006`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L192) | 10 | THE REGISTRY HOLDS NO ELEMENT CARVE ALREADY SPELLS INLINE |
-| [`CARVE-P10-007`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L217) | 10 | THE CORE SEMANTIC NAMES ARE CLOSED |
+| [`CARVE-P10-001`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L101) | 10 | AN EMPTY CONTAINER BODY |
+| [`CARVE-P10-002`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L130) | 10 | A ROW IS A ROW, IN EVERY SECTION |
+| [`CARVE-P10-003`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L148) | 10 | SEMANTIC SPAN ATTRIBUTES |
+| [`CARVE-P10-004`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L160) | 10 | A DERIVED ATTRIBUTE YIELDS TO AN AUTHORED ONE OF THE SAME NAME |
+| [`CARVE-P10-005`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L169) | 10 | LEFTOVER ATTRIBUTES RIDE THE OUTERMOST SEMANTIC ELEMENT |
+| [`CARVE-P10-006`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L191) | 10 | THE REGISTRY HOLDS NO ELEMENT CARVE ALREADY SPELLS INLINE |
+| [`CARVE-P10-007`](https://github.com/markup-carve/carve/blob/main/resources/spec/19-html-serialization.ebnf#L216) | 10 | THE CORE SEMANTIC NAMES ARE CLOSED |

--- a/resources/grammar.ebnf
+++ b/resources/grammar.ebnf
@@ -51,11 +51,7 @@
    - The files in resources/spec/*.ebnf are the NORMATIVE specification of
      Carve. resources/grammar.ebnf is their generated, byte-for-byte aggregate
      for consumers that need one file. `npm run spec:check` rejects drift.
-     Where another document disagrees with these source modules, these source
-     modules govern.
-     The clauses define behavior. Reviewed corpus pairs pin concrete examples;
-     they do not silently override a clause. A disagreement between a clause
-     and a committed pair is a defect to resolve in both artifacts. The
+     Where any document disagrees with those sources, the sources win. The
      specification is LAYERED: PART 0 (layout automaton)
      -> PARTS 1-8 (EBNF productions + the GUARD NOTATION above) -> PART 9
      (operational semantics for the non-context-free rules) -> PART 9R
@@ -70,8 +66,9 @@
      compatibility measurements and decision archaeology. Those facts may
      explain a current rule but do not belong inside its normative algorithm.
    - resources/examples/*.md and the generated tests/corpus/* pairs are the
-     CONFORMANCE EXAMPLES. Every example is checked in CI. A behavior change
-     needs a reviewed pair, but that pair does not supersede a clause.
+     CONFORMANCE CONTRACT: every example is checked against the reference
+     implementation in CI. A spec change is not real until a corpus pair
+     pins it.
    - resources/carve-core.ohm and scripts/spec/*.mjs are DERIVED CHECKERS.
      They execute what this file states so that a contradiction inside it
      becomes visible. They are not a fourth implementation whose behavior
@@ -6970,9 +6967,8 @@ EOF = (* end of file *) ;
    PART 10: HTML SERIALIZATION CONVENTIONS (NORMATIVE)
    ============================================================================
 
-   These conventions define the exact bytes illustrated by the corpus. A
-   disagreement between a clause and a committed pair is a defect in one or
-   both artifacts; neither silently overrides the other.
+   These conventions define the exact bytes the corpus pins. On any
+   disagreement the corpus wins.
 
    1. ATTRIBUTE ORDER. Attributes serialize in the AUTHOR's source order
       (the recorded `order`; see the RENDER ORDER rule in PART 4 and

--- a/resources/spec/00-preamble.ebnf
+++ b/resources/spec/00-preamble.ebnf
@@ -51,11 +51,7 @@
    - The files in resources/spec/*.ebnf are the NORMATIVE specification of
      Carve. resources/grammar.ebnf is their generated, byte-for-byte aggregate
      for consumers that need one file. `npm run spec:check` rejects drift.
-     Where another document disagrees with these source modules, these source
-     modules govern.
-     The clauses define behavior. Reviewed corpus pairs pin concrete examples;
-     they do not silently override a clause. A disagreement between a clause
-     and a committed pair is a defect to resolve in both artifacts. The
+     Where any document disagrees with those sources, the sources win. The
      specification is LAYERED: PART 0 (layout automaton)
      -> PARTS 1-8 (EBNF productions + the GUARD NOTATION above) -> PART 9
      (operational semantics for the non-context-free rules) -> PART 9R
@@ -70,8 +66,9 @@
      compatibility measurements and decision archaeology. Those facts may
      explain a current rule but do not belong inside its normative algorithm.
    - resources/examples/*.md and the generated tests/corpus/* pairs are the
-     CONFORMANCE EXAMPLES. Every example is checked in CI. A behavior change
-     needs a reviewed pair, but that pair does not supersede a clause.
+     CONFORMANCE CONTRACT: every example is checked against the reference
+     implementation in CI. A spec change is not real until a corpus pair
+     pins it.
    - resources/carve-core.ohm and scripts/spec/*.mjs are DERIVED CHECKERS.
      They execute what this file states so that a contradiction inside it
      becomes visible. They are not a fourth implementation whose behavior

--- a/resources/spec/19-html-serialization.ebnf
+++ b/resources/spec/19-html-serialization.ebnf
@@ -2,9 +2,8 @@
    PART 10: HTML SERIALIZATION CONVENTIONS (NORMATIVE)
    ============================================================================
 
-   These conventions define the exact bytes illustrated by the corpus. A
-   disagreement between a clause and a committed pair is a defect in one or
-   both artifacts; neither silently overrides the other.
+   These conventions define the exact bytes the corpus pins. On any
+   disagreement the corpus wins.
 
    1. ATTRIBUTE ORDER. Attributes serialize in the AUTHOR's source order
       (the recorded `order`; see the RENDER ORDER rule in PART 4 and


### PR DESCRIPTION
Restores the corpus-authority wording that #1916 rewrote in passing.

That PR was about binding stable ids to normative clauses. Along the way it
also changed who wins a disagreement: a corpus pair went from the thing that
makes a spec change real to an example that "does not supersede a clause",
and PART 10's "on any disagreement the corpus wins" became "a defect in one
or both artifacts; neither silently overrides the other". No parse or render
moved, so the PR body's "does not change the Carve language" held - but how
future disagreements get settled did change, and that was not the PR under
review.

Three statements go back to their previous wording:

- the preamble's CONFORMANCE CONTRACT, including that a spec change is not
  real until a corpus pair pins it
- the preamble's "where any document disagrees with those sources, the
  sources win", without the clause-over-pair paragraph appended to it
- PART 10's "these conventions define the exact bytes the corpus pins; on any
  disagreement the corpus wins"

`docs/case-study/syntax.md` returns to the same sentence, so all four agree
again.

`CONTRIBUTING.md` keeps its #1916 edit. Naming `resources/spec/*.ebnf` rather
than the generated `resources/grammar.ebnf` is about which file is authored,
not about whether a committed pair outranks a clause, and the section's
bullets already say a checker yields to a committed golden.

The regenerated rule-index pages move only because the source line numbers
their links carry shifted.
