### PR TITLE
Declare residual AST span/value divergences after the 1b27b68 bump

### DIFF
--- a/resources/ast-span-divergence.txt
+++ b/resources/ast-span-divergence.txt
@@ -687,3 +687,36 @@
 # carve-rs#1308, and the same run reports BINDING PARITY differing from carve-rs
 # on the four `410` documents. That is a stale `ext/carve/Cargo.toml` pin in
 # carve-rb, not a span this file could declare.
+
+# RE-MEASURED 2026-09-07 for the carve#1963 release gate, at carve-js 9e5319f2,
+# carve-rs (markup-carve/carve-rs#1568) and carve-php (markup-carve/carve-php#1921)
+# over 1685 corpus documents plus 3 synthetic samples. The comment-span findings
+# #1963 names are FIXED in those two engine PRs, not declared. What remains is
+# four rows across three documents, each a legitimate cross-engine difference the
+# bump exposed - none flagged by the source-side PART 12 SS4 checker
+# (checkOpeningMarkup / checkStopsAtChildren), so none is provably one engine's
+# violation. Named per document and suspected owner in markup-carve/carve#1965.
+#
+# NOT DECLARED HERE: the `list`, `list_item`, `code_block` rows and the 455-half
+# of the two definition rows are carve-js's `endOffset past end of source` bug on
+# the `455` family, fixed separately; they clear with that fix and the counts
+# below are the residual after it.
+#
+#   definition_description (extent)  447-...-13  js and rs span the description
+#                                    over its hoisted footnote and link-ref-def
+#                                    SIBLINGS; php stops earlier (carve#1522).
+#   definition_list (extent)         447-...-13  follows the description shape.
+#   footnote (extent)                456-...     js starts the hoisted note one
+#                                    codepoint into the indent; rs and php on the
+#                                    `[` marker. `footnote` is not in
+#                                    OPENING_MARKUP, so no side is source-named.
+#   block_quote (extent)             458-...     php has not ported carve#1962; it
+#                                    spans the quote past its closing boundary,
+#                                    js and rs end at it.
+#
+# markup-carve/carve#1965, markup-carve/carve#1963.
+
+definition_description (extent) 1
+definition_list (extent) 1
+footnote (extent) 1
+block_quote (extent) 1

--- a/resources/ast-value-divergence.txt
+++ b/resources/ast-value-divergence.txt
@@ -168,3 +168,14 @@
 #
 # which is the FIXED direction the pair exists to report. The row and
 # `LAST_MEASURED` in tests/ast-values.test.mjs go together, as their notes say.
+
+# AND AGAIN 2026-09-07, for the carve#1963 release gate. carve-php has not ported
+# markup-carve/carve#1962 (a wrapped attribute block does not reach past a quote's
+# closing boundary), so on 458-a-wrapped-attribute-block-ends-at-its-quote it
+# attaches the block to a paragraph carve-js and carve-rs never build, and that
+# paragraph carries three attribute fields the other two do not. One document,
+# three fields, one lag - tracked with the span rows in markup-carve/carve#1965.
+
+paragraph.attrs.classes 1 markup-carve/carve#1965
+paragraph.attrs.id 1 markup-carve/carve#1965
+paragraph.attrs.order 1 markup-carve/carve#1965


### PR DESCRIPTION
## What

Declares the residual cross-engine AST span/value divergences the `1b27b68` corpus bump exposed, so `npm run ast:check` (PART 12 conformance, the carve#1963 gate) can reconcile them instead of failing on undeclared rows.

The `comment` findings #1963 names are **fixed in the engines**, not declared here:
- carve-rs: markup-carve/carve-rs#1568
- carve-php: markup-carve/carve-php#1921

## What is declared

Four span rows and three value fields, across three documents. None is flagged by the source-side PART 12 §4 checker (`checkOpeningMarkup` / `checkStopsAtChildren`), so none is provably one engine's violation — they are legitimate cross-engine differences. Per-document detail and suspected owners: markup-carve/carve#1965.

- `definition_description` / `definition_list (extent)` — `447-…-13`: js and rs span a description over its hoisted footnote and link-ref-def siblings; php stops earlier (carve#1522).
- `footnote (extent)` — `456-…`: js starts the hoisted note one codepoint into the indent; rs and php on the `[` marker. `footnote` is absent from `OPENING_MARKUP`, so no side is source-named.
- `block_quote (extent)` + `paragraph.attrs.{classes,id,order}` — `458-…`: carve-php has not ported carve#1962, so it spans the quote past its closing boundary and attaches an attribute block to a paragraph the other two engines never build.

## Dependency (read before merging)

The counts are the **residual after the separate carve-js `endOffset past end of source` fix on the `455` family**. That carve-js bug currently inflates `definition_description`/`definition_list` and adds `list`/`list_item`/`code_block` rows; those clear with the carve-js fix and are deliberately **not** declared here. Reconciled with the checker's own `reconcileSpans` / `reconcileDeclared`:

- against today's engine mains: `definition_description`/`definition_list` report COUNT and `list`/`list_item`/`code_block` report NEW (all the carve-js `455` bug); `footnote`, `block_quote` and the three value fields already reconcile clean.
- against the engines with the carve-js `455` fix applied: **both files reconcile clean.**

So this merges green only once carve-rs#1568, carve-php#1921 and the carve-js `455` fix have landed. It is the convergence piece of #1963.

Refs markup-carve/carve#1963, markup-carve/carve#1965.
