### PR TITLE
fix: a span-start row inside the indentation names no engine

### DIFF
--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -551,7 +551,10 @@ function reportSpanDisagreements(present) {
     }
     console.log('  EXTENT rows are PART 12 §4, and WHICH END moved decides which engine owes it:')
     console.log('    startOffset differs - a span "begins at the markup that opens the construct",')
-    console.log('      so the engine spanning the content alone moves (carve#913, checkOpeningMarkup).')
+    console.log('      so the engine spanning the content alone moves (carve#913, checkOpeningMarkup),')
+    console.log('      UNLESS the starts differ only inside the line\'s LEADING INDENTATION.')
+    console.log('      checkOpeningMarkup walks over that run before matching a marker, so both')
+    console.log('      readings pass it and no engine owes the row (carve#1928).')
     console.log('    endOffset differs, startOffset unanimous - a span "ends immediately after the')
     console.log('      last source codepoint the construct owns", and a container with no closer ends')
     console.log('      at its last child, so the WIDE engine moves (checkStopsAtChildren, over the')
@@ -575,6 +578,11 @@ function reportSpanDisagreements(present) {
       '  START. A span "begins at the markup that opens the construct"',
       '  (markup-carve/carve#913), so an engine spanning the content alone is the one that',
       '  moves. checkOpeningMarkup in scripts/spec/ast-positions.mjs is the source-side rule.',
+      '  It permits a start anywhere in the line\'s LEADING INDENTATION, because the indent',
+      '  is what places a nested item\'s marker - so on a row where the starts differ only',
+      '  inside that run, both readings pass it and NEITHER engine owes the row. Taking the',
+      '  sentence literally there names the engine that begins at the markup, which is the',
+      '  conformant one (markup-carve/carve#1928).',
       '  END. A span "ends immediately after the last source codepoint the construct owns",',
       '  and a container with no closer "ends at its last child", so on those rows the WIDE',
       '  engine is the one that moves. checkStopsAtChildren, over the types in',

--- a/scripts/spec/ast-spans.mjs
+++ b/scripts/spec/ast-spans.mjs
@@ -42,6 +42,11 @@
  * opens the construct". Most of what this panel reports is that question,
  * so those rows are engines owing a fix rather than an open convention.
  *
+ * NOT ALL OF THEM. `checkOpeningMarkup` permits a start anywhere in the line's
+ * leading indentation, so two engines can start a span at different offsets in
+ * that run and both pass the source-side rule. Such a row is owed by nobody and
+ * cannot be retired by fixing an engine (markup-carve/carve#1928).
+ *
  * What this module still does not do is say WHICH engine owes it, because that
  * needs the source and this module only has the trees. It reports a
  * DISAGREEMENT; the rules that name a side live in ./ast-positions.mjs and each


### PR DESCRIPTION
Part of #1923. It does not close it - the rest of that run is engine lag,
listed at the bottom.

`THREE-WAY SPAN COMPARISON` reported a `comment (extent)` row on corpus
`444-an-opener-at-or-past-a-description-body-s-column-closes-its-paragraph-9`
and told the reader that a start-offset row is owed by "the engine spanning the
content alone". That names carve-php, which is the one engine whose span begins
at the markup.

`checkOpeningMarkup` does not enforce §4's start sentence literally: when
everything before the offset on the line is whitespace it walks forward over the
indent run before matching a marker. The comment is deliberate and the reason is
about containers - the indent is what places a nested item's marker - but
nothing narrows it to containers.

## Measured

```
:: term
:  definition
    %% c
tail
```

Same tree and same HTML in all three engines. The `comment`:

| engine | startColumn | startOffset | that offset is |
| --- | --- | --- | --- |
| carve-js `5df1793` | 4 | 25 | the fourth space of the indent |
| carve-rs (main, 11:05 UTC) | 4 | 25 | the fourth space of the indent |
| carve-php (main) | 5 | 26 | the first `%` |

`checkOpeningMarkup` reports none of the three, so no engine fix retires the
row. carve-js and carve-php reproduced locally at `237f78e1`; the carve-rs
figure is from AST conformance run 33747569582, which builds every engine from
its own main.

Same class as #1637, where the END half of the same paragraph pointed at the
engine with no end-side finding at all. The question itself - may a leaf span
begin inside the indentation, or only at its markup - is filed at #1928.

## What still holds #1923 red

Engine defects, not declarations:

- markup-carve/carve-js#1623 - a degraded comment fence publishes
  `startColumn: 0` and a start offset on the preceding newline (7 documents,
  schema-invalid, no ledger by design).
- markup-carve/carve-js#1624 - a marker folded into a quote lands in a
  paragraph with no positions (3 documents).
- markup-carve/carve-rs#1543 - a degraded comment fence ends the item where the
  line form keeps the lazy follower (`446`, 6 documents).
- markup-carve/carve-rs#1532 - the `447` host-column band (7 `definition_list`
  and 7 `definition_description` span rows plus all 3 value rows).
- markup-carve/carve-rs#1537 and markup-carve/carve-php#1882 - the `448` fold.
