### PR TITLE
docs: keep primary pages reader-focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,8 @@ Carve 0.1 is specified. Before 1.0, minor releases may change the grammar.
 - [Rust implementation](https://github.com/markup-carve/carve-rs)
 - [Documentation](https://markup-carve.github.io/carve/)
 
-The three reference implementations use the same tests. More than 1,500 core
-input/output tests and 49 optional input/output tests cover the language and its
-shared optional features. Current differences are recorded in the
+The reference implementations are tested with the same Carve documents and
+expected output. Current differences are recorded in the
 [implementation comparison](https://markup-carve.github.io/carve/implementation-comparison).
 
 ## Development

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -24,8 +24,8 @@ The rest of this page lists supported diagram languages and output options.
 
 ## Supported diagram languages
 
-The optional `FencedRender` extension recognizes these eight fence names and
-generates an HTML element for the selected browser library.
+The optional `FencedRender` extension recognizes these fence names and generates
+an HTML element for the selected drawing library.
 
 | Fence word | Draws | Mode |
 | ---------- | ----- | ---- |
@@ -94,47 +94,31 @@ like `-->` survives intact:
 <div class="chart" role="img" aria-label="chart"><script type="application/json">{"type":"bar"}</script></div>
 ```
 
-### The marker is an image, and it is named
+### Give a diagram a useful name
 
-The body of a text-mode fence is diagram **source**. Before the client library
-runs - and if it never runs, which is the default, since no engine ships one - a
-reader announces the backslashes and arrows as prose; afterwards the injected
-`<svg>` has no accessible name either. `role="img"` says the block IS an image
-whether or not the script arrives, and the name says which one (carve#1468).
+Add an `aria-label` when the fence word alone would not tell someone what the
+diagram shows:
 
-- **The role and the name travel together.** An `img` with no accessible name is
-  skipped entirely, which is worse than the source being read out, so setting
-  the label to the empty string removes the role as well.
-- **The default is the extension's own class word** (`mermaid`, `d2`, `chart`).
-  That is the fence's own word wherever a preset claims one language, and the
-  class wherever it claims aliases: a `dot` fence and a `puml` fence are named
-  `graphviz` and `plantuml`, after the class they render into, so one preset
-  names every fence it claims alike. Either way the word is one the extension
-  already carries rather than invented English - so there is nothing here to
-  translate and this is an option on the extension rather than a `labels` key
-  ([extensions §1.5](./extensions#_1-5-the-strings-an-extension-writes-itself)).
-  A host that wants a reader to hear something better sets it, and an author can
-  name one diagram with `{aria-label="Deploy flow"}` on the fence.
-- **The author's own `role` or `aria-label` wins**, matched
-  ASCII-case-insensitively because HTML attribute names are. An author who wrote
-  only a name still gets the role - losing it there would leave the defect on
-  the one fence whose author cared enough to name it.
-- **The no-renderer static fallback is NOT named.** That path really is source
-  text in a `<pre><code>`; calling it an image would hide the one thing it
-  exists to show.
+````carve
+{aria-label="Deployment flow"}
+``` mermaid
+flowchart LR
+  Build --> Test --> Deploy
+```
+````
+
+In browser output, the generated element uses that label. Without one, the
+extension uses its class word, such as `mermaid`, `graphviz`, or `plantuml`.
+For text-based formats, the source remains in that labeled element until the
+drawing library replaces it. To leave otherwise-unnamed fences without an image
+role or default label, configure the extension with `label: ''`.
 
 ## Rendering without a browser
 
-For PDF, email, or any output with no client-side JavaScript, `renderStatic`
-accepts a **renderers** map. The standard keys are `mermaid`, `chart`,
-`graphviz` and `math`; implementations must use exactly these names so one config
-behaves identically across engines.
-
-Renderers are synchronous (`source -> string`). An async tool such as `mmdc` or
-an HTTP service must run in a build step and be supplied as a pre-resolved
-lookup, not awaited inside the render. A renderer typically returns a
-self-contained `data:` image URI, so if you sanitize the static HTML afterwards,
-**allow the `data:` scheme for images** or the diagram is silently stripped.
+For PDF, email, or another output without browser JavaScript, select static mode
+and pass a renderers map keyed by each fence's generated CSS class. A renderer
+can return a self-contained `data:` image URI. If you sanitize the resulting
+HTML, allow `data:` for images or the sanitizer will remove the diagram.
 
 Working per-engine recipes are in
 [Static Rendering Recipes](/static-rendering-recipes).
@@ -155,20 +139,22 @@ finished output:
 
 ## When a diagram cannot be drawn
 
-When the extension is off, or no renderer is supplied for that key, the fence
-falls back to its **source as a code block**. It never renders blank. The
-diagram description stays readable in the document, which is the point of
-keeping it as text in the first place.
+The fallback depends on how the document is rendered:
+
+- With the extension off, the fence is an ordinary code block.
+- In browser output, text-based formats keep their source in the prepared,
+  labeled element until a drawing library replaces it. JSON-based formats keep
+  their data in the page, but no chart appears without the library.
+- In static output, a fence with no configured renderer becomes a source code
+  block. It has no image role or extension-supplied name, although attributes
+  written by the author remain.
+
+The diagram never disappears silently, and its source remains in the document.
 
 See [Output without JavaScript](/graceful-degradation) for every output format.
 
 ## Enabling
 
-`FencedRender` is an implementation-specific extension and starts disabled.
-Enable it for a document or project; see the
-[Optional Features and Extensions](/extensions) and each implementation's own
-`docs/extensions.md` for the client libraries it pairs with.
-
-This output is implementation-specific and is not part of the shared
-input/output tests. An implementation can therefore update its supported
-diagram libraries without changing the Carve specification.
+`FencedRender` starts disabled. Enable it for a document or project, then choose
+the drawing libraries you want. See [Optional Features and
+Extensions](/extensions) and your implementation's extension documentation.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -130,7 +130,7 @@ Opt-in extensions that add non-core syntax.
 
 | Project | Target | Notes |
 |---|---|---|
-| [carve-php-media-embed](https://github.com/markup-carve/carve-php-media-embed) | carve-php | Embeds audio/video from 30+ providers via dereuromark/media-embed. |
+| [carve-php-media-embed](https://github.com/markup-carve/carve-php-media-embed) | carve-php | Embeds audio and video through dereuromark/media-embed. |
 | [carve-php-chat](https://github.com/markup-carve/carve-php-chat) | carve-php | Renders Carve to chat-platform markup (WhatsApp, Slack, Telegram, Discord) via data-driven flavor definitions. |
 
 ## Benchmarks

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -6,22 +6,20 @@ description: Side-by-side Carve source and the output it produces, split by what
 # Examples
 
 Each example shows Carve source and its HTML output. Select **Rendered** to see
-the result. The JavaScript, PHP, and Rust implementations are tested against
-these expected outputs.
+the result.
 
 The examples are grouped by whether a feature is always available, must be
 enabled, or applies only to unusual input.
 
-| Page | What is on it | Pinned in |
-|---|---|---|
-| [**Core**](/examples/core) | Syntax available without configuration and supported by every implementation. | Required input/output tests |
-| [**Optional features**](/examples/extensions) | Features shared by all implementations but disabled initially, plus application-specific extensions. | Shared optional tests or application tests |
-| [**Parser and output settings**](/examples/processor-options) | Typography settings, heading-section wrappers, and non-HTML output. | Shared optional tests |
-| [**Edge cases**](/examples/edge-cases/) | Unmatched, incomplete, or intentionally literal syntax. | Required input/output tests |
+| Page | What is on it |
+|---|---|
+| [**Core**](/examples/core) | Syntax available without configuration and supported by every implementation. |
+| [**Optional features**](/examples/extensions) | Features available in every implementation that you enable explicitly, plus extensions supplied by an application. |
+| [**Parser and output settings**](/examples/processor-options) | Typography settings, heading-section wrappers, and non-HTML output. |
+| [**Edge cases**](/examples/edge-cases/) | Unmatched, incomplete, or intentionally literal syntax. |
 
-Every comparison on the Core and Edge Cases pages comes from the same
-[input/output tests](/grammar) used by the JavaScript, PHP, and Rust
-implementations. The displayed HTML is generated from those tests.
+The displayed HTML for Core and Edge Cases is generated from examples shared by
+the JavaScript, PHP, and Rust implementations.
 
 The Optional Features and Settings pages show saved output because the result
 depends on configuration that this site does not enable.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -10,8 +10,8 @@ Sheet](/cheatsheet) lists the syntax.
 
 ## Install a renderer
 
-The JavaScript, PHP, and Rust implementations use the same core conformance
-corpus.
+The JavaScript, PHP, and Rust implementations are tested with the same Carve
+documents and expected output.
 
 ### JavaScript / TypeScript — [`carve-js`](https://github.com/markup-carve/carve-js)
 
@@ -84,11 +84,11 @@ are available without configuration.
 
 A few features must be enabled separately:
 
-- **Widely implemented optional features (Tier 2)** — citations `[@key]`,
+- **Available everywhere, but opt-in** — citations `[@key]`,
   bare-URL autolinking, mention/tag → URL templates, a collapsible `details`
   widget, `list-table`. Enable them in your parser configuration.
-- **Implementation-specific features (Tier 3)** — for example Mermaid diagrams, a
-  table of contents, heading permalinks. Register the ones you want.
+- **Dependent on the implementation** — for example Mermaid diagrams, a table
+  of contents, and heading permalinks. Register the ones you want.
 
 The `:name[…]` inline form and `::: name` block form are always recognized. An
 application can register code that changes the output for a name. Without that

--- a/docs/migrate-from-markdown.md
+++ b/docs/migrate-from-markdown.md
@@ -367,7 +367,7 @@ const html = carveToHtml(source, { sections: false })
 <p>A paragraph.</p>
 ```
 
-Nothing else changes when it is off - ids, dedup, `</#id>` cross-references, `[Heading][]` references, and `::: toc` all resolve against the slug, not the element carrying it. Check your engine's release notes for whether it ships the option yet; the wrapper is the default and is what the conformance corpus pins.
+Nothing else changes when it is off - ids, dedup, `</#id>` cross-references, `[Heading][]` references, and `::: toc` all resolve against the slug, not the element carrying it. Check your engine's release notes for whether it ships the option yet; the wrapper remains the tested default across implementations.
 
 Two related shapes are worth knowing while you audit selectors. A heading **inside** a blockquote, div, admonition, or list item is never wrapped - it emits `<h* id="…">` in place, which is also exactly what every heading looks like with `sections: false`. And on a wrapped heading only the id hoists: `{#install .featured}` gives `<section id="install"><h2 class="featured">`, so a class you attached to a heading still selects the heading.
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -320,12 +320,10 @@ source - the branch becomes a container, so the fence widens at every level.
 ## Why this is not syntax
 
 Every recipe here could have been a construct in the language. None of them
-should be. A construct costs a grammar production, a node type, a rule in three
-engines, four editor grammars and a corpus category - and buys a document older
-engines cannot read. The container seam costs nothing, degrades to a readable
-nested list wherever the CSS is absent, and lets a house style ship recipes the
-language never has to know about.
+needs to be. Ordinary containers and attributes keep the document readable when
+the stylesheet is absent and let a project add its own visual conventions
+without inventing specialized syntax.
 
 That is also why these class names are a convention rather than a spec rule, and
-why the layer is a separate import: opting in is how a consumer says they use
-those words the way carve-css means them.
+why the layer is a separate import: adding the stylesheet opts into the meaning
+that carve-css gives those words.

--- a/tests/docs-controlled-vocabulary.test.mjs
+++ b/tests/docs-controlled-vocabulary.test.mjs
@@ -17,6 +17,7 @@ const authorFacingPages = [
   'docs/recipes.md',
   'docs/diagrams.md',
   'docs/svg-images.md',
+  'docs/ecosystem.md',
 ]
 
 const unexplainedInternalTerms = [
@@ -28,6 +29,12 @@ const unexplainedInternalTerms = [
   /\bhost degradation\b/i,
   /\bsource-positioned losses?\b/i,
   /\bhydrat(?:e|es|ed|ing|ion)\b/i,
+  /\bconformance corpus\b/i,
+  /\bcorpus categor(?:y|ies)\b/i,
+]
+
+const volatileMarketingMetrics = [
+  /\b(?:more than|over|about|approximately)?\s*[1-9][\d,]+\+?\s+(?:[\w/-]+\s+){0,4}(?:tests|examples|providers|platforms)\b/i,
 ]
 
 test('main author-facing pages do not use unexplained internal terminology', () => {
@@ -35,6 +42,15 @@ test('main author-facing pages do not use unexplained internal terminology', () 
     const text = readFileSync(resolve(root, path), 'utf8')
     for (const term of unexplainedInternalTerms) {
       assert.doesNotMatch(text, term, `${path} uses internal terminology ${term}`)
+    }
+  }
+})
+
+test('main author-facing pages do not advertise volatile inventory counts', () => {
+  for (const path of authorFacingPages) {
+    const text = readFileSync(resolve(root, path), 'utf8')
+    for (const metric of volatileMarketingMetrics) {
+      assert.doesNotMatch(text, metric, `${path} advertises volatile metric ${metric}`)
     }
   }
 })

--- a/tests/readme-corpus-count.test.mjs
+++ b/tests/readme-corpus-count.test.mjs
@@ -1,62 +1,21 @@
 /*
- * The README's conformance row counts the corpus, and nothing ever checked it.
- *
- * It said "492 corpus examples ... plus 28 optional-corpus examples" while the
- * corpus held 1,025 and 41. Both numbers were right the day they were written,
- * and every corpus addition since made them a little more wrong - silently,
- * because the row is prose and the corpus is a directory, and no test joined
- * the two. The row is the first number a reader sees about how much of the
- * language is pinned, so understating it by half is not a cosmetic slip.
- *
- * The required-corpus claim is deliberately a floor ("Over N"), so routine
- * growth does not churn the README on every merge. A floor rots in one
- * direction only - downward, as the corpus grows past it - so this test pins
- * both ends: the floor must be true, and it must not trail the real count by
- * more than a release cycle's worth of growth.
- *
- * The optional corpus is small enough that an exact number stays readable, so
- * it is pinned exactly.
+ * Corpus inventory belongs in generated or maintainer-facing reports. Exact or
+ * approximate totals on the repository landing page drift as tests are added
+ * and make an implementation detail compete with reader-facing guidance.
  */
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { readFileSync, readdirSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
-const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const root = resolve(import.meta.dirname, '..')
 const readme = readFileSync(resolve(root, 'README.md'), 'utf8')
 
-/** How far the README's floor may trail the real count before it must be raised. */
-const SLACK = 250
-
-const examples = (dir) =>
-  readdirSync(resolve(root, dir)).filter((name) => name.endsWith('.crv')).length
-
-test('the README\'s corpus floor is true and not stale', () => {
-  const match = readme.match(/More than ([\d,]+) core\s+input\/output tests/)
-  assert.ok(match, 'the README states a floor for the core input/output tests')
-
-  const claimed = Number(match[1].replace(/,/g, ''))
-  const actual = examples('tests/corpus')
-
-  assert.ok(
-    actual >= claimed,
-    `README claims more than ${claimed} core tests; tests/corpus holds ${actual}`,
-  )
-  assert.ok(
-    claimed >= actual - SLACK,
-    `tests/corpus holds ${actual} examples; the README floor of ${claimed} trails it by more than ${SLACK} - raise it`,
-  )
-})
-
-test('the README\'s optional-corpus count is exact', () => {
-  const match = readme.match(/and ([\d,]+) optional input\/output tests/)
-  assert.ok(match, 'the README states the optional input/output test count')
-
-  assert.equal(
-    Number(match[1].replace(/,/g, '')),
-    examples('tests/corpus-optional'),
-    'the README optional-corpus count matches tests/corpus-optional',
+test('the README keeps volatile corpus counts out of reader-facing prose', () => {
+  assert.doesNotMatch(
+    readme,
+    /\b(?:more than|over|about|approximately)?\s*[1-9][\d,]+\+?\s+(?:[\w/-]+\s+){0,4}(?:tests|examples)\b/i,
+    'README describes shared coverage without advertising an inventory count',
   )
 })


### PR DESCRIPTION
## Summary

- remove volatile test and provider counts from primary reader-facing pages
- describe optional features by availability instead of internal tier labels
- reorganize the examples overview around what readers can use and configure
- simplify the recipes rationale to explain the author-visible benefit
- rewrite diagram guidance around authoring, accessibility, browser output, and static-output fallbacks
- expand the human-facing documentation guard to cover the ecosystem page, maintainer vocabulary, and volatile inventory claims

The generated normative rule index keeps its exact rule totals because it is an auditing reference whose counts are regenerated automatically. Version numbers and numbers used to demonstrate syntax are likewise unchanged.

## Verification

- `npm test` — 3,468 passed, 0 failed, 1 skipped
- `npm run docs:build`
- focused documentation, sample, navigation, and link tests — 128 passed
- `git diff --check`
- two Claude CLI review passes; all actionable findings addressed
