### PR TITLE
ci: give the declarations job the HTTPS rewrite the other jobs already have

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,10 @@ jobs:
     # `npm run declarations:check`, which is the verdict that requires both.
     name: declarations are visible and every window is declared
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 10 like every other job here. At 5 the cap sat inside `npm ci`'s own range
+    # and killed the job mid-install, which then reported as a declaration
+    # failure - the wrong component entirely (carve#1942).
+    timeout-minutes: 10
 
     steps:
       - name: Check out carve
@@ -56,7 +59,20 @@ jobs:
           node-version: 24
           cache: npm
 
-      - run: npm ci
+      # THE REASON THIS JOB STALLED. `docs build` and `mermaid diagrams valid`
+      # both rewrite the git dependencies to HTTPS before installing; this job
+      # did not, so `npm ci` fetched carve-js, carve-grammars and
+      # vite-plugin-carve over ssh://git@github.com and hung there (carve#1942).
+      - name: Prefer HTTPS for Git dependencies
+        run: |
+          git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+          git config --global url."https://github.com/".insteadOf git@github.com:
+
+      # Its own cap, so an install stall fails AS an install stall instead of
+      # taking the job down and reading as a declaration finding.
+      - name: Install
+        timeout-minutes: 5
+        run: npm ci
 
       # PER-PR MODE, not the release verdict (carve#1811). The two answer
       # different questions and the engine-pin ledger is where they part: a


### PR DESCRIPTION
Closes #1942.

The cap was the symptom. The cause is that this job is the only one that
installs git dependencies without rewriting them to HTTPS first.

`docs build` and `mermaid diagrams valid` both run a "Prefer HTTPS for Git
dependencies" step before `npm ci`. The declarations job did not, so it fetched
carve-js, carve-grammars and vite-plugin-carve over SSH and stalled there - three
consecutive runs of one unchanged commit died at 5m16s-5m18s inside `npm ci`,
and a fourth re-run of that same commit passed in 1m41s.

Two changes, because the cap made the stall unreadable as well as fatal:

- **the rewrite step**, matching the two jobs that already have it;
- **install gets its own step and its own 5-minute cap, under a 10-minute job.**
  It was the only job here below 10, and 5 sits inside `npm ci`'s own range, so
  the install took the whole job down and GitHub reported a declaration failure
  for a job that never reached the declaration check.

Successful durations for this job over one day: 41s, 47s, 51s, 1m19s, 3m48s,
3m51s. The spread already reached 77% of the old budget, so the failures were
the cap catching up with the range rather than an outlier.

The conformance job also lacks the rewrite, but it has a 10-minute cap and has
not been failing - left alone deliberately rather than swept in.
