### PR TITLE
fix(tooling): let the `declared` policy pass on a list read from source

### DIFF
--- a/scripts/declaration-audit.mjs
+++ b/scripts/declaration-audit.mjs
@@ -246,7 +246,7 @@ const MANIFEST = [
   // `liveRows` collapses every whitespace run in a `js` row to one space - so
   // `declared` on a `js` entry reports every row UNDECLARED and can never pass.
   // Filed as markup-carve/carve#1939; when it is fixed this entry can move.
-  { repo: 'spec', path: 'tests/ast-positions.test.mjs', name: 'DECLARED_LEAF_INDENT_START', kind: 'js', policy: 'manual', guard: 'two-way', owner: 'tests/ast-positions.test.mjs' },
+  { repo: 'spec', path: 'tests/ast-positions.test.mjs', name: 'DECLARED_LEAF_INDENT_START', kind: 'js', policy: 'declared', guard: 'two-way', owner: 'tests/ast-positions.test.mjs' },
   { repo: 'spec', path: 'tests/the-two-import-exits-agree.test.mjs', name: 'UNMET', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'tests/the-two-import-exits-agree.test.mjs' },
   { repo: 'spec', path: 'tests/optional-corpus.test.mjs', name: 'AHEAD_OF_PIN', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'tests/optional-corpus.test.mjs' },
   { repo: 'spec', path: 'tests/examples-tier3.test.mjs', name: 'AHEAD_OF_PIN', kind: 'js', policy: 'owed', guard: 'two-way', owner: 'tests/a-tier3-example-ahead-of-the-pin-is-declared.test.mjs' },
@@ -527,6 +527,50 @@ function topLevelEntries(inner) {
   return parts.map((p) => p.trim()).filter((p) => p.length > 0)
 }
 
+/**
+ * Collapse whitespace runs that lie OUTSIDE string literals, leaving what is
+ * inside one byte for byte.
+ *
+ * A row read from source is a slab of code, so the newline and indentation
+ * wrapping a multi-line entry are layout and must go. The spaces INSIDE a
+ * literal are what a human typed, and the `declared` policy reads a two-space
+ * run there as the separator between a row's key and its reason. Collapsing
+ * both alike left that policy unable to pass on ANY source-derived kind - `js`,
+ * `php` and `rust` all reported every row undeclared, whatever the source said
+ * (carve#1939).
+ *
+ * Collapsing outside literals only is what separates the two cases. Preserving
+ * every two-space run instead would make a multi-line entry's own indentation
+ * look like a separator, so a row with no reason at all would read as declared
+ * - the mirror of the defect, and the harder one to notice.
+ */
+function collapseBetweenLiterals(text) {
+  let out = ''
+  let i = 0
+  while (i < text.length) {
+    const c = text[i]
+    if (c === '"' || c === "'" || c === '`') {
+      out += c
+      i += 1
+      while (i < text.length) {
+        if (text[i] === '\\') { out += text.slice(i, i + 2); i += 2; continue }
+        out += text[i]
+        if (text[i] === c) { i += 1; break }
+        i += 1
+      }
+      continue
+    }
+    if (/\s/.test(c)) {
+      out += ' '
+      while (i < text.length && /\s/.test(text[i])) i += 1
+      continue
+    }
+    out += c
+    i += 1
+  }
+  return out
+}
+
 /** Rows of a `.txt` ledger: every line that is neither blank nor a `#` comment. */
 function txtRows(src) {
   return src.split('\n').map((l) => l.trimEnd()).filter((l) => l.trim() !== '' && !l.trimStart().startsWith('#'))
@@ -629,7 +673,7 @@ function liveRows(entry, src) {
   const inner = outer.length === 1 && /^\[[\s\S]*\]$/.test(outer[0])
     ? topLevelEntries(outer[0].slice(1, -1))
     : outer
-  return inner.map((row) => row.replace(/\s+/g, ' ').slice(0, 120))
+  return inner.map((row) => collapseBetweenLiterals(row).slice(0, 120))
 }
 
 /* ------------------------------------------------------------------ input */
@@ -673,7 +717,7 @@ function listFiles(repo, dir) {
 
 /* ------------------------------------------------------------------- main */
 
-export const __internals = { blankComments, declarationIndex, bracketedBlock, topLevelEntries, liveRows, classifyPinDistance, gitPinStatus, isDeclarationName, undeclaredLedgerRows, MANIFEST }
+export const __internals = { blankComments, collapseBetweenLiterals, declarationIndex, bracketedBlock, topLevelEntries, liveRows, classifyPinDistance, gitPinStatus, isDeclarationName, undeclaredLedgerRows, MANIFEST }
 
 if (process.env.CARVE_DECL_AUDIT_LIB === '1') {
   // Imported for its helpers by the self-test; do not run the audit.

--- a/tests/declaration-audit-counts-what-it-claims.test.mjs
+++ b/tests/declaration-audit-counts-what-it-claims.test.mjs
@@ -32,7 +32,7 @@ import { join } from 'node:path'
 
 process.env.CARVE_DECL_AUDIT_LIB = '1'
 const { __internals } = await import('../scripts/declaration-audit.mjs')
-const { liveRows, blankComments, classifyPinDistance, gitPinStatus, isDeclarationName, MANIFEST } = __internals
+const { liveRows, blankComments, classifyPinDistance, gitPinStatus, isDeclarationName, undeclaredLedgerRows, MANIFEST } = __internals
 
 const rows = (kind, name, src) => {
   const out = liveRows({ kind, name }, src)
@@ -125,13 +125,69 @@ test('a missing declaration is an ERROR, never zero', () => {
 })
 
 test('every manifest entry names a policy and a guard the reporter understands', () => {
-  const policies = new Set(['owed', 'permitted', 'split', 'manual'])
+  // `declared` belongs here as much as the rest: the reporter has always
+  // implemented it, and leaving it out of this set meant an entry could only
+  // reach it through `prPolicy`, which nothing validated at all (carve#1939).
+  const policies = new Set(['owed', 'permitted', 'split', 'manual', 'declared'])
   const guards = new Set(['two-way', 'one-way', 'none'])
   for (const entry of MANIFEST) {
     assert.ok(policies.has(entry.policy), `${entry.path} :: ${entry.name} has policy ${entry.policy}`)
+    if (entry.prPolicy !== undefined) {
+      assert.ok(policies.has(entry.prPolicy), `${entry.path} :: ${entry.name} has prPolicy ${entry.prPolicy}`)
+    }
     assert.ok(guards.has(entry.guard), `${entry.path} :: ${entry.name} has guard ${entry.guard}`)
     assert.ok(entry.owner, `${entry.path} :: ${entry.name} names no owner - an entry nobody owns cannot be retired`)
   }
+})
+
+test('the `declared` policy can pass, and fail, on a source-derived list', () => {
+  // It could do NEITHER until carve#1939. `liveRows` collapsed every whitespace
+  // run in a row read from source, which removed the two-space separator that
+  // `undeclaredLedgerRows` searches for - so `declared` reported every row
+  // undeclared on `js`, `php` and `rust` alike, whatever the source said. A
+  // policy that is selectable, documented and unreachable is the carve#755
+  // shape, and it went unnoticed because only `txt` entries had used it.
+  //
+  // Both directions are asserted per kind. Passing alone would be satisfied by
+  // a check that cannot fail, which is the failure being retired here.
+  const declared = {
+    js: "const D = [\n  'alpha.crv 1  a reason a human wrote',\n]",
+    php: "const D = [\n    'alpha.crv 1  a reason a human wrote',\n];",
+    rust: 'const D: &[&str] = &[\n    "alpha.crv 1  a reason a human wrote",\n];',
+  }
+  const bare = {
+    js: "const D = [\n  'alpha.crv 1',\n]",
+    php: "const D = [\n    'alpha.crv 1',\n];",
+    rust: 'const D: &[&str] = &[\n    "alpha.crv 1",\n];',
+  }
+  for (const kind of ['js', 'php', 'rust']) {
+    assert.deepEqual(
+      undeclaredLedgerRows(rows(kind, 'D', declared[kind])),
+      [],
+      `a ${kind} row carrying a reason must count as declared`,
+    )
+    assert.equal(
+      undeclaredLedgerRows(rows(kind, 'D', bare[kind])).length,
+      1,
+      `a ${kind} row with no reason must still be reported`,
+    )
+  }
+})
+
+test('a multi-line row does not read its own indentation as a separator', () => {
+  // The mirror defect, and the one that would be harder to see: preserving
+  // every two-space run rather than only what is inside a literal would let the
+  // layout of a row spanning several source lines stand in for a reason, so a
+  // list declaring nothing would pass. The collapse runs BETWEEN literals only.
+  // The first entry spans two source lines, and there are two entries so the
+  // `new Map([...])` unwrap does not flatten them. Its indentation is therefore
+  // INSIDE the row, which is the only place a phantom separator can come from.
+  const src = "const D = [\n  ['alpha.crv',\n    1],\n  ['beta.crv', 2],\n]"
+  const live = rows('js', 'D', src)
+  assert.equal(live[0], "['alpha.crv', 1]", 'layout between literals collapses to a single space')
+  const faults = undeclaredLedgerRows(live)
+  assert.equal(faults.length, 2, 'neither bare row may be rescued by its own layout')
+  for (const fault of faults) assert.match(fault, /no reason given/)
 })
 
 test('a staleness anchor belongs only to a guard that claims to be two-directional', () => {


### PR DESCRIPTION
Closes #1939.

**It could not fire.** `liveRows` collapses every whitespace run in a row read
from source; `undeclaredLedgerRows` splits a row on a run of two or more spaces
to separate its key from its reason. The collapse removes exactly what the
search needs, so `policy: 'declared'` reported every row undeclared whatever the
source said.

**Two premises corrected.**

The ticket names `js`. Measured, it is every source-derived kind - `js`, `php`
and `rust` all route through that one collapse. `txt`, `json` and `js-string`
do not, which is why the two ledgers already on `declared` never showed it.

And a second, structural block sat on top of the first: the manifest validator
accepted only `owed`, `permitted`, `split` and `manual`. `declared` was
reachable only through `prPolicy`, a field nothing validated at all. Both are
fixed here.

**Why not the suggested patch.** Preserving every two-space run trades the
defect for its mirror. A row spanning several source lines would read its own
indentation as a separator, so a list declaring nothing would pass:

```
['alpha.crv',
  1]
```

collapses under that patch to `['alpha.crv',  1]`, and the two spaces before
`1` are then read as the separator - a bare row scored as declared. The
collapse here runs BETWEEN string literals and leaves their contents byte for
byte, which is the distinction that separates layout from what a human typed.
That case is pinned.

**Blast radius.** Over all 44 source-derived manifest entries, 40 reachable on
this machine: **zero rows change text**. The fix is purely enabling.

**Proof it now fires.** `DECLARED_LEAF_INDENT_START` moves from `manual` to
`declared`, so a real `js` entry exercises the policy instead of leaving it
latent a second time. It reads `14 (14 declared)`.

| mutation | audit says |
| --- | --- |
| none | `14 (14 declared)`, passes |
| collapse reverted | `14 (0 declared) <== UNDECLARED`, fails |
| one row's reason stripped | `14 (13 declared) <== UNDECLARED`, names the row |

The two new unit tests discriminate all three variants: the reverted collapse
fails the `declared` test, and the suggested patch fails the multi-line test.
