### PR TITLE
docs: make reference pages reader-focused

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -149,7 +149,7 @@ export default defineConfig({
             items: [
               { text: 'Case Study', link: '/case-study/' },
               { text: 'Technical Rationale', link: '/technical-rationale' },
-              { text: 'Built-in Features', link: '/native-features-analysis' },
+              { text: 'Feature Availability', link: '/native-features-analysis' },
               { text: 'Security', link: '/security' },
               { text: 'Output Without JavaScript', link: '/graceful-degradation' },
               { text: 'Static Output Recipes', link: '/static-rendering-recipes' },
@@ -248,7 +248,7 @@ export default defineConfig({
                 { text: 'Import, Security & Extensions', link: '/rules/imports-security-extensions' },
               ],
             },
-            { text: 'Built-in Features', link: '/native-features-analysis' },
+            { text: 'Feature Availability', link: '/native-features-analysis' },
             { text: 'Carve vs Markdown/Djot/MDX', link: '/comparison' },
             { text: 'Divergence from Djot', link: '/divergence-from-djot' },
             { text: 'Whitespace Across Formats', link: '/portable-whitespace' },

--- a/docs/ast-json.md
+++ b/docs/ast-json.md
@@ -901,7 +901,11 @@ carried - 45 documents, carve-js alone against the other two - and it was
 deleted when carve-rs landed the last producer
 ([carve#750](https://github.com/markup-carve/carve/issues/750) is closed).
 
-## Conformance status
+::: details Maintainer notes: current implementation status
+
+The shape sections on this page are the contract application developers should
+use. The following measurements and issue history explain current
+implementation gaps; they are not additional API requirements.
 
 Run `node scripts/ast-conformance.mjs` in this repo against sibling checkouts of
 the engines. It reports two things a schema cannot: nodes with no position, and
@@ -1188,6 +1192,8 @@ That is also why the §3a row is worth keeping while the others go. The spec
 says what the shape is, then the engines conform, then the pin moves; a row is
 the honest record of where an engine is in that order, and it has to be deleted
 when the order finishes rather than left behind as a fact.
+
+:::
 
 ## Definition lists
 

--- a/docs/blocks-and-attributes.md
+++ b/docs/blocks-and-attributes.md
@@ -278,7 +278,11 @@ A name is reserved only where Carve has no other **inline** spelling for that el
 - `samp`, `var`, `cite` and `dfn` are the [SemanticSpan extension](/extensions)'s - same spelling, same rules, off until a host enables it. Until then they stay ordinary attributes.
 - An abbreviation definition (`*[HTML]: HyperText Markup Language`) also emits `<abbr>`, and that is a different mechanism rather than a second spelling: it expands every occurrence document-wide, where `[HTML]{abbr="…"}` marks one, with its own title, and can mark a term no definition declares.
 
-The `:name[content]{attrs}` form has no core handler at all - `:kbd[Tab]` is `<span class="ext-kbd">Tab</span>` unless the extension is enabled, where it is accepted as a **soft-deprecated** spelling and slated for removal in 0.2.
+The `:name[content]{attrs}` form is generic extension syntax. Without the
+SemanticSpan extension, `:kbd[Tab]` renders as
+`<span class="ext-kbd">Tab</span>`. With the extension enabled, that older
+spelling still works during the transition to `[Tab]{kbd}`, but is scheduled
+for removal in Carve 0.2.
 
 ## Consumed structural keys
 
@@ -420,7 +424,7 @@ A `{…}` on the line before a list attaches to the **list**, not to an item. To
 - ordinary item
 ```
 
-**Whitespace is the discriminator** (normative):
+**Whitespace is the discriminator:**
 
 - `-{.c} text` - the `{.c}` abuts the marker, so it is part of the marker and attributes the `<li>` -> `<li class="c">text</li>`.
 - `- {.c} text` - a space before `{`, so the `{.c}` is ordinary item **content** (literal), not a li-attribute -> `<li>{.c} text</li>`.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -79,12 +79,12 @@ that remain in the paragraph, and closing markers that do not start a block.
 
 | | Markdown | Djot | MDX | **Carve** |
 |---|:---:|:---:|:---:|:---:|
-| Sanitization mandated by the spec | ❌ consumer's job | ❌ consumer's job | n/a | ✅ §25, corpus-pinned |
+| Built-in safety requirements | ❌ consumer's job | ❌ consumer's job | n/a | ✅ URL, attribute, Unicode, and resource protections |
 | URL / attribute / DoS hardening by default | ❌ | ❌ | ❌ | ✅ always on |
 | Raw HTML default | ⚠️ on (libs vary) | ⚠️ on | runs JS | ⚠️ on, one-flag opt-out / safe mode |
 | Embeds live components / JS | ❌ | ❌ | ✅ (its purpose) | ❌ by design |
 | Independent implementations | many, divergent | several (js, lua, rust, go) | JS-only | **php · js · rs, conformance-tested** |
-| Shared spec test corpus | ❌ | ⚠️ | ❌ | ✅ |
+| Implementations share expected results | ⚠️ | ⚠️ | ❌ | ✅ |
 
 See [Security → How Carve compares on security](/security#how-carve-compares-on-security)
 for the detailed breakdown and caveats.

--- a/docs/format-bridges.md
+++ b/docs/format-bridges.md
@@ -88,51 +88,24 @@ target cannot be interactive - the interaction, never the words. A bridge
 governs what a *converter* may drop when a target model is smaller than
 Carve's - a node, never in silence.
 
-## Testing conversion in both directions
+## Check conversion in both directions
 
-The corpus now records this measurement directly for built-in import routes.
-At the current JavaScript engine pin, 675 of 1,636 documents return to their
-canonical Carve source through HTML, and 410 through Markdown. The exact counts
-are a bidirectional ratchet in `resources/import-roundtrip-baseline.json`: a
-regression and an improvement both require inspection rather than silently
-changing the published baseline.
+Before storing converted content, test both directions on documents that matter
+to your application:
 
-Bridges are usually justified by reach: one conversion unlocks a whole family of
-outputs. That is true, and it is not the most interesting property.
+1. Convert Carve to the target format and inspect the loss report.
+2. Convert the result back to Carve.
+3. Compare the visible content and the structures your workflow depends on.
 
-HTML conformance cannot prove the AST holds a thing. A field can be present in
-the schema, absent from every renderer, and no HTML test will ever notice,
-because HTML is lossy by construction - there is no element whose absence
-implicates the field. Fields that no source spells and no renderer prints are
-exactly the ones that rot unobserved.
+A target format may legitimately lack a Carve construct. That construct should
+be reported as degraded or dropped. The reverse direction is more important:
+an unmapped construct in the target document must be an error, because silently
+skipping it destroys content.
 
-A bridge to a mature foreign AST asks a question HTML never asks: *is there
-somewhere to put this?* It gets asked in both directions, and the two answers
-mean different things:
-
-- **Carve to foreign.** A Carve node with no equivalent is a limit of the
-  target. Expected, uninteresting, reported as dropped or degraded.
-- **Foreign to Carve.** A construct the Carve AST cannot hold is a limit of
-  **Carve**. That is a finding about the language, and it is the same diagnostic
-  the [HTML import contract](./html-import) raises for a structure Carve cannot
-  spell.
-
-So a bridge is a distribution route and an audit at once. Round-tripping the
-corpus through a foreign model is one of the few checks that can fail because
-the exchange format is missing something, rather than because a renderer is.
-
-That is also why the fidelity gate on a bridge is worth stating precisely.
-carve-php's corpus sweep is narrow on purpose: a document whose types the editor
-model fully covers must round-trip to **byte-identical HTML**; a document that
-loses something is allowed to differ, because it must. A single gate over
-everything would have to be loose enough to pass the lossy documents, and would
-then stop detecting anything.
-
-The other half of that gate is what happens to the exemptions. carve-grammars
-drives its round trip off a coverage matrix and fails when a *skipped* category
-round-trips cleanly for every one of its files, which forces the skip to be
-promoted. Without that direction the exemption list only ever grows, and a list
-that only grows stops describing anything.
+The repository maintains detailed round-trip baselines for its built-in
+converters in `resources/import-roundtrip-baseline.json`. Those measurements
+are development gates rather than compatibility promises, so this guide does
+not publish their changing totals.
 
 ## The bridges that exist
 
@@ -151,11 +124,15 @@ one stored document with no Node runtime anywhere in the pipeline.
 carve-js and carve-rs have no bridge of their own. Both accept a `prosemirror`
 adapter for [HTML import](./html-import), which normalizes editor-produced HTML
 on the way in - a different job, at a different stage, from converting a
-ProseMirror document. For carve-js that is by design, since the ProseMirror
-vocabulary and its schema live in carve-grammars and restating them in the
-engine is the drift the next section describes.
+ProseMirror document. For carve-js that is by design: the ProseMirror vocabulary
+and its schema live in carve-grammars, avoiding a second copy that could drift.
 
-## One vocabulary, copied rather than restated
+:::: details Bridge implementer notes
+
+The remainder explains how bridge implementations keep their vocabularies
+aligned. Application developers can stop after the bridge table.
+
+**One vocabulary, copied rather than restated**
 
 A bridge needs a name for every Carve node type in the target's vocabulary, and
 the tempting mistake is for each implementation to write that mapping down
@@ -176,7 +153,7 @@ than editor content. A bridge reads its degradation list from there instead of
 inventing one, which is what keeps two bridges to the same model from disagreeing
 about what was lost.
 
-### A name is only half a vocabulary
+**A name is only half a vocabulary**
 
 Naming the node a type becomes leaves the attributes to each implementation, and
 that is where two bridges to the same model actually drifted: one wrote `ref`,
@@ -200,7 +177,7 @@ FIXTURES beside itself: a set of Carve sources with the exact target document
 each must produce. A bridge in another runtime copies them and asserts against
 them, which turns "we both read the same map" into something a test can fail.
 
-### The preservation node is part of the wire
+**The preservation node is part of the wire**
 
 A bridge that keeps an unmodeled construct as exact source needs somewhere to
 put it, and that node crosses runtimes like any other. carve-grammars writes a
@@ -219,7 +196,7 @@ Pandoc's side needs no shared map, because it reads the serialized
 pins. Any engine that can write that JSON can feed the bridge, not only the one
 it ships beside.
 
-## An application's own node type
+**An application's own node type**
 
 A bridge does not need to know about an application's private constructs for
 them to survive. An attributed container carries them as data:
@@ -234,4 +211,6 @@ them to survive. An attributed container carries them as data:
 That crosses into a ProseMirror document as the generic Carve div node with both
 data attributes intact, and comes back spelled the same way. A genuinely new
 *editor* node - one with its own ProseMirror name - belongs in the shared map
-first, for the reason the previous section gives.
+first so every bridge uses the same vocabulary.
+
+::::

--- a/docs/graceful-degradation.md
+++ b/docs/graceful-degradation.md
@@ -38,7 +38,7 @@ The table describes the JavaScript, PHP, and Rust implementations.
 
 | Construct | Interactive HTML | Static / PDF / Markdown / Plain | Status |
 | --- | --- | --- | --- |
-| Tabs / code-group | clickable tabs; `[label]` is the tab header | each panel shown in sequence, **its `[label]` as a caption heading** | see normative rule below |
+| Tabs / code-group | clickable tabs; `[label]` is the tab header | each panel shown in sequence, **its `[label]` as a caption heading** | see the label rule below |
 | Disclosure (`details`) | native `<details>`/`<summary>` (interactive without scripts) | native `<details open>` - kept, not flattened | special case - see below |
 | Spoiler | blurred until revealed | revealed | hiding is not retained |
 | Mermaid / charts | script-drawn diagram | diagram source preserved (a ` ```mermaid ` fence in Markdown); for PDF the extension SHOULD pre-render to SVG/PNG at build time | source never lost; image needs build-time render |
@@ -73,7 +73,7 @@ verbatim). The exception is tabs/code-group, whose distinguishing text is a
 This is the line between disclosure and the script-dependent constructs:
 tabs/code-group/spoiler need a script or stylesheet to be interactive, so they
 flatten in `static`; `details` does not, so it stays itself. The only static
-requirement is the `open` attribute - without it a print engine could render the
+requirement is the `open` attribute - without it a PDF renderer could render the
 disclosure collapsed and hide the body.
 
 **Email and other no-`<details>` targets.** A few email clients ignore the
@@ -113,7 +113,7 @@ with no indication of which is which:
 rendered to Markdown without the fallback collapses to two unlabeled code spans -
 the reader cannot tell "Installation" from "Usage". The authored labels are gone.
 
-## Normative rule: unconsumed labels render as captions
+## How unused labels appear
 
 > A renderer that does not consume a fenced div's grouping `[label]` (because no
 > group extension is active for the target) MUST render the label as a visible
@@ -187,10 +187,9 @@ lost:
 1. **HTML to PDF.** Render Carve to HTML in **`mode: "static"`** with a
    `renderers` map (so tabs become labeled stacked sections, disclosures expand,
    mermaid/charts **pre-render** to SVG/PNG, and **math** renders server-side).
-   Pass that self-contained HTML to a print engine
-   (weasyprint, headless Chromium). Because client scripts never run in a print
-   engine, anything left to client JS would otherwise be blank - the disabled
-   extensions plus pre-rendering are what make the PDF complete.
+   Pass that self-contained HTML to a PDF tool such as WeasyPrint or headless
+   Chromium. Client scripts do not run in that pipeline, so disabling
+   interactive extensions and pre-rendering visuals make the PDF complete.
 2. **Markdown to PDF.** Render Carve to Markdown (the fallback is automatic),
    then hand it to a Markdown-to-PDF toolchain (for example pandoc). Diagram
    and math source survive as fenced blocks for that toolchain to handle.

--- a/docs/native-features-analysis.md
+++ b/docs/native-features-analysis.md
@@ -2,30 +2,23 @@
 description: Why some features are built into Carve while others must be enabled separately.
 ---
 
-# Built-in and optional features
+# Feature availability
 
-This design record compares djot-php extensions with Carve and explains which
-features became part of Carve syntax.
+Use this page to see what works without configuration, what can be switched
+off, and what needs an extension. For syntax examples, start with the
+[cheat sheet](/cheatsheet).
 
-## Criteria for built-in features
+## What is available by default
 
-A feature should be built into Carve syntax if:
-1. It affects document semantics, not just rendering
-2. It's universally useful across contexts
-3. It has clear, unambiguous syntax
-4. It follows Carve's visual mnemonic principles
-
-A feature should remain an **extension** if:
-1. It's implementation/output-specific (HTML attributes, etc.)
-2. It's context-dependent (wiki links depend on wiki software)
-3. It integrates third-party tools (Mermaid, etc.)
-4. It's a rendering concern (permalinks, ToC generation)
+Features fall into three groups: always available, available by default with an
+opt-out, and opt-in or application-supplied - for example Mermaid rendering in
+a documentation site.
 
 ---
 
-## Native Features (Core Carve Syntax)
+## Core syntax
 
-### Already in Carve Spec
+### Familiar document features
 
 | Feature | Carve Syntax | Status |
 |---------|-------------|--------|
@@ -41,10 +34,11 @@ A feature should remain an **extension** if:
 | Attributes | `{#id .class key=value}` | ✅ In spec (4.10) |
 | Extensions | `:type[content]{attrs}` | ✅ In spec (4.20) |
 
-### Added to Carve Spec
+### Carve-specific features
 
-These were proposed during this analysis and have since landed in the spec.
-Grammar references point at `resources/grammar.ebnf`.
+These features are part of Carve today. The comparison column shows the
+equivalent spelling in djot-php, one of the projects Carve originally drew
+experience from. Grammar references point at `resources/grammar.ebnf`.
 
 | Feature | djot-php Syntax | Carve Syntax | Status |
 |---------|-----------------|-------------|--------|
@@ -59,10 +53,10 @@ Grammar references point at `resources/grammar.ebnf`.
 
 ---
 
-## Native Additions (in spec)
+## Features Carve adds
 
-The features below were the concrete proposals from this analysis. All are now
-part of Carve syntax; the examples remain as a feature-level reference.
+The features below are part of Carve syntax; the examples provide a quick
+feature-level reference.
 
 ### 1. Captions (`^`)
 
@@ -142,11 +136,11 @@ combine on one span where the `:type[…]` form cannot nest.
 
 ---
 
-## Implementation Extensions (Not Native)
+## Optional and application features
 
 These should remain implementation-specific, not part of Carve syntax:
 
-| djot-php Extension | Why Not Native |
+| djot-php extension | Why it stays outside core syntax |
 |--------------------|----------------|
 | **ExternalLinksExtension** | HTML attribute concern (`target`, `rel`) |
 | **DefaultAttributesExtension** | Implementation convenience |
@@ -184,8 +178,8 @@ These should remain implementation-specific, not part of Carve syntax:
 
 ## Disabling / Restricting Features
 
-Can a processor turn native features off? It depends on the tier (see
-Conformance Core below for the full split).
+Can a processor turn features off? It depends on the tier; the availability
+summary below gives the full split.
 
 > This MUST / SHOULD / MAY split is the same model as the Tier-1/2/3 taxonomy in
 > the normative [extensions contract](./extensions): **MUST** = Tier-1 core
@@ -207,15 +201,13 @@ processor-level mechanism; it is not encoded in `resources/grammar.ebnf`.
 
 ---
 
-## Conformance Core (what every implementation MUST produce)
+## Availability summary
 
-The native/extension split above answers "what belongs in the language."
-This answers the question a *second* implementer (e.g. carve-php) needs:
-**what must I produce to be conformant, and what is optional?** Byte-level
-output rules live in `resources/grammar.ebnf` PART 10; this is the
-feature-level boundary.
+The availability split answers what an author can use everywhere and what
+requires configuration. Exact output rules live in `resources/grammar.ebnf`;
+this section stays at the feature level.
 
-### MUST (core) — pinned by the corpus, identical across implementations
+### Always available
 
 - **Blocks:** headings (+ `<section>` wrapping, §13), paragraphs,
   thematic breaks, fenced code, blockquotes, lists (ordered
@@ -233,11 +225,11 @@ feature-level boundary.
 - **Semantics:** automatic heading ids (jgm/djot#393 run-replacement, case-preserving, non-ASCII preserved, smart typography reversed to ASCII before slugging; opt-in lowercase and opt-in ASCII fold; cross-references resolve case-insensitively), id de-duplication,
   order-independent reference/abbreviation/footnote resolution.
 
-### SHOULD / configurable (on by default, a processor MAY disable)
+### Available by default, with an opt-out
 
 - `@mention` and `#tag` shorthands, smart typography (grammar PART 9 §19).
 
-### MAY / out of core (processor-level)
+### Opt-in or supplied by an application
 
 - Includes (<code v-pre>{{ … }}</code>, §19, with the security requirements there).
 - The `:type[content]` extension *registry* beyond the generic fallback.

--- a/docs/parsing-ambiguities.md
+++ b/docs/parsing-ambiguities.md
@@ -6,9 +6,9 @@ description: How Carve reads syntax that could otherwise have more than one inte
 
 **Non-normative.**
 
-This page explains syntax that readers or parser developers may interpret in
-more than one way. It is explanatory, not part of the specification. If it
-conflicts with the [formal grammar](./grammar), the grammar applies.
+This guide explains what ambiguous-looking source means in practice. The formal
+rules live in the [grammar](./grammar); examples here focus on the result an
+author sees.
 
 ---
 
@@ -37,16 +37,16 @@ The **same-delimiter adjacency** part of that rule — a delimiter adjacent to
 another of the same delimiter (before or after) does not open — applies to all
 five single-character delimiters. So a doubled delimiter is always literal:
 `**x**`, `~~x~~`, and `==x==` render verbatim, exactly like `//x//` and
-`__x__` (corpus `74-doubled-emphasis-delimiters`). (`^` and `,` are not
+`__x__`. (`^` and `,` are not
 delimiters at all — superscript/subscript are the braced `{^x^}` / `{,x,}`
 forms only.)
 
 **This means a path in an emphasizing position still italicizes:**
-`/usr/local/` → `<em>usr/local</em>` (verified — corpus `01-emphasis-6`),
+`/usr/local/` → `<em>usr/local</em>`,
 because the opening `/` is at line start and the inner slashes are literal
 content. An intraword path fragment like `a/b/c` stays literal because the `/`
 is alphanumeric-flanked and cannot open; `x /a/b y` stays literal because the
-closing `/` is followed by an alphanumeric (corpus `01-emphasis-9`).
+closing `/` is followed by an alphanumeric.
 
 **Recommendation:** For paths that sit in an emphasizing position, use code
 fencing - they're code anyway:
@@ -176,7 +176,7 @@ if (x < 5)                     # Literal <
 ```
 The first line is bold, not a list item, because `*` is NOT followed by
 whitespace. The second stays literal text: an opener without a matching
-closer never emphasizes (corpus `01-emphasis-3`).
+closer never emphasizes.
 
 List requires `* ` (asterisk + space). Bold opener requires `*` + non-whitespace
 AND a valid closer ahead.
@@ -206,8 +206,7 @@ AND a valid closer ahead.
 | `@john!` | `@john` | `!` |
 | `email@domain.com` | - | (not a mention, no word boundary before @) |
 
-The same name rule applies to `#tags` (`#release-1.0` is one tag). Pinned by
-corpus `89-mention-and-tag-name-boundaries`.
+The same name rule applies to `#tags` (`#release-1.0` is one tag).
 
 ---
 
@@ -308,9 +307,7 @@ stack in a single left-to-right pass: linear time, no backtracking.
 - `%%` is a comment marker when **preceded by whitespace or at the start of
   the inline run** (line start counts) — including a *trailing* comment after
   text: `Visible. %% this tail is a comment` keeps only `Visible.`
-  (corpus `46-comments-2`)
 - The comment runs to the end of the line; it never crosses a line break
-  (corpus `46-comments-6`)
 - Without preceding whitespace `%%` is literal: `The value is 50%% increase`
   stays literal text — percentages are safe
 - `\%%` (escaped first percent) is literal
@@ -387,9 +384,10 @@ y
 
 `%% z` in the fence's place gives that. A `%%%` WITH a closer does not - a
 terminated fence at column 0 is a comment BLOCK at the document's own opener
-column and it ends the item (corpus 214). Every current engine answers column 0
-the terminated fence's way for the degraded spelling too, which is
-markup-carve/carve#1903.
+column and it ends the item. Current implementations also end the item for the
+unterminated, column-zero `%%%` spelling, rather than producing the illustrated
+grammar result. Until [that gap](https://github.com/markup-carve/carve/issues/1903)
+closes, use the `%% z` line form when the follower must stay in the item.
 
 **Provenance marker (tool-written):**
 - Tooling such as `carve fmt --stamp` writes a trailing comment recording the
@@ -614,14 +612,13 @@ collected/consumed (an attribute line floats forward to the next block, §15).
 | `1. a` / `   [r]: /u` / `   after` | one tight item with two paragraphs | definition is at the item's content column |
 | `- text` / `  # H` | item: text + heading | heading interrupts inside the item |
 
-Normative statement: `resources/grammar.ebnf` PART 9 §10. Verified by corpus
-`05-lists-12` and the `76-paragraph-interruption` family.
+The formal statement is in `resources/grammar.ebnf`, PART 9 §10.
 
 ---
 
 ## 18. Single-Line Headings (Nothing Folds INTO a Heading)
 
-**Rule (normative, grammar PART 2):** a heading **ends at the newline**.
+**Rule:** a heading **ends at the newline**.
 Nothing folds into it - the next line begins whatever block it begins, exactly
 as after any other closed block. A `^ ` caption line is no exception: it does
 not fold in, and it does not attach either, because a heading is not one of
@@ -637,9 +634,8 @@ outside
 Heading **plus** paragraph: `<h1 id="Title">Title</h1>` then `<p>outside</p>`.
 
 This used to be one heading holding both lines, with id `Title-outside`, and
-this document called it the biggest authoring trap in the heading syntax. It is
-gone rather than documented: see `divergence-from-djot` §14 for why, and corpus
-`82-single-line-headings` for the pins.
+this document called it the biggest authoring trap in the heading syntax. That
+older behavior is gone; see `divergence-from-djot` §14 for the rationale.
 
 ```carve
 # Title

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -83,125 +83,29 @@ Denying `div` still removes callouts, through the subtype rule: an `admonition`
 answers to its own name and to `div`. A host that wants today's "deny every
 named fence" behavior denies both.
 
-### Parsed documents have more object types than profiles use
+### Parsed documents contain additional object types
 
-This page lists content that a profile can allow or deny. Parsed document JSON
-also contains `tag`, `smart_punctuation`, `literal_inline`, and the `document`
-root. Profiles group those objects with related content because separate rules
-would not provide a useful permission. Code that reads parsed document JSON
-must still accept them.
+Profiles describe content permissions, not every internal object in parsed
+document JSON. The `document` root and the `smart_punctuation` and
+`literal_inline` objects are not separately deniable.
 
-`raw_text` is a separate case and is NOT carried. It is formatter-internal, and
-PART 12 §5 keeps it off the wire; PART 12 §3a goes further and says there is no
-such node at all, because the reversion that would have needed one does not
-happen. So it is neither deniable nor serialized, and a consumer should not
-expect it. Measured: no engine emits it for any of the 655 corpus documents,
-and `resources/ast-schema.json` does not name it.
+A **`tag`** node is classified as **`mention`** because both represent a
+named inline token for permission purposes. Denying `mention` denies both;
+naming `tag` directly in an allow or deny list does nothing and produces no
+diagnostic. A profile cannot
+allow mentions while denying tags.
 
-### A definition line is content, so the definition types are deniable
+`smart_punctuation` is classified as `text`, and the inline literal
+`` !`…` `` is classified as `code`. Formatter-internal `raw_text` is not
+serialized and cannot be named in a profile. The `document` root is always
+allowed.
 
-`abbreviation_def` and `link_reference_definition` are in the Block vocabulary
-above, and both were kept out of it until carve#771 on the reasoning that a
-definition line renders nothing. That reasoning was measured against the HTML
-target only, and it does not survive the other three.
-
-**`abbreviation_def` is output today.** All three engines emit the definition
-line on `markdown`, `plain` and `ansi`, and drop it only on `html`:
-
-```
-HTML is fine.
-
-*[HTML]: HyperText
-```
-
-```
-html      <p><abbr title="HyperText">HTML</abbr> is fine.</p>
-markdown  <abbr title="HyperText">HTML</abbr> is fine.
-
-          *[HTML]: HyperText
-plain     HTML is fine.
-
-          *[HTML]: HyperText
-```
-
-A host restricting untrusted input on any of those three targets is looking at
-authored text it may have a reason to withhold, so it must be able to name the
-type. "Renders nothing" described one target out of four.
-
-**`link_reference_definition` moves with it**, which is what this page has always
-said - the two are one case. The reason is now PART 11 §10a rather than a
-measurement: that clause is normative, and since PART 12 §10 gave the link
-definition a node it covers all three definition kinds, requiring an unused
-definition of any kind to survive the Markdown, plain-text and terminal
-renderers. So the same authored line is required output there. Stated plainly
-because the page has been wrong here once already: **no engine emits the unused
-link definition line yet**, so denying the type withholds nothing on any target
-at the time of writing. Its vocabulary membership follows the clause, not the
-current output.
-
-**`citation_definition` joins them** under PART 12 §18, which gives the fourth
-definition kind a node for the same reason: `[@key]: {author= year=} entry` is
-authored text a host may have a reason to withhold, and it is text a formatter
-has to be able to put back. It is Tier-2, so it appears only where the Citations
-extension is enabled - a profile denying the type on input that never enables
-citations denies something the parse cannot produce, which is true of every
-extension type in this list and not a reason to leave it out.
-
-What a deny takes is the definition LINE, never the EXPANSION it fed. The
-inline `abbreviation`, and the `link` or `image` a reference resolves to, are
-separate entries in this vocabulary and keep rendering. Denying the definition
-denies exactly the definition.
-
-The membership settles a second thing, which is why both types had to move
-together. A type outside the vocabulary resolves through the three steps below
-on its node's own axis, and the string-only form of the allow/deny query has no
-axis to resolve on - so a host that denied `abbreviation_def` and then asked
-`isTypeAllowed('abbreviation_def')` was told `true`, while the same profile
-answered `false` for the same node in the tree. Two APIs, one profile, opposite
-answers. In the vocabulary, both answer `false`.
-
-A **`tag`** node - the AST form of `#tag` - is deliberately **NOT** its own
-vocabulary entry: it is classified as **`mention`**, and all three
-implementations agree on that. `@user` and `#tag` are parsed by the same
-boundary rules (PART 9 §7) and render through the same inert-span mechanism, so
-they are one trust class rather than two. Denying `mention` denies both:
-
-```js
-const p = Profile.minimal()
-p.denyInline(['mention'])
-applyProfile(parse('hi @user'), p).violations  // [{ nodeType: 'mention', ... }]
-applyProfile(parse('hi #tag'), p).violations   // [{ nodeType: 'mention', ... }]
-```
-
-The consequence is worth stating plainly, because it is a real limit: a host
-CANNOT allow mentions while denying tags. `tag` is not addressable, so naming it
-in `allowedInline` or `deniedInline` does nothing at all - silently, since an
-unrecognized identifier is not an error. A host that needs one without the other
-has to deny `mention` and reintroduce the wanted construct through an extension.
-
-A **`smart_punctuation`** node - the AST form of a typographic substitution,
-carrying the resolved kind and the author's source run (PART 9 §8) - is
-classified as **`text`**. It is ordinary visible prose with no capability of its
-own: an em dash is not a different trust level from the words around it. Denying
-it would express nothing a `text` denial does not already express, so it is not
-separately nameable here.
-
-Types serving a formatter rather than a document are **not** in this
-vocabulary and cannot be named in a profile. An implementation may carry a
-node preserving literal source for round-trip formatting (carve-php calls it
-`raw_text`); denying it would break `fmt` while expressing nothing about the
-document's content.
-
-The inline literal of PART 9 §27 (`` !`…` ``) is classified as **`code`** for
-profiles — it is a code span with the `<code>` wrapper dropped, sharing code's
-verbatim capture, escaping, and trailing-attribute surface, so it is allowed
-exactly where `code` is and denied where `code` is. (Types are trust classes,
-not one per AST node: `inline_footnote` and `footnote_ref` likewise fold into
-`footnote`.) It is not classified as `text`: with attributes it renders a
-`<span>` carrying class/id/style just as an attributed code span does, which is
-`code`'s trust level, not plain text's.
-
-The `document` root is always allowed and cannot be denied.
+Definition lines are authored content, so `abbreviation_def`,
+`link_reference_definition`, and the optional `citation_definition` are
+separately deniable. Current renderers do not yet emit an unused link-reference
+definition on non-HTML targets, so denying that type may presently remove
+nothing. A deny removes the definition line, never the abbreviation, link, or
+image that it supplied.
 
 ## The profile model
 
@@ -216,7 +120,7 @@ A profile carries:
 | `maxLength` | max output length in bytes (0 = unlimited) | `0` |
 | `disallowedAction` | what to do with a disallowed node | `to_text` |
 
-### Resolution (normative)
+### How allow and deny lists resolve
 
 For a node of type `T`, in its axis (inline or block):
 
@@ -237,8 +141,7 @@ the implementation's vocabulary predates. A vocabulary gap makes a type
 un-nameable, never invisible. An allow list still excludes unknown types, so a
 restrictive profile loses no safety.
 
-`document` is always allowed and cannot be denied. Deny always beats allow;
-an allowlist is a closed set.
+Deny always beats allow; an allowlist is a closed set.
 
 ### Actions on a disallowed node
 
@@ -310,7 +213,7 @@ disable raw-HTML passthrough on the renderer (`allowRawHtml: false`), ideally
 both. The two controls are independent: the profile gates AST node types; the
 renderer flag gates whether raw content is serialized verbatim or escaped.
 
-### The `carve` target does not apply a profile (normative)
+### Formatting source does not apply a profile
 
 A profile is a statement about what may be **rendered**. The `carve` target does
 not render: it writes the document back as Carve source, and PART 11 §1 makes
@@ -337,7 +240,7 @@ fails safe (carve#759).
 Nothing here changes the other targets: `html`, `markdown`, `plain` and `ansi`
 all apply the profile, because all four RENDER.
 
-## Presets (normative)
+## Presets
 
 Four presets MUST exist with exactly these definitions.
 
@@ -402,7 +305,9 @@ to_text'd, stripped, or raises a violation).
 Presets: **`unrestricted`** (all schemes/hosts), **`internalOnly`**
 (`allowExternal = false`), **`allowlist(domains)`** (only the listed hosts).
 
-## Implementation notes
+::: details Implementation and compatibility notes
+
+**Implementation notes**
 
 - Profiles are a **core** capability in every implementation (a safety feature,
   not an opt-in plugin).
@@ -413,7 +318,7 @@ Presets: **`unrestricted`** (all schemes/hosts), **`internalOnly`**
 - Parity is byte-checked against `carve-php` via golden fixtures (the presets
   and the resolution rule above are the shared source of truth).
 
-## Parity battery
+**Parity battery**
 
 `tests/profile-fixtures.json` is the **shared golden battery**: a set of
 `{carve, profile, html}` fixtures rendered by carve-php (the reference) covering
@@ -422,3 +327,5 @@ carve-rs assert their own profile output against this file (comparing
 trailing-newline-insensitively, since renderers differ on a trailing `\n`), so a
 profile divergence in any implementation is caught. Regenerate with
 `tests/gen-profile-fixtures.php` from a carve-php checkout.
+
+:::

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,8 +15,8 @@ Carve has no *implicit* raw-HTML passthrough. Authored bare `<` and `>` carry no
 special meaning and are escaped on output rather than interpreted.
 
 There is one *explicit*, author-opted raw passthrough - `` ```=html `` blocks
-and `` `…`{=html} `` inline - which emits verbatim HTML and is on by default
-(it is corpus-pinned). For UNTRUSTED input you MUST disable it: set
+and `` `…`{=html} `` inline - which emits verbatim HTML and is on by default.
+For UNTRUSTED input you MUST disable it: set
 `allowRawHtml: false` (carve-js) / `Options::with_raw_html(false)` (carve-rs) /
 enable `SafeMode` (carve-php), which escapes the raw content to text instead of
 emitting it.
@@ -125,12 +125,11 @@ Specifically, on every rendered element:
   attributes - `title`, `alt`, `aria-label` - are deliberately **not**
   tokenized, so an ordinary colon in text is never mistaken for a scheme.
 
-All other attributes pass through with their values HTML-escaped (quotes
-included, so a value cannot break out of its attribute). This baseline is
-identical across carve-php, carve-js and carve-rs, except for the URL-list rule
-above: the corpus pins it and the three engines are implementing it, so check
-the [implementation comparison](./implementation-comparison) page for the
-current window.
+All other attributes pass through with their values HTML-escaped, including
+quotes, so a value cannot break out of its attribute. The URL-list rule for
+`srcset`, `imagesrcset`, `ping`, and `attributionsrc` is newer than the rest of
+this baseline; check the [implementation comparison](/implementation-comparison)
+before relying on it in your chosen engine.
 
 ## Invisible Unicode and Trojan Source (always on)
 
@@ -175,7 +174,7 @@ containers (blockquote / div / list / admonition) and inline constructs
 a fixed nesting depth (200). Past the cap, further openers degrade to literal
 text instead of recursing, so a deeply nested document parses in time linear in
 its size rather than the ~O(n^2) a naive nested-link rescan would cost. The cap
-is enforced by all three implementations.
+is enforced by the JavaScript, PHP, and Rust implementations.
 
 **Output amplification is bounded too.** Expansion features whose output can
 exceed their input — abbreviation expansion (`*[KEY]: …`) and the generated
@@ -242,13 +241,12 @@ does not launder an attack:
 Most lightweight-markup ecosystems treat sanitization as the *consumer's* job:
 the format says nothing about safety, and you are expected to bolt on a
 sanitizer (or pick a "safe mode") yourself. Carve is unusual in that the
-baseline defenses on this page are **part of the specification** (grammar
-PART 9 §25), **pinned by the shared corpus**, and **enforced identically by all
-three implementations** with no configuration.
+baseline defenses on this page are always-on parts of Carve and require no
+configuration.
 
-| | Spec mandates sanitization? | URL scheme filtering | Attribute hardening | Trojan Source / bidi | Raw HTML default | DoS bounds in spec |
+| | Built-in safety requirements? | URL scheme filtering | Attribute hardening | Trojan Source / bidi | Raw HTML default | Required DoS bounds |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|
-| **Carve** | **yes** (§25/§26, corpus-pinned, 3 impls) | always-on denylist | always-on (incl. extension wrappers, CSS-escape decoding) | **always-on strip + NFC ids** | **on, one-flag opt-out / safe mode** | yes (linear-time, depth caps, output budgets) |
+| **Carve** | **yes** | always-on denylist | always-on, including extension wrappers and CSS-escape decoding | **always-on strip + NFC ids** | **on, one-flag opt-out / safe mode** | yes (linear-time, depth caps, output budgets) |
 | CommonMark / markdown-it / marked | no | none (consumer's job) | no attribute model | none | on (libs vary; `markdown-it` defaults off) | no (several ReDoS CVEs historically) |
 | GitHub GFM | no - platform sanitizer | via GitHub's separate allowlist | via GitHub's sanitizer | none in the format | sanitized server-side | no |
 | Djot (Carve's parent) | no | none mandated | none mandated | none | on | no |
@@ -419,11 +417,9 @@ reach an `href` — the robust, future-proof posture for that deployment.
 
 ## Beyond the baseline: SafeMode and Profiles
 
-The baseline on this page - the URL scheme denylist, the attribute name/value
-hardening, the raw-HTML escape switch, and the DoS resource bounds - is the
-normative default, mandated by the grammar (`resources/grammar.ebnf` PART 9 §25)
-and pinned by the corpus ("Security hardening" examples). It is enforced by all
-three implementations (carve-php, carve-js, carve-rs) without any configuration.
+The baseline on this page - the URL scheme denylist, attribute hardening,
+raw-HTML escape switch, and resource bounds - is the default and needs no
+configuration.
 `SafeMode` / `Profile` are **optional, implementation-level**
 policy objects that layer a broader surface ON TOP (scheme allowlists,
 domain allow/deny, `rel=nofollow`, feature restriction, nesting / length


### PR DESCRIPTION
## Summary

- rewrite the highest-priority reference pages around reader tasks and stable behavior
- make the medium-priority feature and comparison pages clearer and less implementation-led
- move detailed implementation history and measurements into collapsed maintainer notes
- remove volatile totals from user-facing guidance while preserving repository gates and paths
- align the Feature Availability title in navigation

## Pages covered

High priority: AST JSON, format bridges, profiles, parsing ambiguities, and security.

Medium priority: graceful degradation, blocks and attributes, feature availability, and the ecosystem comparison.

## Verification

- `npm run docs:build`
- `npm test` (the first full run caught one changed example delimiter; corrected afterward)
- targeted executable docs, vocabulary, navigation, and repository-link tests after the correction (131 passed)
- Claude review of the completed diff; actionable findings addressed
