### PR TITLE
spec: a trailing line after a consumed definition is placed by column-reach (carve#1946)

### DIFF
--- a/docs/implementation-comparison-methodology.md
+++ b/docs/implementation-comparison-methodology.md
@@ -75,9 +75,10 @@ and
 and
 `456-a-definition-nested-past-a-footnote-body-is-a-note-and-a-reference-below-it-resolves`
 and
-`457-a-container-closer-closes-its-container-in-a-footnote-body-too`
+`457-a-container-closer-closes-its-container-in-a-footnote-body-too`,
+`458-a-wrapped-attribute-block-ends-at-its-quote-and-reaches-no-line-below-it`
 and
-`458-a-wrapped-attribute-block-ends-at-its-quote-and-reaches-no-line-below-it`.
+`459-a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach`.
 
 Each landed on a host with no engine checkouts, so the run above could not be
 retaken and its numbers describe the corpus WITHOUT them. Editing the

--- a/resources/example-pages.txt
+++ b/resources/example-pages.txt
@@ -623,6 +623,7 @@ index: examples/edge-cases/index.md
   a-definition-nested-past-a-footnote-body-is-a-note-and-a-reference-below-it-resolves
   a-container-closer-closes-its-container-in-a-footnote-body-too
   a-wrapped-attribute-block-ends-at-its-quote-and-reaches-no-line-below-it
+  a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach
   an-empty-unterminated-container-ends-at-a-flush-left-line
   an-abbreviation-definition-outside-document-level-is-not-an-invisible-line
 [edge-attributes] Attributes

--- a/resources/examples/edge-cases.md
+++ b/resources/examples/edge-cases.md
@@ -34848,3 +34848,91 @@ same.
 ```
 
 :::
+
+
+## A trailing line after a consumed definition is placed by column-reach
+
+In the nested stack (markup-carve/carve#1946), a definition consumed below the
+notes and the line following it belong to the innermost note whose BODY CONTENT
+COLUMN - its own marker column plus two - the line's indentation reaches. The
+two rows of the section above pin the OUTER band; these pin the MID and INNER
+ones, so all three sinks are covered.
+
+The MID band: the payload sits at column 4, past the mid note's body column
+(marker 2 plus two) but short of the inner note's (marker 6 plus two), so `[r]`
+is consumed inside `[^g]` and `TAILWORD` is its second paragraph.
+
+::: compare
+
+```carve
+[^f]: outer
+
+  [^g]: mid
+
+      [^h]: inner
+
+    [r]: /url
+    TAILWORD
+
+x[^f] [^g] [^h] [t][r]
+```
+
+```html
+<p>x<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> <a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a> <a id="fnref3" href="#fn3" role="doc-noteref"><sup>3</sup></a> <a href="/url">t</a></p>
+<section role="doc-endnotes" aria-label="Footnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>outer<a href="#fnref1" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>mid</p>
+      <p>TAILWORD<a href="#fnref2" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn3">
+      <p>inner<a href="#fnref3" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+:::
+
+The INNER band: the payload sits at column 7, past the inner note's own body
+column (marker 4 plus two), so `[r]` and `TAILWORD` land in `[^h]`.
+
+::: compare
+
+```carve
+[^f]: outer
+
+  [^g]: mid
+
+    [^h]: inner
+
+       [r]: /url
+       TAILWORD
+
+x[^f] [^g] [^h] [t][r]
+```
+
+```html
+<p>x<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> <a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a> <a id="fnref3" href="#fn3" role="doc-noteref"><sup>3</sup></a> <a href="/url">t</a></p>
+<section role="doc-endnotes" aria-label="Footnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>outer<a href="#fnref1" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>mid<a href="#fnref2" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn3">
+      <p>inner</p>
+      <p>TAILWORD<a href="#fnref3" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+:::

--- a/resources/import-roundtrip-baseline.json
+++ b/resources/import-roundtrip-baseline.json
@@ -1,11 +1,11 @@
 {
   "engine": "@markup-carve/carve",
   "engineCommit": "4e2023768c81e12db09cfb8a9da56e12327c017e",
-  "corpusDocuments": 1685,
+  "corpusDocuments": 1687,
   "htmlImportPopulation": {
-    "completed": 1684,
-    "canonicalFixedPoints": 1683,
-    "renderedTextPreserved": 1668,
+    "completed": 1686,
+    "canonicalFixedPoints": 1685,
+    "renderedTextPreserved": 1670,
     "expectedRejections": [
       "182-openers-past-the-nesting-cap-are-one-paragraph.crv"
     ]

--- a/scripts/spec/layout.mjs
+++ b/scripts/spec/layout.mjs
@@ -1665,9 +1665,44 @@ const opensAuthoredBase = (line) => opensSubBlock(line) || isLinkDef(line) ||
  */
 export function normalizeAuthoredBodyBases(lines, state = {}, footnoteBody = false) {
   const out = []
+  // Whether a nested note has been flushed to column 0 whose fixed body column
+  // (2) a following plain paragraph could wrongly reach. It arms the paragraph
+  // dedent below and is disarmed by the next structural block, whose own
+  // continuations must keep their indent (raised by codex review).
+  let flushedNote = false
   for (let index = 0; index < lines.length; index++) {
     const line = lines[index]
     const measured = indentCols(line)
+    if (footnoteBody && measured.rest !== '' && FOOTNOTE_DEF.test(measured.rest)) {
+      // A NESTED NOTE is flushed to column 0 - the collector recognizes a note
+      // only there - together with its WHOLE body: every following line that
+      // reaches the note's own body column, `c + 2` (PART 9 §16), blank runs
+      // tolerated. A note's body stands two columns past its OWN marker, not the
+      // frame's fixed 2; measuring from the marker is what gives the mid and
+      // inner notes their own reach, where the fixed reading had only an outer
+      // and an inner sink and dropped a trailing line in the band between them
+      // to the outer note (markup-carve/carve#1946, carve-js#1664,
+      // carve-php#1895). Capturing the subtree in one piece lets the recursive
+      // collector rebuild the nested notes level by level with a consistent
+      // column. A NOTE ONE COLUMN SHY of this note's body column does not reach
+      // it, so the walk stops and it becomes the next note here - a sibling, not
+      // a child.
+      const c = measured.col
+      const bodyCol = c + FOOTNOTE_BODY_COLUMN
+      let last = index
+      for (let end = index + 1; end < lines.length; end++) {
+        const lm = indentCols(lines[end])
+        if (lm.rest === '') continue
+        if (lm.col >= bodyCol) { last = end; continue }
+        break
+      }
+      for (let k = index; k <= last; k++) {
+        out.push(isBlank(lines[k]) ? lines[k] : dedent(lines[k], c))
+      }
+      index = last
+      flushedNote = true
+      continue
+    }
     const establishesBase = measured.col > 0 && opensAuthoredBase(measured.rest)
     // A LIST ITEM IS A CONTAINER TOO (carve#1781). `opensSubBlock` answers a
     // different question - whether a blank-separated sub-block leaves a list
@@ -1681,9 +1716,21 @@ export function normalizeAuthoredBodyBases(lines, state = {}, footnoteBody = fal
     const protectsInnermostContainer = measured.col === 0 &&
       (opensSubBlock(measured.rest) || matchMarkerAt(measured) !== null)
     if (!establishesBase && !protectsInnermostContainer) {
-      out.push(line)
+      // A plain PARAGRAPH sibling of a note just flushed to column 0 keeps a
+      // leading indent that is not structural: the note's body column is now the
+      // fixed 2, so a paragraph at the note's marker column would read as that
+      // note's content. Strip its indent to keep it out (markup-carve/carve#1946).
+      // Only when a note WAS flushed - without one there is nothing to over-reach,
+      // and the indent may belong to a preceding block whose lazy continuation
+      // this is (the `dd` of a definition list keeps its indented follower).
+      const noteSiblingParagraph = footnoteBody && flushedNote && measured.col > 0 &&
+        matchMarkerAt(measured) === null && !opensSubBlock(measured.rest)
+      out.push(noteSiblingParagraph ? dedent(line, measured.col) : line)
       continue
     }
+    // A structural block (a container, a list marker) ends the note-sibling run:
+    // its own indented continuations are its content, not an over-reach.
+    flushedNote = false
 
     const base = establishesBase ? measured.col : 0
     const candidate = lines.slice(index).map((source) => {

--- a/tests/corpus/459-a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach-2.crv
+++ b/tests/corpus/459-a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach-2.crv
@@ -1,0 +1,10 @@
+[^f]: outer
+
+  [^g]: mid
+
+    [^h]: inner
+
+       [r]: /url
+       TAILWORD
+
+x[^f] [^g] [^h] [t][r]

--- a/tests/corpus/459-a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach-2.html
+++ b/tests/corpus/459-a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach-2.html
@@ -1,0 +1,16 @@
+<p>x<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> <a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a> <a id="fnref3" href="#fn3" role="doc-noteref"><sup>3</sup></a> <a href="/url">t</a></p>
+<section role="doc-endnotes" aria-label="Footnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>outer<a href="#fnref1" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>mid<a href="#fnref2" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn3">
+      <p>inner</p>
+      <p>TAILWORD<a href="#fnref3" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+  </ol>
+</section>

--- a/tests/corpus/459-a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach.crv
+++ b/tests/corpus/459-a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach.crv
@@ -1,0 +1,10 @@
+[^f]: outer
+
+  [^g]: mid
+
+      [^h]: inner
+
+    [r]: /url
+    TAILWORD
+
+x[^f] [^g] [^h] [t][r]

--- a/tests/corpus/459-a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach.html
+++ b/tests/corpus/459-a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach.html
@@ -1,0 +1,16 @@
+<p>x<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> <a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a> <a id="fnref3" href="#fn3" role="doc-noteref"><sup>3</sup></a> <a href="/url">t</a></p>
+<section role="doc-endnotes" aria-label="Footnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>outer<a href="#fnref1" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>mid</p>
+      <p>TAILWORD<a href="#fnref2" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn3">
+      <p>inner<a href="#fnref3" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+  </ol>
+</section>

--- a/tests/spec/459-a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach.test
+++ b/tests/spec/459-a-trailing-line-after-a-consumed-definition-is-placed-by-column-reach.test
@@ -1,0 +1,61 @@
+A trailing line after a consumed definition is placed by column-reach
+
+```
+[^f]: outer
+
+  [^g]: mid
+
+      [^h]: inner
+
+    [r]: /url
+    TAILWORD
+
+x[^f] [^g] [^h] [t][r]
+.
+<p>x<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> <a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a> <a id="fnref3" href="#fn3" role="doc-noteref"><sup>3</sup></a> <a href="/url">t</a></p>
+<section role="doc-endnotes" aria-label="Footnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>outer<a href="#fnref1" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>mid</p>
+      <p>TAILWORD<a href="#fnref2" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn3">
+      <p>inner<a href="#fnref3" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+```
+[^f]: outer
+
+  [^g]: mid
+
+    [^h]: inner
+
+       [r]: /url
+       TAILWORD
+
+x[^f] [^g] [^h] [t][r]
+.
+<p>x<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> <a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a> <a id="fnref3" href="#fn3" role="doc-noteref"><sup>3</sup></a> <a href="/url">t</a></p>
+<section role="doc-endnotes" aria-label="Footnotes">
+  <hr>
+  <ol>
+    <li id="fn1">
+      <p>outer<a href="#fnref1" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn2">
+      <p>mid<a href="#fnref2" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+    <li id="fn3">
+      <p>inner</p>
+      <p>TAILWORD<a href="#fnref3" role="doc-backlink" aria-label="Back to reference">↩</a></p>
+    </li>
+  </ol>
+</section>
+```


### PR DESCRIPTION
Pins the spec-and-corpus side of the nested-note trailing-line ruling (#1946), which all three engines already implement byte-identically (markup-carve/carve-js#1664, markup-carve/carve-php#1926, markup-carve/carve-rs#1573).

## The gap

In a stack of nested footnote definitions the executable-spec oracle (`scripts/spec`) measured every note's body against a fixed two-column margin. That left only an outer and an inner sink and no mid tier, so a definition consumed below the notes - and the trailing line that follows it - fell to the OUTER note whenever it sat in the band between the mid and inner body columns. The engines had already been corrected; the oracle still gave the old outer-for-all reading, so the corpus could not pin the mid and inner cells.

## The oracle change

`normalizeAuthoredBodyBases` now measures a note's body column from its OWN marker (marker + 2, PART 9 §16) when it normalizes a footnote body. A nested note is flushed to column 0 together with its whole body - the following lines that reach its own body column - so the recursive collector rebuilds each level with a consistent column, and a note one column shy of an open one's body column falls out as a sibling rather than a child. A plain paragraph left beside a flushed note has its indent stripped so it cannot read as that note's content; a line that opens a block keeps its indent.

The result is byte-identical to carve-js, carve-php and carve-rs (each built from its current main) across the whole ruling grid - `m` in 1..7, `i` in m+1..m+6, `p` in 0..14. On every geometry the three engines agree on, the oracle now matches them exactly, and no other corpus document's expected HTML moves.

## The corpus rows

Section 459 pins the two bands the outer-band section above could not.

The mid band - the payload sits at column 4, past the mid note's body column but short of the inner note's, so `[r]` and `TAILWORD` land in `[^g]`:

```carve
[^f]: outer

  [^g]: mid

      [^h]: inner

    [r]: /url
    TAILWORD

x[^f] [^g] [^h] [t][r]
```

The inner band - the payload sits at column 7, past the inner note's own body column, so they land in `[^h]`:

```carve
[^f]: outer

  [^g]: mid

    [^h]: inner

       [r]: /url
       TAILWORD

x[^f] [^g] [^h] [t][r]
```

The counting gates move with the two documents: the section is routed on the definitions docs page, declared as added since the published comparison run so the quoted core-corpus ratio is unchanged, and the import round-trip population is bumped by two.
