### PR TITLE
Pin the block-image divergence in the comparison, and stop the docs site from contradicting it

### DIFF
--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -41,6 +41,10 @@ const fullscreen = ref(false)
 // it?" is not a question this component can answer. Reloading the playground
 // without a fragment gives a normal, raw-HTML-enabled session back.
 const fromSharedLink = ref(false)
+// The engine the sender was on. A link made in Rust mode still opens on JS
+// (see applyShareLink), so the preview has to say that rather than let the
+// recipient assume they are looking at what the sender saw.
+const sharedEngine = ref<Engine | null>(null)
 // Feedback for the share button. It reports through the icon (plus an
 // aria-live line for screen readers) rather than a text label beside it: a
 // label that appears and disappears would reflow the toolbar row each time.
@@ -56,9 +60,24 @@ async function applyShareLink(): Promise<void> {
   source.value = state.source
   // The Rust engine renders through a WASM binding with no options, so raw
   // HTML cannot be turned off there. A shared document therefore stays on the
-  // JS engine (see the disabled button in the toolbar).
+  // JS engine (see the disabled button in the toolbar). The two engines do not
+  // carry the same extension set, so a link made in Rust mode can render
+  // differently here - `sharedEngine` is what the note reports.
+  sharedEngine.value = state.engine === 'rust' ? 'rust' : 'js'
   engine.value = 'js'
 }
+
+const sharedNoteText = computed<string>(() =>
+  sharedEngine.value === 'rust'
+    ? 'shared link: raw HTML off, JavaScript engine'
+    : 'shared link: raw HTML off',
+)
+
+const sharedNoteTitle = computed<string>(() =>
+  sharedEngine.value === 'rust'
+    ? 'This document arrived in a link made in Rust (WASM) mode. The WASM build cannot turn raw HTML off, so it renders here on the JavaScript engine instead - which carries a few extensions carve-rs does not, so the output can differ from what the sender saw.'
+    : 'This document arrived in a link, so raw HTML is not rendered and the Rust engine is not offered',
+)
 
 function shareUrl(encoded: string): string {
   const { origin, pathname, search } = window.location
@@ -700,9 +719,9 @@ void mermaidInit
             v-if="fromSharedLink"
             class="pg-shared-note"
             role="note"
-            title="This document arrived in a link, so raw HTML is not rendered and the Rust engine is not offered"
+            :title="sharedNoteTitle"
           >
-            shared link: raw HTML off
+            {{ sharedNoteText }}
           </span>
         </div>
         <div

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -411,6 +411,14 @@
   border-radius: 6px;
   display: block;
 }
+
+/* VitePress' reset makes every image a block. Carve keeps an image that shares
+ * a paragraph inline, and the playground is where that difference is taught. */
+.carve-render p img {
+  display: inline;
+  max-width: 100%;
+  height: auto;
+}
 .carve-render figcaption {
   margin-top: 0.45rem;
   padding-left: 0.6rem;

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -56,6 +56,8 @@ that remain in the paragraph, and closing markers that do not start a block.
 |---|:---:|:---:|:---:|:---:|
 | Tables | 🧩 GFM | ✅ | 🧩 GFM | ✅ |
 | Table rowspan / colspan | ❌ | ❌ | ❌ | ✅ |
+| Captions on figures, tables, code, quotes | 🧩 Pandoc, images only | ⚠️ tables only | 🧩 component | ✅ one `^ ` line, every captionable block |
+| A lone image is a block | ❌ wrapped in `<p>` | ❌ wrapped in `<p>` | ❌ | ✅ bare `<img>`, so a caption has a host |
 | Footnotes | 🧩 | ✅ | 🧩 | ✅ |
 | Math | 🧩 | ✅ | 🧩 | ✅ |
 | Definition lists | 🧩 | ✅ | 🧩 | ✅ |
@@ -66,6 +68,13 @@ that remain in the paragraph, and closing markers that do not start a block.
 | Editorial / critic markup | ❌ | ❌ | ❌ | ✅ |
 | Frontmatter | ⚠️ tooling | ❌ | 🧩 | ✅ |
 | Symbols / emoji shortcodes | 🧩 | ✅ symbols, mapped via filters | 🧩 | ✅ `:name:` symbols, mapped via config |
+
+Djot already spells a table caption `^ Caption`. Carve keeps that spelling and
+lets it attach to any captionable block. The two rules work together: a lone
+image is a block rather than paragraph text, which is what gives the caption
+line something to attach to, and the pair renders as `<figure>` with a
+`<figcaption>`. Markdown and Djot wrap the same image in a paragraph, so the
+caption has to be written as raw HTML.
 
 ## Docs & cross-referencing
 


### PR DESCRIPTION
Three things, all from one question: does Carve treat images as block elements?

## The comparison table did not say so

It carried no row for captions and none for block images, so the page a reader
uses to choose between the languages was silent about a divergence that changes
the HTML of an everyday document. Both new cells were measured rather than
recalled: Djot renders `^ Caption` after a table as `<caption>` and the same
line after an image as literal text, and Pandoc's implicit_figures is
images-only with the alt text as the caption.

## The docs site styled every image as a block

VitePress' reset carries `img,svg,video,canvas,audio,iframe,embed,object { display: block }`
and nothing restored inline, so an image sharing a paragraph rendered on its own
line in the playground preview - indistinguishable from a promoted block image.
The playground is where that positional rule is taught.

Everything inside a `<p>` is inline by construction, so `.carve-render p img`
is exact. It cannot be pushed further: a promoted block image and an inline
image in a tight list item are both `li > img`, which no selector can tell
apart. Same blind spot that hid the engine disagreement in #1660.

## A shared link silently changed engine

`copyShareLink` encodes the sender's engine and `applyShareLink` overwrote it
with `js`, unread. The override is correct and stays - the WASM binding exposes
no raw-HTML switch (measured: it emits a `=html` payload unescaped), so a
document written by whoever sent the link must render where `allowRawHtml` can
be turned off. What was missing is telling the recipient. The engines do not
carry the same extension set, so a document built and checked in Rust mode can
render differently for whoever opens the link, and the only hint was a tooltip
about raw HTML on a disabled button.

Follow-ups filed elsewhere: markup-carve/carve-wasm#70 asks for the `rawHtml`
option that would let a shared link honor its engine and retire this note, and
markup-carve/carve-css#8 covers a bare block image having no sizing of its own
in the shipped stylesheet - masked here by VitePress' reset, not masked for
anyone else.
