### PR TITLE
spec: a leaf span begins at its markup, a container keeps the indent latitude

### DIFF
--- a/docs/ast-json-contract.md
+++ b/docs/ast-json-contract.md
@@ -249,6 +249,14 @@ both are stated in §4: the inner half of a combined `/*x*/`, whose span is the
 outer one trimmed by the two-character delimiters, and a table cell, which runs
 between the pipes because the `|` opens the row.
 
+**Leading indentation belongs to the span only where it places the construct.**
+A nested container may begin part way into that run, at its parent's content
+column, because the run is what puts its marker where it is. A **leaf** has no
+marker to place, so its span begins at the markup itself: a comment written at a
+description body's content column begins at the `%`, not at the first space of
+the indentation before it. Both readings used to satisfy this sentence, which is
+what markup-carve/carve#1928 settled.
+
 A span **ends immediately after the last source codepoint the construct owns**.
 Closing delimiters and attached attributes are included; a following newline,
 blank line, or unattached attribute block is not. Containers end at their

--- a/scripts/ast-conformance.mjs
+++ b/scripts/ast-conformance.mjs
@@ -487,6 +487,14 @@ function reportValueDisagreements(present) {
  * rule for that end says the WIDE one does - carve#1637, where six of eight
  * rows were end-only and the text pointed at the one engine with no end-side
  * finding at all.
+ *
+ * THE START HALF HAD THE SAME DEFECT, one ruling later. It told the reader that
+ * a row differing only inside the leading indentation was owed by nobody, which
+ * was true while `checkOpeningMarkup` walked that run for every type. carve#1928
+ * withdrew the latitude from LEAF types, so on those rows the engine starting in
+ * the indent does owe it - and the old text named carve-php, the engine that
+ * begins at the markup, as the one to change. Both halves now say which side
+ * only after the row says which rule applies.
  */
 function reportSpanDisagreements(present) {
   const byKey = new Map()
@@ -551,10 +559,13 @@ function reportSpanDisagreements(present) {
     }
     console.log('  EXTENT rows are PART 12 §4, and WHICH END moved decides which engine owes it:')
     console.log('    startOffset differs - a span "begins at the markup that opens the construct",')
-    console.log('      so the engine spanning the content alone moves (carve#913, checkOpeningMarkup),')
-    console.log('      UNLESS the starts differ only inside the line\'s LEADING INDENTATION.')
-    console.log('      checkOpeningMarkup walks over that run before matching a marker, so both')
-    console.log('      readings pass it and no engine owes the row (carve#1928).')
+    console.log('      so the engine that starts LATER, at the markup, is the conformant one and')
+    console.log('      the earlier engine moves (carve#913, checkOpeningMarkup).')
+    console.log('      WHERE THE STARTS DIFFER ONLY INSIDE THE LEADING INDENTATION, the type')
+    console.log('      decides: a CONTAINER may begin part way into that run at its parent\'s')
+    console.log('      content column, so no engine owes the row; a LEAF begins at its markup, so')
+    console.log('      the engine starting in the indent owes it (carve#1928,')
+    console.log('      INDENT_LATITUDE in scripts/spec/ast-positions.mjs).')
     console.log('    endOffset differs, startOffset unanimous - a span "ends immediately after the')
     console.log('      last source codepoint the construct owns", and a container with no closer ends')
     console.log('      at its last child, so the WIDE engine moves (checkStopsAtChildren, over the')
@@ -576,13 +587,17 @@ function reportSpanDisagreements(present) {
       'the source - and WHICH RULE names a side depends on WHICH END of the span moved.',
       'PART 12 §4 has two sentences and they point at different checkers:',
       '  START. A span "begins at the markup that opens the construct"',
-      '  (markup-carve/carve#913), so an engine spanning the content alone is the one that',
-      '  moves. checkOpeningMarkup in scripts/spec/ast-positions.mjs is the source-side rule.',
-      '  It permits a start anywhere in the line\'s LEADING INDENTATION, because the indent',
-      '  is what places a nested item\'s marker - so on a row where the starts differ only',
-      '  inside that run, both readings pass it and NEITHER engine owes the row. Taking the',
-      '  sentence literally there names the engine that begins at the markup, which is the',
-      '  conformant one (markup-carve/carve#1928).',
+      '  (markup-carve/carve#913), so the engine that starts EARLIER - short of the markup -',
+      '  is the one that moves. checkOpeningMarkup in scripts/spec/ast-positions.mjs is the',
+      '  source-side rule, and it does NOT name one side for every row: where the starts',
+      '  differ only inside the line\'s LEADING INDENTATION the TYPE decides. A CONTAINER may',
+      '  begin part way into that run, at its parent\'s content column, because the run is',
+      '  what places its marker - there both readings pass and neither engine owes the row.',
+      '  A LEAF has no marker to place, so it begins at the markup and the engine starting',
+      '  in the indent owes it (markup-carve/carve#1928; the set is INDENT_LATITUDE).',
+      '  Read the node TYPE off the row before naming a side. Reading every indent row as',
+      '  "nobody owes it" named carve-php, which begins at the markup, as the one to change',
+      '  on 444-an-opener-at-or-past-a-description-body-s-column-closes-its-paragraph-9.',
       '  END. A span "ends immediately after the last source codepoint the construct owns",',
       '  and a container with no closer "ends at its last child", so on those rows the WIDE',
       '  engine is the one that moves. checkStopsAtChildren, over the types in',

--- a/scripts/declaration-audit.mjs
+++ b/scripts/declaration-audit.mjs
@@ -236,6 +236,17 @@ const MANIFEST = [
   // - and two name coverage that carve#1878 may or may not close.
   { repo: 'spec', path: 'tests/html-import-contract.check.mjs', name: 'NOT_COVERED_HERE', kind: 'js', policy: 'manual', guard: 'two-way', owner: 'npm run html-import:check' },
   { repo: 'spec', path: 'tests/ast-positions.test.mjs', name: 'DECLARED_OVER_REACH', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'tests/ast-positions.test.mjs' },
+  // carve#1928's ruling made a LEAF begin at its markup, so fourteen corpus
+  // documents are owed by carve-js and carve-rs until they move. `manual` for
+  // the reason DECLARED_UNREACHABLE below is: the count is judged by the test
+  // that owns the list, which compares it against a live measurement and so
+  // fails in BOTH directions, and the reasons on each row are for the reader.
+  //
+  // NOT `declared`: that policy needs `<slug><two spaces><reason>`, and
+  // `liveRows` collapses every whitespace run in a `js` row to one space - so
+  // `declared` on a `js` entry reports every row UNDECLARED and can never pass.
+  // Filed as markup-carve/carve#1939; when it is fixed this entry can move.
+  { repo: 'spec', path: 'tests/ast-positions.test.mjs', name: 'DECLARED_LEAF_INDENT_START', kind: 'js', policy: 'manual', guard: 'two-way', owner: 'tests/ast-positions.test.mjs' },
   { repo: 'spec', path: 'tests/the-two-import-exits-agree.test.mjs', name: 'UNMET', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'tests/the-two-import-exits-agree.test.mjs' },
   { repo: 'spec', path: 'tests/optional-corpus.test.mjs', name: 'AHEAD_OF_PIN', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'tests/optional-corpus.test.mjs' },
   { repo: 'spec', path: 'tests/examples-tier3.test.mjs', name: 'AHEAD_OF_PIN', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'tests/a-tier3-example-ahead-of-the-pin-is-declared.test.mjs' },

--- a/scripts/spec/ast-positions.mjs
+++ b/scripts/spec/ast-positions.mjs
@@ -487,6 +487,41 @@ export const OPENING_MARKUP = new Map(
  * all. Zero findings and zero examined are the same output from a clean run
  * and from a run that never happened.
  */
+/**
+ * The types whose span may begin PART WAY into the line's leading indentation.
+ *
+ * BLOCK CONTAINERS ONLY, which is markup-carve/carve#1928's ruling: a LEAF span
+ * begins at its markup, a CONTAINER keeps the indent latitude. The reason the
+ * latitude exists is container-specific - the indent is what places a nested
+ * item's marker, and a nested list's span legitimately starts at its parent's
+ * content column rather than at the marker (corpus 245 and two others). That
+ * reason does not reach a leaf, and until the ruling nothing narrowed it, so a
+ * leaf inherited the latitude by accident and PART 12 §4's sentence had two
+ * conformant readings.
+ *
+ * Measured over the corpus before it was narrowed: of 3362 spans this rule
+ * examines, exactly three types passed ONLY because of the walk - `list` (10)
+ * and `list_item` (12), which are the reason it exists, and `comment` (14),
+ * which is the leaf the ruling moves. Every other type already matched at its
+ * own `startOffset`, so naming the containers costs nothing that was relying on
+ * it.
+ *
+ * A TYPE SET rather than "has children", for the reason `OPENING_MARKUP` is
+ * one: an EMPTY container is still a container, and a leaf that happens to hold
+ * inline children (a `heading`, a `link`) is still reached by its own markup
+ * rather than placed by an indent run.
+ */
+export const INDENT_LATITUDE = new Set([
+  'admonition',
+  'block_quote',
+  'definition_list',
+  'div',
+  'line_block',
+  'list',
+  'list_item',
+  'table',
+])
+
 export function checkOpeningMarkup(doc, codepoints, findings) {
   let examined = 0
   for (const [node, path] of walkNodes(doc)) {
@@ -500,16 +535,21 @@ export function checkOpeningMarkup(doc, codepoints, findings) {
     if (!pos || !Number.isInteger(pos.startOffset) || !Number.isInteger(pos.endOffset)) continue
     if (pos.startOffset > codepoints.length) continue
     // LEADING INDENTATION, and the line's own - not any whitespace the span
-    // happens to open on. The clause puts the indent inside the span because the
-    // indent is what places a nested item's marker, and a nested list's span
-    // legitimately starts PART WAY into that run, at its parent's content
-    // column (corpus 245 and two others). What the run may not do is skip
-    // whitespace that follows text on the line: a span opening on a space in
-    // mid-line has not begun at the construct's markup, and walking past it
+    // happens to open on. The clause puts the indent inside a CONTAINER's span
+    // because the indent is what places a nested item's marker, and a nested
+    // list's span legitimately starts PART WAY into that run, at its parent's
+    // content column (corpus 245 and two others). What the run may not do is
+    // skip whitespace that follows text on the line: a span opening on a space
+    // in mid-line has not begun at the construct's markup, and walking past it
     // turned that into a pass.
+    //
+    // A LEAF GETS NO SUCH LATITUDE (markup-carve/carve#1928). The reason above
+    // is about placing a child's marker, so it says nothing about a construct
+    // with no children to place, and §4 reads literally there: the span begins
+    // at the markup. `INDENT_LATITUDE` is the set the reason reaches.
     let at = pos.startOffset
-    let indented = true
-    for (let k = at - 1; k >= 0; k--) {
+    let indented = INDENT_LATITUDE.has(node.type)
+    for (let k = at - 1; indented && k >= 0; k--) {
       const c = codepoints[k]
       if (c === '\n' || c === '\r') break
       if (c !== ' ' && c !== '\t') { indented = false; break }

--- a/tests/ast-positions.test.mjs
+++ b/tests/ast-positions.test.mjs
@@ -344,7 +344,13 @@ test('no corpus document has a span starting on a line terminator', () => {
         // pinned below and fails in both directions, so nothing is lost by
         // filtering it out here.
         !f.startsWith('span reaches past its last child') &&
-        !f.startsWith('span covers more than its own markup'),
+        !f.startsWith('span covers more than its own markup') &&
+        // AND NOT carve#1928's leaf/indent class, declared document by document
+        // in the opening-markup test below, for the same reason: this test's
+        // subject is a span starting on a line terminator, and fourteen
+        // findings of another class landing in it would bury the one it exists
+        // to catch.
+        !f.startsWith('pos does not begin at the markup that opens'),
     )
     assert.deepEqual(unexpected, [], `${name}\n${unexpected.join('\n')}`)
   }
@@ -937,6 +943,42 @@ test('a nested list starting part way into the indent run is accepted', () => {
   assert.deepEqual(findingsFor(doc, source), [])
 })
 
+/*
+ * THE CORPUS, DECLARED RED, for the START rule.
+ *
+ * markup-carve/carve#1928 ruled that a LEAF span begins at its markup and only
+ * a CONTAINER keeps the indent latitude, so `checkOpeningMarkup` stopped walking
+ * the leading run for leaf types. Fourteen corpus documents place a `comment`
+ * one to three codepoints into that run in the carve-js this repository pins,
+ * and each is now reported rather than passing on latitude the ruling withdrew.
+ *
+ * Every one is the same shape: the span starts on a space and the `%` is one to
+ * three codepoints later. carve-php already begins at the markup and owes none
+ * of them; the ports are markup-carve/carve-js#1631 and
+ * markup-carve/carve-rs#1549.
+ *
+ * IT FAILS IN BOTH DIRECTIONS, like DECLARED_OVER_REACH below: a document that
+ * starts violating is not on the list and fails, and one that stops is on the
+ * list with a count that no longer matches. Deleting lines here is the closing
+ * step of each engine's fix.
+ */
+const DECLARED_LEAF_INDENT_START = [
+  '183-a-comment-is-recognized-at-any-column.crv 1  a comment at an item content column; carve-js starts 1 codepoint short of the `%`',
+  '187-a-comment-fence-is-a-comment-at-any-column-too.crv 1  the fence spelling of the same shape, 1 short',
+  '189-a-comment-under-a-nested-item-does-not-close-it.crv 1  nested item, 1 short',
+  '191-a-blank-after-a-comment-still-ends-the-item.crv 1  nested item, 1 short',
+  '192-a-comment-fence-under-a-nested-item-does-not-close-it-either.crv 1  nested item, fence spelling, 1 short',
+  '26-comments-7.crv 1  indented comment, 2 short',
+  '26-comments-8.crv 1  indented comment, 2 short',
+  '430-below-a-definition-body-s-column-an-invisible-line-folds-as-text-5.crv 1  below a description body column, 2 short',
+  '444-an-opener-at-or-past-a-description-body-s-column-closes-its-paragraph-9.crv 1  carve#1928 own row: offset 25 vs the `%` at 26; carve-php already at 26',
+  '446-a-degraded-comment-fence-leaves-a-lazy-follower-where-the-line-form-does-9.crv 1  degraded fence, 2 short',
+  '449-a-comment-below-a-description-body-s-column-ends-the-body-11.crv 1  description body column, 1 short',
+  '449-a-comment-below-a-description-body-s-column-ends-the-body-12.crv 1  description body column, 2 short',
+  '449-a-comment-below-a-description-body-s-column-ends-the-body-13.crv 1  description body column, 1 short',
+  '449-a-comment-below-a-description-body-s-column-ends-the-body-6.crv 1  description body column, 3 short',
+]
+
 test('no corpus document begins a span away from its opening markup', () => {
   // The synthetic documents above prove the rule fires; this proves it does not
   // fire on a real one, over every type the table names. The EXAMINED count is
@@ -945,6 +987,7 @@ test('no corpus document begins a span away from its opening markup', () => {
   const dir = resolve(repo, 'tests/corpus')
   const cases = readdirSync(dir).filter((name) => name.endsWith('.crv'))
   let examined = 0
+  const measured = new Map()
   for (const name of cases) {
     const raw = readFileSync(resolve(dir, name), 'utf8')
     // Measured against the source PART 0 INPUT hands the parser, not the
@@ -957,8 +1000,16 @@ test('no corpus document begins a span away from its opening markup', () => {
     const source = replaceNulls(raw)
     const findings = []
     examined += checkOpeningMarkup(parse(raw), [...source], findings)
-    assert.deepEqual(findings, [], `${name}\n${findings.join('\n')}`)
+    if (findings.length > 0) measured.set(name, findings.length)
   }
+  assert.deepEqual(
+    [...measured.entries()].map(([name, count]) => `${name} ${count}`).sort(),
+    // The KEY half only. Each row also carries a reason after two spaces,
+    // which is what `npm run declarations:pr` requires of a declared ledger -
+    // a bare slug there is a window TOLERATED rather than declared.
+    [...DECLARED_LEAF_INDENT_START].map((row) => row.split(/\s{2,}/)[0]).sort(),
+    'update DECLARED_LEAF_INDENT_START in the commit that moves the engines, never to quiet a run',
+  )
   assert.ok(examined > 1000, `only ${examined} span(s) reached the opening-markup rule`)
 })
 


### PR DESCRIPTION
Closes #1928.

**The ruling.** A LEAF span begins at its markup. A CONTAINER keeps the indent
latitude. `checkOpeningMarkup` walked the leading indent run before matching a
marker for every node type; its own comment gives a container-specific reason
(the indent is what places a nested item's marker, and a nested list's span
legitimately starts at its parent's content column, corpus 245). Nothing
narrowed it, so a leaf inherited the latitude by accident and PART 12 §4 had two
conformant readings.

**What decides the set.** `INDENT_LATITUDE` is the block-container types the
reason reaches. Measured over the corpus BEFORE narrowing, of the 3362 spans the
rule examines, exactly three types passed only because of the walk:

| type | spans passing only via the walk |
| --- | --- |
| `comment` | 14 |
| `list_item` | 12 |
| `list` | 10 |

`list` and `list_item` are the reason the latitude exists; `comment` is the leaf
the ruling moves. Every other type already matched at its own `startOffset`, so
naming the containers costs nothing that was relying on it.

**Blast radius.** This oracle arbitrates for all three engines, so the direction
matters more than the count. Against the pinned carve-js: **14 documents newly
reported, 0 stop being reported.** All fourteen are one shape - the span starts
on a space and the `%` is one to three codepoints later - so every one moves an
engine TOWARD the markup and none away from it. carve-php begins at the markup
and is not reported at all, by construction of the rule rather than by
exemption. The ticket's own row reproduces exactly: `444-...-9` at offset 25
against the `%` at 26.

Declared in `DECLARED_LEAF_INDENT_START`, which fails in both directions, and
owed by markup-carve/carve-js#1631 and markup-carve/carve-rs#1549.

**The panel's advice was inverted for this shape**, which is the same defect
#1637 fixed on the END half. It said a row differing only inside the leading
indentation was owed by nobody - true while the walk applied to every type, and
after the ruling it named carve-php, the one conformant engine, as the one to
change. Both halves now name a side only after the row says which rule applies,
and the START half tells the reader to look at the node TYPE first.

**One thing found on the way.** The list is registered `manual` rather than
`declared`, because a `declared` policy can never pass on a `js` entry:
`liveRows` collapses every whitespace run to one space, and
`undeclaredLedgerRows` needs the two-space separator it just removed. Latent - no
`js` entry used `declared` before - and filed as #1939 with a suggested fix. The
`manual` policy is accurate here regardless: the two-way gate is the test that
owns the list and compares it against a live measurement.

**What makes this row unusual.** All three engines produce the same tree and the
same HTML; only the positions differ, and `checkOpeningMarkup` reported none of
the three. The row could not be retired by fixing an engine, which is why it
needed a ruling rather than a port.

**Gates.** `test`, `core:check`, `spec:check`, `spec:rules:check`,
`html-import:check`, `escape:check`, `grammar:reach`, `docs:pages`,
`docs:build`, `engine:report -- --check`, `declarations:pr`. `codex review`
raised nothing.