### PR TITLE
A closed fence in a description body ends it

### DIFF
--- a/docs/implementation-comparison-methodology.md
+++ b/docs/implementation-comparison-methodology.md
@@ -59,7 +59,9 @@ Corpus added since this run: `441-a-definition-between-two-open-content-columns-
 `447-the-host-does-not-change-which-column-a-definition-reaches`,
 `448-a-marker-folds-into-a-quote-below-it`
 and
-`449-a-comment-below-a-description-body-s-column-ends-the-body`.
+`449-a-comment-below-a-description-body-s-column-ends-the-body`
+and
+`450-a-closed-fence-in-a-description-body-ends-it`.
 
 Each landed on a host with no engine checkouts, so the run above could not be
 retaken and its numbers describe the corpus WITHOUT them. Editing the

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -615,6 +615,7 @@ index: examples/edge-cases/index.md
   the-host-does-not-change-which-column-a-definition-reaches
   below-a-definition-body-s-column-an-invisible-line-folds-as-text
   a-comment-below-a-description-body-s-column-ends-the-body
+  a-closed-fence-in-a-description-body-ends-it
   an-abbreviation-definition-outside-document-level-is-not-an-invisible-line
 [edge-attributes] Attributes
 > Attribute lines and inline blocks, names and values, classes, booleans and the semantic/language sugar.

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -33723,3 +33723,128 @@ the two axes crossed, so neither can be read as the one doing the work.
 ```
 
 :::
