### PR TITLE
tooling: a sibling repo's own OWED lag no longer gates a spec PR per-PR

### DIFF
--- a/scripts/declaration-audit.mjs
+++ b/scripts/declaration-audit.mjs
@@ -717,7 +717,26 @@ function listFiles(repo, dir) {
 
 /* ------------------------------------------------------------------- main */
 
-export const __internals = { blankComments, collapseBetweenLiterals, declarationIndex, bracketedBlock, topLevelEntries, liveRows, classifyPinDistance, gitPinStatus, isDeclarationName, undeclaredLedgerRows, MANIFEST }
+// The policy an entry is judged under in PER-PR mode - the verdict, not the
+// entry, is what the mode changes (carve#1811).
+//
+//   - a manifest `prPolicy` wins where the entry opted in: the two engine-lag
+//     ledgers read as `declared`, so a well-formed window passes and a
+//     malformed one still fails.
+//   - a SIBLING repo's own OWED lag reads as `manual` (carve#1908): its gaps
+//     are declared and gated in the engine's own tree, and a spec PR never
+//     edits a sibling, so a sibling's lag cannot answer "is THIS pull request
+//     defective". The row stays visible and stays OWED in release mode.
+//   - everything else keeps its own policy.
+//
+// Release mode never calls this: a tag requires every owed list empty.
+function perPrPolicy(entry) {
+  if (entry.prPolicy !== undefined) return entry.prPolicy
+  if (entry.repo !== 'spec' && entry.policy === 'owed') return 'manual'
+  return entry.policy
+}
+
+export const __internals = { blankComments, perPrPolicy, collapseBetweenLiterals, declarationIndex, bracketedBlock, topLevelEntries, liveRows, classifyPinDistance, gitPinStatus, isDeclarationName, undeclaredLedgerRows, MANIFEST }
 
 if (process.env.CARVE_DECL_AUDIT_LIB === '1') {
   // Imported for its helpers by the self-test; do not run the audit.
@@ -807,7 +826,8 @@ for (const entry of MANIFEST) {
 
   // The verdict, not the entry, is what the mode changes. `prPolicy` applies
   // only in `per-pr` mode and only where the manifest opted in (carve#1811).
-  const policy = !strict && entry.prPolicy !== undefined ? entry.prPolicy : entry.policy
+  //
+  const policy = strict ? entry.policy : perPrPolicy(entry)
 
   let owed = rows.length
   let permitted = 0

--- a/tests/the-per-pr-audit-defers-to-a-live-check.test.mjs
+++ b/tests/the-per-pr-audit-defers-to-a-live-check.test.mjs
@@ -45,7 +45,7 @@ const repo = resolve(here, '..')
 
 process.env.CARVE_DECL_AUDIT_LIB = '1'
 const { __internals } = await import('../scripts/declaration-audit.mjs')
-const { undeclaredLedgerRows, MANIFEST } = __internals
+const { undeclaredLedgerRows, MANIFEST, perPrPolicy } = __internals
 
 const workflow = readFileSync(join(repo, '.github/workflows/ci.yml'), 'utf8')
 const pkg = JSON.parse(readFileSync(join(repo, 'package.json'), 'utf8'))
@@ -87,21 +87,41 @@ test('the per-PR workflow still gates undeclared drift, which is what the lenien
   )
 })
 
-test('exactly two manifest entries are judged differently per-PR, and they are the engine-lag ledgers', () => {
-  const relaxed = MANIFEST.filter((entry) => entry.prPolicy !== undefined)
+test('per-PR relaxes exactly the two engine-lag ledgers and the siblings own lag, nothing else', () => {
+  // The SPEC entries whose per-PR policy differs from their release policy are
+  // the two engine-lag ledgers, via the manifest `prPolicy` they opted into.
+  const specRelaxed = MANIFEST.filter(
+    (e) => e.repo === 'spec' && perPrPolicy(e) !== e.policy,
+  )
   assert.deepEqual(
-    relaxed.map((entry) => [entry.path, entry.policy, entry.prPolicy]).sort(),
+    specRelaxed.map((e) => [e.path, e.policy, perPrPolicy(e)]).sort(),
     [
       ['resources/engine-fmt-drift.txt', 'owed', 'declared'],
       ['resources/engine-pin-drift.txt', 'owed', 'declared'],
     ],
-    'a third ledger now reads differently per-PR - only the two engine-lag ledgers describe a window a PR opens',
+    'a spec ledger other than the two engine-lag ones now reads differently per-PR',
   )
-  // The AST divergence ledgers and the rest stay owed in BOTH modes. Named
-  // rather than counted, because the count is what a relaxation would keep.
-  const owedInBothModes = new Set(
-    MANIFEST.filter((e) => e.policy === 'owed' && e.prPolicy === undefined).map((e) => e.path),
-  )
+
+  // Every SIBLING repo's OWED lag reads as `manual` per-PR and stays `owed` for
+  // release - carve#1908: a sibling's declared gap never gates a spec PR, but a
+  // tag still requires the whole fleet clean. Paired both directions so a rule
+  // that relaxed nothing, or that relaxed release too, would fail here.
+  const siblingOwed = MANIFEST.filter((e) => e.repo !== 'spec' && e.policy === 'owed')
+  assert.ok(siblingOwed.length > 0, 'expected sibling owed entries; the manifest shape changed')
+  for (const e of siblingOwed) {
+    assert.equal(perPrPolicy(e), 'manual', `${e.repo} ${e.path} :: ${e.name} still gates a spec PR per-PR`)
+    assert.equal(e.policy, 'owed', `${e.repo} ${e.path} :: ${e.name} stopped being owed for release`)
+  }
+
+  // A sibling's NON-owed entry (e.g. an explicit `manual`) is untouched, so the
+  // relaxation is about the `owed` lag and not a blanket sibling pass.
+  for (const e of MANIFEST.filter((x) => x.repo !== 'spec' && x.policy !== 'owed')) {
+    assert.equal(perPrPolicy(e), e.policy, `${e.repo} ${e.path} :: ${e.name} was relaxed but was not owed`)
+  }
+
+  // The spec's own AST divergence ledgers and the UNDECLARED sweep stay owed in
+  // BOTH modes - the leniency is for siblings and the two declared windows, not
+  // for the spec's own debt.
   for (const path of [
     'resources/ast-span-divergence.txt',
     'resources/ast-value-divergence.txt',
@@ -109,7 +129,9 @@ test('exactly two manifest entries are judged differently per-PR, and they are t
     'resources/converter-drift.txt',
     'resources/oracle-divergence.txt',
   ]) {
-    assert.ok(owedInBothModes.has(path), `${path} is no longer owed per-PR`)
+    const e = MANIFEST.find((x) => x.repo === 'spec' && x.path === path)
+    assert.ok(e, `${path} left the manifest`)
+    assert.equal(perPrPolicy(e), 'owed', `${path} is no longer owed per-PR`)
   }
 })
 


### PR DESCRIPTION
Implements Mark's ruling on the declarations-gate: a sibling repo's declared
`KNOWN_GAP` (OWED) no longer blocks a carve spec PR that did not introduce it.
It stays visible in the ledger; it just stops red-gating `declarations:pr` on
unrelated PRs.

## Why

carve-php#1908 is two well-formed `KNOWN_GAPS` on carve-php's own main - owed,
and unfixable without a spec ruling. Because `declarations:pr` read every
sibling `owed` ledger as a blocker, those two gaps went red on **every open spec
PR** and exposed main to a stale-green (its last green run predates the
carve-php commit). A sibling's gap is the engine's own lag, declared in the
engine's own tree and gated by the engine's own CI; a spec PR never edits a
sibling, so it can neither introduce nor fix one. The per-PR question - is THIS
pull request defective - is not one a sibling's lag can answer.

## What changes

Per-PR mode judges a sibling's own `owed` entry as `manual`: rows still read,
still printed with their count, still listed in the MANUAL block - visible - but
owed count zero, so it does not fail the gate. Verified:

```
per-pr:  carve-php tests/CarveCorpusTest.php  KNOWN_GAPS  2  manual   -> PASSED
release: carve-php tests/CarveCorpusTest.php  KNOWN_GAPS  2  owed  <== OWED -> FAILED
```

Release mode is untouched - a tag still requires every owed list empty across
the whole fleet.

## Scope guard

The decision moves into `perPrPolicy(entry)`, exported for the test:

- a manifest `prPolicy` still wins - the two engine-lag ledgers read `declared`;
- a sibling's `owed` reads `manual`;
- everything else keeps its own policy.

The spec's own AST-divergence ledgers and the UNDECLARED sweep stay owed in both
modes - the leniency is for siblings and the two declared windows, never for the
spec's own debt. The rewritten guard test asserts all four boundaries through
`perPrPolicy`, paired both directions, so a rule that relaxed nothing - or
relaxed release too, or relaxed a spec ledger - fails here.

Unblocks #1954 (the empty-table fix, already correct) and every open spec PR.
