### PR TITLE
fix(spec): a description stops at its last child, like every other closerless container

### DIFF
--- a/scripts/spec/ast-positions.mjs
+++ b/scripts/spec/ast-positions.mjs
@@ -172,15 +172,10 @@ export function checkContainment(doc, findings) {
  *   places reach past their last child, all of them over spaces, and the same
  *   sentence that puts the leading run inside the span puts the trailing one
  *   there. Adding the type would report the cell's own source as nobody's.
- *   `definition_description` reaches past its last child on NOTHING measured -
- *   36 placed on the corpus, none of them over-reaching - because every trailing
- *   run a description line carries lands on the enclosing `definition_list`
- *   instead, which IS in this set: `:: t` / `:  a` / blank / `   b<SP><SP>` ends
- *   the description at `b` and the list two codepoints later. Adding it would be
- *   a type that cannot fire, which this file already refused once below.
  *
- * THE CLAIM ABOVE WAS FALSE FOR THREE TYPES UNTIL carve#1574, and they are in
- * the set now rather than excused in this comment. `footnote` (27 of 73 placed),
+ * THE CLAIM ABOVE WAS FALSE FOR THREE TYPES UNTIL carve#1574, AND FOR A FOURTH
+ * UNTIL carve#1923, and they are in the set now rather than excused in this
+ * comment. `footnote` (27 of 73 placed),
  * `definition_term` (2 of 43) and `heading` (1 of 136) each reached past their
  * last child on real corpus documents while being named by none of the
  * categories above - so a reader auditing the guard was told they had been
@@ -203,6 +198,27 @@ export function checkContainment(doc, findings) {
  * every other closerless container. The 30 documents this newly reports are
  * declared red with the rest in tests/ast-positions.test.mjs and close when the
  * engines move.
+
+ * `definition_description` WAS EXCLUDED ON A MEASUREMENT THROUGH ONE ENGINE, and
+ * that is the whole defect. The excuse said it "reaches past its last child on
+ * NOTHING measured - 36 placed on the corpus, none of them over-reaching", and
+ * re-measured today that claim still HOLDS for the reference: 141 placed on the
+ * pinned carve-js, 130 with a placed child, 0 over-reaching. But this rule does
+ * not run against the reference alone. `scripts/ast-conformance.mjs` applies it
+ * to every engine, and carve-rs ends the description over a footnote definition
+ * hoisted out of it - `447-the-host-does-not-change-which-column-a-definition-reaches-12`
+ * spans it 5..31 where carve-js and carve-php stop at 5..11, the list's own end.
+ * A type that cannot fire on the reference can still be the only rule that
+ * reaches another engine, so "nothing measured" has to name WHICH tree was
+ * measured before it can excuse a type.
+ *
+ * The 7 documents were invisible precisely because the type was absent: with no
+ * rule on the description, carve-rs's parent `definition_list` ends at its last
+ * child correctly - that child being the over-wide description - so the parent
+ * passes too, and the pair surfaced only as two undeclared three-way span rows
+ * with matching counts (carve#1923). Hoisting is what makes the two readings
+ * differ, and carve#1522 already ruled that a hoisted sibling is not a child,
+ * which is the narrow reading carve-js and carve-php take.
  *
  * `definition_list` IS PRESENT, AND IT USED TO BE THE ONE EXCEPTION. It has no
  * closer, so §4 ends it at its last placed `definition_term` or
@@ -258,6 +274,7 @@ export function checkContainment(doc, findings) {
  */
 export const ENDS_AT_LAST_CHILD = new Set([
   'block_quote',
+  'definition_description',
   'definition_list',
   'definition_term',
   'figure',

--- a/tests/ast-positions.test.mjs
+++ b/tests/ast-positions.test.mjs
@@ -1294,6 +1294,122 @@ test('a definition list that stops at its last description is accepted', () => {
   assert.ok(ENDS_AT_LAST_CHILD.has('definition_list'))
 })
 
+/*
+ * A DESCRIPTION STOPS AT ITS LAST CHILD TOO (PART 12 section 4, carve#1923).
+ *
+ * The shape carve-rs and the other two engines answer differently, reduced to a
+ * tree. `447-the-host-does-not-change-which-column-a-definition-reaches-12`:
+ *
+ *     :: t
+ *     :  - a
+ *         [^n]: note text
+ *
+ * The footnote definition on line 3 sits inside the description body - its
+ * column 5 clears the body's content column of 4 - and is hoisted out of the
+ * tree by section 7, leaving the bullet list as the description's last placed
+ * child at 11. carve-js and carve-php end the description there; carve-rs ends
+ * it at 31, over source no child of it covers. carve#1522 already ruled a
+ * hoisted sibling is not a child, so the narrow reading is the conformant one
+ * and the wide engine owes the row.
+ *
+ * The pair matters more than usual here because the type was ABSENT from
+ * `ENDS_AT_LAST_CHILD` until this ticket, and its absence is why 7 documents
+ * diverged in silence: with the description unchecked, carve-rs's enclosing
+ * `definition_list` still ends at its last child - the over-wide description -
+ * so the parent passed as well.
+ */
+test('a description reaching past its last child is reported', () => {
+  const source = ':: t\n:  - a\n    [^n]: note text\n'
+  const doc = {
+    type: 'document',
+    children: [
+      {
+        type: 'definition_list',
+        pos: pos(0, 31),
+        items: [
+          { type: 'definition_term', pos: pos(0, 4), children: [] },
+          {
+            type: 'definition_description',
+            pos: pos(5, 31),
+            children: [
+              {
+                type: 'list',
+                pos: pos(5, 11),
+                items: [
+                  {
+                    type: 'list_item',
+                    pos: pos(8, 11),
+                    children: [
+                      {
+                        type: 'paragraph',
+                        pos: pos(8, 11),
+                        children: [{ type: 'text', pos: pos(8, 11) }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+  const findings = stopFindings(doc, source)
+  assert.equal(
+    findings.length,
+    1,
+    `expected the description's over-reach to be reported, got: ${JSON.stringify(findings)}`,
+  )
+  assert.match(findings[0], /definition_description/)
+  // THE TYPE IS WHAT MAKES IT FIRE. Removing `definition_description` from the
+  // set makes this exact tree pass, which is the state carve#1923 ended and the
+  // reason a bare `assert.deepEqual(..., [])` next door was not enough.
+  assert.ok(ENDS_AT_LAST_CHILD.has('definition_description'))
+})
+
+test('a description that stops at its last child is accepted', () => {
+  // The other direction, so the finding above is the RULE and not the document:
+  // the same tree with carve-js's narrow end reports nothing.
+  const source = ':: t\n:  - a\n    [^n]: note text\n'
+  const doc = {
+    type: 'document',
+    children: [
+      {
+        type: 'definition_list',
+        pos: pos(0, 11),
+        items: [
+          { type: 'definition_term', pos: pos(0, 4), children: [] },
+          {
+            type: 'definition_description',
+            pos: pos(5, 11),
+            children: [
+              {
+                type: 'list',
+                pos: pos(5, 11),
+                items: [
+                  {
+                    type: 'list_item',
+                    pos: pos(8, 11),
+                    children: [
+                      {
+                        type: 'paragraph',
+                        pos: pos(8, 11),
+                        children: [{ type: 'text', pos: pos(8, 11) }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+  assert.deepEqual(stopFindings(doc, source), [])
+})
+
 test('the parse tree cannot answer for a definition list, so the corpus pass reads the wire shape', () => {
   // The reason the corpus pass below serializes before it checks, pinned so it
   // cannot be simplified back. carve-js parses a definition list into bare
@@ -1507,11 +1623,15 @@ test('a table cell is bounded by the pipes on BOTH sides, which is why it is abs
   assert.ok(!ENDS_AT_LAST_CHILD.has('table_cell'))
 })
 
-test('a definition description has nothing after its last child, which is why it is absent', () => {
-  // The other absence carve#1574 had to account for. A description ends where
-  // its last block ends and has nothing after it to claim, so naming the type
-  // would be a check that cannot fail - which this file refused once already
-  // for `definition_list` itself.
+test('a definition description ends at its last child ON THE REFERENCE, which is why its absence looked safe', () => {
+  // The observation is unchanged and still true; the conclusion drawn from it
+  // was wrong, and carve#1923 is what retired it. A description ends where its
+  // last block ends ON THE PINNED carve-js - 141 placed over the corpus, 130
+  // with a placed child, 0 over-reaching - so naming the type looked like a
+  // check that cannot fail. But `scripts/ast-conformance.mjs` runs this rule
+  // against EVERY engine, and carve-rs ends a description over a footnote
+  // definition hoisted out of it on 7 documents. "Nothing measured" has to name
+  // which tree was measured before it can excuse a type.
   //
   // The trailing run PART 2 excludes from content used to land on the enclosing
   // `definition_list`, which is where it was reported. Since
@@ -1527,7 +1647,9 @@ test('a definition description has nothing after its last child, which is why it
   assert.equal([...source].slice(list.pos.startOffset, list.pos.endOffset).join(''), ':: t\n:  a\n\n   b')
   assert.equal(description.pos.endOffset, description.children.at(-1).pos.endOffset)
   assert.deepEqual(stopFindings(wire, source), [])
-  assert.ok(!ENDS_AT_LAST_CHILD.has('definition_description'))
+  // In the set now, and this document still reports nothing - which is the
+  // point: adding the type costs the reference no finding and reaches carve-rs.
+  assert.ok(ENDS_AT_LAST_CHILD.has('definition_description'))
 })
 
 /*


### PR DESCRIPTION
Bearbeitet #1923 - the half of it this repo owns. The carve-rs half
(`448-a-marker-folds-into-a-quote-below-it`, markup-carve/carve-rs#1537) is
untouched here, so #1923 stays open.

## What the run actually said

Re-measured at run 33866896586. `PART 12 conformance` failed on one thing only:
three undeclared three-way span rows. The panel prints the offsets, and they
name the engine:

| row | docs | carve-js | carve-rs | carve-php |
| --- | --- | --- | --- | --- |
| `definition_list` (extent) | 7 | `0..11` | **`0..31`** | `0..11` |
| `definition_description` (extent) | 7 | `5..11` | **`5..31`** | `5..11` |
| `comment` (extent) | 1 | `25..30` | `25..30` | **`26..30`** |

## The 7/7 pair is one cause, and it is a missing check here

On `447-the-host-does-not-change-which-column-a-definition-reaches-12`:

```
:: t
:  - a
    [^n]: note text
```

Line 3 clears the body's content column, so the footnote definition is authored
inside the description and hoisted out by §7. The bullet list is then the
description's last placed child, ending at 11. carve-js and carve-php end the
description there; carve-rs ends it at 31.

`definition_description` was the one closerless container absent from
`ENDS_AT_LAST_CHILD`, excused as a type that could not fire. **That excuse was
measured through the reference only.** Re-measured it still holds for carve-js -
141 placed, 130 with a placed child, 0 over-reaching - but the rule also runs
against every engine in `scripts/ast-conformance.mjs`, and carve-rs over-reaches
on seven documents.

The absence is exactly why they were silent: with the description unchecked,
carve-rs's enclosing `definition_list` still ends at its last child - the
over-wide description - so the parent passed too. Hence two rows with matching
counts and no engine owing either.

carve#1522 already ruled a hoisted sibling is not a child, so the narrow reading
is the conformant one and **carve-rs owes the seven**. This is the fourth type
brought in under the same clause the previous three were.

## The `comment` row is already settled

Start moved, end unanimous, so it is the `checkOpeningMarkup` case.
`444-...-9` line 3 is `    %% c`; the markup begins at offset 26 and carve-php
starts there, while carve-js and carve-rs start at 25, the last space of the
indentation. #1940 ruled a leaf begins at its markup and deliberately left
`comment` out of `INDENT_LATITUDE`, so **carve-js and carve-rs owe that row**.
No change needed here - the run predates #1940 by six minutes.

So none of the three rows should be declared. Declaring would bake in a
divergence a missing check hid.

## Blast radius

The pinned reference gains no finding: `DECLARED_OVER_REACH` stays empty and all
ten gates pass unchanged. What moves is attribution - carve-rs's seven documents
become a named finding instead of an unattributed ledger row.

Proved it fires rather than assumed. A reduced tree of the divergent document is
reported; the narrow spelling of the same tree is not; and removing the type
from the set reddens both that pair and the test that recorded the old
conclusion.