+
+## A closed fence in a description body ends it
+
+`A FENCED BODY IS NOT A PARAGRAPH` and `FENCE KIND DOES NOT DETERMINE CONTAINER
+REACH` say S4's lazy branch asks for an OPEN PARAGRAPH, and that a code fence
+body cannot hold one at all. So a body whose last block is a CLOSED fence has
+nothing for the flush-left line to continue, and the line is the document's.
+The list-item host pins the same answer at `270-a-real-div-in-a-container-and-the-flush-left-line-after-it-3`
+and `86-list-lazy-continuation-7`; these rows pin the description-body host
+(markup-carve/carve#1930).
+
+::: compare
+
+```carve
+:: term
+:  definition
+   ::: note
+   body
+   :::
+tail
+```
+
+```html
+<dl>
+  <dt>term</dt>
+  <dd>
+    <p>definition</p>
+    <aside class="admonition note" aria-label="Note">
+      <p>body</p>
+    </aside>
+  </dd>
+</dl>
+<p>tail</p>
+```
+
+:::
+
+The CODE-fence spelling of the same rule, which is the one the normative clause
+names outright.
+
+::: compare
+
+```carve
+:: term
+:  definition
+   ```
+   c
+   ```
+tail
+```
+
+```html
+<dl>
+  <dt>term</dt>
+  <dd>
+    <p>definition</p>
+    <pre><code>c
+</code></pre>
+  </dd>
+</dl>
+<p>tail</p>
+```
+
+:::
+
+CONTROL -- an UNTERMINATED fence is the opposite answer, and the reason the rule
+is about the closed fence rather than about the fence line: an unterminated
+fence opens no block, so the paragraph above it is still open and the flush-left
+line folds into the body.
+
+::: compare
+
+```carve
+:: term
+:  definition
+   ```
+   c
+tail
+```
+
+```html
+<dl>
+  <dt>term</dt>
+  <dd>definition
+<code>
+c
+tail</code></dd>
+</dl>
+```
+
+:::
+
+A `:::` INSIDE A CODE FENCE is payload, not the container's closer. The rule
+reads the body's fence state, and a code fence's contents are opaque to it -
+mistaking the payload for the closer would make the real closer look like an
+opener and pull the flush-left line back in.
+
+::: compare
+
+````carve
+:: term
+:  definition
+   ::: note
+   ```
+   :::
+   ```
+   :::
+tail
+````
+
+````html
+<dl>
+  <dt>term</dt>
+  <dd>
+    <p>definition</p>
+    <aside class="admonition note" aria-label="Note">
+      <pre><code>:::
+</code></pre>
+    </aside>
+  </dd>
+</dl>
+<p>tail</p>
+````
+
+:::

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,17 +1,17 @@
 {
   "engine": "@markup-carve/carve",
   "engineCommit": "4e2023768c81e12db09cfb8a9da56e12327c017e",
-  "corpusDocuments": 1645,
+  "corpusDocuments": 1649,
   "htmlImportPopulation": {
-    "completed": 1644,
-    "canonicalFixedPoints": 1643,
-    "renderedTextPreserved": 1629,
+    "completed": 1648,
+    "canonicalFixedPoints": 1647,
+    "renderedTextPreserved": 1633,
     "expectedRejections": [
       "182-openers-past-the-nesting-cap-are-one-paragraph.crv"
     ]
   },
   "renderImportRoundTrips": {
-    "html": 671,
+    "html": 674,
     "markdown": 406
   }
 }

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -1472,7 +1472,75 @@ function bodyLeavesParagraphOpen(bodyLines, quoted = false, depth = 0) {
     return bodyLeavesParagraphOpen(inner, true, depth + 1)
   }
 
+  // A CLOSED FENCE IS NOT AN OPEN PARAGRAPH (carve#1930). `opensParagraph` is
+  // handed the body's last LINE and has no fence branch, so a bare ``` or a bare
+  // `:::` fell through to its `return true` and reported a paragraph open -
+  // folding the flush-left line below into a `dd` whose last block was a closed
+  // block. `A FENCED BODY IS NOT A PARAGRAPH` and `FENCE KIND DOES NOT DETERMINE
+  // CONTAINER REACH` (both NORMATIVE, resources/spec/01-layout.ebnf) say S4's
+  // lazy branch asks for an OPEN paragraph, and that a code fence body cannot
+  // hold one at all.
+  //
+  // An UNTERMINATED fence is the opposite answer and keeps the old one: it opens
+  // no block, so the paragraph above it is still open (corpus
+  // `367-an-unterminated-fence-at-a-content-column-opens-no-block-so-the-paragraph-stays-open`).
+  if (bodyClosesAFenceAt(bodyLines, last)) return false
+
   return opensParagraph(bodyLines[last], false, tableOpenAfter(bodyLines.slice(0, last)))
+}
+
+// Whether the body's line `last` CLOSES a fence opened earlier in the body.
+//
+// Tracked from the top rather than pattern-matched on the one line, because a
+// bare ``` is an opener and a closer in the same shape: which one it is depends
+// on every line above it. A code fence's payload is OPAQUE and is skipped
+// wholesale - a `:::` line inside one is content, and reading it as a colon
+// fence's closer would make the real closer look like an opener and fold the
+// line below back into the body.
+function bodyClosesAFenceAt(bodyLines, last) {
+  let closedAt = -1
+  let k = 0
+  while (k <= last) {
+    const code = FENCE.exec(bodyLines[k])
+    if (code && parseFenceInfo(code[2]) !== null) {
+      const end = findCloser(bodyLines, k, code[1])
+      // An unterminated fence opens no block, so nothing below it is closed
+      // either: the paragraph above stays open and `opensParagraph` answers.
+      if (end === -1 || end > last) return false
+      closedAt = end
+      k = end + 1
+      continue
+    }
+    if (isColonBlockOpener(bodyLines[k]) && !COLON_CLOSER.test(bodyLines[k])) {
+      const run = COLON_FENCE.exec(bodyLines[k])[1]
+      const end = findColonCloserSkippingCode(bodyLines, k, run, last)
+      if (end === -1) return false
+      closedAt = end
+      k = end + 1
+      continue
+    }
+    k++
+  }
+  return closedAt === last
+}
+
+// The colon fence opened at `openIdx` closes on a BARE run of its own length
+// (PART 2). Code-fence payloads in between are opaque and are stepped over.
+function findColonCloserSkippingCode(bodyLines, openIdx, run, last) {
+  let j = openIdx + 1
+  while (j <= last) {
+    const code = FENCE.exec(bodyLines[j])
+    if (code && parseFenceInfo(code[2]) !== null) {
+      const inner = findCloser(bodyLines, j, code[1])
+      if (inner === -1 || inner > last) return -1
+      j = inner + 1
+      continue
+    }
+    const closer = COLON_CLOSER.exec(bodyLines[j])
+    if (closer && closer[1].length === run.length) return j
+    j++
+  }
+  return -1
 }
 
 // A sub-BLOCK attached to an open list item after a blank line: it nests and

--- a/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-2.crv
+++ b/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-2.crv
@@ -1,0 +1,6 @@
+:: term
+:  definition
+   ```
+   c
+   ```
+tail

--- a/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-2.html
+++ b/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-2.html
@@ -1,0 +1,9 @@
+<dl>
+  <dt>term</dt>
+  <dd>
+    <p>definition</p>
+    <pre><code>c
+</code></pre>
+  </dd>
+</dl>
+<p>tail</p>

