### PR TITLE
docs: restore the influence credits and say where the parts come from

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ The reference implementations are tested with the same Carve documents and
 expected output. Current differences are recorded in the
 [implementation comparison](https://markup-carve.github.io/carve/implementation-comparison).
 
+## Influences
+
+- **Markdown** - ubiquitous baseline; paragraph interruption without a blank line
+- **[Djot](https://djot.net/)** (John MacFarlane) - rigorous parsing, attributes, foundation
+- **Org-mode** - `/italic/` syntax, TODO states
+- **Creole** - `|=` table headers
+- **AsciiDoc** - admonitions, document structure
+- **CriticMarkup** - editorial annotations
+
 ## Development
 
 This repository contains the specification, corpus, and documentation site.

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,6 +104,15 @@ Core syntax is always available. Some features, including citations, automatic
 URL linking, and diagrams, must be enabled separately. The [optional features
 table](./extensions#feature-tiers-quick-reference) lists their availability.
 
+## Influences
+
+- **Markdown** - ubiquitous baseline; paragraph interruption without a blank line
+- **[Djot](https://djot.net/)** (John MacFarlane) - rigorous parsing, attributes, foundation
+- **Org-mode** - `/italic/` syntax, TODO states
+- **Creole** - `|=` table headers
+- **AsciiDoc** - admonitions, document structure
+- **CriticMarkup** - editorial annotations
+
 ## Reference
 
 - [Formal grammar](./grammar)

--- a/docs/technical-rationale.md
+++ b/docs/technical-rationale.md
@@ -506,6 +506,33 @@ Press [Ctrl+C]{kbd}.
 The technical point is not merely convenience. Native syntax gives the parser a
 clear semantic target and gives implementations a common contract.
 
+## Where the parts come from
+
+Carve takes its parsing rationale from Djot and its authoring ergonomics from
+Markdown. Neither is a fork: the ideas were adopted deliberately and the
+divergences are recorded in [Divergence from Djot](./divergence-from-djot) and
+[Coming from Markdown](./migrate-from-markdown).
+
+**From Djot** - linear parsing with no backtracking, local inline
+tokenization, single-character emphasis, arbitrary `{#id .class key=value}`
+attributes on any element, generic `:::` containers, and the rule that content
+means the same thing inside a container as outside it. The parser contract
+above is Djot's model, kept.
+
+**From Markdown** - paragraph interruption. A block opener on a new line
+starts a block with no blank line required (PART 9 §10). Djot requires the
+blank line; Carve follows Markdown here because writers expect a list or
+heading to start where they wrote it.
+
+**From Creole** - `|=` for table headers. The wiki markup got this right:
+marking the header cells themselves needs no separator row under the first row,
+so a table stays readable in source and a header can appear anywhere a row can.
+
+Carve's own additions - visual mnemonics, captions, cross-references,
+auto-resolving wiki links, list continuation, admonitions, abbreviations,
+comments, mentions and tags, and target-aware rendering - are the subject of
+the section above and of the [Case Study](./case-study/).
+
 ## Concrete ambiguities Carve resolves
 
 ## Paths vs italics


### PR DESCRIPTION
The `## Influences` list was removed from both entry points in #1908 when they were made concise, and nothing replaced it. It credited Djot, Org-mode, Creole, AsciiDoc and CriticMarkup in one line each - the only place the language's roots were recorded for a reader who is not going to read the case study.

Restored to `README.md` and `docs/index.md`, with two deliberate changes rather than a literal revert.

**Markdown is credited too.** The list never named it, though the docs are explained against it throughout: the technical rationale opens on "the problem Markdown leaves unsolved", there is a whole migration guide, `comparison.md` is *Carve vs Markdown/Djot/MDX*, and paragraph interruption is a rule Carve takes from Markdown *against* Djot. An influence list that omits the baseline every other page compares to was incomplete.

**The bullets use hyphens.** The `docs/index.md` copy had em-dashes; neither entry point uses an em-dash anywhere else today, so a literal restore would have introduced a character these two files do not use.

Wording, Djot link and the `(John MacFarlane)` credit are otherwise untouched.

### The rationale section

`docs/technical-rationale.md` gains **Where the parts come from**, between "What Carve changes on top of Djot" and "Concrete ambiguities Carve resolves": the parser model from Djot, paragraph interruption from Markdown, `|=` from Creole.

The page argued at length about both Djot and Markdown without ever saying which ideas were adopted from where, and it never mentioned Creole at all. The two additions do different jobs - Influences credits all six roots in a line each, the section explains *why* for the three that shape the parser.

### Not included

The 27-point **Design Principles** list that #1908 also removed from `README.md`. About half of its points restate material already in `technical-rationale.md` (the visual-mnemonics list appears in both, nearly verbatim), so restoring it whole would duplicate rather than document. Its provenance framing - From Djot / From Markdown / Carve Additions - is what the new section carries instead. It remains in history at `f59cc880^` if a scannable one-page index is wanted later.