--- a/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-3.crv
+++ b/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-3.crv
@@ -1,0 +1,5 @@
+:: term
+:  definition
+   ```
+   c
+tail

--- a/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-3.html
+++ b/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-3.html
@@ -1,0 +1,7 @@
+<dl>
+  <dt>term</dt>
+  <dd>definition
+<code>
+c
+tail</code></dd>
+</dl>

--- a/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-4.crv
+++ b/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-4.crv
@@ -1,0 +1,8 @@
+:: term
+:  definition
+   ::: note
+   ```
+   :::
+   ```
+   :::
+tail

--- a/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-4.html
+++ b/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it-4.html
@@ -1,0 +1,11 @@
+<dl>
+  <dt>term</dt>
+  <dd>
+    <p>definition</p>
+    <aside class="admonition note" aria-label="Note">
+      <pre><code>:::
+</code></pre>
+    </aside>
+  </dd>
+</dl>
+<p>tail</p>

--- a/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it.crv
+++ b/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it.crv
@@ -1,0 +1,6 @@
+:: term
+:  definition
+   ::: note
+   body
+   :::
+tail

--- a/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it.html
+++ b/tests/corpus/450-a-closed-fence-in-a-description-body-ends-it.html
@@ -1,0 +1,10 @@
+<dl>
+  <dt>term</dt>
+  <dd>
+    <p>definition</p>
+    <aside class="admonition note" aria-label="Note">
+      <p>body</p>
+    </aside>
+  </dd>
+</dl>
+<p>tail</p>

--- a/tests/spec/450-a-closed-fence-in-a-description-body-ends-it.test
+++ b/tests/spec/450-a-closed-fence-in-a-description-body-ends-it.test
@@ -1,0 +1,79 @@
+A closed fence in a description body ends it
+
+```
+:: term
+:  definition
+   ::: note
+   body
+   :::
+tail
+.
+<dl>
+  <dt>term</dt>
+  <dd>
+    <p>definition</p>
+    <aside class="admonition note" aria-label="Note">
+      <p>body</p>
+    </aside>
+  </dd>
+</dl>
+<p>tail</p>
+```
+
+````
+:: term
+:  definition
+   ```
+   c
+   ```
+tail
+.
+<dl>
+  <dt>term</dt>
+  <dd>
+    <p>definition</p>
+    <pre><code>c
+</code></pre>
+  </dd>
+</dl>
+<p>tail</p>
+````
+
+````
+:: term
+:  definition
+   ```
+   c
+tail
+.
+<dl>
+  <dt>term</dt>
+  <dd>definition
+<code>
+c
+tail</code></dd>
+</dl>
+````
+
+````
+:: term
+:  definition
+   ::: note
+   ```
+   :::
+   ```
+   :::
+tail
+.
+<dl>
+  <dt>term</dt>
+  <dd>
+    <p>definition</p>
+    <aside class="admonition note" aria-label="Note">
+      <pre><code>:::
+</code></pre>
+    </aside>
+  </dd>
+</dl>
+<p>tail</p>
+````


### PR DESCRIPTION
Closes #1930.

The comment half of that ticket is already fixed by #1934, so this is the fence
half only.

The oracle folded a flush-left line into a `dd` whose last block was a CLOSED
fence, where all three engines publish it at document level:

```
:: term
:  definition
   ::: note
   body
   :::
tail
```

`bodyLeavesParagraphOpen` asks `opensParagraph` about the body's last LINE, and
that predicate has no fence branch at all - a bare ``` or a bare `:::` falls
through to its final `return true` and reports a paragraph open. `A FENCED BODY
IS NOT A PARAGRAPH` and `FENCE KIND DOES NOT DETERMINE CONTAINER REACH` (both
NORMATIVE) say S4's lazy branch asks for an OPEN paragraph and that a code fence
body cannot hold one, and the list-item host is pinned the other way at corpus
270 and 86.

The fence state is tracked from the top of the body rather than pattern-matched
on the one line, because a bare ``` is an opener and a closer in the same shape
and only the lines above it decide which.

**A code fence's payload is opaque.** A `:::` inside one is content; reading it
as the colon fence's closer would make the real closer look like an opener and
fold the line below back in. That was a live bug in my first version of the
tracker, caught in review, and it is pinned as its own row.

**An unterminated fence keeps the old answer**, which is why the rule is about
the closed fence rather than about the fence line: it opens no block, so the
paragraph above it is still open.

Four pairs, including both controls. Nothing else would catch a regression here
- two carve-js tickets were filed against the oracle's reading with the sign
backwards before anyone measured it.

Measured against carve-rs `aea04297` on every row: it agrees with all four.
carve-js and carve-php were measured on the same shapes in the ticket.
